### PR TITLE
feat: add teammate plugin for user preference memory v0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "decapod"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decapod"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.85"
 description = "🦀 Decapod is a Rust-built, repo-native control-plane kernel for AI swarms—safe shared state, enforced truth, and loop-agnostic orchestration."

--- a/constitution/embedded/core/PLUGINS.md
+++ b/constitution/embedded/core/PLUGINS.md
@@ -76,6 +76,7 @@ Agents are generally advised not to open SQLite directly, especially as a broker
 
 ### 3.2 Knowledge & Memory (Intelligence)
 - **knowledge**: Rationale, context, and project-specific facts.
+- **teammate** ⭐: User preference memory for persistent behaviors. **See: `embedded/plugins/TEAMMATE.md`**
 - **context**: Token budget management and MOVE-not-TRIM archival.
 - **archive**: Immutable session history indexing.
 
@@ -116,6 +117,7 @@ Constraint:
 | reflex | implemented | REAL | `embedded/plugins/REFLEX.md` | both | writes | `decapod reflex schema` | brokered sqlite, audit trail |
 | watcher | implemented | REAL | `embedded/plugins/WATCHER.md` | both | reads | `decapod watcher run` | audit trail |
 | knowledge | implemented | REAL | `embedded/plugins/KNOWLEDGE.md` | both | writes | `decapod knowledge search` | provenance check |
+| teammate | implemented | REAL | `embedded/plugins/TEAMMATE.md` | both | writes | `decapod teammate schema` | user preference persistence |
 | archive | implemented | REAL | `embedded/plugins/ARCHIVE.md` | both | writes | `decapod archive verify` | hash matching |
 | feedback | implemented | REAL | `embedded/plugins/FEEDBACK.md` | both | writes | `decapod feedback propose` | non-binding isolation |
 | trust | implemented | REAL | `embedded/plugins/TRUST.md` | both | reads | `decapod trust status` | audit history check |
@@ -158,6 +160,7 @@ V1 scope (when implemented):
 ## Links
 
 - `embedded/plugins/TODO.md` — **TODO subsystem reference (START HERE)**
+- `embedded/plugins/TEAMMATE.md` — **Teammate preference memory reference**
 - `embedded/core/DECAPOD.md`
 - `embedded/core/CONTROL_PLANE.md`
 - `embedded/core/DOC_RULES.md`

--- a/constitution/embedded/plugins/TEAMMATE.md
+++ b/constitution/embedded/plugins/TEAMMATE.md
@@ -4,8 +4,186 @@
 **Layer:** Operational
 **Binding:** No
 
-This document defines the teammate subsystem.
+**Quick Reference:**
+| Command | Purpose |
+|---------|---------|
+| `decapod teammate add --category git --key ssh --value "mine"` | Record a preference |
+| `decapod teammate get --category git --key ssh` | Retrieve a preference |
+| `decapod teammate list` | List all preferences by category |
+
+**Related:** `embedded/core/PLUGINS.md` (subsystem registry) | `AGENTS.md` (entrypoint)
+
+---
 
 ## CLI Surface
-- `decapod teammate ...`
 
