### PR TITLE
feat: consolidate fragmented sqlite databases into 4 core bins

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -194,7 +194,7 @@ fn format_db_open_diagnostics(db_path: &Path, stage: &str, err: &rusqlite::Error
 }
 
 pub fn knowledge_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::KNOWLEDGE_DB_NAME)
+    root.join(schemas::MEMORY_DB_NAME)
 }
 
 pub fn initialize_knowledge_db(root: &Path) -> Result<(), error::DecapodError> {
@@ -204,7 +204,21 @@ pub fn initialize_knowledge_db(root: &Path) -> Result<(), error::DecapodError> {
 
     let broker = DbBroker::new(root);
     broker.with_conn(&db_path, "decapod", None, "knowledge.init", |conn| {
-        conn.execute(schemas::KNOWLEDGE_DB_SCHEMA, [])?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
+        conn.execute_batch(schemas::KNOWLEDGE_DB_SCHEMA)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_NODES)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_SOURCES)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EDGES)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_TYPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_STATUS)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_SCOPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_PRIORITY)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_UPDATED)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_SOURCES_NODE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_SOURCE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TARGET)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TYPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EVENTS_NODE)?;
         Ok(())
     })?;
 
@@ -212,7 +226,7 @@ pub fn initialize_knowledge_db(root: &Path) -> Result<(), error::DecapodError> {
 }
 
 pub fn decide_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::DECIDE_DB_NAME)
+    root.join(schemas::MEMORY_DB_NAME)
 }
 
 pub fn initialize_decide_db(root: &Path) -> Result<(), error::DecapodError> {
@@ -222,13 +236,13 @@ pub fn initialize_decide_db(root: &Path) -> Result<(), error::DecapodError> {
 
     let broker = DbBroker::new(root);
     broker.with_conn(&db_path, "decapod", None, "decide.init", |conn| {
-        conn.execute(schemas::DECIDE_DB_SCHEMA_META, [])?;
-        conn.execute(schemas::DECIDE_DB_SCHEMA_SESSIONS, [])?;
-        conn.execute(schemas::DECIDE_DB_SCHEMA_DECISIONS, [])?;
-        conn.execute(schemas::DECIDE_DB_INDEX_DECISIONS_SESSION, [])?;
-        conn.execute(schemas::DECIDE_DB_INDEX_DECISIONS_TREE, [])?;
-        conn.execute(schemas::DECIDE_DB_INDEX_SESSIONS_TREE, [])?;
-        conn.execute(schemas::DECIDE_DB_INDEX_SESSIONS_STATUS, [])?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
+        conn.execute_batch(schemas::DECIDE_DB_SCHEMA_SESSIONS)?;
+        conn.execute_batch(schemas::DECIDE_DB_SCHEMA_DECISIONS)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_SESSION)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_TREE)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_TREE)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_STATUS)?;
         Ok(())
     })?;
 

--- a/src/core/schemas.rs
+++ b/src/core/schemas.rs
@@ -1,24 +1,165 @@
-//! Centralized database schema definitions for all Decapod subsystems.
+//! Centralized database schema definitions for all Decapod consolidated bins.
 //!
-//! This module contains the canonical SQL schemas for every Decapod database.
-//! Schemas are versioned and deterministic - changes require migration events.
-//!
-//! # For AI Agents
-//!
-//! - **Do not modify schemas directly**: Propose changes via `decapod feedback propose`
-//! - **Schemas are binding contracts**: Subsystems depend on these exact structures
-//! - **Schema versioning**: Some subsystems track schema versions in `meta` tables
-//! - **Deterministic replay**: Event-sourced subsystems (TODO, health) rebuild from these schemas
+//! Decapod uses 4 consolidated SQLite databases ("bins") to manage state:
+//! 1. governance.db: Rules, policies, health, feedback, and archives.
+//! 2. memory.db: Governed knowledge graph, decisions, and teammate preferences.
+//! 3. automation.db: Scheduled tasks (cron) and event triggers (reflex).
+//! 4. todo.db: Transactional task tracking with event-sourcing.
 
-// --- Knowledge ---
+// --- 1. Governance Bin ---
+pub const GOVERNANCE_DB_NAME: &str = "governance.db";
 
-/// Knowledge database file name
-pub const KNOWLEDGE_DB_NAME: &str = "knowledge.db";
+pub const POLICY_DB_SCHEMA_APPROVALS: &str = "
+    CREATE TABLE IF NOT EXISTS approvals (
+        approval_id TEXT PRIMARY KEY,
+        action_fingerprint TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        ts TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        expires_at TEXT
+    )
+";
+pub const POLICY_DB_SCHEMA_INDEX: &str =
+    "CREATE INDEX IF NOT EXISTS idx_approvals_fingerprint ON approvals(action_fingerprint)";
 
