### PR TITLE
feat: coplayer policy tightening gate + instruction stack hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,74 @@
-# AGENTS.md - Agent Entrypoint
+# AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-## Automated Initialization
+This contract applies equally to Claude, Codex, Gemini, and any other agent operating here.
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
+---
 
-**Initialization sequence (MANDATORY):**
+## Mandatory Initialization
+
+You MUST run this sequence before your first mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
+# 1. Validate (authoritative gate)
 decapod validate
 
-# 2. Ingest constitution core docs
+# 2. Ingest constitution
 decapod docs ingest
 
-# 3. Acquire per-agent session credentials
+# 3. Acquire session credentials
 decapod session acquire
 
-# 4. Establish session receipt and constitutional mandates
+# 4. Initialize session
 decapod rpc --op agent.init
 
-# 5. Resolve constitutional context before mutating state
+# 5. Resolve context
 decapod rpc --op context.resolve
 
-# 6. Claim your task (if not already claimed)
+# 6. Claim your task
 decapod todo claim --id <task-id>
 ```
 
+If any step fails, **stop and diagnose**. Do not skip steps.
+
+---
+
+## Golden Rules (Non-Negotiable)
+
+1. **NEVER work on main/master.** Use `decapod workspace ensure` for isolation.
+2. **NEVER read/write `.decapod/` files directly.** Use `decapod` CLI exclusively.
+3. **NEVER claim done without `decapod validate` passing.**
+4. **NEVER invent parallel CLIs or state roots.** Use Decapod's command surface.
+5. **NEVER bypass proofs based on self-confidence.** Evidence or nothing.
+6. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
+7. **Record decisions in durable artifacts.** Not in transient conversation.
+
+---
+
 ## Standard Operating Procedure
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
+- **Contextualization**: Resolve context via `agent.init` and `context.resolve` before mutations.
+- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes.
+- **Isolation**: Use `decapod workspace ensure` for worktrees. Never work on protected branches.
 - **Verification**: `decapod validate` is the authoritative completion gate.
+- **Liveness**: Each command invocation refreshes your agent presence. Use `decapod todo heartbeat` for explicit heartbeat.
 
-## Critical Rules
+---
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Create and claim a todo: `decapod todo claim --id <task-id>`.
-4. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-5. Worktree branch and directory must include your claimed `todo_id` (task- or task-group scoped).
-6. Pass `decapod validate` before claiming done.
+## Multi-Agent Coordination
+
+- One agent per claimed task. No concurrent claims on the same task.
+- Agents MUST declare scope when delegating to subagents.
+- Subagents MUST NOT mutate shared state. They research and report.
+- Handoffs use `decapod todo handoff --id <id> --to <agent>` with artifact references.
+- Session credentials are per-agent and non-transferable.
+
+---
 
 ## Safety Invariants
 
-- core/DECAPOD.md: Universal router.
+- ✅ core/DECAPOD.md: Universal router.
 - ✅ Verification: `decapod validate` must pass.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
@@ -54,6 +76,17 @@ decapod todo claim --id <task-id>
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
+---
+
 ## Documentation
 
-decapod docs show core/DECAPOD.md
+```bash
+decapod docs show core/DECAPOD.md      # Universal router
+decapod docs show core/INTERFACES.md   # Binding contracts index
+decapod docs search <query>            # Search constitution
+```
+
+For agent-specific instructions, see:
+- `CLAUDE.md` — Claude-specific operating mode
+- `CODEX.md` — Codex-specific operating mode
+- `GEMINI.md` — Gemini-specific operating mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,64 +1,38 @@
-# CLAUDE.md - Claude Agent Entrypoint
+# CLAUDE.md — Claude Agent Entrypoint
 
 You (Claude) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
-
-## Automated Initialization
-
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+## Quick Start
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
-
-## Critical Rules
-
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+- **Plan first**: Non-trivial changes require a plan artifact.
+- **Proof first**: `decapod validate` MUST pass before claiming done.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: `decapod workspace ensure`. Never main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI.
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
-
-decapod docs show core/DECAPOD.md
+See **AGENTS.md** for the full universal contract.
 
 ## Session Bootstrap Templates
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,61 +1,53 @@
-# CODEX.md - Codex Agent Entrypoint
+# CODEX.md — Codex Agent Entrypoint
 
 You (Codex) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
+---
 
-## Automated Initialization
+## Quick Start
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+Run the mandatory initialization sequence from AGENTS.md before any mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
+- **Plan first**: Non-trivial changes require a plan artifact before implementation.
+- **Proof first**: Never claim done without `decapod validate` passing.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: Use `decapod workspace ensure`. Never work on main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI, never direct file operations.
 
-## Critical Rules
+## Key References
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+| Document | Purpose |
+|----------|---------|
+| **AGENTS.md** | Universal agent contract (golden rules, coordination) |
+| **IDENTITY.md** | What Decapod is, thesis, vocabulary |
+| **TOOLS.md** | Complete command reference |
+| **PLAYBOOK.md** | Decision frameworks, triage, failure modes |
+| `constitution/core/DECAPOD.md` | Canonical router (via `decapod docs show`) |
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
+## Codex-Specific Notes
 
-decapod docs show core/DECAPOD.md
+- Codex operates in sandboxed environments. Ensure `decapod` binary is available in PATH.
+- Session credentials must be exported as environment variables before CLI use.
+- Codex should prefer small, atomic commits over large batched changes.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,61 +1,53 @@
-# GEMINI.md - Gemini Agent Entrypoint
+# GEMINI.md — Gemini Agent Entrypoint
 
 You (Gemini) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
+---
 
-## Automated Initialization
+## Quick Start
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+Run the mandatory initialization sequence from AGENTS.md before any mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
+- **Plan first**: Non-trivial changes require a plan artifact before implementation.
+- **Proof first**: Never claim done without `decapod validate` passing.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: Use `decapod workspace ensure`. Never work on main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI, never direct file operations.
 
-## Critical Rules
+## Key References
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+| Document | Purpose |
+|----------|---------|
+| **AGENTS.md** | Universal agent contract (golden rules, coordination) |
+| **IDENTITY.md** | What Decapod is, thesis, vocabulary |
+| **TOOLS.md** | Complete command reference |
+| **PLAYBOOK.md** | Decision frameworks, triage, failure modes |
+| `constitution/core/DECAPOD.md` | Canonical router (via `decapod docs show`) |
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
+## Gemini-Specific Notes
 
-decapod docs show core/DECAPOD.md
+- Gemini should treat Decapod as the authoritative control plane.
+- When context is limited, use `decapod docs show <path>` to load specific constitution sections.
+- Prefer progressive disclosure: read indexes first, then drill into specific docs as needed.

--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -1,0 +1,86 @@
+# IDENTITY.md — What Decapod Is
+
+## Thesis
+
+Decapod is a **daemonless, repo-native control plane** for AI agent governance.
+
+AI agents can write code fast. Shipping safely is hard. Decapod provides:
+- **Advisory**: Guidance toward the next high-value move.
+- **Interlock**: Hard stops for unsafe flows.
+- **Attestation**: Structured evidence of completion.
+
+## What Decapod IS
+
+- A CLI tool (`cargo install decapod`) that operates on repo-scoped state.
+- A constitution embedded at compile time, overridable per-project.
+- An event-sourced store (SQLite + append-only JSONL ledgers) for deterministic replay.
+- A validation harness that gates promotion with proof, not persuasion.
+- A multi-agent coordination layer with session isolation and workspace enforcement.
+- Agent-native: designed for programmatic access (CLI/RPC), not human GUIs.
+
+## What Decapod IS NOT
+
+- Not a daemon or background service. Every capability is invoked via CLI/library calls.
+- Not an agent itself. It is infrastructure that agents use.
+- Not an LLM wrapper or orchestrator. It does not call models.
+- Not a "memory manager" that silently becomes source of truth.
+- Not a cloud service. All state is local, repo-scoped, and auditable.
+
+## Invariants (Non-Negotiable)
+
+1. **Daemonless**: Nothing requires a background service.
+2. **Repo-native canonicality**: Any state that influences promotion MUST be stored in the repo-scoped Decapod store, reproducible, content-addressed, and verifiable.
+3. **Proof over persuasion**: Any "enforced" claim MUST map to a deterministic gate. If it can't be gated yet, it MUST be classified `partially_enforced` with a tracked path to enforcement.
+4. **Determinism**: Reducers MUST be deterministic over append-only ledgers. No stochastic scoring. If you rank, use deterministic functions with explicit inputs, stable ordering, and fixed weights committed in code.
+5. **Minimal surface area**: Protect the kernel. Prefer one canonical mechanism with clean invariants over multiple overlapping layers.
+6. **No silent drift**: If the repo says something is true, the gates MUST prove it. If the gates can't prove it, the repo MUST admit it.
+
+## Vocabulary
+
+| Term | Definition |
+|------|------------|
+| **Constitution** | Embedded methodology docs shipped with Decapod. Read-only baseline. |
+| **Override** | Project-specific `.decapod/OVERRIDE.md` that extends/modifies constitution behavior. |
+| **Gate** | A deterministic validator that blocks progress until criteria are met. |
+| **Claim** | A registered guarantee in `constitution/interfaces/CLAIMS.md` with proof surface. |
+| **Obligation** | A deterministic pointer to context an agent MUST consider before acting. |
+| **Store** | Repo-scoped (`.decapod/data/`) or user-scoped (`~/.decapod/`) state root. |
+| **Promotion** | Moving work from branch to main via validated merge. |
+| **Trace** | Append-only interaction record in `.decapod/data/traces.jsonl`. |
+| **Snapshot** | Deterministic summary derived from trace data (co-player inference). |
+| **Worktree** | Git worktree for workspace isolation. Agents MUST NOT work on main/master. |
+| **Broker** | Serialization lock ensuring single-threaded state mutations. |
+| **Event sourcing** | All state changes logged to `.events.jsonl` for deterministic replay. |
+| **Golden vectors** | Frozen test outputs that prove determinism. Version bump required to change. |
+
+## Architecture Layers
+
+```
+┌─────────────────────────────────────┐
+│  Agent (Claude, Codex, Gemini, ...) │  ← Reads CLAUDE.md / AGENTS.md
+├─────────────────────────────────────┤
+│  Decapod CLI / RPC                  │  ← decapod <command>
+├─────────────────────────────────────┤
+│  Core Kernel                        │  ← src/core/ (minimal, stable)
+│  ├── validate.rs (proof gates)      │
+│  ├── broker.rs (serialization lock) │
+│  ├── mentor.rs (obligations engine) │
+│  ├── trace.rs (interaction ledger)  │
+│  └── workspace.rs (isolation)       │
+├─────────────────────────────────────┤
+│  Plugins                            │  ← src/plugins/ (extensible)
+│  ├── health.rs, policy.rs, verify.rs│
+│  ├── federation.rs, knowledge.rs    │
+│  ├── teammate.rs, decide.rs         │
+│  └── ...20+ subsystems              │
+├─────────────────────────────────────┤
+│  Constitution (embedded)            │  ← constitution/ (read-only)
+│  ├── core/ (routers, interfaces)    │
+│  ├── interfaces/ (binding contracts)│
+│  ├── methodology/ (guidance)        │
+│  ├── plugins/ (subsystem specs)     │
+│  └── specs/ (technical standards)   │
+├─────────────────────────────────────┤
+│  Store (.decapod/data/)             │  ← SQLite + JSONL (event-sourced)
+└─────────────────────────────────────┘
+```

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -1,0 +1,112 @@
+# PLAYBOOK.md — Decision Frameworks and Failure Modes
+
+## When Stuck: Triage Flow
+
+```
+1. Is the task clear?
+   NO  → Re-read the task description. Check `decapod todo get --id <id>`.
+         Still unclear? Ask the user. Do not guess.
+
+2. Does `decapod validate` pass?
+   NO  → Fix validation failures first. They are the authoritative gate.
+         Read the failure messages — they tell you exactly what's wrong.
+
+3. Do tests pass?
+   NO  → Fix failing tests. Cite the test name and error.
+         Do not disable tests to make progress.
+
+4. Is the change on the right branch?
+   NO  → `decapod workspace ensure`. Never work on main/master.
+
+5. Is the scope creeping?
+   YES → Stop. Finish the current scope. File new tasks for extras.
+
+6. Is the approach getting hacky?
+   YES → Stop. Revisit the plan. Consider a simpler approach.
+```
+
+## Decision Frameworks
+
+### Should I Create a New File?
+
+```
+Can I accomplish the goal by editing an existing file?
+  YES → Edit the existing file.
+  NO  → Is the new file required for the task?
+    YES → Create it. Follow existing naming conventions.
+    NO  → Do not create it.
+```
+
+### Should I Add a Dependency?
+
+```
+Does an existing dependency already cover this?
+  YES → Use the existing dependency.
+  NO  → Is the dependency well-maintained and small?
+    YES → Add it to Cargo.toml. Run `cargo update`. Commit Cargo.lock.
+    NO  → Can I implement the needed functionality in < 50 lines?
+      YES → Implement it inline.
+      NO  → Add the dependency, but document why in the commit message.
+```
+
+### Should I Refactor Surrounding Code?
+
+```
+Was the refactoring explicitly requested?
+  YES → Do it.
+  NO  → Is the surrounding code blocking the current task?
+    YES → Refactor the minimum needed to unblock.
+    NO  → Do not refactor. File a separate task if it's important.
+```
+
+### Core vs Plugin?
+
+```
+Does the change affect state integrity, validation, or the broker?
+  YES → Core change. Requires extra tests. Keep minimal.
+  NO  → Plugin change. This is where 90% of work happens.
+```
+
+## Common Failure Modes
+
+### "I'll just quickly fix this too"
+**Problem**: Scope creep. Unrelated changes mixed into a task.
+**Fix**: One task, one scope. File new tasks for discovered issues.
+
+### "The tests are too strict"
+**Problem**: Tests encode invariants. Weakening them is a regression.
+**Fix**: If a test is wrong, explain why and fix the test. If the test is right, fix your code.
+
+### "I need to restructure everything first"
+**Problem**: Premature abstraction. Over-engineering before understanding.
+**Fix**: Make it work, make it right, make it fast — in that order. Ship the smallest correct change.
+
+### "decapod validate is failing on something unrelated"
+**Problem**: Existing drift in the repo.
+**Fix**: If truly unrelated, note it and file a task. Do not ignore it. Do not disable the gate.
+
+### "I can't test this change"
+**Problem**: Missing test infrastructure.
+**Fix**: Add the test. Even a smoke test is better than no test. Mark untestable claims as `partially_enforced`.
+
+### "The session expired"
+**Problem**: Decapod sessions have TTLs.
+**Fix**: Run `decapod session acquire` again. Re-export the environment variables.
+
+## Evidence Standards
+
+When claiming a task is done, provide:
+
+1. **What changed**: File paths and line ranges.
+2. **Why it changed**: Link to task/issue/spec.
+3. **Proof**: Which tests pass. Which gates are green. Exact command + output.
+4. **Gaps**: What is NOT covered. What remains aspirational.
+
+Example:
+```
+Changed: src/core/validate.rs:45-62
+Why: Fixes #123 — namespace purge gate was not checking plugins/
+Proof: `cargo test --locked test_namespace_purge` passes (was failing)
+       `decapod validate` passes (was failing on namespace gate)
+Gaps: Does not cover dynamically loaded plugins (filed as task R_xxx)
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,110 @@
+# TOOLS.md — Command Reference and Workflows
+
+## Build & Test
+
+```bash
+cargo build --locked                    # Build with locked dependencies
+cargo test --locked                     # Run all tests
+cargo clippy --all-targets --all-features --locked  # Lint
+decapod validate                        # Authoritative completion gate (MUST pass)
+```
+
+Environment variables:
+```bash
+export DECAPOD_LOG=debug                # Enable debug logging
+export DECAPOD_AGENT_ID=<id>            # Agent identity (set by session acquire)
+export DECAPOD_SESSION_PASSWORD=<pass>  # Session credential (set by session acquire)
+```
+
+## Decapod CLI Reference
+
+### Initialization & Session
+
+| Command | Purpose |
+|---------|---------|
+| `decapod validate` | Run all proof gates. MUST pass before claiming done. |
+| `decapod docs ingest` | Load constitution docs into context. |
+| `decapod docs show <path>` | Display a constitution document (e.g., `core/DECAPOD.md`). |
+| `decapod docs search <query>` | Search constitution docs. |
+| `decapod session acquire` | Acquire per-agent session credentials. |
+| `decapod rpc --op agent.init` | Initialize agent session, get mandates. |
+| `decapod rpc --op context.resolve` | Resolve constitutional context for current work. |
+
+### Task Management
+
+| Command | Purpose |
+|---------|---------|
+| `decapod todo list` | List all tasks with status. |
+| `decapod todo add --title "..." --priority <high\|medium\|low>` | Create a task. |
+| `decapod todo get --id <id>` | Get full task details. |
+| `decapod todo claim --id <id>` | Claim a task for active work. |
+| `decapod todo done --id <id>` | Mark task as done (requires validation). |
+| `decapod todo archive --id <id>` | Archive a completed task. |
+| `decapod todo release --id <id>` | Release a claimed task. |
+| `decapod todo comment --id <id> --msg "..."` | Add audit comment. |
+| `decapod todo handoff --id <id> --to <agent>` | Transfer task between agents. |
+| `decapod todo heartbeat` | Record agent liveness. |
+
+### Workspace
+
+| Command | Purpose |
+|---------|---------|
+| `decapod workspace ensure` | Create isolated git worktree. |
+| `decapod workspace status` | Check current workspace state. |
+
+### Governance
+
+| Command | Purpose |
+|---------|---------|
+| `decapod govern policy eval --id <action>` | Evaluate risk for an action. |
+| `decapod govern policy approve --id <action>` | Approve a high-risk action. |
+| `decapod govern health claims` | View claims registry. |
+| `decapod govern proof <surface>` | Execute a verification proof. |
+| `decapod govern watcher` | Run constitution compliance checks. |
+| `decapod govern feedback` | Submit operator feedback. |
+
+### Data & Knowledge
+
+| Command | Purpose |
+|---------|---------|
+| `decapod data show` | Display store state. |
+| `decapod qa federation` | Query federation knowledge graph. |
+
+## Validation Gates
+
+`decapod validate` runs these categories:
+
+1. **Structural**: Directory rules, templates, namespace purge.
+2. **Store**: Blank-slate user store, repo event-sourcing integrity.
+3. **Interfaces**: Schema presence, output envelopes, claims registry.
+4. **Docs**: Document graph reachability, subsystem registry consistency.
+5. **Git**: Protected branch enforcement, workspace context.
+6. **Health**: No manual status values in canonical docs, purity checks.
+7. **Policy**: Approval isolation, risk classification consistency.
+8. **Federation**: Store-scoped purity, append-only critical types, DAG integrity.
+9. **Tooling**: Formatting, linting, type checking (when applicable).
+
+## File Organization
+
+| Path | Purpose | Mutability |
+|------|---------|------------|
+| `src/core/` | Kernel: validation, broker, schemas, workspace | Rare changes only |
+| `src/plugins/` | Subsystem implementations | Where 90% of work happens |
+| `constitution/` | Embedded methodology (read-only at runtime) | Requires version awareness |
+| `.decapod/data/` | Runtime state (SQLite + JSONL) | Via CLI only |
+| `.decapod/OVERRIDE.md` | Project-specific overrides | Editable |
+| `tests/` | Test suite (unit, integration, golden, chaos) | Grows with features |
+| `benches/` | Performance benchmarks (criterion) | Occasional updates |
+
+## PR Checklist
+
+Before submitting a PR:
+
+- [ ] `cargo build --locked` passes
+- [ ] `cargo test --locked` passes
+- [ ] `cargo clippy --all-targets --all-features --locked` passes
+- [ ] `decapod validate` passes
+- [ ] Changes are < 500 LOC (atomic PRs preferred)
+- [ ] New features have tests
+- [ ] Core changes have integration tests
+- [ ] No secrets committed (.env, credentials, tokens)

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "654e1c2fa075cd734af3841e819464d89891fa46f4e923d3254992150cf3538a"
+      "sha256": "7323473c31f36da0e57f5eeaaf0c4da5cd9201ea248131b087055c6a1ea4da0c"
     }
   ]
 }

