### PR TITLE
fix: add push-tag for bump PR merge

### DIFF
--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -1,0 +1,32 @@
+name: Push Tag on Merge
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  push-tag:
+    name: Push Tag on Merge
+    runs-on: ubuntu-latest
+    if: github.repository == 'DecapodLabs/decapod' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'bump-v')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push tags to origin
+        run: |
+          git fetch --tags origin master
+          for tag in $(git tag); do
+            if ! git ls-remote --tags origin "$tag" | grep -q "$tag"; then
+              echo "Pushing tag: $tag"
+              git push origin "$tag"
+            fi
+          done


### PR DESCRIPTION
# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