-/// Knowledge database schema SQL
-///
-/// Stores structured knowledge entries with provenance tracking.
-/// Each entry must reference its source (claim, proof, or external pointer).
+pub const HEALTH_DB_SCHEMA_CLAIMS: &str = "
+    CREATE TABLE IF NOT EXISTS claims (
+        id TEXT PRIMARY KEY,
+        subject TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        provenance TEXT,
+        created_at TEXT NOT NULL
+    )
+";
+pub const HEALTH_DB_SCHEMA_PROOF_EVENTS: &str = "
+    CREATE TABLE IF NOT EXISTS proof_events (
+        event_id TEXT PRIMARY KEY,
+        claim_id TEXT NOT NULL,
+        ts TEXT NOT NULL,
+        surface TEXT NOT NULL,
+        result TEXT NOT NULL,
+        sla_seconds INTEGER NOT NULL,
+        FOREIGN KEY(claim_id) REFERENCES claims(id)
+    )
+";
+pub const HEALTH_DB_SCHEMA_HEALTH_CACHE: &str = "
+    CREATE TABLE IF NOT EXISTS health_cache (
+        claim_id TEXT PRIMARY KEY,
+        computed_state TEXT NOT NULL,
+        reason TEXT,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(claim_id) REFERENCES claims(id)
+    )
+";
+
+pub const FEEDBACK_DB_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS feedback (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        text TEXT NOT NULL,
+        links TEXT,
+        created_at TEXT NOT NULL
+    )
+";
+
+pub const ARCHIVE_DB_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS archives (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        summary_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )
+";
+
+// --- 2. Memory Bin ---
+pub const MEMORY_DB_NAME: &str = "memory.db";
+pub const MEMORY_EVENTS_NAME: &str = "memory.events.jsonl";
+pub const MEMORY_SCHEMA_VERSION: u32 = 1;
+
+pub const MEMORY_DB_SCHEMA_META: &str = "
+    CREATE TABLE IF NOT EXISTS meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+";
+
+pub const MEMORY_DB_SCHEMA_NODES: &str = "
+    CREATE TABLE IF NOT EXISTS nodes (
+        id TEXT PRIMARY KEY,
+        node_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        priority TEXT NOT NULL DEFAULT 'notable',
+        confidence TEXT NOT NULL DEFAULT 'agent_inferred',
+        title TEXT NOT NULL,
+        body TEXT NOT NULL DEFAULT '',
+        scope TEXT NOT NULL DEFAULT 'repo',
+        tags TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        effective_from TEXT,
+        effective_to TEXT,
+        dir_path TEXT NOT NULL,
+        actor TEXT NOT NULL DEFAULT 'decapod'
+    )
+";
+
+pub const MEMORY_DB_SCHEMA_SOURCES: &str = "
+    CREATE TABLE IF NOT EXISTS sources (
+        id TEXT PRIMARY KEY,
+        node_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY(node_id) REFERENCES nodes(id)
+    )
+";
+
+pub const MEMORY_DB_SCHEMA_EDGES: &str = "
+    CREATE TABLE IF NOT EXISTS edges (
+        id TEXT PRIMARY KEY,
+        source_id TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        edge_type TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        actor TEXT NOT NULL DEFAULT 'decapod',
+        FOREIGN KEY(source_id) REFERENCES nodes(id),
+        FOREIGN KEY(target_id) REFERENCES nodes(id)
+    )
+";
+
+pub const MEMORY_DB_SCHEMA_EVENTS: &str = "
+    CREATE TABLE IF NOT EXISTS federation_events (
+        event_id TEXT PRIMARY KEY,
+        ts TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        node_id TEXT,
+        payload TEXT NOT NULL,
+        actor TEXT NOT NULL
+    )
+";
+
+pub const MEMORY_DB_INDEX_NODES_TYPE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_type ON nodes(node_type)";
+pub const MEMORY_DB_INDEX_NODES_STATUS: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_status ON nodes(status)";
+pub const MEMORY_DB_INDEX_NODES_SCOPE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_scope ON nodes(scope)";
+pub const MEMORY_DB_INDEX_NODES_PRIORITY: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_priority ON nodes(priority)";
+pub const MEMORY_DB_INDEX_NODES_UPDATED: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_updated ON nodes(updated_at)";
+pub const MEMORY_DB_INDEX_SOURCES_NODE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_sources_node ON sources(node_id)";
+pub const MEMORY_DB_INDEX_EDGES_SOURCE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_edges_source ON edges(source_id)";
+pub const MEMORY_DB_INDEX_EDGES_TARGET: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_edges_target ON edges(target_id)";
+pub const MEMORY_DB_INDEX_EDGES_TYPE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_edges_type ON edges(edge_type)";
+pub const MEMORY_DB_INDEX_EVENTS_NODE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_fed_events_node ON federation_events(node_id)";
+
+// Legacy Knowledge Schema (preserved for migration)
 pub const KNOWLEDGE_DB_SCHEMA: &str = "
     CREATE TABLE IF NOT EXISTS knowledge (
         id TEXT PRIMARY KEY,
@@ -34,24 +175,116 @@ pub const KNOWLEDGE_DB_SCHEMA: &str = "
     )
 ";
 
