### PR TITLE
fix: correct auto-tag and push-tag workflow sequence

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -55,4 +55,19 @@ jobs:
           git checkout -b "bump-v${{ steps.bump.outputs.new }}"
           git commit -m "chore: bump version to v${{ steps.bump.outputs.new }}"
           git tag -a "v${{ steps.bump.outputs.new }}" -m "Release v${{ steps.bump.outputs.new }}"
-          git push origin "bump-v${{ steps.bump.outputs.new }}" --tags
+          git push origin "bump-v${{ steps.bump.outputs.new }}"
+
+      - name: Create Pull Request
+        if: steps.bump.outputs.new != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore: bump version to v${{ steps.bump.outputs.new }}" \
+            --body "Auto-generated version bump to v${{ steps.bump.outputs.new }}
+
+          This PR will trigger tag creation and release when merged.
+
+          Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>" \
+            --base master \
+            --head "bump-v${{ steps.bump.outputs.new }}"

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -21,12 +21,29 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push tags to origin
+      - name: Create and push tag
         run: |
-          git fetch --tags origin master
-          for tag in $(git tag); do
-            if ! git ls-remote --tags origin "$tag" | grep -q "$tag"; then
-              echo "Pushing tag: $tag"
-              git push origin "$tag"
-            fi
-          done
+          # Extract version from branch name (bump-v0.1.20 -> v0.1.20)
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          TAG_NAME="${BRANCH_NAME#bump-}"
+
+          echo "Branch: $BRANCH_NAME"
+          echo "Tag to create and push: $TAG_NAME"
+
+          # Get version from Cargo.toml to verify
+          CARGO_VERSION=$(grep '^version =' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+          echo "Cargo.toml version: $CARGO_VERSION"
+
+          # Verify tag matches Cargo.toml version
+          if [ "$TAG_NAME" != "v$CARGO_VERSION" ]; then
+            echo "Error: Tag name ($TAG_NAME) doesn't match Cargo.toml version (v$CARGO_VERSION)"
+            exit 1
+          fi
+
+          # Configure git
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          # Create and push the tag
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"


### PR DESCRIPTION
**Problem:**
1. auto-tag.yml was pushing tags immediately with --tags flag, triggering release.yml before PR review
2. push-tag.yml tried to push already-pushed tags, making it redundant
3. No automatic PR creation, requiring manual intervention

**Solution:**
1. auto-tag.yml:
   - Remove --tags flag from git push (only push branch, not tags)
   - Add automatic PR creation step

2. push-tag.yml:
   - Extract version from merged bump branch name
   - Create and push the specific tag for that version
   - Verify tag matches Cargo.toml version

**Flow:**
1. PR merged to master → auto-tag.yml runs
2. auto-tag.yml bumps version, creates branch+local tag, pushes branch, creates PR
3. Bump PR merged → push-tag.yml runs
4. push-tag.yml creates and pushes tag → triggers release.yml

# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
