### PR TITLE
feat: add multi-language tooling gates and config protection to validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ debug/
 out.log
 err.log
 .decapod/generated/sessions/
+
+# --- Claude Code Hooks ---
+.claude/


### PR DESCRIPTION
## Summary

Expands Decapod's tooling validation gates to support multiple languages beyond Rust.

## Changes

- **Multi-language tooling gates**: Validates Python (ruff), Shell (shellcheck), YAML (yamllint), Dockerfile (hadolint) in addition to existing Rust checks
- **Config protection**: Linter config files (, , etc.) now have CRITICAL risk level in policy.rs, blocking modifications
- **.gitignore**: Added  to prevent accidental commits of Claude Code hooks

## Why this matters

Enforces code quality across the full stack at validation time. The config protection prevents agents from "fixing" violations by loosening rules instead of fixing code.

## Testing

Run  to verify tooling gates pass.