-// --- TODO ---
+// Legacy Decide Schemas (preserved for migration)
+pub const DECIDE_DB_SCHEMA_SESSIONS: &str = "
+    CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        tree_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'active',
+        federation_node_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        completed_at TEXT,
+        dir_path TEXT NOT NULL,
+        scope TEXT NOT NULL DEFAULT 'repo',
+        actor TEXT NOT NULL DEFAULT 'decapod'
+    )
+";
+pub const DECIDE_DB_SCHEMA_DECISIONS: &str = "
+    CREATE TABLE IF NOT EXISTS decisions (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        question_id TEXT NOT NULL,
+        tree_id TEXT NOT NULL,
+        question_text TEXT NOT NULL,
+        chosen_value TEXT NOT NULL,
+        chosen_label TEXT NOT NULL,
+        rationale TEXT DEFAULT '',
+        user_note TEXT DEFAULT '',
+        federation_node_id TEXT,
+        created_at TEXT NOT NULL,
+        actor TEXT NOT NULL DEFAULT 'decapod',
+        FOREIGN KEY(session_id) REFERENCES sessions(id)
+    )
+";
 
-/// TODO database file name
+// Decoupled name mapping for compatibility
+pub const KNOWLEDGE_DB_NAME: &str = "knowledge.db";
+pub const FEDERATION_DB_NAME: &str = "federation.db";
+pub const FEDERATION_EVENTS_NAME: &str = "federation.events.jsonl";
+pub const FEDERATION_SCHEMA_VERSION: u32 = 1;
+pub const FEDERATION_DB_SCHEMA_META: &str = MEMORY_DB_SCHEMA_META;
+pub const FEDERATION_DB_SCHEMA_NODES: &str = MEMORY_DB_SCHEMA_NODES;
+pub const FEDERATION_DB_SCHEMA_SOURCES: &str = MEMORY_DB_SCHEMA_SOURCES;
+pub const FEDERATION_DB_SCHEMA_EDGES: &str = MEMORY_DB_SCHEMA_EDGES;
+pub const FEDERATION_DB_SCHEMA_EVENTS: &str = MEMORY_DB_SCHEMA_EVENTS;
+pub const FEDERATION_DB_INDEX_NODES_TYPE: &str = MEMORY_DB_INDEX_NODES_TYPE;
+pub const FEDERATION_DB_INDEX_NODES_STATUS: &str = MEMORY_DB_INDEX_NODES_STATUS;
+pub const FEDERATION_DB_INDEX_NODES_SCOPE: &str = MEMORY_DB_INDEX_NODES_SCOPE;
+pub const FEDERATION_DB_INDEX_NODES_PRIORITY: &str = MEMORY_DB_INDEX_NODES_PRIORITY;
+pub const FEDERATION_DB_INDEX_NODES_UPDATED: &str = MEMORY_DB_INDEX_NODES_UPDATED;
+pub const FEDERATION_DB_INDEX_SOURCES_NODE: &str = MEMORY_DB_INDEX_SOURCES_NODE;
+pub const FEDERATION_DB_INDEX_EDGES_SOURCE: &str = MEMORY_DB_INDEX_EDGES_SOURCE;
+pub const FEDERATION_DB_INDEX_EDGES_TARGET: &str = MEMORY_DB_INDEX_EDGES_TARGET;
+pub const FEDERATION_DB_INDEX_EDGES_TYPE: &str = MEMORY_DB_INDEX_EDGES_TYPE;
+pub const FEDERATION_DB_INDEX_EVENTS_NODE: &str = MEMORY_DB_INDEX_EVENTS_NODE;
+
+pub const DECIDE_DB_NAME: &str = "decisions.db";
+pub const DECIDE_SCHEMA_VERSION: u32 = 1;
+pub const DECIDE_DB_SCHEMA_META: &str = MEMORY_DB_SCHEMA_META;
+pub const DECIDE_DB_INDEX_DECISIONS_SESSION: &str = "CREATE INDEX IF NOT EXISTS idx_decisions_session ON decisions(session_id)";
+pub const DECIDE_DB_INDEX_DECISIONS_TREE: &str = "CREATE INDEX IF NOT EXISTS idx_decisions_tree ON decisions(tree_id)";
+pub const DECIDE_DB_INDEX_SESSIONS_TREE: &str = "CREATE INDEX IF NOT EXISTS idx_sessions_tree ON sessions(tree_id)";
+pub const DECIDE_DB_INDEX_SESSIONS_STATUS: &str = "CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status)";
+
+// --- 3. Automation Bin ---
+pub const AUTOMATION_DB_NAME: &str = "automation.db";
+pub const CRON_DB_NAME: &str = "cron.db";
+pub const REFLEX_DB_NAME: &str = "reflex.db";
+
+pub const CRON_DB_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS cron_jobs (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        schedule TEXT NOT NULL,
+        command TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        last_run TEXT,
+        next_run TEXT,
+        tags TEXT DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT,
+        dir_path TEXT NOT NULL,
+        scope TEXT NOT NULL
+    )
+";
+
+pub const REFLEX_DB_SCHEMA: &str = "
+    CREATE TABLE IF NOT EXISTS reflexes (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        trigger_type TEXT NOT NULL,
+        trigger_config TEXT DEFAULT '{}',
+        action_type TEXT NOT NULL,
+        action_config TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        tags TEXT DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT,
+        dir_path TEXT NOT NULL,
+        scope TEXT NOT NULL
+    )
+";
+
+// --- 4. Transactional Bin (TODO) ---
 pub const TODO_DB_NAME: &str = "todo.db";
