### PR TITLE
docs(readme): add research links, proof-gate example, validate output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@
   <a href="https://ko-fi.com/decapodlabs"><img alt="Ko-fi" src="https://img.shields.io/badge/Support-Ko--fi-ff5f5f?logo=ko-fi&logoColor=white"></a>
 </p>
 
-<p align="center">
-  ☕ Like Decapod? <a href="https://ko-fi.com/decapodlabs"><strong>Buy us a coffee on Ko-fi</strong></a> 💙
-</p>
-
 ---
 
 ## Why Decapod 🧠
@@ -36,10 +32,17 @@ Decapod is **invoked by agents; it never runs in the background**. It is a singl
 - Retrieve **canon (constitution .md fragments)** as context.
 - Provide authoritative schemas for **structured state** (todos, knowledge, decisions).
 - Run deterministic **validation/proof gates** to decide when work is truly done.
+  Example gate: *forbid direct pushes to protected branches* — fails if the agent has unpushed commits on main.
 
-Traces are stored locally in `.decapod/data/traces.jsonl`. Bindings are introspectable via `context.bindings`.
+AGENTS.md stays tiny (entrypoint). OVERRIDE.md handles local exceptions. Everything else is pulled just-in-time.
 
-Decapod is architecture-agnostic software. It is not a Linux kernel binding and is not coupled to a specific OS or CPU architecture.
+Traces: `.decapod/data/traces.jsonl`. Bindings: `context.bindings`. Architecture-agnostic (not coupled to a specific OS or CPU).
+
+Recent independent research confirms this design direction: [Evaluating AGENTS.md](https://arxiv.org/pdf/2602.11988) (Gloaguen et al., ETH SRI, 2026; [AgentBench repo](https://github.com/eth-sri/agentbench)) found that LLM-generated context files tend to reduce agent performance while increasing cost by over 20 %; human-written minimal requirements can help slightly. Decapod was built independently and without knowledge of ETH SRI's AgentBench research or this paper.
+
+<p align="center">
+  ☕ Like Decapod? <a href="https://ko-fi.com/decapodlabs"><strong>Buy us a coffee on Ko-fi</strong></a> 💙
+</p>
 
 ## Assurance Model ✅
 
@@ -74,6 +77,13 @@ AI Agent(s)  <---->  Decapod Runtime  <---->  Repository + Policy
 ## Getting Started 🚀
 
 Install Decapod with Cargo, initialize it in your repository, and let your agent operate through the Decapod contract instead of direct ad-hoc repo mutation.
+
+```text
+$ decapod validate
+  ✅ constitution/core    PASS
+  ✅ workspace isolation  PASS
+  ❌ uncommitted changes  FAIL — 2 files modified outside worktree
+```
 
 For command details and full usage, use `decapod --help`.
 


### PR DESCRIPTION
- Embed ETH SRI AgentBench research with independence statement
- Add concrete proof-gate example (protected-branch interlock)
- Add `decapod validate` PASS/FAIL output in Getting Started
- State AGENTS.md/OVERRIDE.md/JIT context philosophy inline
- Relocate Ko-fi block below "Why Decapod"

# What changed (one sentence)
<!-- Be precise. Example: "Add GitHub Issues connector plugin that syncs TODO.md to issues with idempotent upserts." -->

## Why (what problem / what user outcome)
<!-- No ideology. Describe impact. -->

## Scope
- [ ] Core
- [ ] Plugin
- [ ] Docs
- [ ] CI / tooling

## How to test (required)
<!-- Paste exact commands + expected output. -->
Commands run:
- 
Expected result:
- 

## Risk / blast radius (required)
<!-- What could break, where, and how badly. -->
- Affected components:
- Backward compat:
- Failure modes:

## Evidence (required)
<!-- At least one: logs, screenshots, or trace output. Prefer logs. -->
- Logs / output:

---

# Plugin checklist (required if plugin touched)
- [ ] Plugin has a clear name and category (connector / adapter / cache / proof-eval / workflow).
- [ ] README/docs updated with purpose + configuration + example usage.
- [ ] Versioning / compat notes included (Decapod version, API surface used).
- [ ] Idempotency defined (what happens on re-run).
- [ ] Error handling defined (retries, backoff, hard-fail vs soft-fail).
- [ ] Permissions / secrets model stated (what it reads, what it writes, where secrets live).
- [ ] Proof surface or validation harness included (even minimal).
- [ ] Includes a minimal “smoke test” path (CI or documented local commands).

# Core checklist (required if core touched)
- [ ] Public interfaces documented (or explicitly unchanged).
- [ ] Added/updated tests covering the change.
- [ ] Failure behavior is deterministic (no silent partial success).
- [ ] Logging added/updated at the right level (info/warn/error) with actionable context.