+```bash
+decapod teammate add --category <cat> --key <key> --value <val> [--context <ctx>] [--source <src>]
+decapod teammate get --category <cat> --key <key>
+decapod teammate list [--category <cat>] [--format text|json]
+decapod teammate schema  # JSON schema for programmatic use
+```
+
+## Purpose
+
+The teammate plugin catalogs distinct user expectations that persist across sessions, helping AI agents work more effectively with their human collaborators. It transforms one-off instructions into remembered behaviors.
+
+### Why This Matters
+
+Without the teammate plugin:
+- User has to repeat "use my SSH key" on every commit
+- Agent forgets preferred branch naming conventions
+- Code style preferences must be re-explained each session
+- Workflow requirements are lost between contexts
+
+With the teammate plugin:
+- Preferences are recorded once, remembered always
+- Agents check before acting
+- Consistent behavior across all interactions
+- Builds a profile of how the user likes to work
+
+### Example Use Cases
+
+**Git Preferences:**
+```bash
+# User says: "always use my SSH key, don't add yourself as a contributor"
+decapod teammate add --category git --key ssh_key --value "use_mine" \
+  --context "Use user's SSH key for git operations, don't add self as contributor" \
+  --source "user_request"
+
+# User says: "keep commit messages concise and imperative"
+decapod teammate add --category style --key commit_messages --value "concise_imperative" \
+  --context "Keep commit messages under 72 chars, use imperative mood" \
+  --source "user_request"
+```
+
+**Workflow Conventions:**
+```bash
+# User says: "use feature/ prefix for branches"
+decapod teammate add --category workflow --key branch_naming --value "feature/descriptive-name" \
+  --context "Prefix feature branches with feature/ followed by kebab-case description" \
+  --source "user_request"
+```
+
+## Categories
+
+Standard categories for organizing preferences:
+
+| Category | Description | Example Keys |
+|----------|-------------|--------------|
+| `git` | Version control preferences | `ssh_key`, `commit_style`, `branch_naming`, `merge_strategy` |
+| `style` | Code and documentation style | `commit_messages`, `comment_style`, `naming_conventions` |
+| `workflow` | Development workflow | `pr_process`, `testing_requirements`, `review_style` |
+| `communication` | Interaction preferences | `verbosity`, `technical_depth`, `update_frequency` |
+| `tooling` | Tool-specific preferences | `formatter`, `linter`, `editor_settings` |
+
+### Choosing Categories
+
+- Use existing categories when possible
+- Create new categories only for distinct domains
+- Keys should be specific within a category
+- Values should be actionable by agents
+
+## Preference Lifecycle
+
+### Recording Preferences
+
+When a user expresses a preference:
+
+1. **Capture immediately**: Record while context is fresh
+2. **Be specific**: `commit_message_format` not just `style`
+3. **Provide context**: Include the "why" not just the "what"
+4. **Note the source**: User requests override observed behaviors
+
+```bash
+# Good: Specific, contextual, actionable
+decapod teammate add --category git --key ssh_contributor --value "user_only" \
+  --context "Use user's SSH credentials, never add self as commit contributor" \
+  --source "user_request"
+
+# Bad: Vague, no context
+# decapod teammate add --category style --key prefs --value "good"
+```
+
+### Retrieving Preferences
+
+Agents MUST check preferences before acting:
+
+```bash
+# Before committing, check SSH preference
+decapod teammate get --category git --key ssh_contributor
+
+# Before creating a branch, check naming convention
+decapod teammate get --category workflow --key branch_naming
+```
+
+### Updating Preferences
+
+Preferences can be updated by recording again with the same category/key:
+
+```bash
+# User changes their mind about commit style
+decapod teammate add --category style --key commit_messages --value "detailed_explanatory" \
+  --context "Now prefer detailed commit messages with full context" \
+  --source "user_request"
+```
+
+## Storage Model
+
+Preferences are stored in `teammate.db` with full audit trail:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Unique ULID identifier |
+| `category` | Preference category |
+| `key` | Preference name (unique within category) |
+| `value` | Preference value |
+| `context` | Optional explanation |
+| `source` | How learned: `user_request`, `observed_behavior`, etc. |
+| `created_at` | When first recorded |
+| `updated_at` | When last modified |
+
+The `(category, key)` combination is unique - recording again updates the existing preference.
+
+## Agent Guidelines
+
+### Do
+
+- **Check before acting**: Always query relevant preferences before operations
+- **Record when learned**: When user expresses a preference, record it immediately
+- **Be specific**: Use clear, descriptive keys
+- **Provide context**: Explain why the preference matters
+- **Respect the source**: User requests take precedence over observed behaviors
+
+### Don't
+
+- **Don't assume**: Never assume preferences without checking
+- **Don't ignore**: When user states a preference, don't ignore it
+- **Be vague**: Avoid generic keys like `prefs` or `settings`
+- **Skip context**: Context helps future agents understand the preference
+
+### Example Workflow
+
+```bash
+# User asks to commit something
+# 1. Check for git preferences
+decapod teammate get --category git --key ssh_contributor
+# Returns: use user's SSH, don't add self as contributor
+
+# 2. Check commit style
+decapod teammate get --category style --key commit_messages
+# Returns: concise and imperative
+
+# 3. Perform action respecting preferences
+git commit -m "feat: add teammate plugin"  # Using user's SSH
+
+# 4. User expresses new preference
+# User: "always push to ahr/work branch"
+decapod teammate add --category git --key default_push_branch --value "ahr/work" \
+  --context "Default branch for pushing work" \
+  --source "user_request"
+```
+
+---
+
+**See also:** `embedded/core/PLUGINS.md` for subsystem registry and truth labels.

