### PR TITLE
feat: integrate Plankton write-time enforcement into Decapod

### DIFF
--- a/assets/plankton_config.json
+++ b/assets/plankton_config.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "_comment": "Decapod-managed Plankton hooks configuration",
+  "languages": {
+    "python": true,
+    "shell": true,
+    "yaml": true,
+    "json": true,
+    "toml": true,
+    "dockerfile": true,
+    "markdown": true,
+    "typescript": {
+      "enabled": false
+    }
+  },
+  "protected_files": [
+    ".markdownlint.jsonc",
+    ".markdownlint-cli2.jsonc",
+    ".shellcheckrc",
+    ".yamllint",
+    ".hadolint.yaml",
+    ".jscpd.json",
+    ".flake8",
+    "taplo.toml",
+    ".ruff.toml",
+    "ty.toml",
+    "biome.json",
+    ".oxlintrc.json",
+    ".semgrep.yml",
+    "knip.json"
+  ],
+  "exclusions": [
+    "tests/",
+    "docs/",
+    ".venv/",
+    "scripts/",
+    "node_modules/",
+    ".git/",
+    ".claude/"
+  ],
+  "phases": {
+    "auto_format": true,
+    "subprocess_delegation": true
+  },
+  "subprocess": {
+    "timeout": 300,
+    "model_selection": {
+      "sonnet_patterns": "C901|PLR[0-9]+|PYD[0-9]+|FAST[0-9]+|ASYNC[0-9]+|unresolved-import|MD[0-9]+|D[0-9]+|complexity",
+      "opus_patterns": "unresolved-attribute|type-assertion",
+      "volume_threshold": 5
+    }
+  },
+  "package_managers": {
+    "python": "uv",
+    "javascript": "bun",
+    "allowed_subcommands": {
+      "npm": ["audit", "view", "pack", "publish", "whoami", "login"],
+      "pip": ["download"],
+      "yarn": ["audit", "info"],
+      "pnpm": ["audit", "info"],
+      "poetry": [],
+      "pipenv": []
+    }
+  }
+}

