### PR TITLE
ci: use explicit --token for publish and add secret verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,18 @@ jobs:
           $BINARY docs list | grep "embedded/core/DECAPOD.md"
           echo "Guardrail passed - Binary functional."
 
+      - name: Verify Secret Presence
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]; then
+            echo "❌ ERROR: CARGO_REGISTRY_TOKEN is empty or not found in GitHub Secrets."
+            echo "Please ensure you have added it to Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+          echo "✅ Secret is present."
+
       - name: Publish to Crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --allow-dirty
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --locked --allow-dirty
 
       - name: Package Binary
         run: |


### PR DESCRIPTION
# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