-
-/// TODO event log file name
-///
-/// Event-sourced append-only log for deterministic rebuild of todo.db
 pub const TODO_EVENTS_NAME: &str = "todo.events.jsonl";
-
-/// TODO database schema version
-///
-/// Used for migration tracking in the `meta` table
 pub const TODO_SCHEMA_VERSION: u32 = 13;
 
-/// TODO metadata table schema
-///
-/// Stores schema version and other metadata key-value pairs
 pub const TODO_DB_SCHEMA_META: &str = "
     CREATE TABLE IF NOT EXISTS meta (
         key TEXT PRIMARY KEY,
@@ -59,11 +292,6 @@ pub const TODO_DB_SCHEMA_META: &str = "
     )
 ";
 
-/// TODO tasks table schema
-///
-/// Core task tracking table with full lifecycle support (open → in-progress → completed → closed)
-/// `owner`: Static field set at creation for task ownership/responsibility
-/// `assigned_to`: Dynamic field for active agent assignment (claim/release)
 pub const TODO_DB_SCHEMA_TASKS: &str = "
     CREATE TABLE IF NOT EXISTS tasks (
         id TEXT PRIMARY KEY,
@@ -130,11 +358,6 @@ pub const TODO_DB_SCHEMA_INDEX_VERIFICATION_STATUS: &str = "
     ON task_verification(last_verified_status)
 ";
 
-/// Task categories table schema
-///
-/// Predefined categories that agents can claim ownership of:
-/// - Software lifecycle: features, bugs, docs, ci, refactor, tests, security, performance
-/// - By subsystem: backend, frontend, api, database, infra, tooling, ux
 pub const TODO_DB_SCHEMA_CATEGORIES: &str = "
     CREATE TABLE IF NOT EXISTS categories (
         id TEXT PRIMARY KEY,
@@ -148,7 +371,6 @@ pub const TODO_DB_SCHEMA_CATEGORIES: &str = "
 pub const TODO_DB_SCHEMA_INDEX_CATEGORY_NAME: &str =
     "CREATE INDEX IF NOT EXISTS idx_categories_name ON categories(name)";
 
-/// Agent category ownership claims table schema.
 pub const TODO_DB_SCHEMA_AGENT_CATEGORY_CLAIMS: &str = "
     CREATE TABLE IF NOT EXISTS agent_category_claims (
         id TEXT PRIMARY KEY,
@@ -162,7 +384,6 @@ pub const TODO_DB_SCHEMA_AGENT_CATEGORY_CLAIMS: &str = "
 pub const TODO_DB_SCHEMA_INDEX_AGENT_CATEGORY_AGENT: &str =
     "CREATE INDEX IF NOT EXISTS idx_agent_category_agent ON agent_category_claims(agent_id)";
 
-/// Agent presence/heartbeat table schema.
 pub const TODO_DB_SCHEMA_AGENT_PRESENCE: &str = "
     CREATE TABLE IF NOT EXISTS agent_presence (
         agent_id TEXT PRIMARY KEY,
@@ -175,8 +396,6 @@ pub const TODO_DB_SCHEMA_AGENT_PRESENCE: &str = "
 pub const TODO_DB_SCHEMA_INDEX_AGENT_PRESENCE_LAST_SEEN: &str =
     "CREATE INDEX IF NOT EXISTS idx_agent_presence_last_seen ON agent_presence(last_seen)";
 
-/// Agent trust tiers table schema.
-/// Trust levels: untrusted, basic, verified, core
 pub const TODO_DB_SCHEMA_AGENT_TRUST: &str = "
     CREATE TABLE IF NOT EXISTS agent_trust (
         agent_id TEXT PRIMARY KEY,
@@ -190,7 +409,6 @@ pub const TODO_DB_SCHEMA_AGENT_TRUST: &str = "
 pub const TODO_DB_SCHEMA_INDEX_AGENT_TRUST_LEVEL: &str =
     "CREATE INDEX IF NOT EXISTS idx_agent_trust_level ON agent_trust(trust_level)";
 
-/// Risk zones table schema for operational boundaries
 pub const TODO_DB_SCHEMA_RISK_ZONES: &str = "
     CREATE TABLE IF NOT EXISTS risk_zones (
         id TEXT PRIMARY KEY,
@@ -205,7 +423,6 @@ pub const TODO_DB_SCHEMA_RISK_ZONES: &str = "
 pub const TODO_DB_SCHEMA_INDEX_RISK_ZONES_NAME: &str =
     "CREATE INDEX IF NOT EXISTS idx_risk_zones_name ON risk_zones(zone_name)";
 
-/// Task ownership table for multiple owners support
 pub const TODO_DB_SCHEMA_TASK_OWNERS: &str = "
     CREATE TABLE IF NOT EXISTS task_owners (
         id TEXT PRIMARY KEY,
@@ -220,7 +437,6 @@ pub const TODO_DB_SCHEMA_TASK_OWNERS: &str = "
 pub const TODO_DB_SCHEMA_INDEX_TASK_OWNERS_TASK: &str =
     "CREATE INDEX IF NOT EXISTS idx_task_owners_task ON task_owners(task_id)";
 
-/// Task dependency edges for explicit dependency graph queries.
 pub const TODO_DB_SCHEMA_TASK_DEPENDENCIES: &str = "
     CREATE TABLE IF NOT EXISTS task_dependencies (
         id TEXT PRIMARY KEY,
@@ -237,7 +453,6 @@ pub const TODO_DB_SCHEMA_INDEX_TASK_DEPS_TASK: &str =
     "CREATE INDEX IF NOT EXISTS idx_task_dependencies_task ON task_dependencies(task_id)";
 pub const TODO_DB_SCHEMA_INDEX_TASK_DEPS_DEPENDS_ON: &str = "CREATE INDEX IF NOT EXISTS idx_task_dependencies_depends_on ON task_dependencies(depends_on_task_id)";
 
-/// Agent expertise table for category specialization
 pub const TODO_DB_SCHEMA_AGENT_EXPERTISE: &str = "
     CREATE TABLE IF NOT EXISTS agent_expertise (
         id TEXT PRIMARY KEY,
@@ -253,292 +468,8 @@ pub const TODO_DB_SCHEMA_AGENT_EXPERTISE: &str = "
 pub const TODO_DB_SCHEMA_INDEX_AGENT_EXPERTISE_AGENT: &str =
     "CREATE INDEX IF NOT EXISTS idx_agent_expertise_agent ON agent_expertise(agent_id)";
 
-// --- Federation ---
-
-/// Federation database file name
-pub const FEDERATION_DB_NAME: &str = "federation.db";
-
-/// Federation event log file name
-///
-/// Event-sourced append-only log for deterministic rebuild of federation.db
-pub const FEDERATION_EVENTS_NAME: &str = "federation.events.jsonl";
-
-/// Federation database schema version
-pub const FEDERATION_SCHEMA_VERSION: u32 = 1;
-
-/// Federation metadata table schema
-pub const FEDERATION_DB_SCHEMA_META: &str = "
-    CREATE TABLE IF NOT EXISTS meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-    )
-";
-
-/// Federation nodes table schema
-///
-/// Typed memory objects with lifecycle, provenance, and governance semantics.
-/// Each node is a "claim" — an assertion with metadata about reliability and lineage.
-pub const FEDERATION_DB_SCHEMA_NODES: &str = "
-    CREATE TABLE IF NOT EXISTS nodes (
-        id TEXT PRIMARY KEY,
-        node_type TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'active',
-        priority TEXT NOT NULL DEFAULT 'notable',
-        confidence TEXT NOT NULL DEFAULT 'agent_inferred',
-        title TEXT NOT NULL,
-        body TEXT NOT NULL DEFAULT '',
-        scope TEXT NOT NULL DEFAULT 'repo',
-        tags TEXT NOT NULL DEFAULT '',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        effective_from TEXT,
-        effective_to TEXT,
-        dir_path TEXT NOT NULL,
-        actor TEXT NOT NULL DEFAULT 'decapod'
-    )
-";
-
-/// Federation sources table schema
-///
-/// Provenance pointers for nodes. Critical nodes require at least one source.
-/// Each source must use a scheme prefix: file:, url:, cmd:, commit:, event:
-pub const FEDERATION_DB_SCHEMA_SOURCES: &str = "
-    CREATE TABLE IF NOT EXISTS sources (
-        id TEXT PRIMARY KEY,
-        node_id TEXT NOT NULL,
-        source TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        FOREIGN KEY(node_id) REFERENCES nodes(id)
-    )
-";
-
-/// Federation edges table schema
-///
-/// Typed directed edges between nodes forming the knowledge graph.
-/// Edge types: relates_to, depends_on, supersedes, invalidated_by
-pub const FEDERATION_DB_SCHEMA_EDGES: &str = "
-    CREATE TABLE IF NOT EXISTS edges (
-        id TEXT PRIMARY KEY,
-        source_id TEXT NOT NULL,
-        target_id TEXT NOT NULL,
-        edge_type TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        actor TEXT NOT NULL DEFAULT 'decapod',
-        FOREIGN KEY(source_id) REFERENCES nodes(id),
-        FOREIGN KEY(target_id) REFERENCES nodes(id)
-    )
-";
-
-/// Federation event log table (mirrors JSONL for in-DB queries)
-pub const FEDERATION_DB_SCHEMA_EVENTS: &str = "
-    CREATE TABLE IF NOT EXISTS federation_events (
-        event_id TEXT PRIMARY KEY,
-        ts TEXT NOT NULL,
-        event_type TEXT NOT NULL,
-        node_id TEXT,
-        payload TEXT NOT NULL,
-        actor TEXT NOT NULL
-    )
-";
-
-pub const FEDERATION_DB_INDEX_NODES_TYPE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_type ON nodes(node_type)";
-pub const FEDERATION_DB_INDEX_NODES_STATUS: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_status ON nodes(status)";
-pub const FEDERATION_DB_INDEX_NODES_SCOPE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_scope ON nodes(scope)";
-pub const FEDERATION_DB_INDEX_NODES_PRIORITY: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_priority ON nodes(priority)";
-pub const FEDERATION_DB_INDEX_NODES_UPDATED: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_nodes_updated ON nodes(updated_at)";
-pub const FEDERATION_DB_INDEX_SOURCES_NODE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_sources_node ON sources(node_id)";
-pub const FEDERATION_DB_INDEX_EDGES_SOURCE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_edges_source ON edges(source_id)";
-pub const FEDERATION_DB_INDEX_EDGES_TARGET: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_edges_target ON edges(target_id)";
-pub const FEDERATION_DB_INDEX_EDGES_TYPE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_edges_type ON edges(edge_type)";
-pub const FEDERATION_DB_INDEX_EVENTS_NODE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_fed_events_node ON federation_events(node_id)";
-
-// --- Cron ---
-pub const CRON_DB_NAME: &str = "cron.db";
-pub const CRON_DB_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS cron_jobs (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        description TEXT DEFAULT '',
-        schedule TEXT NOT NULL,
-        command TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'active',
-        last_run TEXT,
-        next_run TEXT,
-        tags TEXT DEFAULT '',
-        created_at TEXT NOT NULL,
-        updated_at TEXT,
-        dir_path TEXT NOT NULL,
-        scope TEXT NOT NULL
-    )
-";
-
-// --- Reflex ---
-pub const REFLEX_DB_NAME: &str = "reflex.db";
-pub const REFLEX_DB_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS reflexes (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        description TEXT DEFAULT '',
-        trigger_type TEXT NOT NULL,
-        trigger_config TEXT DEFAULT '{}',
-        action_type TEXT NOT NULL,
-        action_config TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'active',
-        tags TEXT DEFAULT '',
-        created_at TEXT NOT NULL,
-        updated_at TEXT,
-        dir_path TEXT NOT NULL,
-        scope TEXT NOT NULL
-    )
-";
-
-// --- Health ---
 pub const HEALTH_DB_NAME: &str = "health.db";
-pub const HEALTH_DB_SCHEMA_CLAIMS: &str = "
-    CREATE TABLE IF NOT EXISTS claims (
-        id TEXT PRIMARY KEY,
-        subject TEXT NOT NULL,
-        kind TEXT NOT NULL,
-        provenance TEXT,
-        created_at TEXT NOT NULL
-    )
-";
-pub const HEALTH_DB_SCHEMA_PROOF_EVENTS: &str = "
-    CREATE TABLE IF NOT EXISTS proof_events (
-        event_id TEXT PRIMARY KEY,
-        claim_id TEXT NOT NULL,
-        ts TEXT NOT NULL,
-        surface TEXT NOT NULL,
-        result TEXT NOT NULL,
-        sla_seconds INTEGER NOT NULL,
-        FOREIGN KEY(claim_id) REFERENCES claims(id)
-    )
-";
-pub const HEALTH_DB_SCHEMA_HEALTH_CACHE: &str = "
-    CREATE TABLE IF NOT EXISTS health_cache (
-        claim_id TEXT PRIMARY KEY,
-        computed_state TEXT NOT NULL,
-        reason TEXT,
-        updated_at TEXT NOT NULL,
-        FOREIGN KEY(claim_id) REFERENCES claims(id)
-    )
-";
-
-// --- Policy ---
 pub const POLICY_DB_NAME: &str = "policy.db";
-pub const POLICY_DB_SCHEMA_APPROVALS: &str = "
-    CREATE TABLE IF NOT EXISTS approvals (
-        approval_id TEXT PRIMARY KEY,
-        action_fingerprint TEXT NOT NULL,
-        actor TEXT NOT NULL,
-        ts TEXT NOT NULL,
-        scope TEXT NOT NULL,
-        expires_at TEXT
-    )
-";
-pub const POLICY_DB_SCHEMA_INDEX: &str =
-    "CREATE INDEX IF NOT EXISTS idx_approvals_fingerprint ON approvals(action_fingerprint)";
-
-// --- Archive ---
-pub const ARCHIVE_DB_NAME: &str = "archive.db";
-pub const ARCHIVE_DB_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS archives (
-        id TEXT PRIMARY KEY,
-        path TEXT NOT NULL,
-        content_hash TEXT NOT NULL,
-        summary_hash TEXT NOT NULL,
-        created_at TEXT NOT NULL
-    )
-";
-
-// --- Feedback ---
 pub const FEEDBACK_DB_NAME: &str = "feedback.db";
-pub const FEEDBACK_DB_SCHEMA: &str = "
-    CREATE TABLE IF NOT EXISTS feedback (
-        id TEXT PRIMARY KEY,
-        source TEXT NOT NULL,
-        text TEXT NOT NULL,
-        links TEXT,
-        created_at TEXT NOT NULL
-    )
-";
-
-// --- Decide ---
-
-/// Decisions database file name
-pub const DECIDE_DB_NAME: &str = "decisions.db";
-
-/// Decisions database schema version
-pub const DECIDE_SCHEMA_VERSION: u32 = 1;
-
-/// Decisions metadata table schema
-pub const DECIDE_DB_SCHEMA_META: &str = "
-    CREATE TABLE IF NOT EXISTS meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-    )
-";
-
-/// Decision sessions table schema
-///
-/// Groups related decisions from a single decision tree walkthrough.
-/// Each session targets one tree (web-app, microservice, etc.) and tracks
-/// completion status. Cross-linked to federation.db via federation_node_id.
-pub const DECIDE_DB_SCHEMA_SESSIONS: &str = "
-    CREATE TABLE IF NOT EXISTS sessions (
-        id TEXT PRIMARY KEY,
-        tree_id TEXT NOT NULL,
-        title TEXT NOT NULL,
-        description TEXT DEFAULT '',
-        status TEXT NOT NULL DEFAULT 'active',
-        federation_node_id TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        completed_at TEXT,
-        dir_path TEXT NOT NULL,
-        scope TEXT NOT NULL DEFAULT 'repo',
-        actor TEXT NOT NULL DEFAULT 'decapod'
-    )
-";
-
-/// Individual decisions table schema
-///
-/// Each row is one answered question within a session. Stores both the
-/// machine-readable value and human-readable label for the chosen option.
-/// Cross-linked to federation.db via federation_node_id.
-pub const DECIDE_DB_SCHEMA_DECISIONS: &str = "
-    CREATE TABLE IF NOT EXISTS decisions (
-        id TEXT PRIMARY KEY,
-        session_id TEXT NOT NULL,
-        question_id TEXT NOT NULL,
-        tree_id TEXT NOT NULL,
-        question_text TEXT NOT NULL,
-        chosen_value TEXT NOT NULL,
-        chosen_label TEXT NOT NULL,
-        rationale TEXT DEFAULT '',
-        user_note TEXT DEFAULT '',
-        federation_node_id TEXT,
-        created_at TEXT NOT NULL,
-        actor TEXT NOT NULL DEFAULT 'decapod',
-        FOREIGN KEY(session_id) REFERENCES sessions(id)
-    )
-";
-
-pub const DECIDE_DB_INDEX_DECISIONS_SESSION: &str =
-    "CREATE INDEX IF NOT EXISTS idx_decisions_session ON decisions(session_id)";
-pub const DECIDE_DB_INDEX_DECISIONS_TREE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_decisions_tree ON decisions(tree_id)";
-pub const DECIDE_DB_INDEX_SESSIONS_TREE: &str =
-    "CREATE INDEX IF NOT EXISTS idx_sessions_tree ON sessions(tree_id)";
-pub const DECIDE_DB_INDEX_SESSIONS_STATUS: &str =
-    "CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status)";
+pub const ARCHIVE_DB_NAME: &str = "archive.db";
+pub const TEAMMATE_DB_NAME: &str = "teammate.db";

--- a/src/plugins/archive.rs
+++ b/src/plugins/archive.rs
@@ -18,7 +18,7 @@ pub struct ArchiveEntry {
 }
 
 pub fn archive_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::ARCHIVE_DB_NAME)
+    root.join(schemas::GOVERNANCE_DB_NAME)
 }
 
 pub fn initialize_archive_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/cron.rs
+++ b/src/plugins/cron.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use ulid::Ulid;
 
 fn cron_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::CRON_DB_NAME)
+    root.join(schemas::AUTOMATION_DB_NAME)
 }
 
 pub fn initialize_cron_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/decide.rs
+++ b/src/plugins/decide.rs
@@ -845,14 +845,14 @@ fn now_ts() -> String {
 }
 
 fn decide_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::DECIDE_DB_NAME)
+    root.join(schemas::MEMORY_DB_NAME)
 }
 
 pub fn initialize_decide_db(root: &Path) -> Result<(), error::DecapodError> {
     let db_path = decide_db_path(root);
     let conn = crate::core::db::db_connect(&db_path.to_string_lossy())?;
 
-    conn.execute_batch(schemas::DECIDE_DB_SCHEMA_META)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
     conn.execute_batch(schemas::DECIDE_DB_SCHEMA_SESSIONS)?;
     conn.execute_batch(schemas::DECIDE_DB_SCHEMA_DECISIONS)?;
     conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_SESSION)?;

--- a/src/plugins/federation.rs
+++ b/src/plugins/federation.rs
@@ -256,7 +256,7 @@ fn now_ts() -> String {
 }
 
 pub fn federation_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::FEDERATION_DB_NAME)