--- a/assets/plankton_multi_linter.sh
+++ b/assets/plankton_multi_linter.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# multi_linter.sh - Decapod Plankton PostToolUse hook for multi-language linting
+# Supports: Python (ruff), Shell (shellcheck+shfmt), YAML (yamllint), 
+#           JSON, TOML (taplo), Dockerfile (hadolint), Markdown (markdownlint-cli2)
+#
+# Three-Phase Architecture:
+#   Phase 1: Auto-format files (silent on success)
+#   Phase 2: Collect unfixable violations as JSON
+#   Phase 3: Delegate to Claude subprocess for fixes, then verify
+
+set -euo pipefail
+trap 'kill 0' SIGTERM
+
+if ! command -v jaq >/dev/null 2>&1; then
+  echo "[hook] error: jaq is required but not found. Install: brew install jaq" >&2
+  exit 0
+fi
+
+CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/hooks/config.json"
+
+load_config() {
+  if [[ -f "${CONFIG_FILE}" ]]; then
+    CONFIG_JSON=$(cat "${CONFIG_FILE}")
+  else
+    CONFIG_JSON='{}'
+  fi
+}
+
+is_language_enabled() {
+  local lang="$1"
+  local enabled
+  enabled=$(echo "${CONFIG_JSON}" | jaq -r ".languages.${lang}" 2>/dev/null)
+  [[ "${enabled}" != "false" ]]
+}
+
+get_exclusions() {
+  local defaults='["tests/","docs/",".venv/","scripts/","node_modules/",".git/",".claude/"]'
+  echo "${CONFIG_JSON}" | jaq -r ".exclusions // ${defaults} | .[]" 2>/dev/null
+}
+
+is_auto_format_enabled() {
+  local enabled
+  enabled=$(echo "${CONFIG_JSON}" | jaq -r '.phases.auto_format' 2>/dev/null)
+  [[ "${enabled}" != "false" ]]
+}
+
+is_subprocess_enabled() {
+  local enabled
+  enabled=$(echo "${CONFIG_JSON}" | jaq -r '.phases.subprocess_delegation' 2>/dev/null)
+  [[ "${enabled}" != "false" ]]
+}
+
+should_exclude() {
+  local file="$1"
+  while IFS= read -r pattern; do
+    if [[ "${file}" == ${pattern} ]]; then
+      return 0
+    fi
+  done < <(get_exclusions)
+  return 1
+}
+
+run_ruff_format() {
+  local file="$1"
+  if command -v ruff >/dev/null 2>&1; then
+    ruff format "$file" 2>/dev/null || true
+  fi
+}
+
+run_ruff_check() {
+  local file="$1"
+  if ! command -v ruff >/dev/null 2>&1; then
+    return 0
+  fi
+  ruff check --output-format=json "$file" 2>/dev/null || echo "[]"
+}
+
+run_shellcheck() {
+  local file="$1"
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    return 0
+  fi
+  shellcheck --format=json "$file" 2>/dev/null || echo "[]"
+}
+
+run_shfmt() {
+  local file="$1"
+  if command -v shfmt >/dev/null 2>&1; then
+    shfmt -w "$file" 2>/dev/null || true
+  fi
+}
+
+run_yamllint() {
+  local file="$1"
+  if ! command -v yamllint >/dev/null 2>&1; then
+    return 0
+  fi
+  yamllint -f json "$file" 2>/dev/null || echo "[]"
+}
+
+run_taplo() {
+  local file="$1"
+  if ! command -v taplo >/dev/null 2>&1; then
+    return 0
+  fi
+  taplo check "$file" 2>&1 || echo "[]"
+}
+
+run_hadolint() {
+  local file="$1"
+  if ! command -v hadolint >/dev/null 2>&1; then
+    return 0
+  fi
+  hadolint "$file" 2>&1 || true
+}
+
+run_markdownlint() {
+  local file="$1"
+  if ! command -v markdownlint >/dev/null 2>&1; then
+    return 0
+  fi
+  markdownlint "$file" 2>&1 || true
+}
+
+get_file_language() {
+  local file="$1"
+  case "${file}" in
+    *.py) echo "python" ;;
+    *.sh|*.bash) echo "shell" ;;
+    *.yaml|*.yml) echo "yaml" ;;
+    *.json) echo "json" ;;
+    *.toml) echo "toml" ;;
+    Dockerfile|Dockerfile.*) echo "dockerfile" ;;
+    *.md) echo "markdown" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+phase1_autoformat() {
+  local file="$1"
+  local lang
+  lang=$(get_file_language "$file")
+
+  case "${lang}" in
+    python) run_ruff_format "$file" ;;
+    shell) run_shfmt "$file" ;;
+    *) ;;
+  esac
+}
+
+phase2_collect_violations() {
+  local file="$1"
+  local lang
+  lang=$(get_file_language "$file")
+  local violations="[]"
+
+  case "${lang}" in
+    python) violations=$(run_ruff_check "$file") ;;
+    shell) violations=$(run_shellcheck "$file") ;;
+    yaml) violations=$(run_yamllint "$file") ;;
+    toml) 
+      if ! run_taplo "$file" >/dev/null 2>&1; then
+        violations=$(echo '[{"line": 1, "message": "TOML validation failed"}]')
+      fi
+      ;;
+    dockerfile)
+      if ! run_hadolint "$file" >/dev/null 2>&1; then
+        violations=$(echo '[{"line": 1, "message": "Dockerfile linting failed"}]')
+      fi
+      ;;
+    markdown)
+      if ! run_markdownlint "$file" >/dev/null 2>&1; then
+        violations=$(echo '[{"line": 1, "message": "Markdown linting failed"}]')
+      fi
+      ;;
+  esac
+
+  echo "$violations"
+}
+
+phase3_delegate_fixes() {
+  local file="$1"
+  local violations="$2"
+
+  local violation_count
+  violation_count=$(echo "$violations" | jaq 'length' 2>/dev/null || echo "0")
+
+  if [[ "$violation_count" -eq 0 ]] || [[ "$violation_count" -eq "0" ]]; then
+    return 0
+  fi
+
+  echo "[hook] Delegating $violation_count violation(s) to Claude for fixes..."
+
+  local fix_prompt="Fix the following linting violations in ${file}:
+
+$(echo "$violations" | jaq -c '.[] | "\(.line): \(.message)"' 2>/dev/null | tr -d '"' | sed 's/^/  /')
+
+Apply the fixes directly to the file. Do not modify linter configuration files."
+
+  echo "$fix_prompt" | claude --dangerously-skip-permissions -p "$(cat)" >/dev/null 2>&1 || true
+
+  return 0
+}
+
+main() {
+  load_config
+
+  local tool_name="${1:-}"
+  local file_path="${2:-}"
+
+  if [[ -z "$file_path" ]]; then
+    exit 0
+  fi
+
+  if should_exclude "$file_path"; then
+    exit 0
+  fi
+
+  local lang
+  lang=$(get_file_language "$file_path")
+
+  if ! is_language_enabled "$lang"; then
+    exit 0
+  fi
+
+  if is_auto_format_enabled; then
+    phase1_autoformat "$file_path"
+  fi
+
+  local violations
+  violations=$(phase2_collect_violations "$file_path")
+
+  local violation_count
+  violation_count=$(echo "$violations" | jaq 'length' 2>/dev/null || echo "0")
+
+  if [[ "$violation_count" -gt 0 ]] && [[ "$violation_count" -ne "0" ]]; then
+    echo "[hook] Found $violation_count violation(s) in $file_path"
+
+    if is_subprocess_enabled; then
+      phase3_delegate_fixes "$file_path" "$violations"
+    fi
+
+    exit 2
+  fi
+
+  exit 0
+}
+
+main "$@"