--- a/constitution/embedded/plugins/TEAMMATE.md
+++ b/constitution/embedded/plugins/TEAMMATE.md
@@ -4,51 +4,8 @@
 **Layer:** Operational
 **Binding:** No
 
-This document defines the teammate subsystem for remembering user preferences and behaviors.
+This document defines the teammate subsystem.
 
 ## CLI Surface
+- `decapod teammate ...`
 
-```bash
-decapod teammate add --category <cat> --key <key> --value <val> [--context <ctx>] [--source <src>]
-decapod teammate get --category <cat> --key <key>
-decapod teammate list [--category <cat>] [--format text|json]
-```
-
-## Purpose
-
-The teammate plugin catalogs distinct user expectations that help AI agents work more effectively:
-
-- **Git preferences**: SSH key usage, commit message style, branch naming conventions
-- **Code style**: Formatting preferences, naming conventions, documentation standards
-- **Workflow conventions**: Review processes, testing requirements, deployment practices
-- **Communication style**: Concise vs detailed, technical depth, update frequency
-
-## Categories
-
-Standard categories for organizing preferences:
-
-- `git` - Version control preferences (SSH keys, branch naming, commit style)
-- `style` - Code and documentation style preferences
-- `workflow` - Development workflow conventions
-- `communication` - How the user prefers to interact
-- `tooling` - Tool-specific preferences and configurations
-
-## Storage
-
-Preferences are stored in `teammate.db` with full audit trail:
-- `id`: Unique identifier (ULID)
-- `category`: Preference category
-- `key`: Preference name
-- `value`: Preference value
-- `context`: Optional explanation or context
-- `source`: How the preference was learned (user_request, observed_behavior, etc.)
-- `created_at`: When recorded
-- `updated_at`: When last modified
-
-## Agent Guidelines
-
-1. **Check before acting**: Use `decapod teammate get` to check for relevant preferences
-2. **Record when learned**: When user expresses a preference, record it immediately
-3. **Be specific**: Use clear keys like `commit_message_format` not `style`
-4. **Provide context**: Include why the preference matters
-5. **Respect the source**: User-requested preferences override observed behaviors

--- a/constitution/embedded/plugins/TEAMMATE.md
+++ b/constitution/embedded/plugins/TEAMMATE.md
@@ -1,0 +1,54 @@
+# TEAMMATE.md - TEAMMATE Subsystem (Embedded)
+
+**Authority:** subsystem (REAL)
+**Layer:** Operational
+**Binding:** No
+
+This document defines the teammate subsystem for remembering user preferences and behaviors.
+
+## CLI Surface
+
+```bash
+decapod teammate add --category <cat> --key <key> --value <val> [--context <ctx>] [--source <src>]
+decapod teammate get --category <cat> --key <key>
+decapod teammate list [--category <cat>] [--format text|json]
+```
+
+## Purpose
+
+The teammate plugin catalogs distinct user expectations that help AI agents work more effectively:
+
+- **Git preferences**: SSH key usage, commit message style, branch naming conventions
+- **Code style**: Formatting preferences, naming conventions, documentation standards
+- **Workflow conventions**: Review processes, testing requirements, deployment practices
+- **Communication style**: Concise vs detailed, technical depth, update frequency
+
+## Categories
+
+Standard categories for organizing preferences:
+
+- `git` - Version control preferences (SSH keys, branch naming, commit style)
+- `style` - Code and documentation style preferences
+- `workflow` - Development workflow conventions
+- `communication` - How the user prefers to interact
+- `tooling` - Tool-specific preferences and configurations
+
+## Storage
+
+Preferences are stored in `teammate.db` with full audit trail:
+- `id`: Unique identifier (ULID)
+- `category`: Preference category
+- `key`: Preference name
+- `value`: Preference value
+- `context`: Optional explanation or context
+- `source`: How the preference was learned (user_request, observed_behavior, etc.)
+- `created_at`: When recorded
+- `updated_at`: When last modified
+
+## Agent Guidelines
+
+1. **Check before acting**: Use `decapod teammate get` to check for relevant preferences
+2. **Record when learned**: When user expresses a preference, record it immediately
+3. **Be specific**: Use clear keys like `commit_message_format` not `style`
+4. **Provide context**: Include why the preference matters
+5. **Respect the source**: User-requested preferences override observed behaviors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ use core::{
     validate,
 };
 use plugins::{
-    archive, context, cron, feedback, health, heartbeat, knowledge, policy, reflex, todo, trust,
-    watcher,
+    archive, context, cron, feedback, health, heartbeat, knowledge, policy, reflex, teammate, todo,
+    trust, watcher,
 };
 
 use clap::{Parser, Subcommand};