+    root.join(schemas::MEMORY_DB_NAME)
 }
 
 fn federation_events_path(root: &Path) -> PathBuf {
@@ -491,28 +491,28 @@ pub fn initialize_federation_db(root: &Path) -> Result<(), error::DecapodError> 
     let db_path = federation_db_path(root);
     let conn = crate::core::db::db_connect(&db_path.to_string_lossy())?;
 
-    conn.execute_batch(schemas::FEDERATION_DB_SCHEMA_META)?;
-    conn.execute_batch(schemas::FEDERATION_DB_SCHEMA_NODES)?;
-    conn.execute_batch(schemas::FEDERATION_DB_SCHEMA_SOURCES)?;
-    conn.execute_batch(schemas::FEDERATION_DB_SCHEMA_EDGES)?;
-    conn.execute_batch(schemas::FEDERATION_DB_SCHEMA_EVENTS)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_NODES)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_SOURCES)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EDGES)?;
+    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EVENTS)?;
 
     // Indexes
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_NODES_TYPE)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_NODES_STATUS)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_NODES_SCOPE)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_NODES_PRIORITY)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_NODES_UPDATED)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_SOURCES_NODE)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_EDGES_SOURCE)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_EDGES_TARGET)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_EDGES_TYPE)?;
-    conn.execute_batch(schemas::FEDERATION_DB_INDEX_EVENTS_NODE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_TYPE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_STATUS)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_SCOPE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_PRIORITY)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_UPDATED)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_SOURCES_NODE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_SOURCE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TARGET)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TYPE)?;
+    conn.execute_batch(schemas::MEMORY_DB_INDEX_EVENTS_NODE)?;
 
     // Version tracking
     conn.execute(
         "INSERT OR IGNORE INTO meta(key, value) VALUES('schema_version', ?1)",
-        params![schemas::FEDERATION_SCHEMA_VERSION.to_string()],
+        params![schemas::MEMORY_SCHEMA_VERSION.to_string()],
     )?;
 
     // Create events file if missing

