### PR TITLE
feat: add category field to tasks with migration

### DIFF
--- a/src/core/schemas.rs
+++ b/src/core/schemas.rs
@@ -47,7 +47,7 @@ pub const TODO_EVENTS_NAME: &str = "todo.events.jsonl";
 /// TODO database schema version
 ///
 /// Used for migration tracking in the `meta` table
-pub const TODO_SCHEMA_VERSION: u32 = 2;
+pub const TODO_SCHEMA_VERSION: u32 = 3;
 
 /// TODO metadata table schema
 ///
@@ -80,7 +80,8 @@ pub const TODO_DB_SCHEMA_TASKS: &str = "
         parent_task_id TEXT,
         priority TEXT DEFAULT 'medium',
         depends_on TEXT DEFAULT '',
-        blocks TEXT DEFAULT ''
+        blocks TEXT DEFAULT '',
+        category TEXT DEFAULT ''
     )
 ";
 

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -224,7 +224,7 @@ fn schemas_errors_and_validate_entrypoint_are_exercised() {
     assert_eq!(schemas::KNOWLEDGE_DB_NAME, "knowledge.db");
     assert_eq!(schemas::TODO_DB_NAME, "todo.db");
     assert_eq!(schemas::TODO_EVENTS_NAME, "todo.events.jsonl");
-    assert_eq!(schemas::TODO_SCHEMA_VERSION, 2);
+    assert_eq!(schemas::TODO_SCHEMA_VERSION, 3);
     assert!(!schemas::TODO_DB_SCHEMA_META.trim().is_empty());
     assert!(!schemas::TODO_DB_SCHEMA_TASKS.trim().is_empty());
     assert!(!schemas::TODO_DB_SCHEMA_TASK_EVENTS.trim().is_empty());


### PR DESCRIPTION
- Add category column to tasks table
- Schema v2→v3 migration to add column and populate from title/tags
- infer_category() auto-detects category from task content
- Update Task struct and queries to include category field
- Categories: bugs, features, docs, ci, refactor, tests, security, etc.

# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
