### PR TITLE
perf(validate): add --verbose timing and parallelize expensive gates

### DIFF
--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -38,6 +38,7 @@ use serde_json;
 use std::cell::RefCell;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 use ulid::Ulid;
 
 thread_local! {
@@ -251,13 +252,37 @@ fn warn(message: &str, warn_count: &mut u32) {
     VALIDATION_WARNS.with(|v| v.borrow_mut().push(message.to_string()));
 }
 
-fn info(message: &str) {
-    let _ = message;
+fn info(_message: &str) {}
+
+struct TimedGate {
+    name: &'static str,
+    start: Instant,
+    verbose: bool,
 }
 
-fn trace_gate(name: &str) {
-    if std::env::var("DECAPOD_VALIDATE_TRACE").ok().as_deref() == Some("1") {
-        println!("validate: trace {}", name);
+impl TimedGate {
+    fn new(name: &'static str, verbose: bool) -> Self {
+        if verbose {
+            println!("validate: [{name}] starting...");
+        }
+        Self {
+            name,
+            start: Instant::now(),
+            verbose,
+        }
+    }
+}
+
+impl Drop for TimedGate {
+    fn drop(&mut self) {
+        if self.verbose {
+            let elapsed = self.start.elapsed();
+            println!(
+                "validate: [{name}] done ({elapsed:.2?})",
+                name = self.name,
+                elapsed = elapsed
+            );
+        }
     }
 }
 
@@ -1002,20 +1027,29 @@ fn validate_schema_determinism(
     info("Schema Determinism Gate");
     let exe = std::env::current_exe().map_err(error::DecapodError::IoError)?;
 
-    let run_schema = || -> Result<String, error::DecapodError> {
+    let run_schema = move |exe: PathBuf| -> Result<String, String> {
         let out = std::process::Command::new(&exe)
             .env("DECAPOD_BYPASS_SESSION", "1")
             .arg("data")
             .arg("schema")
             .arg("--deterministic")
             .output()
-            .map_err(error::DecapodError::IoError)?;
-        let text = String::from_utf8_lossy(&out.stdout).to_string();
-        Ok(text)
+            .map_err(|e| e.to_string())?;
+        Ok(String::from_utf8_lossy(&out.stdout).to_string())
     };
 
-    let s1 = run_schema()?;
-    let s2 = run_schema()?;
+    let exe2 = exe.clone();
+    let h1 = std::thread::spawn(move || run_schema(exe));
+    let h2 = std::thread::spawn(move || run_schema(exe2));
+
+    let s1 = h1
+        .join()
+        .map_err(|_| error::DecapodError::ValidationError("schema thread panicked".into()))?
+        .map_err(|e| error::DecapodError::ValidationError(e))?;
+    let s2 = h2
+        .join()
+        .map_err(|_| error::DecapodError::ValidationError("schema thread panicked".into()))?
+        .map_err(|e| error::DecapodError::ValidationError(e))?;
 
     if s1 == s2 && !s1.is_empty() {
         pass("Schema output is deterministic", pass_count);
@@ -1085,11 +1119,20 @@ fn validate_risk_map_violations(
     store: &Store,
     pass_count: &mut u32,
     fail_count: &mut u32,
+    pre_read_broker: Option<&str>,
 ) -> Result<(), error::DecapodError> {
     info("Zone Violation Gate");
-    let audit_log = store.root.join("broker.events.jsonl");
-    if audit_log.exists() {
-        let content = fs::read_to_string(audit_log)?;
+    let fallback;
+    let content = match pre_read_broker {
+        Some(c) => c,
+        None => {
+            let audit_log = store.root.join("broker.events.jsonl");
+            if !audit_log.exists() { return Ok(()); }
+            fallback = fs::read_to_string(audit_log)?;
+            &fallback
+        }
+    };
+    {
         let mut offenders = Vec::new();
         for line in content.lines() {
             if line.contains("\".decapod/\"") && line.contains("\"op\":\"todo.add\"") {
@@ -1112,6 +1155,7 @@ fn validate_policy_integrity(
     store: &Store,
     pass_count: &mut u32,
     fail_count: &mut u32,
+    pre_read_broker: Option<&str>,
 ) -> Result<(), error::DecapodError> {
     info("Policy Integrity Gates");
     let db_path = store.root.join("policy.db");
@@ -1122,9 +1166,20 @@ fn validate_policy_integrity(
 
     let _conn = db::db_connect_for_validate(&db_path.to_string_lossy())?;
 
-    let audit_log = store.root.join("broker.events.jsonl");
-    if audit_log.exists() {
-        let content = fs::read_to_string(audit_log)?;
+    let fallback;
+    let content_opt = match pre_read_broker {
+        Some(c) => Some(c),
+        None => {
+            let audit_log = store.root.join("broker.events.jsonl");
+            if audit_log.exists() {
+                fallback = fs::read_to_string(audit_log)?;
+                Some(fallback.as_str())
+            } else {
+                None
+            }
+        }
+    };
+    if let Some(content) = content_opt {
         let mut offenders = Vec::new();
         for line in content.lines() {
             if line.contains("\"op\":\"policy.approve\"")
@@ -1156,6 +1211,7 @@ fn validate_knowledge_integrity(
     store: &Store,
     pass_count: &mut u32,
     fail_count: &mut u32,
+    pre_read_broker: Option<&str>,
 ) -> Result<(), error::DecapodError> {
     info("Knowledge Integrity Gate");
     let db_path = store.root.join("knowledge.db");
@@ -1192,9 +1248,20 @@ fn validate_knowledge_integrity(
         );
     }
 
-    let audit_log = store.root.join("broker.events.jsonl");
-    if audit_log.exists() {
-        let content = fs::read_to_string(audit_log)?;
+    let fallback;
+    let content_opt = match pre_read_broker {
+        Some(c) => Some(c),
+        None => {
+            let audit_log = store.root.join("broker.events.jsonl");
+            if audit_log.exists() {
+                fallback = fs::read_to_string(audit_log)?;
+                Some(fallback.as_str())
+            } else {
+                None
+            }
+        }
+    };
+    if let Some(content) = content_opt {
         let mut offenders = Vec::new();
         for line in content.lines() {
             if line.contains("\"op\":\"knowledge.add\"") && line.contains("\"db_id\":\"health.db\"")
@@ -1352,8 +1419,13 @@ fn validate_repomap_determinism(
 ) -> Result<(), error::DecapodError> {
     info("Repo Map Determinism Gate");
     use crate::core::repomap;
-    let m1 = serde_json::to_string(&repomap::generate_map(decapod_dir)).unwrap();
-    let m2 = serde_json::to_string(&repomap::generate_map(decapod_dir)).unwrap();
+    let dir1 = decapod_dir.to_path_buf();
+    let dir2 = decapod_dir.to_path_buf();
+    let h1 = std::thread::spawn(move || serde_json::to_string(&repomap::generate_map(&dir1)).unwrap());
+    let h2 = std::thread::spawn(move || serde_json::to_string(&repomap::generate_map(&dir2)).unwrap());
+
+    let m1 = h1.join().map_err(|_| error::DecapodError::ValidationError("repomap thread panicked".into()))?;
+    let m2 = h2.join().map_err(|_| error::DecapodError::ValidationError("repomap thread panicked".into()))?;
 
     if m1 == m2 && !m1.is_empty() {
         pass("Repo map output is deterministic", pass_count);
@@ -1385,11 +1457,23 @@ fn validate_watcher_purity(
     store: &Store,
     pass_count: &mut u32,
     fail_count: &mut u32,
+    pre_read_broker: Option<&str>,
 ) -> Result<(), error::DecapodError> {
     info("Watcher Purity Gate");
-    let audit_log = store.root.join("broker.events.jsonl");
-    if audit_log.exists() {
-        let content = fs::read_to_string(audit_log)?;
+    let fallback;
+    let content_opt = match pre_read_broker {
+        Some(c) => Some(c),
+        None => {
+            let audit_log = store.root.join("broker.events.jsonl");
+            if audit_log.exists() {
+                fallback = fs::read_to_string(audit_log)?;
+                Some(fallback.as_str())
+            } else {
+                None
+            }
+        }
+    };
+    if let Some(content) = content_opt {
         let mut offenders = Vec::new();
         for line in content.lines() {
             if line.contains("\"actor\":\"watcher\"") {
@@ -1519,11 +1603,23 @@ fn validate_canon_mutation(
     store: &Store,
     pass_count: &mut u32,
     fail_count: &mut u32,
+    pre_read_broker: Option<&str>,
 ) -> Result<(), error::DecapodError> {
     info("Canon Mutation Gate");
-    let audit_log = store.root.join("broker.events.jsonl");
-    if audit_log.exists() {
-        let content = fs::read_to_string(audit_log)?;
+    let fallback;
+    let content_opt = match pre_read_broker {
+        Some(c) => Some(c),
+        None => {
+            let audit_log = store.root.join("broker.events.jsonl");
+            if audit_log.exists() {
+                fallback = fs::read_to_string(audit_log)?;
+                Some(fallback.as_str())
+            } else {
+                None
+            }
+        }
+    };
+    if let Some(content) = content_opt {
         let mut offenders = Vec::new();
         for line in content.lines() {
             if line.contains("\"op\":\"write\"")
@@ -2151,10 +2247,12 @@ pub fn run_validation(
     store: &Store,
     decapod_dir: &Path,
     _home_dir: &Path,
+    verbose: bool,
 ) -> Result<(), error::DecapodError> {
     VALIDATION_FAILS.with(|v| v.borrow_mut().clear());
     VALIDATION_WARNS.with(|v| v.borrow_mut().clear());
     REPO_FILES_CACHE.with(|v| v.borrow_mut().clear());
+    let total_start = Instant::now();
     println!("validate: running");
 
     // Directly get content from embedded assets
@@ -2167,76 +2265,85 @@ pub fn run_validation(
     let mut fail_count = 0;
     let mut warn_count = 0;
 
+    // Pre-read broker.events.jsonl once for gates that need it
+    let broker_events_path = store.root.join("broker.events.jsonl");
+    let broker_content: Option<String> = if broker_events_path.exists() {
+        fs::read_to_string(&broker_events_path).ok()
+    } else {
+        None
+    };
+
     // Store validations
     match store.kind {
         StoreKind::User => {
-            trace_gate("validate_user_store_blank_slate");
+            let _tg = TimedGate::new("validate_user_store_blank_slate", verbose);
             validate_user_store_blank_slate(&mut pass_count, &mut fail_count)?;
         }
         StoreKind::Repo => {
-            trace_gate("validate_repo_store_dogfood");
+            let _tg = TimedGate::new("validate_repo_store_dogfood", verbose);
             validate_repo_store_dogfood(store, &mut pass_count, &mut fail_count, decapod_dir)?;
         }
     }
 
-    trace_gate("validate_repo_map");
-    validate_repo_map(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_no_legacy_namespaces");
-    validate_no_legacy_namespaces(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_embedded_self_contained");
-    validate_embedded_self_contained(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_docs_templates_bucket");
-    validate_docs_templates_bucket(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_entrypoint_invariants");
-    validate_entrypoint_invariants(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_interface_contract_bootstrap");
-    validate_interface_contract_bootstrap(&mut pass_count, &mut fail_count, decapod_dir)?;
+    { let _tg = TimedGate::new("validate_repo_map", verbose);
+    validate_repo_map(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_no_legacy_namespaces", verbose);
+    validate_no_legacy_namespaces(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_embedded_self_contained", verbose);
+    validate_embedded_self_contained(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_docs_templates_bucket", verbose);
+    validate_docs_templates_bucket(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_entrypoint_invariants", verbose);
+    validate_entrypoint_invariants(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_interface_contract_bootstrap", verbose);
+    validate_interface_contract_bootstrap(&mut pass_count, &mut fail_count, decapod_dir)?; }
     println!("validate: gate Four Invariants Gate");
-    trace_gate("validate_health_purity");
-    validate_health_purity(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_project_scoped_state");
-    validate_project_scoped_state(store, &mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_schema_determinism");
-    validate_schema_determinism(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_health_cache_integrity");
-    validate_health_cache_integrity(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_risk_map");
-    validate_risk_map(store, &mut pass_count, &mut warn_count)?;
-    trace_gate("validate_risk_map_violations");
-    validate_risk_map_violations(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_policy_integrity");
-    validate_policy_integrity(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_knowledge_integrity");
-    validate_knowledge_integrity(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_lineage_hard_gate");
-    validate_lineage_hard_gate(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_repomap_determinism");
-    validate_repomap_determinism(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_watcher_audit");
-    validate_watcher_audit(store, &mut pass_count, &mut warn_count)?;
-    trace_gate("validate_watcher_purity");
-    validate_watcher_purity(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_archive_integrity");
-    validate_archive_integrity(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_control_plane_contract");
-    validate_control_plane_contract(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_canon_mutation");
-    validate_canon_mutation(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_heartbeat_invocation_gate");
-    validate_heartbeat_invocation_gate(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_markdown_primitives_roundtrip_gate");
-    validate_markdown_primitives_roundtrip_gate(store, &mut pass_count, &mut fail_count)?;
-    trace_gate("validate_federation_gates");
-    validate_federation_gates(store, &mut pass_count, &mut warn_count)?;
-    trace_gate("validate_git_workspace_context");
-    validate_git_workspace_context(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_git_protected_branch");
-    validate_git_protected_branch(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_tooling_gate");
-    validate_tooling_gate(&mut pass_count, &mut fail_count, decapod_dir)?;
-    trace_gate("validate_state_commit_gate");
-    validate_state_commit_gate(&mut pass_count, &mut fail_count, decapod_dir)?;
+    { let _tg = TimedGate::new("validate_health_purity", verbose);
+    validate_health_purity(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_project_scoped_state", verbose);
+    validate_project_scoped_state(store, &mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_schema_determinism", verbose);
+    validate_schema_determinism(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_health_cache_integrity", verbose);
+    validate_health_cache_integrity(store, &mut pass_count, &mut fail_count)?; }
+    { let _tg = TimedGate::new("validate_risk_map", verbose);
+    validate_risk_map(store, &mut pass_count, &mut warn_count)?; }
+    { let _tg = TimedGate::new("validate_risk_map_violations", verbose);
+    validate_risk_map_violations(store, &mut pass_count, &mut fail_count, broker_content.as_deref())?; }
+    { let _tg = TimedGate::new("validate_policy_integrity", verbose);
+    validate_policy_integrity(store, &mut pass_count, &mut fail_count, broker_content.as_deref())?; }
+    { let _tg = TimedGate::new("validate_knowledge_integrity", verbose);
+    validate_knowledge_integrity(store, &mut pass_count, &mut fail_count, broker_content.as_deref())?; }
+    { let _tg = TimedGate::new("validate_lineage_hard_gate", verbose);
+    validate_lineage_hard_gate(store, &mut pass_count, &mut fail_count)?; }
+    { let _tg = TimedGate::new("validate_repomap_determinism", verbose);
+    validate_repomap_determinism(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_watcher_audit", verbose);
+    validate_watcher_audit(store, &mut pass_count, &mut warn_count)?; }
+    { let _tg = TimedGate::new("validate_watcher_purity", verbose);
+    validate_watcher_purity(store, &mut pass_count, &mut fail_count, broker_content.as_deref())?; }
+    { let _tg = TimedGate::new("validate_archive_integrity", verbose);
+    validate_archive_integrity(store, &mut pass_count, &mut fail_count)?; }
+    { let _tg = TimedGate::new("validate_control_plane_contract", verbose);
+    validate_control_plane_contract(store, &mut pass_count, &mut fail_count)?; }
+    { let _tg = TimedGate::new("validate_canon_mutation", verbose);
+    validate_canon_mutation(store, &mut pass_count, &mut fail_count, broker_content.as_deref())?; }
+    { let _tg = TimedGate::new("validate_heartbeat_invocation_gate", verbose);
+    validate_heartbeat_invocation_gate(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_markdown_primitives_roundtrip_gate", verbose);
+    validate_markdown_primitives_roundtrip_gate(store, &mut pass_count, &mut fail_count)?; }
+    { let _tg = TimedGate::new("validate_federation_gates", verbose);
+    validate_federation_gates(store, &mut pass_count, &mut warn_count)?; }
+    { let _tg = TimedGate::new("validate_git_workspace_context", verbose);
+    validate_git_workspace_context(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_git_protected_branch", verbose);
+    validate_git_protected_branch(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_tooling_gate", verbose);
+    validate_tooling_gate(&mut pass_count, &mut fail_count, decapod_dir)?; }
+    { let _tg = TimedGate::new("validate_state_commit_gate", verbose);
+    validate_state_commit_gate(&mut pass_count, &mut fail_count, decapod_dir)?; }
 
+    let elapsed = total_start.elapsed();
     let fail_total = VALIDATION_FAILS
         .with(|v| v.borrow().len() as u32)
         .max(fail_count);
@@ -2244,8 +2351,8 @@ pub fn run_validation(
         .with(|v| v.borrow().len() as u32)
         .max(warn_count);
     println!(
-        "validate: summary pass={} fail={} warn={}",
-        pass_count, fail_total, warn_total
+        "validate: summary pass={} fail={} warn={} elapsed={:.2?}",
+        pass_count, fail_total, warn_total, elapsed
     );
 
     VALIDATION_FAILS.with(|v| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,9 @@ struct ValidateCli {
     /// Output format: 'text' or 'json'.
     #[clap(long, default_value = "text")]
     format: String,
+    /// Print per-gate timing information.
+    #[clap(long, short = 'v')]
+    verbose: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -1588,7 +1591,7 @@ fn run_validate_command(
         _ => project_store.clone(),
     };
 
-    validate::run_validation(&store, &decapod_root, &decapod_root)?;
+    validate::run_validation(&store, &decapod_root, &decapod_root, validate_cli.verbose)?;
     mark_validation_completed(project_root)?;
     Ok(())
 }
@@ -3188,7 +3191,7 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
             // We need to capture the output of validate::run_validation
             // For now, we'll just run it and return a simple success result
             // as it currently prints to stdout and manages thread-local state.
-            let res = validate::run_validation(&project_store, project_root, project_root);
+            let res = validate::run_validation(&project_store, project_root, project_root, false);
 
             match res {
                 Ok(_) => success_response(

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -129,6 +129,7 @@ fn epoch_secs(ts: &str) -> Option<i64> {
 
 fn normalize_validate_output(raw: &str) -> String {
     let ansi = Regex::new(r"\x1B\[[0-9;]*[A-Za-z]").expect("valid ANSI regex");
+    let elapsed_re = Regex::new(r" elapsed=\S+").expect("valid elapsed regex");
     let stripped = ansi.replace_all(raw, "");
     stripped
         .lines()
@@ -138,7 +139,8 @@ fn normalize_validate_output(raw: &str) -> String {
             if line.contains("decapod_validate_user_") || line.contains("decapod_validate_repo_") {
                 "<tmp_validate_path>".to_string()
             } else {
-                line.to_string()
+                // Strip non-deterministic elapsed timing from summary line
+                elapsed_re.replace_all(line, "").to_string()
             }
         })
         .collect::<Vec<_>>()

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -474,7 +474,7 @@ fn schemas_errors_and_validate_entrypoint_are_exercised() {
         root: store_root.path().to_path_buf(),
     };
 
-    let result = validate::run_validation(&store, repo.path(), repo.path());
+    let result = validate::run_validation(&store, repo.path(), repo.path(), false);
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
## Summary

- Add `--verbose` / `-v` flag to `decapod validate` that prints per-gate start/done timing using an RAII `TimedGate` struct
- Always print total elapsed time in the summary line (e.g. `validate: summary pass=116 fail=0 warn=3 elapsed=2m15s`)
- Parallelize the two subprocess calls in `validate_schema_determinism` and the two `generate_map` calls in `validate_repomap_determinism` using `std::thread::spawn`
- Pre-read `broker.events.jsonl` once at the top of `run_validation` and pass it to the 5 gates that previously each read it independently (`validate_risk_map_violations`, `validate_policy_integrity`, `validate_knowledge_integrity`, `validate_watcher_purity`, `validate_canon_mutation`)

## Test plan

- [ ] `cargo build` compiles cleanly
- [ ] `DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate --verbose` shows per-gate timing
- [ ] `DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate` still works (summary-only, now includes elapsed)
- [ ] Compare total elapsed time before/after to measure improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)