--- a/src/plugins/feedback.rs
+++ b/src/plugins/feedback.rs
@@ -16,7 +16,7 @@ pub struct FeedbackEntry {
 }
 
 pub fn feedback_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::FEEDBACK_DB_NAME)
+    root.join(schemas::GOVERNANCE_DB_NAME)
 }
 
 pub fn initialize_feedback_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/health.rs
+++ b/src/plugins/health.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use ulid::Ulid;
 
 pub fn health_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::HEALTH_DB_NAME)
+    root.join(schemas::GOVERNANCE_DB_NAME)
 }
 
 pub fn initialize_health_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/knowledge.rs
+++ b/src/plugins/knowledge.rs
@@ -15,8 +15,10 @@ pub struct KnowledgeEntry {
     pub created_at: String,
 }
 
+use crate::core::schemas;
+
 pub fn knowledge_db_path(root: &Path) -> PathBuf {
-    root.join("knowledge.db")
+    root.join(schemas::MEMORY_DB_NAME)
 }
 
 pub fn add_knowledge(

--- a/src/plugins/policy.rs
+++ b/src/plugins/policy.rs
@@ -155,7 +155,7 @@ pub struct RiskMap {
 }
 
 pub fn policy_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::POLICY_DB_NAME)
+    root.join(schemas::GOVERNANCE_DB_NAME)
 }
 
 pub fn initialize_policy_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/reflex.rs
+++ b/src/plugins/reflex.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use ulid::Ulid;
 
 fn reflex_db_path(root: &Path) -> PathBuf {
-    root.join(schemas::REFLEX_DB_NAME)
+    root.join(schemas::AUTOMATION_DB_NAME)
 }
 
 pub fn initialize_reflex_db(root: &Path) -> Result<(), error::DecapodError> {

--- a/src/plugins/teammate.rs
+++ b/src/plugins/teammate.rs
@@ -328,7 +328,7 @@ pub struct SimilarityGroup {
 // ============================================================================
 
 pub fn teammate_db_path(root: &Path) -> PathBuf {
-    root.join(TEAMMATE_DB_NAME)
+    root.join(crate::core::schemas::MEMORY_DB_NAME)
 }
 
 fn now_iso() -> String {


### PR DESCRIPTION
- Merges 11+ plugin databases into governance.db, memory.db, automation.db, and todo.db.
- Implements systematic data migration from legacy databases.
- Updates all plugins to use shared database paths.
- Verified with agent RPC integration tests.

# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