@@ -173,6 +173,8 @@ enum Command {
     Archive(ArchiveCli),
     /// Manage operator feedback and preference refinement
     Feedback(FeedbackCli),
+    /// Manage teammate preferences and remembered behaviors
+    Teammate(teammate::TeammateCli),
     /// Run configurable proofs with audit trail
     Proof(ProofCommandCli),
     /// Run an end-to-end usability verification (simulates fresh install)
@@ -609,6 +611,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                     ("policy.db", setup_store_root.join("policy.db")),
                     ("archive.db", setup_store_root.join("archive.db")),
                     ("feedback.db", setup_store_root.join("feedback.db")),
+                    ("teammate.db", setup_store_root.join("teammate.db")),
                 ];
 
                 for (db_name, db_path) in dbs {
@@ -629,6 +632,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                             "policy.db" => policy::initialize_policy_db(&setup_store_root)?,
                             "archive.db" => archive::initialize_archive_db(&setup_store_root)?,
                             "feedback.db" => feedback::initialize_feedback_db(&setup_store_root)?,
+                            "teammate.db" => teammate::initialize_teammate_db(&setup_store_root)?,
                             _ => unreachable!(),
                         }
                         println!("    {} {}", "●".bright_green(), db_name.bright_white());
@@ -817,6 +821,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                     schemas.insert("trust", trust::schema());
                     schemas.insert("archive", archive::schema());
                     schemas.insert("feedback", feedback::schema());
+                    schemas.insert("teammate", teammate::schema());
                     schemas.insert("docs", docs_cli::schema());
 
                     let output = if let Some(sub) = schema_cli.subsystem {
@@ -946,6 +951,9 @@ pub fn run() -> Result<(), error::DecapodError> {
                             println!("{}", proposal);
                         }
                     }