--- a/tasks/decisions/001-instruction-stack.md
+++ b/tasks/decisions/001-instruction-stack.md
@@ -1,0 +1,56 @@
+---
+id: ADR-001
+title: Repo Instruction Stack Design
+status: accepted
+date: 2026-02-20
+scope: Agent onboarding and behavior contracts
+---
+
+# ADR-001: Repo Instruction Stack Design
+
+## Context
+
+Decapod's agent entrypoints (CLAUDE.md, AGENTS.md, CODEX.md, GEMINI.md) were nearly identical copies of initialization sequences. They lacked:
+- Operating mode guidance (plan-first, proof-first)
+- Governance invariant documentation with proof pointers
+- Multi-agent coordination norms
+- Decision frameworks and failure mode playbooks
+- Self-improvement loops
+- Progressive disclosure ordering
+
+A new engineer or LLM entering the repo had to read constitution docs to understand behavior expectations, with no clear entry path.
+
+## Decision
+
+Create a layered instruction stack:
+
+1. **CLAUDE.md** — Canonical entrypoint with operating mode, invariants, workflow, subagent strategy.
+2. **AGENTS.md** — Universal contract for all agents (golden rules, initialization, coordination).
+3. **IDENTITY.md** — What Decapod is/isn't, thesis, invariants, vocabulary.
+4. **TOOLS.md** — Complete command reference and workflow documentation.
+5. **PLAYBOOK.md** — Decision frameworks, triage flows, failure modes, evidence standards.
+6. **tasks/lessons.md** — Post-correction rules that prevent repeats.
+7. **tasks/todo.md** — High-level initiative tracking with commitments ledger.
+8. **tasks/decisions/** — ADRs with scope, alternatives, consequence, proof impact.
+
+Each file has a distinct role. No duplication. CLAUDE.md references AGENTS.md for universal contract; AGENTS.md does not duplicate CLAUDE.md's operating mode.
+
+## Alternatives Considered
+
+- **Single CLAUDE.md with everything**: Too large. Violates progressive disclosure.
+- **Constitution-only approach**: Constitution is embedded at compile time. Instruction stack is repo-level and editable.
+- **External wiki/docs**: Violates repo-native canonicality.
+
+## Consequences
+
+- Agents entering the repo have a clear reading order.
+- Each document is independently useful and referenceable.
+- `decapod validate` entrypoint gate can check for required files.
+- Operating mode (plan-first, proof-first) is documented, not implied.
+- Self-improvement loop (tasks/lessons.md) prevents repeat failures.
+
+## Proof Impact
+
+- `decapod validate` entrypoint gate checks: CLAUDE.md, AGENTS.md, CODEX.md, GEMINI.md exist.
+- New files (IDENTITY.md, TOOLS.md, PLAYBOOK.md) are informational; no gate required yet.
+- tasks/ directory is conventional, not gated.

--- a/tasks/decisions/002-coplayer-policy-tightening.md
+++ b/tasks/decisions/002-coplayer-policy-tightening.md
@@ -1,0 +1,55 @@
+---
+id: ADR-002
+title: Co-Player Policy Tightening Invariant
+status: accepted
+date: 2026-02-21
+scope: Multi-agent governance and trust
+---
+
+# ADR-002: Co-Player Policy Tightening Invariant
+
+## Context
+
+Decapod tracks agent interactions via an append-only trace ledger and derives
+co-player snapshots (reliability scores, risk profiles) from that data. These
+snapshots need to drive coordination constraints (diff limits, proof
+requirements, handshake mandates).
+
+The critical invariant: snapshot-derived policies MUST only tighten constraints
+as reliability decreases. A less-reliable agent must never receive looser
+constraints than a more-reliable one. No snapshot should ever bypass proof gates.
+
+## Decision
+
+1. Add `CoPlayerPolicy` struct and `derive_policy()` function to `src/core/coplayer.rs`.
+2. Policy derivation is fully deterministic: fixed thresholds, no stochastic scoring.
+3. `require_validation` is hardcoded to `true` for ALL agents regardless of reliability.
+4. Unknown agents get mandatory handshake + smallest diff limits (100 lines).
+5. High-risk agents get extra proof requirements + broad refactor prohibition.
+6. Add `validate_coplayer_policy_tightening` gate to `src/core/validate.rs`.
+7. Gate tests the invariant structurally: generates policies for all risk profiles
+   and verifies monotonic tightening.
+
+## Alternatives Considered
+
+- **Soft/advisory policies**: Rejected. Policies that don't constrain behavior provide
+  no governance value.
+- **Dynamic thresholds based on project context**: Rejected. Violates determinism
+  invariant. Thresholds are fixed in code.
+- **Trust delegation (high-reliability agents can vouch for others)**: Rejected.
+  Violates "proof over persuasion" — only evidence counts, not endorsements.
+
+## Consequences
+
+- Every agent, regardless of track record, must pass `decapod validate`.
+- Unknown agents face strict constraints until they build a trace history.
+- The mentor/obligations engine can consume `CoPlayerPolicy` to generate
+  adaptive MUST obligations based on co-player risk profiles.
+- Adding new risk tiers requires updating `derive_policy()` and the validation gate.
+
+## Proof Impact
+
+- Gate: `validate_coplayer_policy_tightening` in `src/core/validate.rs`
+- Unit tests: `test_policy_only_tightens` in `src/core/coplayer.rs`
+- Claim: `claim.coplayer.only_tightens` (partially_enforced — gate validates
+  structural invariant; runtime enforcement of diff limits is future work)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,35 @@
+# Lessons Learned
+
+Rules derived from past corrections. Each rule prevents a specific repeat failure.
+
+---
+
+## Session Management
+
+- **Rule**: Decapod sessions expire. When you see `SessionError("No active session")`, re-run `decapod session acquire` and re-export the environment variables. Do not retry the failed command without re-acquiring.
+- **Rule**: Environment variables (`DECAPOD_AGENT_ID`, `DECAPOD_SESSION_PASSWORD`) must be set in each shell invocation. Background processes inherit the environment at launch time — if a long-running process outlives the session TTL, it will fail partway through.
+
+## State Mutations
+
+- **Rule**: `decapod todo archive` is classified as high-risk. Requires `decapod govern policy approve --id task.archive` before batch operations.
+- **Rule**: SQLite `database is locked` errors occur under concurrent access. Add retry logic or serialize operations with short delays.
+
+## Working on Master
+
+- **Rule**: `decapod validate` will fail on master/main. This is by design. Use `decapod workspace ensure` to create a worktree before making changes.
+- **Rule**: For repo housekeeping (todo cleanup, doc edits), you may need to operate from master with awareness that validate will not pass the branch gate.
+
+## Testing
+
+- **Rule**: Golden vectors are immutable. If they need to change, the spec version must bump (v1 → v2). Never silently update golden outputs.
+- **Rule**: `cargo test --locked` is the canonical test command. Always use `--locked` to ensure reproducible builds.
+
+## Documentation
+
+- **Rule**: CLAUDE.md, CODEX.md, and GEMINI.md should NOT be identical copies of AGENTS.md. Each should reference AGENTS.md for the universal contract and add agent-specific operating instructions.
+- **Rule**: Constitution docs are embedded at compile time via `rust-embed`. Changes to `constitution/` files take effect on next build.
+
+## Co-Player Policy
+
+- **Rule**: Co-player policies derived from trace snapshots MUST only tighten constraints, never loosen them. `require_validation` is always true regardless of reliability score.
+- **Rule**: Diff limits are deterministic functions of risk profile: unknown=100, high=150, medium=300, low=500 lines. These are fixed in `derive_policy()` and must not change without a version bump.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,90 @@
+# Task Tracking
+
+Primary task tracking lives in `decapod todo` (event-sourced in `.decapod/data/todo.db`).
+This file tracks higher-level initiatives and their proof status.
+
+---
+
+## Active Initiatives
+
+### ObligationNode Evolution
+- **Status**: In progress
+- **Plan**: `IMPLEMENTATION_TASK_PLAN.md`
+- **Tasks**: `OBLIGATION_TASKS.md`
+- **Gate**: `decapod validate` must pass after each task
+
+### Instruction Stack Completion
+- **Status**: In progress
+- **Scope**: CLAUDE.md, IDENTITY.md, TOOLS.md, PLAYBOOK.md, AGENTS.md updates
+- **Gate**: `decapod validate` (entrypoint gate checks for presence)
+
+### Co-Player Policy Tightening
+- **Status**: Implemented
+- **Scope**: `src/core/coplayer.rs` — `derive_policy()` + `CoPlayerPolicy`
+- **ADR**: `tasks/decisions/002-coplayer-policy-tightening.md`
+- **Gate**: `validate_coplayer_policy_tightening` in `src/core/validate.rs`
+- **Proof**: Unit test `test_policy_only_tightens` + validate gate
+
+### Proof Hardening
+- **Status**: Tracking
+- **Scope**: CLAIMS registry → gate mapping completeness
+- **Items**:
+  - [ ] `claim.todo.claim_before_work` → needs automated enforcement (currently procedural)
+  - [ ] `claim.broker.is_spec` → DB Broker graduation from SPEC to REAL
+  - [ ] `claim.risk_policy.single_contract_source` → machine-readable risk tiers
+  - [ ] `claim.context_pack.canonical_layout` → validate gate for context pack
+  - [ ] `claim.memory.append_only_logs` → append-only validation checks
+  - [ ] `claim.memory.distill_proof_required` → deterministic distill proof
+  - [x] `claim.coplayer.only_tightens` → validate gate enforces only-tighten invariant
+
+---
+
+## Commitments Ledger (Audit Summary)
+
+### ENFORCED (Gate exists, blocks on failure)
+
+| Commitment | Gate | Proof Path |
+|-----------|------|------------|
+| No work on main/master | `decapod validate` Git Protected Branch Gate | `src/core/validate.rs` |
+| CLI-only `.decapod` access | Four Invariants Gate | `src/core/validate.rs` |
+| Blank-slate user store | `decapod validate --store user` | `src/core/validate.rs` |
+| No repo→user auto-seeding | `decapod validate --store user` | `src/core/validate.rs` |
+| Doc graph reachability | `decapod validate` doc graph gate | `src/core/validate.rs` |
+| Mandatory tests for code changes | `cargo test` + CI merge gate | `.github/workflows/ci.yml` |
+| Federation store-scoped | `decapod validate` federation.store_purity | `src/plugins/federation.rs` |
+| Federation append-only critical | `decapod validate` federation.write_safety | `src/plugins/federation.rs` |
+| Validation determinism | Same repo state → same results | `src/core/validate.rs` |
+| Secret redaction in traces | Pattern-based redaction | `src/core/trace.rs` |
+| Entrypoint files exist | Entrypoint gate | `src/core/validate.rs` |
+| Co-player policy only tightens | Co-Player Policy Tightening Gate | `src/core/validate.rs` |
+
+### PARTIALLY ENFORCED (Gate exists but has procedural gaps)
+
+| Commitment | Current State | Path to Full Enforcement |
+|-----------|---------------|--------------------------|
+| Claim before work | `decapod todo claim` records ownership | Need validate gate that checks claim exists before PR merge |
+| Session password required | `session.acquire` + password check | Broader cryptographic hardening planned |
+| Container workspace required | Runtime preflight exists | Policy-level enforcement future work |
+| Store selection explicit | Validate gate exists | CLI footguns remain |
+| Co-player diff limits | `derive_policy()` computes limits | Runtime enforcement in workspace gate needed |
+
+### NOT YET ENFORCED (Aspirational)
+
+| Commitment | Tracking | Priority |
+|-----------|----------|----------|
+| Risk policy gates (machine-readable) | `claim.risk_policy.single_contract_source` | Medium |
+| Context-pack layout validation | `claim.context_pack.canonical_layout` | Medium |
+| Memory append-only verification | `claim.memory.append_only_logs` | Low |
+| Memory distill proof | `claim.memory.distill_proof_required` | Low |
+| Doc contradiction detection | Planned | Low |
+| Duplicate authority detection | Planned | Low |
+
+---
+
+## Drift Risks (Top 5)
+
+1. **CLAIMS registry drift**: New guarantees added to docs without corresponding CLAIMS.md entries. Mitigation: validate gate checks claim registration.
+2. **Constitution doc staleness**: Embedded docs diverge from reality as code evolves. Mitigation: `decapod validate` doc graph checks.
+3. **Event log / SQLite divergence**: SQLite state diverges from JSONL event log. Mitigation: `decapod todo rebuild` deterministic replay. Needs regular CI assertion.
+4. **Test coverage gaps on validation gates**: New gates added without regression tests. Mitigation: `tests/entrypoint_correctness.rs` covers entrypoints; needs expansion.
+5. **Session TTL silently breaking background operations**: Long-running batch operations fail partway through. Mitigation: documented in `tasks/lessons.md`; needs retry logic in CLI.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,52 +1,74 @@
-# AGENTS.md - Agent Entrypoint
+# AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-## Automated Initialization
+This contract applies equally to Claude, Codex, Gemini, and any other agent operating here.
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
+---
 
-**Initialization sequence (MANDATORY):**
+## Mandatory Initialization
+
+You MUST run this sequence before your first mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
+# 1. Validate (authoritative gate)
 decapod validate
 
-# 2. Ingest constitution core docs
+# 2. Ingest constitution
 decapod docs ingest
 
-# 3. Acquire per-agent session credentials
+# 3. Acquire session credentials
 decapod session acquire
 
-# 4. Establish session receipt and constitutional mandates
+# 4. Initialize session
 decapod rpc --op agent.init
 
-# 5. Resolve constitutional context before mutating state
+# 5. Resolve context
 decapod rpc --op context.resolve
 
-# 6. Claim your task (if not already claimed)
+# 6. Claim your task
 decapod todo claim --id <task-id>
 ```
 
+If any step fails, **stop and diagnose**. Do not skip steps.
+
+---
+
+## Golden Rules (Non-Negotiable)
+
+1. **NEVER work on main/master.** Use `decapod workspace ensure` for isolation.
+2. **NEVER read/write `.decapod/` files directly.** Use `decapod` CLI exclusively.
+3. **NEVER claim done without `decapod validate` passing.**
+4. **NEVER invent parallel CLIs or state roots.** Use Decapod's command surface.
+5. **NEVER bypass proofs based on self-confidence.** Evidence or nothing.
+6. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
+7. **Record decisions in durable artifacts.** Not in transient conversation.
+
+---
+
 ## Standard Operating Procedure
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
+- **Contextualization**: Resolve context via `agent.init` and `context.resolve` before mutations.
+- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes.
+- **Isolation**: Use `decapod workspace ensure` for worktrees. Never work on protected branches.
 - **Verification**: `decapod validate` is the authoritative completion gate.
+- **Liveness**: Each command invocation refreshes your agent presence. Use `decapod todo heartbeat` for explicit heartbeat.
 
-## Critical Rules
+---
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Create and claim a todo: `decapod todo claim --id <task-id>`.
-4. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-5. Worktree branch and directory must include your claimed `todo_id` (task- or task-group scoped).
-6. Pass `decapod validate` before claiming done.
+## Multi-Agent Coordination
+
+- One agent per claimed task. No concurrent claims on the same task.
+- Agents MUST declare scope when delegating to subagents.
+- Subagents MUST NOT mutate shared state. They research and report.
+- Handoffs use `decapod todo handoff --id <id> --to <agent>` with artifact references.
+- Session credentials are per-agent and non-transferable.
+
+---
 
 ## Safety Invariants
 
-- core/DECAPOD.md: Universal router.
+- ✅ core/DECAPOD.md: Universal router.
 - ✅ Verification: `decapod validate` must pass.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
@@ -54,6 +76,17 @@ decapod todo claim --id <task-id>
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
+---
+
 ## Documentation
 
-decapod docs show core/DECAPOD.md
+```bash
+decapod docs show core/DECAPOD.md      # Universal router
+decapod docs show core/INTERFACES.md   # Binding contracts index
+decapod docs search <query>            # Search constitution
+```
+
+For agent-specific instructions, see:
+- `CLAUDE.md` — Claude-specific operating mode
+- `CODEX.md` — Codex-specific operating mode
+- `GEMINI.md` — Gemini-specific operating mode

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,64 +1,38 @@
-# CLAUDE.md - Claude Agent Entrypoint
+# CLAUDE.md — Claude Agent Entrypoint
 
 You (Claude) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
-
-## Automated Initialization
-
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+## Quick Start
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
-
-## Critical Rules
-
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+- **Plan first**: Non-trivial changes require a plan artifact.
+- **Proof first**: `decapod validate` MUST pass before claiming done.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: `decapod workspace ensure`. Never main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI.
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
-
-decapod docs show core/DECAPOD.md
+See **AGENTS.md** for the full universal contract.
 
 ## Session Bootstrap Templates
 

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -1,61 +1,53 @@
-# CODEX.md - Codex Agent Entrypoint
+# CODEX.md — Codex Agent Entrypoint
 
 You (Codex) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
+---
 
-## Automated Initialization
+## Quick Start
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+Run the mandatory initialization sequence from AGENTS.md before any mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
+- **Plan first**: Non-trivial changes require a plan artifact before implementation.
+- **Proof first**: Never claim done without `decapod validate` passing.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: Use `decapod workspace ensure`. Never work on main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI, never direct file operations.
 
-## Critical Rules
+## Key References
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+| Document | Purpose |
+|----------|---------|
+| **AGENTS.md** | Universal agent contract (golden rules, coordination) |
+| **IDENTITY.md** | What Decapod is, thesis, vocabulary |
+| **TOOLS.md** | Complete command reference |
+| **PLAYBOOK.md** | Decision frameworks, triage, failure modes |
+| `constitution/core/DECAPOD.md` | Canonical router (via `decapod docs show`) |
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
+## Codex-Specific Notes
 
-decapod docs show core/DECAPOD.md
+- Codex operates in sandboxed environments. Ensure `decapod` binary is available in PATH.
+- Session credentials must be exported as environment variables before CLI use.
+- Codex should prefer small, atomic commits over large batched changes.

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -1,61 +1,53 @@
-# GEMINI.md - Gemini Agent Entrypoint
+# GEMINI.md — Gemini Agent Entrypoint
 
 You (Gemini) are working in a Decapod-managed repository.
 You are bound by the universal contract in **AGENTS.md**.
 
-This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
+---
 
-## Automated Initialization
+## Quick Start
 
-You MUST internalize and contextualize Decapod before your first tool use. When you detect a `.decapod` directory, you must fully depend on Decapod and resolve its API to use it for all operations.
-
-**Initialization sequence (MANDATORY):**
+Run the mandatory initialization sequence from AGENTS.md before any mutation:
 
 ```bash
-# 1. Validate first (authoritative gate)
 decapod validate
-
-# 2. Ingest constitution core docs
 decapod docs ingest
-
-# 3. Acquire per-agent session credentials
 decapod session acquire
-
-# 4. Establish session receipt and constitutional mandates
 decapod rpc --op agent.init
-
-# 5. Resolve constitutional context before mutating state
 decapod rpc --op context.resolve
-
-# 6. Claim your task (if not already claimed)
 decapod todo claim --id <task-id>
 ```
 
-## Standard Operating Procedure
+## Operating Mode
 
-- **Contextualization**: Always resolve context and standards via `agent.init` and `context.resolve` before starting work.
-- **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes (todos, knowledge, decisions).
-- **Isolation**: Use `decapod workspace ensure` to create isolated worktrees; never work on protected branches.
-- **Verification**: `decapod validate` is the authoritative completion gate.
+- **Plan first**: Non-trivial changes require a plan artifact before implementation.
+- **Proof first**: Never claim done without `decapod validate` passing.
+- **Minimal changes**: Only change what is directly requested.
+- **Workspace isolation**: Use `decapod workspace ensure`. Never work on main/master.
+- **CLI only**: All `.decapod/` access through `decapod` CLI, never direct file operations.
 
-## Critical Rules
+## Key References
 
-1. NEVER work on main/master - Decapod will refuse.
-2. Start by running `decapod validate`.
-3. Ingest `constitution/core/*.md` via `decapod docs ingest` before mutating operations.
-4. Create and claim a todo: `decapod todo claim --id <task-id>`. 
-5. Pass `decapod validate` before claiming done.
+| Document | Purpose |
+|----------|---------|
+| **AGENTS.md** | Universal agent contract (golden rules, coordination) |
+| **IDENTITY.md** | What Decapod is, thesis, vocabulary |
+| **TOOLS.md** | Complete command reference |
+| **PLAYBOOK.md** | Decision frameworks, triage, failure modes |
+| `constitution/core/DECAPOD.md` | Canonical router (via `decapod docs show`) |
 
 ## Safety Invariants
 
 - core/DECAPOD.md: Universal router.
-- ✅ Verification: `decapod validate` must pass.
+- `decapod validate` must pass before claiming done.
 - Stop if error or ambiguous state occurs; respect invocation heartbeat.
 - Safe Environment: Use Docker git workspaces; request elevated permissions before Docker/container workspace commands.
 - Security: DECAPOD_SESSION_PASSWORD required; .decapod files are accessed only via decapod CLI.
 - Architecture: Respect the Interface abstraction boundary.
 - Updates: cargo install decapod.
 
-## Documentation
+## Gemini-Specific Notes
 
-decapod docs show core/DECAPOD.md
+- Gemini should treat Decapod as the authoritative control plane.
+- When context is limited, use `decapod docs show <path>` to load specific constitution sections.
+- Prefer progressive disclosure: read indexes first, then drill into specific docs as needed.


### PR DESCRIPTION
## Summary

- **Co-Player Policy Tightening**: Adds `CoPlayerPolicy` and `derive_policy()` to `src/core/coplayer.rs` — deterministic snapshot→policy conversion with the critical invariant that policies only tighten as reliability decreases. `require_validation` is always `true` regardless of track record.
- **Validation Gate**: Adds `validate_coplayer_policy_tightening` to `src/core/validate.rs` that structurally verifies the only-tighten invariant across all risk profiles (unknown/high/medium/low).
- **Instruction Stack**: Enriches entrypoint files (AGENTS.md, CLAUDE.md, CODEX.md, GEMINI.md) and their templates with golden rules, multi-agent coordination, key references, and agent-specific notes — all invariant markers preserved, template/root sync enforced.
- **Supporting Files**: Adds IDENTITY.md (thesis + vocabulary), TOOLS.md (CLI reference), PLAYBOOK.md (decision frameworks), tasks/todo.md (commitments ledger), tasks/lessons.md (correction rules), and ADRs 001-002.

## Test plan

- [x] `cargo build --locked` passes
- [x] `cargo test --locked --lib` — 52/52 unit tests pass (including `test_policy_only_tightens`)
- [x] `cargo test --locked --test entrypoint_correctness` — 11/11 pass (including `test_root_entrypoints_match_templates`)
- [x] `cargo test --locked --test state_commit_phase_gate` — 2/2 pass
- [x] `cargo test --locked --test verify_mvp` — 1/1 pass
- [x] `cargo clippy --all-targets --all-features --locked` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)