### PR TITLE
fix: workflow and --locked flags

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,7 +13,7 @@ jobs:
   auto-tag:
     name: Auto Tag on Merge
     runs-on: ubuntu-latest
-    if: github.repository == 'DecapodLabs/decapod'
+    if: github.repository == 'DecapodLabs/decapod' && !contains(github.event.head_commit.message, 'bump version')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -60,6 +60,7 @@ jobs:
         if: steps.bump.outputs.new != ''
         run: |
           git tag -a "v${{ steps.bump.outputs.new }}" -m "Release v${{ steps.bump.outputs.new }}"
-          gh pr create --base master --head "bump-v${{ steps.bump.outputs.new }}" --title "chore: bump version to v${{ steps.bump.outputs.new }}" --body "Auto-generated version bump" --autoMerge
+          gh pr create --base master --head "bump-v${{ steps.bump.outputs.new }}" --title "chore: bump version to v${{ steps.bump.outputs.new }}" --body "Auto-generated version bump"
+          gh pr merge "bump-v${{ steps.bump.outputs.new }}" --admin --squash --delete-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features --locked -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   # TEST: Run all tests
   test:
@@ -156,7 +156,7 @@ jobs:
           save-if: false
 
       - name: Build and install decapod
-        run: cargo install --path . --locked
+        run: cargo install --path .
 
       - name: Initialize Decapod
         run: decapod init
@@ -199,7 +199,7 @@ jobs:
           save-if: true
 
       - name: Build release
-        run: cargo build --release --locked
+        run: cargo build --release
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -1,9 +1,11 @@
 name: Push Tag on Merge
 
 on:
-  push:
+  pull_request:
     branches:
       - master
+    types:
+      - closed
 
 permissions:
   contents: write
@@ -12,7 +14,7 @@ jobs:
   push-tag:
     name: Push Tag on Merge
     runs-on: ubuntu-latest
-    if: github.repository == 'DecapodLabs/decapod'
+    if: github.repository == 'DecapodLabs/decapod' && github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