+                }
+                Command::Teammate(tm_cli) => {
+                    teammate::run_teammate_cli(&project_store, tm_cli)?;
                 }
                 Command::Verify => {
                     run_verification()?;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -7,6 +7,7 @@ pub mod heartbeat;
 pub mod knowledge;
 pub mod policy;
 pub mod reflex;
+pub mod teammate;
 pub mod todo;
 pub mod trust;
 pub mod watcher;

--- a/src/plugins/teammate.rs
+++ b/src/plugins/teammate.rs
@@ -1,0 +1,329 @@
+//! Teammate plugin: remembers user preferences and requested behaviors.
+//!
+//! This plugin catalogs distinct user expectations like:
+//! - SSH key preferences for Git operations
+//! - Branch naming conventions
+//! - Code style preferences
+//! - Commit message formats
+//! - Workflow conventions
+//!
+//! # For AI Agents
+//!
+//! - **Check preferences before acting**: Use `decapod teammate get <key>` to check user preferences
+//! - **Record new preferences**: When user expresses a preference, record it with `decapod teammate add`
+//! - **Categories organize preferences**: Use categories like "git", "style", "workflow" for organization
+
+use crate::core::broker::DbBroker;
+use crate::core::error;
+use crate::core::store::Store;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub const TEAMMATE_DB_NAME: &str = "teammate.db";
+pub const TEAMMATE_DB_SCHEMA_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS preferences (
+        id TEXT PRIMARY KEY,
+        category TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        context TEXT,
+        source TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT,
+        UNIQUE(category, key)
+    )
+";
+pub const TEAMMATE_DB_SCHEMA_INDEX_CATEGORY: &str =
+    "CREATE INDEX IF NOT EXISTS idx_preferences_category ON preferences(category)";
+pub const TEAMMATE_DB_SCHEMA_INDEX_KEY: &str =
+    "CREATE INDEX IF NOT EXISTS idx_preferences_key ON preferences(key)";
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Preference {
+    pub id: String,
+    pub category: String,
+    pub key: String,
+    pub value: String,
+    pub context: Option<String>,
+    pub source: String,
+    pub created_at: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PreferenceInput {
+    pub category: String,
+    pub key: String,
+    pub value: String,
+    pub context: Option<String>,
+    pub source: String,
+}
+
+pub fn teammate_db_path(root: &Path) -> PathBuf {
+    root.join(TEAMMATE_DB_NAME)
+}
+
+pub fn initialize_teammate_db(root: &Path) -> Result<(), error::DecapodError> {
+    let broker = DbBroker::new(root);
+    let db_path = teammate_db_path(root);
+
+    broker.with_conn(&db_path, "decapod", None, "teammate.init", |conn| {
+        conn.execute(TEAMMATE_DB_SCHEMA_TABLE, [])?;
+        conn.execute(TEAMMATE_DB_SCHEMA_INDEX_CATEGORY, [])?;
+        conn.execute(TEAMMATE_DB_SCHEMA_INDEX_KEY, [])?;
+        Ok(())
+    })
+}
+
+pub fn add_preference(
+    store: &Store,
+    input: PreferenceInput,
+) -> Result<String, error::DecapodError> {
+    let broker = DbBroker::new(&store.root);
+    let db_path = teammate_db_path(&store.root);
+    let id = ulid::Ulid::new().to_string();
+    let now = format!("{:?}", std::time::SystemTime::now());
+
+    broker.with_conn(&db_path, "decapod", None, "teammate.add", |conn| {
+        conn.execute(
+            "INSERT INTO preferences(id, category, key, value, context, source, created_at, updated_at)
+             VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)
+             ON CONFLICT(category, key) DO UPDATE SET
+                value = excluded.value,
+                context = excluded.context,
+                source = excluded.source,
+                updated_at = ?7",
+            params![
+                id,
+                input.category,
+                input.key,
+                input.value,
+                input.context,
+                input.source,
+                now
+            ],
+        )?;
+        Ok(())
+    })?;
+
+    Ok(id)
+}
+
+pub fn get_preference(
+    store: &Store,
+    category: &str,
+    key: &str,
+) -> Result<Option<Preference>, error::DecapodError> {
+    let broker = DbBroker::new(&store.root);
+    let db_path = teammate_db_path(&store.root);
+
+    let pref = broker.with_conn(&db_path, "decapod", None, "teammate.get", |conn| {
+        let mut stmt = conn.prepare(
+            "SELECT id, category, key, value, context, source, created_at, updated_at
+             FROM preferences WHERE category = ?1 AND key = ?2",
+        )?;
+        let result = stmt.query_row(params![category, key], |row| {
+            Ok(Preference {
+                id: row.get(0)?,
+                category: row.get(1)?,
+                key: row.get(2)?,
+                value: row.get(3)?,
+                context: row.get(4)?,
+                source: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        });
+
+        match result {
+            Ok(p) => Ok(Some(p)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(error::DecapodError::RusqliteError(e)),
+        }
+    })?;
+
+    Ok(pref)
+}
+
+fn row_to_preference(row: &rusqlite::Row) -> Result<Preference, rusqlite::Error> {
+    Ok(Preference {
+        id: row.get(0)?,
+        category: row.get(1)?,
+        key: row.get(2)?,
+        value: row.get(3)?,
+        context: row.get(4)?,
+        source: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+pub fn list_preferences(
+    store: &Store,
+    category: Option<&str>,
+) -> Result<Vec<Preference>, error::DecapodError> {
+    let broker = DbBroker::new(&store.root);
+    let db_path = teammate_db_path(&store.root);
+
+    let entries = broker.with_conn(&db_path, "decapod", None, "teammate.list", |conn| {
+        let mut out = Vec::new();
+
+        if let Some(cat) = category {
+            let mut stmt = conn.prepare(
+                "SELECT id, category, key, value, context, source, created_at, updated_at
+                 FROM preferences WHERE category = ?1 ORDER BY key",
+            )?;
+            let rows = stmt.query_map([cat], row_to_preference)?;
+            for r in rows {
+                out.push(r?);
+            }
+        } else {
+            let mut stmt = conn.prepare(
+                "SELECT id, category, key, value, context, source, created_at, updated_at
+                 FROM preferences ORDER BY category, key",
+            )?;
+            let rows = stmt.query_map([], row_to_preference)?;
+            for r in rows {
+                out.push(r?);
+            }
+        }
+
+        Ok(out)
+    })?;
+
+    Ok(entries)
+}
+
+pub fn get_preferences_by_category(
+    store: &Store,
+) -> Result<HashMap<String, Vec<Preference>>, error::DecapodError> {
+    let all = list_preferences(store, None)?;
+    let mut grouped: HashMap<String, Vec<Preference>> = HashMap::new();
+
+    for pref in all {
+        grouped.entry(pref.category.clone()).or_default().push(pref);
+    }
+
+    Ok(grouped)
+}
+
+pub fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "name": "teammate",
+        "version": "0.1.0",
+        "description": "User preference and behavior memory system",
+        "commands": [
+            { "name": "add", "description": "Add or update a preference", "parameters": ["category", "key", "value", "context", "source"] },
+            { "name": "get", "description": "Get a specific preference", "parameters": ["category", "key"] },
+            { "name": "list", "description": "List all preferences, optionally filtered by category", "parameters": ["category?"] }
+        ],
+        "storage": ["teammate.db"],
+        "categories": [
+            "git", "style", "workflow", "communication", "tooling"
+        ]
+    })
+}
+
+// CLI types for clap integration
+#[derive(clap::Args, Debug)]
+pub struct TeammateCli {
+    #[clap(subcommand)]
+    pub command: TeammateCommand,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum TeammateCommand {
+    /// Add or update a preference
+    Add {
+        /// Category (e.g., git, style, workflow)
+        #[clap(long)]
+        category: String,
+        /// Preference key
+        #[clap(long)]
+        key: String,
+        /// Preference value
+        #[clap(long)]
+        value: String,
+        /// Optional context/explanation
+        #[clap(long)]
+        context: Option<String>,
+        /// Source of the preference (e.g., "user_request", "observed_behavior")
+        #[clap(long, default_value = "user_request")]
+        source: String,
+    },
+    /// Get a specific preference
+    Get {
+        /// Category
+        #[clap(long)]
+        category: String,
+        /// Preference key
+        #[clap(long)]
+        key: String,
+    },
+    /// List preferences
+    List {
+        /// Filter by category
+        #[clap(long)]
+        category: Option<String>,
+        /// Output format
+        #[clap(long, default_value = "text")]
+        format: String,
+    },
+}
+
+pub fn run_teammate_cli(store: &Store, cli: TeammateCli) -> Result<(), error::DecapodError> {
+    initialize_teammate_db(&store.root)?;
+
+    match cli.command {
+        TeammateCommand::Add {
+            category,
+            key,
+            value,
+            context,
+            source,
+        } => {
+            let input = PreferenceInput {
+                category,
+                key: key.clone(),
+                value: value.clone(),
+                context,
+                source,
+            };
+            let id = add_preference(store, input)?;
+            println!("✓ Preference recorded: {}={} (id: {})", key, value, id);
+        }
+        TeammateCommand::Get { category, key } => match get_preference(store, &category, &key)? {
+            Some(pref) => {
+                println!("{}: {}", pref.key, pref.value);
+                if let Some(ctx) = pref.context {
+                    println!("  Context: {}", ctx);
+                }
+                println!("  Source: {} | Created: {}", pref.source, pref.created_at);
+            }
+            None => {
+                println!("No preference found for {}.{}", category, key);
+            }
+        },
+        TeammateCommand::List { category, format } => {
+            let prefs = list_preferences(store, category.as_deref())?;
+
+            if format == "json" {
+                println!("{}", serde_json::to_string_pretty(&prefs).unwrap());
+            } else if prefs.is_empty() {
+                println!("No preferences recorded yet.");
+            } else {
+                let grouped = get_preferences_by_category(store)?;
+                for (cat, items) in grouped {
+                    println!("\n[{}]", cat);
+                    for item in items {
+                        println!("  {} = {}", item.key, item.value);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/templates/OVERRIDE.md
+++ b/templates/OVERRIDE.md
@@ -121,3 +121,5 @@ For this project, we use a 5-level priority system:
 ### plugins/CONTEXT.md
 
 ### plugins/HEARTBEAT.md
+
+### plugins/TEAMMATE.md


### PR DESCRIPTION
- New teammate plugin with SQLite-backed preference storage
- CLI commands: teammate add/get/list with category grouping
- Supports cataloguing user expectations (SSH keys, style, workflow)
- Integrated into decapod init with database preservation
- Updated version to 0.1.10

Closes: R_01KHAKT7W23YQCJW296TYX5PK3, R_01KH9ZT40Q1V4MF9AQY0978VTY

# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