--- a/assets/plankton_package_managers.sh
+++ b/assets/plankton_package_managers.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# enforce_package_managers.sh - PreToolUse hook to enforce modern package managers
+# Blocks legacy tools (pip, npm) in favor of modern alternatives (uv, bun)
+
+set -euo pipefail
+
+CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/hooks/config.json"
+
+load_config() {
+  if [[ -f "${CONFIG_FILE}" ]]; then
+    CONFIG_JSON=$(cat "${CONFIG_FILE}")
+  else
+    CONFIG_JSON='{}'
+  fi
+}
+
+get_allowed_subcommands() {
+  local tool="$1"
+  echo "${CONFIG_JSON}" | jaq -r ".package_managers.allowed_subcommands.${tool} // [] | .[]" 2>/dev/null
+}
+
+is_allowed_subcommand() {
+  local tool="$1"
+  local subcommand="$2"
+
+  while IFS= read -r allowed; do
+    if [[ "$subcommand" == "$allowed" ]]; then
+      return 0
+    fi
+  done < <(get_allowed_subcommands "$tool")
+
+  return 1
+}
+
+get_enforced_python() {
+  echo "${CONFIG_JSON}" | jaq -r '.package_managers.python // "uv"' 2>/dev/null
+}
+
+get_enforced_js() {
+  echo "${CONFIG_JSON}" | jaq -r '.package_managers.javascript // "bun"' 2>/dev/null
+}
+
+main() {
+  load_config
+
+  local tool_name="${1:-}"
+  local command_line="${2:-}"
+
+  if [[ -z "$command_line" ]]; then
+    exit 0
+  fi
+
+  case "$tool_name" in
+    Bash)
+      local cmd
+      cmd=$(echo "$command_line" | awk '{print $1}' | xargs basename 2>/dev/null || echo "")
+
+      case "$cmd" in
+        pip|pip3)
+          if ! is_allowed_subcommand "pip" "$(echo "$command_line" | awk '{print $2}' 2>/dev/null || echo "")"; then
+            echo "[hook] ERROR: pip is not allowed. Use '$(get_enforced_python)' instead." >&2
+            echo "[hook] Install: pip install uv && uv pip install <package>" >&2
+            exit 1
+          fi
+          ;;
+        npm)
+          if ! is_allowed_subcommand "npm" "$(echo "$command_line" | awk '{print $2}' 2>/dev/null || echo "")"; then
+            echo "[hook] ERROR: npm is not allowed. Use '$(get_enforced_js)' instead." >&2
+            echo "[hook] Install: bun install <package>" >&2
+            exit 1
+          fi
+          ;;
+        yarn|pnpm)
+          echo "[hook] WARNING: $cmd is not the enforced package manager." >&2
+          echo "[hook] Use '$(get_enforced_js)' instead." >&2
+          exit 1
+          ;;
+        poetry|pipenv)
+          echo "[hook] ERROR: $cmd is not allowed. Use '$(get_enforced_python)' instead." >&2
+          exit 1
+          ;;
+      esac
+      ;;
+  esac
+
+  exit 0
+}
+
+main "$@"

