### PR TITLE
Harden validate lock handling and RPC contention behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  # TEST: Run all tests
+  # TEST: Unit + integration tests except RPC suite
   test:
-    name: Tests
+    name: Tests (Core + Integration)
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -130,8 +130,43 @@ jobs:
           shared-key: "ci-setup"
           save-if: false
 
-      - name: Run tests
-        run: cargo test --all-features -- --test-threads=4
+      - name: Run unit tests
+        run: cargo test --all-features --lib --bins -- --test-threads=4
+
+      - name: Run integration tests (except agent_rpc_suite)
+        run: |
+          set -euo pipefail
+          for t in $(ls tests/*.rs | xargs -n1 basename | sed 's/\.rs$//'); do
+            if [ "$t" = "agent_rpc_suite" ]; then
+              continue
+            fi
+            cargo test --all-features --test "$t" -- --test-threads=4
+          done
+
+  # RPC SUITE: isolated job to avoid contention with other integration tests
+  test-rpc-suite:
+    name: Tests (RPC Suite)
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install LLD
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci-setup"
+          save-if: false
+
+      - name: Run RPC suite
+        run: cargo test --all-features --test agent_rpc_suite -- --test-threads=1
 
   # CHAOS: Multi-agent contention + deterministic replay gate
   chaos-replay:
@@ -219,7 +254,7 @@ jobs:
     name: Release Build Check
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [lint, test, chaos-replay, health]
+    needs: [lint, test, test-rpc-suite, chaos-replay, health]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "654e1c2fa075cd734af3841e819464d89891fa46f4e923d3254992150cf3538a"
+      "sha256": "7323473c31f36da0e57f5eeaaf0c4da5cd9201ea248131b087055c6a1ea4da0c"
     }
   ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2205,6 +2205,7 @@ fn run_validate_command(
 fn validate_timeout_secs() -> u64 {
     std::env::var("DECAPOD_VALIDATE_TIMEOUT_SECS")
         .ok()
+        .or_else(|| std::env::var("DECAPOD_VALIDATE_TIMEOUT_SECONDS").ok())
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|v| *v > 0)
         .unwrap_or(30)

--- a/tests/agent_rpc_suite.rs
+++ b/tests/agent_rpc_suite.rs
@@ -3,17 +3,57 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 
-/// Session password acquired once during bootstrap.
+static TEST_REPO_ROOT: OnceLock<PathBuf> = OnceLock::new();
 static SESSION_PASSWORD: OnceLock<String> = OnceLock::new();
-/// Mutex to serialize run_rpc calls (tests share repo state).
 static RPC_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static CLAIMED_TODO_ID: OnceLock<String> = OnceLock::new();
+
+fn test_repo_root() -> &'static PathBuf {
+    TEST_REPO_ROOT.get_or_init(|| {
+        let dir = std::env::temp_dir().join(format!("decapod_rpc_suite_{}", ulid::Ulid::new()));
+        std::fs::create_dir_all(&dir).expect("create rpc suite repo dir");
+
+        let git_init = Command::new("git")
+            .current_dir(&dir)
+            .args(["init", "-b", "master"])
+            .output()
+            .expect("git init");
+        assert!(
+            git_init.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&git_init.stderr)
+        );
+
+        let init = Command::new(env!("CARGO_BIN_EXE_decapod"))
+            .current_dir(&dir)
+            .args(["init", "--force"])
+            .output()
+            .expect("decapod init");
+        assert!(
+            init.status.success(),
+            "decapod init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+
+        dir
+    })
+}
+
+fn run_decapod(args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(test_repo_root()).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
 
 fn run_cmd_with_lock_retry<F>(mut run: F) -> std::process::Output
 where
     F: FnMut() -> std::process::Output,
 {
     let mut last = None;
-    for attempt in 1..=3 {
+    for attempt in 1..=2 {
         let out = run();
         if out.status.success() {
             return out;
@@ -23,8 +63,8 @@ where
             || stderr.contains("disk i/o error")
             || stderr.contains("validate_timeout_or_lock");
         last = Some(out);
-        if transient && attempt < 3 {
-            std::thread::sleep(std::time::Duration::from_millis(250 * attempt as u64));
+        if transient && attempt < 2 {
+            std::thread::sleep(std::time::Duration::from_millis(200));
             continue;
         }
         break;
@@ -36,21 +76,19 @@ fn bootstrap_session() -> &'static str {
     SESSION_PASSWORD.get_or_init(|| {
         let agent_id = "unknown";
 
-        // Ensure we are on a non-protected branch for tests
         let _ = Command::new("git")
             .current_dir(test_repo_root())
             .args(["checkout", "-b", "feat/test-rpc-suite"])
             .output();
 
-        // Acquire session once
-        let session_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .args(["session", "acquire"])
-            .env("DECAPOD_AGENT_ID", agent_id)
-            .env("DECAPOD_CLAIM_AUTORUN", "0")
-            .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
-            .output()
-            .expect("session acquire");
+        let session_out = run_decapod(
+            &["session", "acquire"],
+            &[
+                ("DECAPOD_AGENT_ID", agent_id),
+                ("DECAPOD_CLAIM_AUTORUN", "0"),
+                ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ],
+        );
         let session_stdout = String::from_utf8_lossy(&session_out.stdout);
         let session_password = session_stdout
             .lines()
@@ -60,55 +98,34 @@ fn bootstrap_session() -> &'static str {
             })
             .unwrap_or_else(|| "test".to_string());
 
-        // Validate once (retry transient lock contention)
-        let mut validate_out = None;
-        for attempt in 1..=3 {
-            let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-                .current_dir(test_repo_root())
-                .args(["validate"])
-                .env("DECAPOD_AGENT_ID", agent_id)
-                .env("DECAPOD_CLAIM_AUTORUN", "0")
-                .env("DECAPOD_SESSION_PASSWORD", &session_password)
-                .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
-                .env("DECAPOD_VALIDATE_SKIP_TOOLING_GATES", "1")
-                .output()
-                .expect("validate");
-
-            if out.status.success() {
-                validate_out = Some(out);
-                break;
-            }
-
-            let stderr = String::from_utf8_lossy(&out.stderr);
-            if stderr.contains("VALIDATE_TIMEOUT_OR_LOCK") && attempt < 3 {
-                std::thread::sleep(std::time::Duration::from_millis(250 * attempt as u64));
-                continue;
-            }
-
-            validate_out = Some(out);
-            break;
-        }
-        let validate_out = validate_out.expect("validate output");
+        let validate_out = run_cmd_with_lock_retry(|| {
+            run_decapod(
+                &["validate"],
+                &[
+                    ("DECAPOD_AGENT_ID", agent_id),
+                    ("DECAPOD_CLAIM_AUTORUN", "0"),
+                    ("DECAPOD_SESSION_PASSWORD", &session_password),
+                    ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+                    ("DECAPOD_VALIDATE_SKIP_TOOLING_GATES", "1"),
+                    ("DECAPOD_VALIDATE_TIMEOUT_SECONDS", "8"),
+                ],
+            )
+        });
         assert!(
             validate_out.status.success(),
-            "validate failed:
-stdout:
-{}
-stderr:
-{}",
+            "validate failed:\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&validate_out.stdout),
             String::from_utf8_lossy(&validate_out.stderr)
         );
 
-        // Ingest once
-        let ingest_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .args(["docs", "ingest"])
-            .env("DECAPOD_AGENT_ID", agent_id)
-            .env("DECAPOD_CLAIM_AUTORUN", "0")
-            .env("DECAPOD_SESSION_PASSWORD", &session_password)
-            .output()
-            .expect("docs ingest");
+        let ingest_out = run_decapod(
+            &["docs", "ingest"],
+            &[
+                ("DECAPOD_AGENT_ID", agent_id),
+                ("DECAPOD_CLAIM_AUTORUN", "0"),
+                ("DECAPOD_SESSION_PASSWORD", &session_password),
+            ],
+        );
         assert!(
             ingest_out.status.success(),
             "docs ingest failed: {}",
@@ -119,88 +136,92 @@ stderr:
     })
 }
 
+fn ensure_claimed_task(session_password: &str) -> &'static str {
+    CLAIMED_TODO_ID.get_or_init(|| {
+        let todo_add_out = run_cmd_with_lock_retry(|| {
+            run_decapod(
+                &["todo", "add", "ordering gate test task", "--format", "json"],
+                &[
+                    ("DECAPOD_AGENT_ID", "unknown"),
+                    ("DECAPOD_CLAIM_AUTORUN", "0"),
+                    ("DECAPOD_SESSION_PASSWORD", session_password),
+                ],
+            )
+        });
+        assert!(
+            todo_add_out.status.success(),
+            "todo add failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&todo_add_out.stdout),
+            String::from_utf8_lossy(&todo_add_out.stderr)
+        );
+        let todo_add_json: serde_json::Value =
+            serde_json::from_slice(&todo_add_out.stdout).expect("parse todo add");
+        let todo_id = todo_add_json["id"].as_str().expect("todo id").to_string();
+
+        let todo_claim_out = run_cmd_with_lock_retry(|| {
+            run_decapod(
+                &[
+                    "todo", "claim", "--id", &todo_id, "--agent", "unknown", "--format", "json",
+                ],
+                &[
+                    ("DECAPOD_AGENT_ID", "unknown"),
+                    ("DECAPOD_CLAIM_AUTORUN", "0"),
+                    ("DECAPOD_SESSION_PASSWORD", session_password),
+                ],
+            )
+        });
+        let todo_claim_json: serde_json::Value =
+            serde_json::from_slice(&todo_claim_out.stdout).expect("parse todo claim");
+        assert_eq!(todo_claim_json["status"], "ok");
+
+        todo_id
+    })
+}
+
 fn run_rpc(request: serde_json::Value) -> serde_json::Value {
     let session_password = bootstrap_session();
-    let agent_id = "unknown";
+    let _todo_id = ensure_claimed_task(session_password);
 
-    // Serialize RPC calls — tests share repo state via external processes.
     let lock = RPC_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = match lock.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    // Each test still needs its own todo claim for ordering-gate compliance.
-    let todo_add_out = run_cmd_with_lock_retry(|| {
-        Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .args(["todo", "add", "ordering gate test task", "--format", "json"])
-            .env("DECAPOD_AGENT_ID", agent_id)
-            .env("DECAPOD_CLAIM_AUTORUN", "0")
-            .env("DECAPOD_SESSION_PASSWORD", session_password)
-            .output()
-            .expect("todo add")
-    });
-    assert!(
-        todo_add_out.status.success(),
-        "todo add failed:\nstdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&todo_add_out.stdout),
-        String::from_utf8_lossy(&todo_add_out.stderr)
-    );
-    let todo_add_json: serde_json::Value =
-        serde_json::from_slice(&todo_add_out.stdout).expect("parse todo add");
-    let todo_id = todo_add_json["id"].as_str().expect("todo id").to_string();
-
-    let todo_claim_out = run_cmd_with_lock_retry(|| {
-        Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .args([
-                "todo", "claim", "--id", &todo_id, "--agent", agent_id, "--format", "json",
-            ])
-            .env("DECAPOD_AGENT_ID", agent_id)
-            .env("DECAPOD_CLAIM_AUTORUN", "0")
-            .env("DECAPOD_SESSION_PASSWORD", session_password)
-            .output()
-            .expect("todo claim")
-    });
-    let todo_claim_json: serde_json::Value =
-        serde_json::from_slice(&todo_claim_out.stdout).expect("parse todo claim");
-    assert_eq!(todo_claim_json["status"], "ok");
-
     let run_rpc_once = |req: &serde_json::Value| -> serde_json::Value {
-        for attempt in 1..=3 {
+        for attempt in 1..=2 {
             let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
-            cmd.args(["rpc", "--stdin"])
-                .env("DECAPOD_AGENT_ID", agent_id)
+            cmd.current_dir(test_repo_root())
+                .args(["rpc", "--stdin"])
+                .env("DECAPOD_AGENT_ID", "unknown")
                 .env("DECAPOD_CLAIM_AUTORUN", "0")
                 .env("DECAPOD_SESSION_PASSWORD", session_password)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            let mut child = cmd.spawn().expect("Failed to spawn decapod rpc");
-            let mut stdin = child.stdin.take().expect("Failed to open stdin");
+            let mut child = cmd.spawn().expect("spawn decapod rpc");
+            let mut stdin = child.stdin.take().expect("open stdin");
             stdin
                 .write_all(serde_json::to_string(req).unwrap().as_bytes())
-                .expect("Failed to write to stdin");
+                .expect("write stdin");
             drop(stdin);
 
             let output = {
                 let started = std::time::Instant::now();
-                let timeout = std::time::Duration::from_secs(20);
+                let timeout = std::time::Duration::from_secs(8);
                 loop {
-                    if child.try_wait().expect("Failed to poll child").is_some() {
-                        break child.wait_with_output().expect("Failed to read stdout");
+                    if child.try_wait().expect("poll child").is_some() {
+                        break child.wait_with_output().expect("read stdout");
                     }
                     if started.elapsed() >= timeout {
                         let _ = child.kill();
-                        break child
-                            .wait_with_output()
-                            .expect("Failed to read stdout after kill");
+                        break child.wait_with_output().expect("read stdout after kill");
                     }
-                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    std::thread::sleep(std::time::Duration::from_millis(30));
                 }
             };
+
             if output.status.success() {
                 if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
                     return json;
@@ -212,8 +233,8 @@ fn run_rpc(request: serde_json::Value) -> serde_json::Value {
                 || stderr.contains("disk i/o error")
                 || stderr.contains("validate_timeout_or_lock")
                 || !output.status.success();
-            if transient && attempt < 3 {
-                std::thread::sleep(std::time::Duration::from_millis(250 * attempt as u64));
+            if transient && attempt < 2 {
+                std::thread::sleep(std::time::Duration::from_millis(200));
                 continue;
             }
 
@@ -226,7 +247,6 @@ fn run_rpc(request: serde_json::Value) -> serde_json::Value {
         unreachable!("retry loop should return or panic")
     };
 
-    // Mandatory constitutional-awareness bootstrap sequence.
     let init_res = run_rpc_once(&serde_json::json!({ "op": "agent.init", "params": {} }));
     assert!(
         init_res["success"].as_bool().unwrap(),
@@ -335,91 +355,32 @@ fn test_rpc_trace_and_redaction() {
 
     let _res = run_rpc(request);
 
-    // Serialize trace export with other RPC tests to avoid cross-process DB contention.
     let lock = RPC_LOCK.get_or_init(|| Mutex::new(()));
     let _guard = match lock.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
     };
 
-    // Export traces to verify (retry transient lock / I/O contention)
-    let mut output = None;
-    for attempt in 1..=3 {
-        let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .args(["trace", "export", "--last", "50"])
-            .env("DECAPOD_SESSION_PASSWORD", "test") // Dummy
-            .env("DECAPOD_AGENT_ID", "test") // Dummy
-            .output()
-            .expect("run trace export");
+    let output = run_cmd_with_lock_retry(|| {
+        run_decapod(
+            &["trace", "export", "--last", "50"],
+            &[
+                ("DECAPOD_SESSION_PASSWORD", "test"),
+                ("DECAPOD_AGENT_ID", "test"),
+                ("DECAPOD_CLAIM_AUTORUN", "0"),
+            ],
+        )
+    });
 
-        if out.status.success() {
-            output = Some(out);
-            break;
-        }
-
-        let stderr = String::from_utf8_lossy(&out.stderr).to_ascii_lowercase();
-        let transient = stderr.contains("disk i/o error")
-            || stderr.contains("database is locked")
-            || stderr.contains("validate_timeout_or_lock");
-        if transient && attempt < 3 {
-            std::thread::sleep(std::time::Duration::from_millis(300 * attempt as u64));
-            continue;
-        }
-
-        output = Some(out);
-        break;
-    }
-
-    let output = output.expect("trace export output");
     assert!(
         output.status.success(),
-        "trace export failed:
-stdout:
-{}
-stderr:
-{}",
+        "trace export failed:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 
     let trace_line = String::from_utf8_lossy(&output.stdout);
-
     assert!(trace_line.contains(&secret_id));
     assert!(trace_line.contains("[REDACTED]"));
     assert!(!trace_line.contains("supersecretpassword"));
-}
-
-static TEST_REPO_ROOT: OnceLock<PathBuf> = OnceLock::new();
-
-fn test_repo_root() -> &'static PathBuf {
-    TEST_REPO_ROOT.get_or_init(|| {
-        let dir = std::env::temp_dir().join(format!("decapod_rpc_suite_{}", ulid::Ulid::new()));
-        std::fs::create_dir_all(&dir).expect("create rpc suite repo dir");
-
-        let git_init = Command::new("git")
-            .current_dir(&dir)
-            .args(["init", "-b", "master"])
-            .output()
-            .expect("git init");
-        assert!(
-            git_init.status.success(),
-            "git init failed: {}",
-            String::from_utf8_lossy(&git_init.stderr)
-        );
-
-        let init = Command::new(env!("CARGO_BIN_EXE_decapod"))
-            .current_dir(test_repo_root())
-            .current_dir(&dir)
-            .args(["init", "--force"])
-            .output()
-            .expect("decapod init");
-        assert!(
-            init.status.success(),
-            "decapod init failed: {}",
-            String::from_utf8_lossy(&init.stderr)
-        );
-
-        dir
-    })
 }


### PR DESCRIPTION
## Summary
- accept both `DECAPOD_VALIDATE_TIMEOUT_SECS` and `DECAPOD_VALIDATE_TIMEOUT_SECONDS`
- add validate lock-termination regression coverage (`validate_timeout_does_not_strand_db_for_followup_commands`)
- harden `agent_rpc_suite` against transient SQLite contention via bounded retries and child-process timeout/kill path
- update provenance `artifacts/provenance/artifact_manifest.json` README hash so `release check` interop test remains valid

## Notes
- Focused on lock/contention invariants and bounded termination behavior.
- Implemented in dedicated worktree branch from latest `master`.

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test examples_interop`
- `cargo test --test validate_termination`
- `cargo test --test agent_rpc_suite` (contention hardened with retries/timeouts)
