### PR TITLE
feat: add Dockerfile template that explodes to .decapod/generated/

### DIFF
--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -187,6 +187,7 @@ pub const TEMPLATE_CODEX: &str = include_str!("../../templates/CODEX.md");
 
 pub const TEMPLATE_README: &str = include_str!("../../templates/README.md");
 pub const TEMPLATE_OVERRIDE: &str = include_str!("../../templates/OVERRIDE.md");
+pub const TEMPLATE_DOCKERFILE: &str = include_str!("../../templates/Dockerfile");
 
 pub fn get_template(name: &str) -> Option<String> {
     match name {
@@ -197,6 +198,7 @@ pub fn get_template(name: &str) -> Option<String> {
 
         "README.md" => Some(TEMPLATE_README.to_string()),
         "OVERRIDE.md" => Some(TEMPLATE_OVERRIDE.to_string()),
+        "Dockerfile" => Some(TEMPLATE_DOCKERFILE.to_string()),
         _ => None,
     }
 }

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -193,6 +193,17 @@ pub fn scaffold_project_entrypoints(
         blend_legacy_entrypoints(&opts.target_dir)?;
     }
 
+    // Explode Dockerfile template to .decapod/generated/
+    let generated_dir = opts.target_dir.join(".decapod/generated");
+    fs::create_dir_all(&generated_dir).map_err(error::DecapodError::IoError)?;
+    if let Some(dockerfile_content) = assets::get_template("Dockerfile") {
+        let dockerfile_path = generated_dir.join("Dockerfile");
+        if !dockerfile_path.exists() {
+            fs::write(&dockerfile_path, dockerfile_content)
+                .map_err(error::DecapodError::IoError)?;
+        }
+    }
+
     Ok(ScaffoldSummary {
         entrypoints_created: ep_created,
         entrypoints_unchanged: ep_unchanged,

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,0 +1,31 @@
+# Default Dockerfile template for Decapod agent environments
+# This template is exploded to .decapod/generated/Dockerfile during project initialization
+# Edit this file to customize the base image and dependencies
+
+FROM ubuntu:22.04
+
+# Install common dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Default tool versions (can be overridden)
+ARG RUST_VERSION=1.85.0
+ARG NODE_VERSION=20
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Default working directory
+WORKDIR /workspace
+
+# Default user
+USER root


### PR DESCRIPTION
## Summary

Add Dockerfile template in  that gets exploded to  during project initialization.

## Why this matters

The Dockerfile template is used for code change testing in git worktree directories. Users can edit this file to customize the base image and dependencies for their agent environments.