### PR TITLE
ci: auto-publish stale tagged versions before release-pr

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,25 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Publish stale tagged versions
+        run: |
+          # Get current version from Cargo.toml
+          CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -n1 | cut -d'"' -f2)
+
+          # Check if tag exists for this version
+          if git rev-parse "v${CARGO_VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${CARGO_VERSION} exists, checking if published..."
+
+            # Check if this version exists on crates.io
+            if ! cargo search decapod --limit 1 | grep -q "decapod = \"${CARGO_VERSION}\""; then
+              echo "Version ${CARGO_VERSION} is tagged but not published. Publishing now..."
+              cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || echo "Publish failed or already exists"
+            else
+              echo "Version ${CARGO_VERSION} already published to crates.io"
+            fi
+          fi
+        continue-on-error: true
+
       - name: Generate GitHub App token
         uses: actions/create-github-app-token@v2
         id: generate-token


### PR DESCRIPTION
# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