--- a/assets/plankton_protect_configs.sh
+++ b/assets/plankton_protect_configs.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# protect_linter_configs.sh - PreToolUse hook to block modifications to linter configs
+# Prevents agents from "fixing" violations by changing the rules instead of the code
+
+set -euo pipefail
+
+CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/hooks/config.json"
+
+load_protected_files() {
+  if [[ -f "${CONFIG_FILE}" ]]; then
+    jaq -r '.protected_files[]' "${CONFIG_FILE}" 2>/dev/null || echo ""
+  else
+    cat << 'EOF'
+.ruff.toml
+ty.toml
+biome.json
+.oxlintrc.json
+.semgrep.yml
+knip.json
+.flake8
+.yamllint
+.shellcheckrc
+.hadolint.yaml
+taplo.toml
+.markdownlint.jsonc
+.markdownlint-cli2.jsonc
+.jscpd.json
+.claude/hooks/*
+.claude/settings.json
+EOF
+  fi
+}
+
+is_protected() {
+  local file="$1"
+  local protected_files
+  protected_files=$(load_protected_files)
+
+  while IFS= read -r pattern; do
+    if [[ -z "$pattern" ]]; then
+      continue
+    fi
+    if [[ "$file" == $pattern ]] || [[ "$file" == *"$pattern" ]]; then
+      return 0
+    fi
+  done <<< "$protected_files"
+
+  return 1
+}
+
+main() {
+  local tool_name="${1:-}"
+  local file_path="${2:-}"
+
+  if [[ -z "$file_path" ]]; then
+    exit 0
+  fi
+
+  case "$tool_name" in
+    Write|Edit)
+      if is_protected "$file_path"; then
+        echo "[hook] ERROR: Cannot modify protected linter configuration file: $file_path" >&2
+        echo "[hook] Fix the code, not the rules. Violations should be resolved by changing the code." >&2
+        exit 1
+      fi
+      ;;
+  esac
+
+  exit 0
+}
+
+main "$@"

--- a/assets/plankton_settings.json
+++ b/assets/plankton_settings.json
@@ -1,0 +1,20 @@
+{
+  "hooks": {
+    "*": {
+      "post": {
+        "matcher": "(Edit|Write)",
+        "hook": "multi_linter.sh"
+      }
+    },
+    "PreToolUse": {
+      "matcher": "Write|Edit",
+      "hook": "protect_linter_configs.sh"
+    },
+    "Bash": {
+      "pre": {
+        "matcher": ".*",
+        "hook": "enforce_package_managers.sh"
+      }
+    }
+  }
+}

--- a/assets/plankton_stop_guardian.sh
+++ b/assets/plankton_stop_guardian.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# stop_config_guardian.sh - Claude Code Stop hook to detect config file tampering
+# Detects if any linter config files were modified during the session
+
+set -euo pipefail
+
+CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/hooks/config.json"
+
+load_protected_files() {
+  if [[ -f "${CONFIG_FILE}" ]]; then
+    jaq -r '.protected_files[]' "${CONFIG_FILE}" 2>/dev/null || echo ""
+  else
+    cat << 'EOF'
+.ruff.toml
+ty.toml
+biome.json
+.oxlintrc.json
+.semgrep.yml
+knip.json
+.flake8
+.yamllint
+.shellcheckrc
+.hadolint.yaml
+taplo.toml
+.markdownlint.jsonc
+.markdownlint-cli2.jsonc
+.jscpd.json
+.claude/hooks/*
+.claude/settings.json
+EOF
+  fi
+}
+
+check_config_tampering() {
+  local protected_files
+  protected_files=$(load_protected_files)
+
+  local tampered=()
+  while IFS= read -r pattern; do
+    if [[ -z "$pattern" ]]; then
+      continue
+    fi
+    # Check if any protected files were modified
+    if git -C "${CLAUDE_PROJECT_DIR}" diff --name-only 2>/dev/null | grep -q "$pattern"; then
+      tampered+=("$pattern")
+    fi
+  done <<< "$protected_files"
+
+  if [[ ${#tampered[@]} -gt 0 ]]; then
+    echo "[hook] WARNING: Detected modification to linter config files during session:" >&2
+    for f in "${tampered[@]}"; do
+      echo "  - $f" >&2
+    done
+    echo "[hook] Restoring original config files..." >&2
+    git -C "${CLAUDE_PROJECT_DIR}" checkout -- "${CLAUDE_PROJECT_DIR}" 2>/dev/null || true
+    echo "[hook] Config files restored. Violations should be fixed in code, not config." >&2
+  fi
+}
+
+main() {
+  # Only run if we're in a git repo and there are changes
+  if ! git -C "${CLAUDE_PROJECT_DIR}" rev-parse --git-dir >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  if git -C "${CLAUDE_PROJECT_DIR}" diff --quiet 2>/dev/null; then
+    exit 0
+  fi
+
+  check_config_tampering
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Integrates Plankton (slop guard for LLM coding agents) into Decapod for write-time code quality enforcement.

## Changes

- `decapod setup hook --plankton`: New command to install Claude Code hooks for multi-language linting
- **Multi-language tooling gates**: Validates Python (ruff), Shell (shellcheck), YAML (yamllint), Dockerfile (hadolint) in addition to existing Rust checks
- **Config protection**: Linter config files (`.ruff.toml`, `.yamllint`, etc.) now have CRITICAL risk level in policy.rs, blocking modifications
- **Package manager enforcement**: Blocks legacy tools (`pip`, `npm`) in favor of modern alternatives (`uv`, `bun`)
- **Session-end config guardian**: Detects and restores tampered linter configs at session end

## Why this matters

LLM coding agents drift from coding standards over time. Plankton enforces quality at write-time (not commit-time), preventing the copy-paste loop of fixing pre-commit errors. The config protection layer prevents agents from 'fixing' violations by loosening rules instead of fixing code.

## Testing

Run `decapod setup hook --plankton` in any project to install the hooks.