### PR TITLE
feat(broker,flight-recorder): crash consistency and governance timeline

### DIFF
--- a/src/core/broker.rs
+++ b/src/core/broker.rs
@@ -136,6 +136,18 @@ impl DbBroker {
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
+
+        // Two-phase logging: only for mutations (reads don't need crash recovery)
+        if !is_read {
+            self.log_event(
+                actor,
+                effective_intent.as_deref(),
+                op_name,
+                &db_id,
+                "pending",
+            )?;
+        }
+
         let conn = db::db_connect(&db_path.to_string_lossy())?;
 
         let result = f(&conn);
@@ -257,6 +269,89 @@ impl DbBroker {
         map.remove(&compound);
         Ok(())
     }
+
+    /// Verify log integrity and detect potential crash-induced divergence.
+    ///
+    /// Scans the audit log for `pending` events that lack a corresponding
+    /// terminal `success` or `error` event, which indicates a process crash
+    /// between the two-phase commit boundaries.
+    pub fn verify_replay(&self) -> Result<ReplayReport, error::DecapodError> {
+        use std::io::BufRead;
+        if !self.audit_log_path.exists() {
+            return Ok(ReplayReport {
+                ts: time::now_epoch_z(),
+                divergences: vec![],
+                total_events: 0,
+            });
+        }
+
+        let f = std::fs::File::open(&self.audit_log_path).map_err(error::DecapodError::IoError)?;
+        let reader = std::io::BufReader::new(f);
+        let mut pending_map = HashMap::new();
+        let mut total_events = 0usize;
+
+        for line in reader.lines() {
+            let line = line.map_err(error::DecapodError::IoError)?;
+            let ev: BrokerEvent = serde_json::from_str(&line).map_err(|e| {
+                error::DecapodError::ValidationError(format!("Invalid audit log entry: {}", e))
+            })?;
+            total_events += 1;
+
+            match ev.status.as_str() {
+                "pending" => {
+                    pending_map.insert(ev.event_id.clone(), ev);
+                }
+                "success" | "error" => {
+                    // Match terminal events to pending events by intent_ref + op + db_id.
+                    // When both have matching intent_ref (including both None), clear the pending.
+                    pending_map.retain(|_, v| {
+                        let intent_match = match (&v.intent_ref, &ev.intent_ref) {
+                            (Some(a), Some(b)) => a == b,
+                            (None, None) => true,
+                            _ => false,
+                        };
+                        !(intent_match && v.op == ev.op && v.db_id == ev.db_id)
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        let divergences = pending_map
+            .into_values()
+            .map(|ev| Divergence {
+                event_id: ev.event_id,
+                op: ev.op,
+                db_id: ev.db_id,
+                ts: ev.ts,
+                intent_ref: ev.intent_ref,
+                reason: "Pending event without terminal status (potential crash)".to_string(),
+            })
+            .collect();
+
+        Ok(ReplayReport {
+            ts: time::now_epoch_z(),
+            divergences,
+            total_events,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReplayReport {
+    pub ts: String,
+    pub divergences: Vec<Divergence>,
+    pub total_events: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Divergence {
+    pub event_id: String,
+    pub op: String,
+    pub db_id: String,
+    pub ts: String,
+    pub intent_ref: Option<String>,
+    pub reason: String,
 }
 
 fn db_lock_map() -> &'static Mutex<HashMap<PathBuf, Arc<Mutex<()>>>> {

--- a/src/core/flight_recorder.rs
+++ b/src/core/flight_recorder.rs
@@ -1,0 +1,332 @@
+//! Governance Flight Recorder
+//!
+//! A read-only timeline renderer that makes the "narrow corridor" legible to humans.
+//! Renders governance events into a timeline: intent -> awareness -> mandate checks ->
+//! claim -> workspace -> edits -> proofs -> publish.
+//!
+//! # For AI Agents
+//!
+//! This is a read-only tool. It renders existing event logs and highlights gaps
+//! rather than fabricating missing structure.
+
+use crate::core::error::DecapodError;
+use crate::core::store::Store;
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "flight-recorder",
+    about = "Render governance timeline from event logs"
+)]
+pub struct FlightRecorderCli {
+    #[clap(subcommand)]
+    command: FlightRecorderCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum FlightRecorderCommand {
+    /// Render governance timeline from event logs
+    Timeline {
+        /// Output format: 'text' or 'json'
+        #[clap(long, default_value = "text")]
+        format: String,
+        /// Limit to N most recent events per source
+        #[clap(long, default_value = "100")]
+        limit: usize,
+    },
+    /// Export transcript as markdown
+    Transcript {
+        /// Output file path (stdout if not specified)
+        #[clap(long)]
+        output: Option<String>,
+        /// Include only events from this actor
+        #[clap(long)]
+        actor: Option<String>,
+    },
+}
+
+pub fn run_flight_recorder_cli(store: &Store, cli: FlightRecorderCli) -> Result<(), DecapodError> {
+    match cli.command {
+        FlightRecorderCommand::Timeline { format, limit } => render_timeline(store, &format, limit),
+        FlightRecorderCommand::Transcript { output, actor } => {
+            render_transcript(store, output.as_deref(), actor.as_deref())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEvent {
+    pub source: String,
+    pub ts: String,
+    pub event_id: String,
+    pub op: String,
+    pub actor: Option<String>,
+    pub session_id: Option<String>,
+    pub correlation_id: Option<String>,
+    pub status: Option<String>,
+    pub details: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Timeline {
+    pub rendered_at: String,
+    pub event_count: usize,
+    pub sources: Vec<String>,
+    pub events: Vec<TimelineEvent>,
+    pub gaps: Vec<String>,
+}
+
+fn render_timeline(store: &Store, format: &str, limit: usize) -> Result<(), DecapodError> {
+    let mut all_events = Vec::new();
+    let mut sources = Vec::new();
+    let mut gaps = Vec::new();
+
+    let event_files = vec![
+        ("broker", store.root.join("broker.events.jsonl")),
+        ("todo", store.root.join("todo.events.jsonl")),
+        ("federation", store.root.join("federation.events.jsonl")),
+        ("proof", store.root.join("proof.events.jsonl")),
+        ("watcher", store.root.join("watcher.events.jsonl")),
+    ];
+
+    for (name, path) in &event_files {
+        if path.exists() {
+            sources.push(name.to_string());
+            match read_events(path, limit) {
+                Ok(events) => {
+                    for mut ev in events {
+                        ev.source = name.to_string();
+                        all_events.push(ev);
+                    }
+                }
+                Err(e) => {
+                    gaps.push(format!("{}: read error - {}", name, e));
+                }
+            }
+        } else {
+            gaps.push(format!("{}: file not found", name));
+        }
+    }
+
+    all_events.sort_by(|a, b| a.ts.cmp(&b.ts));
+
+    if format == "json" {
+        let timeline = Timeline {
+            rendered_at: crate::core::time::now_epoch_z(),
+            event_count: all_events.len(),
+            sources,
+            events: all_events,
+            gaps,
+        };
+        println!("{}", serde_json::to_string_pretty(&timeline).unwrap());
+    } else {
+        println!("===================================================================");
+        println!("          GOVERNANCE FLIGHT RECORDER - TIMELINE");
+        println!("===================================================================");
+        println!();
+        println!("Rendered: {}", crate::core::time::now_epoch_z());
+        println!("Total Events: {}", all_events.len());
+        println!("Sources: {}", sources.join(", "));
+        println!();
+
+        if !gaps.is_empty() {
+            println!("  GAPS / MISSING DATA:");
+            for gap in &gaps {
+                println!("  - {}", gap);
+            }
+            println!();
+        }
+
+        println!("-------------------------------------------------------------------");
+        println!(
+            "{:<12} {:<26} {:<15} {:<20}",
+            "TIME", "OP", "ACTOR", "SOURCE"
+        );
+        println!("-------------------------------------------------------------------");
+
+        for ev in &all_events {
+            let ts_short = if ev.ts.len() > 26 {
+                &ev.ts[0..26]
+            } else {
+                &ev.ts
+            };
+            println!(
+                "{:<12} {:<26} {:<15} {:<20}",
+                ts_short,
+                truncate(&ev.op, 26),
+                truncate(ev.actor.as_deref().unwrap_or("-"), 15),
+                truncate(&ev.source, 20)
+            );
+        }
+
+        println!("-------------------------------------------------------------------");
+        println!();
+        println!("Governance corridor: intent -> claim -> workspace -> proofs -> publish");
+        println!("Use `decapod flight-recorder transcript` for detailed output.");
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() > max {
+        format!("{}...", &s[..max - 3])
+    } else {
+        s.to_string()
+    }
+}
+
+fn read_events(path: &PathBuf, limit: usize) -> Result<Vec<TimelineEvent>, DecapodError> {
+    let file = File::open(path).map_err(DecapodError::IoError)?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+
+    for line in reader.lines() {
+        let line = line.map_err(DecapodError::IoError)?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<serde_json::Value>(&line) {
+            Ok(json) => {
+                let ev = TimelineEvent {
+                    source: "unknown".to_string(),
+                    ts: json
+                        .get("ts")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    event_id: json
+                        .get("event_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    op: json
+                        .get("op")
+                        .or_else(|| json.get("event_type"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string(),
+                    actor: json.get("actor").and_then(|v| v.as_str()).map(String::from),
+                    session_id: json
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    correlation_id: json
+                        .get("correlation_id")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    status: json
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    details: json,
+                };
+                events.push(ev);
+            }
+            Err(_) => continue,
+        }
+
+        if events.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(events)
+}
+
+fn render_transcript(
+    store: &Store,
+    output_path: Option<&str>,
+    actor_filter: Option<&str>,
+) -> Result<(), DecapodError> {
+    let mut all_events = Vec::new();
+
+    let event_files = vec![
+        ("broker", store.root.join("broker.events.jsonl")),
+        ("todo", store.root.join("todo.events.jsonl")),
+        ("federation", store.root.join("federation.events.jsonl")),
+        ("proof", store.root.join("proof.events.jsonl")),
+    ];
+
+    for (name, path) in &event_files {
+        if path.exists() {
+            if let Ok(events) = read_events(path, 10000) {
+                for mut ev in events {
+                    if let Some(filter) = actor_filter {
+                        if ev.actor.as_deref() != Some(filter) {
+                            continue;
+                        }
+                    }
+                    ev.source = name.to_string();
+                    all_events.push(ev);
+                }
+            }
+        }
+    }
+
+    all_events.sort_by(|a, b| a.ts.cmp(&b.ts));
+
+    let mut md = String::new();
+    md.push_str("# Governance Transcript\n\n");
+    md.push_str(&format!(
+        "Generated: {}\n",
+        crate::core::time::now_epoch_z()
+    ));
+    md.push_str(&format!("Total Events: {}\n", all_events.len()));
+    if let Some(f) = actor_filter {
+        md.push_str(&format!("Actor Filter: {}\n", f));
+    }
+    md.push_str("\n---\n\n");
+    md.push_str("## Timeline\n\n");
+
+    for ev in &all_events {
+        md.push_str(&format!("### {} - {}\n\n", ev.ts, ev.op));
+        md.push_str(&format!("- **Source:** {}\n", ev.source));
+        md.push_str(&format!("- **Event ID:** {}\n", ev.event_id));
+        if let Some(actor) = &ev.actor {
+            md.push_str(&format!("- **Actor:** {}\n", actor));
+        }
+        if let Some(session) = &ev.session_id {
+            md.push_str(&format!("- **Session:** {}\n", session));
+        }
+        if let Some(corr) = &ev.correlation_id {
+            md.push_str(&format!("- **Correlation:** {}\n", corr));
+        }
+        if let Some(status) = &ev.status {
+            md.push_str(&format!("- **Status:** {}\n", status));
+        }
+        md.push('\n');
+    }
+
+    md.push_str("---\n\n");
+    md.push_str("*This transcript was generated by the Governance Flight Recorder.*\n");
+    md.push_str("*It renders only existing event data; missing fields are shown as gaps.*\n");
+
+    if let Some(path) = output_path {
+        std::fs::write(path, &md).map_err(DecapodError::IoError)?;
+        println!("Transcript written to: {}", path);
+    } else {
+        println!("{}", md);
+    }
+
+    Ok(())
+}
+
+pub fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "name": "flight-recorder",
+        "version": "0.1.0",
+        "description": "Governance timeline renderer - makes the narrow corridor legible",
+        "commands": [
+            { "name": "timeline", "description": "Render governance timeline from event logs", "parameters": ["format", "limit"] },
+            { "name": "transcript", "description": "Export transcript as markdown", "parameters": ["output", "actor"] }
+        ],
+        "storage": ["read-only over existing event logs"],
+        "notes": "Read-only rendering; never fabricates missing structure"
+    })
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -37,6 +37,7 @@ pub mod docs;
 pub mod docs_cli;
 pub mod error;
 pub mod external_action;
+pub mod flight_recorder;
 pub mod interview;
 pub mod mentor;
 pub mod migration;

--- a/tests/crash_consistency.rs
+++ b/tests/crash_consistency.rs
@@ -1,0 +1,53 @@
+use decapod::core::broker::DbBroker;
+use decapod::core::error::DecapodError;
+
+#[test]
+fn test_demonstrate_crash_divergence_risk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let db_path = root.join("test.db");
+
+    // Initialize DB
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute("CREATE TABLE kv (key TEXT PRIMARY KEY, value TEXT)", [])
+            .unwrap();
+    }
+
+    let broker = DbBroker::new(root);
+
+    // Simulate a crash by panicking inside the closure.
+    let result = std::panic::catch_unwind(|| {
+        let _: Result<(), DecapodError> =
+            broker.with_conn(&db_path, "test-actor", None, "test.op", |conn| {
+                conn.execute("INSERT INTO kv (key, value) VALUES ('k1', 'v1')", [])
+                    .unwrap();
+                // "Crash"
+                panic!("SIMULATED CRASH");
+            });
+    });
+
+    assert!(result.is_err());
+
+    // Verify DB has the data
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let val: String = conn
+            .query_row("SELECT value FROM kv WHERE key = 'k1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(val, "v1");
+    }
+
+    // Verify log DOES have the 'pending' event, but NO terminal event
+    let report = broker.verify_replay().unwrap();
+    assert_eq!(
+        report.divergences.len(),
+        1,
+        "Should detect one divergence from the simulated crash"
+    );
+    assert_eq!(report.divergences[0].op, "test.op");
+    assert_eq!(
+        report.divergences[0].reason,
+        "Pending event without terminal status (potential crash)"
+    );
+}


### PR DESCRIPTION
## Summary

Folds in the valuable changes from PRs #284 and #283, with bug fixes and lint cleanup:

- **Two-phase logging in DbBroker**: `pending` event before mutation, terminal `success`/`error` after. Only applies to write operations (reads skip pending phase). Fixes a matching bug in the original PR where `None` intent_ref caused orphaned pending events.
- **`verify_replay()`** detects crash-induced divergence (orphaned pending events without terminal status).
- **`decapod data broker verify`** CLI command and `decapod validate` integration for audit log integrity.
- **Status field** on `TodoEvent` and `FederationEvent` with `#[serde(default)]` for backward compat. Pending events skipped during DB rebuild.
- **Governance Flight Recorder**: read-only timeline renderer (`decapod flight-recorder timeline/transcript`) aggregating all event log sources with gap detection.

## Changes from original PRs

- Fixed verify_replay matching logic for `None` intent_ref (original PR #284 bug)
- Restricted two-phase pending logging to mutation operations only (not reads)
- Fixed indentation issues in TodoEvent status field additions
- Removed emoji from flight recorder output
- Added `event_type` fallback in flight recorder's loose JSON parsing
- Deferred PR #282 (canonical evidence artifact) due to internal inconsistency with doc deletions

## Test plan

- [x] `tests/crash_consistency.rs` — verifies divergence detection on simulated crash
- [x] `agent_rpc_suite` — all 5 tests pass (validate now includes audit log integrity)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Full `cargo test` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)