### PR TITLE
feat: Phase 3 — LCM + Map operators

### DIFF
--- a/constitution/interfaces/LCM.md
+++ b/constitution/interfaces/LCM.md
@@ -1,0 +1,76 @@
+# LCM — Lossless Context Management
+
+## Purpose
+
+LCM provides the **memory layer** for Decapod agents. It prevents agents from inventing ad-hoc chunking loops while preserving the append-only, deterministic, auditable store model.
+
+Two subsystems:
+
+1. **`decapod lcm`** — Immutable originals ledger + deterministic summary DAG.
+2. **`decapod map`** — Structured parallel processing with scope-reduction enforcement.
+
+## LCM Store Model
+
+### Originals (append-only, never mutated)
+
+Stored in `lcm.events.jsonl` — an append-only JSONL ledger.
+
+Each entry contains:
+- `event_id` — ULID, globally unique
+- `ts` — ISO 8601 timestamp
+- `actor` — agent identifier
+- `content_hash` — SHA256 of raw content bytes (deterministic)
+- `kind` — one of: `event`, `message`, `artifact`, `tool_result`
+- `content` — verbatim original text
+- `metadata` — session_id, source, etc.
+
+### Derived Index
+
+`lcm.db` is a SQLite database that indexes the ledger:
+- `originals_index` — content_hash, event_id, ts, actor, kind, byte_size, session_id
+- `summaries` — summary_hash, ts, scope, original_hashes, summary_text, token_estimate
+- `meta` — key-value configuration
+
+**The index is always rebuildable from the ledger.** If `lcm.db` is deleted, it can be reconstructed by replaying `lcm.events.jsonl`.
+
+### Summaries
+
+Summaries are deterministic:
+- Same originals in timestamp order produce the same summary hash.
+- Summary hash = SHA256(original_hashes joined by comma | summary_text).
+- Summaries reference originals by content hash, forming a DAG.
+
+## Map Operators
+
+### `map llm` — Stateless Parallel Processing
+
+Applies a prompt template + JSON schema to each item in a JSON array. The operator defines the **contract** (input format, output schema, audit trail) — actual LLM inference is pluggable.
+
+### `map agentic` — Subagent Delegation
+
+Delegates items to subagents with mandatory scope-reduction:
+- The `--retain` flag declares what the caller keeps responsibility for.
+- If `--retain` is empty, the command rejects with: "Delegation without retention violates scope-reduction invariant."
+- Each delegation is logged to `map.events.jsonl`.
+
+## Determinism Guarantees
+
+1. **Content addressing**: SHA256 of raw bytes — same content always produces same hash.
+2. **Append-only ledger**: Events are never mutated or deleted.
+3. **Deterministic summaries**: Same originals produce the same summary hash across runs.
+4. **Rebuildable index**: `lcm.db` can always be reconstructed from `lcm.events.jsonl`.
+5. **Audit trail**: All map operations logged with input/output hashes.
+
+## Validation Gate
+
+`decapod validate` includes the **LCM Immutability Gate** which verifies:
+- Every entry's `content_hash` matches SHA256(content).
+- No duplicate `event_id` values.
+- Monotonic timestamps (each entry >= previous).
+
+## Progressive Disclosure
+
+- **Level 0**: `decapod lcm schema` — discover capabilities.
+- **Level 1**: `decapod lcm ingest` / `decapod lcm list` — store and browse originals.
+- **Level 2**: `decapod lcm summarize` / `decapod lcm summary` — produce and inspect summaries.
+- **Level 3**: `decapod map llm` / `decapod map agentic` — structured parallel processing.

--- a/src/core/schemas.rs
+++ b/src/core/schemas.rs
@@ -516,3 +516,47 @@ pub const POLICY_DB_NAME: &str = "policy.db";
 pub const FEEDBACK_DB_NAME: &str = "feedback.db";
 pub const ARCHIVE_DB_NAME: &str = "archive.db";
 pub const TEAMMATE_DB_NAME: &str = "teammate.db";
+
+// --- 5. LCM Bin (Lossless Context Management) ---
+pub const LCM_DB_NAME: &str = "lcm.db";
+pub const LCM_EVENTS_NAME: &str = "lcm.events.jsonl";
+
+pub const LCM_DB_SCHEMA_ORIGINALS_INDEX: &str = "
+    CREATE TABLE IF NOT EXISTS originals_index (
+        content_hash TEXT PRIMARY KEY,
+        event_id TEXT NOT NULL,
+        ts TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        byte_size INTEGER NOT NULL,
+        session_id TEXT
+    )
+";
+
+pub const LCM_DB_SCHEMA_SUMMARIES: &str = "
+    CREATE TABLE IF NOT EXISTS summaries (
+        summary_hash TEXT PRIMARY KEY,
+        ts TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        original_hashes TEXT NOT NULL,
+        summary_text TEXT NOT NULL,
+        token_estimate INTEGER NOT NULL
+    )
+";
+
+pub const LCM_DB_SCHEMA_META: &str = "
+    CREATE TABLE IF NOT EXISTS meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+";
+
+pub const LCM_DB_INDEX_ORIGINALS_KIND: &str =
+    "CREATE INDEX IF NOT EXISTS idx_lcm_originals_kind ON originals_index(kind)";
+pub const LCM_DB_INDEX_ORIGINALS_TS: &str =
+    "CREATE INDEX IF NOT EXISTS idx_lcm_originals_ts ON originals_index(ts)";
+pub const LCM_DB_INDEX_SUMMARIES_SCOPE: &str =
+    "CREATE INDEX IF NOT EXISTS idx_lcm_summaries_scope ON summaries(scope)";
+
+// --- 6. Map Operators ---
+pub const MAP_EVENTS_NAME: &str = "map.events.jsonl";

--- a/src/plugins/lcm.rs
+++ b/src/plugins/lcm.rs
@@ -1,0 +1,691 @@
+//! Lossless Context Management (LCM) — immutable originals ledger + deterministic summary DAG.
+//!
+//! LCM stores verbatim interaction originals in an append-only JSONL ledger
+//! (`lcm.events.jsonl`) and maintains a derived SQLite index (`lcm.db`) that
+//! is always rebuildable from the ledger. Summaries reference originals by
+//! content hash, forming a deterministic DAG.
+
+use crate::core::broker::DbBroker;
+use crate::core::error;
+use crate::core::schemas;
+use crate::core::store::Store;
+use clap::Subcommand;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use ulid::Ulid;
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+fn lcm_db_path(root: &Path) -> PathBuf {
+    root.join(schemas::LCM_DB_NAME)
+}
+
+fn lcm_events_path(root: &Path) -> PathBuf {
+    root.join(schemas::LCM_EVENTS_NAME)
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+pub fn initialize_lcm_db(root: &Path) -> Result<(), error::DecapodError> {
+    fs::create_dir_all(root).map_err(error::DecapodError::IoError)?;
+    let broker = DbBroker::new(root);
+    let db_path = lcm_db_path(root);
+    broker.with_conn(&db_path, "decapod", None, "lcm.init", |conn| {
+        conn.execute(schemas::LCM_DB_SCHEMA_META, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        conn.execute(schemas::LCM_DB_SCHEMA_ORIGINALS_INDEX, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        conn.execute(schemas::LCM_DB_SCHEMA_SUMMARIES, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        conn.execute(schemas::LCM_DB_INDEX_ORIGINALS_KIND, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        conn.execute(schemas::LCM_DB_INDEX_ORIGINALS_TS, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        conn.execute(schemas::LCM_DB_INDEX_SUMMARIES_SCOPE, [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LcmEvent {
+    pub event_id: String,
+    pub ts: String,
+    pub actor: String,
+    pub content_hash: String,
+    pub kind: String,
+    pub content: String,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OriginalEntry {
+    pub content_hash: String,
+    pub event_id: String,
+    pub ts: String,
+    pub actor: String,
+    pub kind: String,
+    pub byte_size: i64,
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SummaryEntry {
+    pub summary_hash: String,
+    pub ts: String,
+    pub scope: String,
+    pub original_hashes: Vec<String>,
+    pub summary_text: String,
+    pub token_estimate: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn now_iso() -> String {
+    crate::core::time::now_epoch_z()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+fn append_jsonl(path: &Path, value: &serde_json::Value) -> Result<(), error::DecapodError> {
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(error::DecapodError::IoError)?;
+    writeln!(f, "{}", serde_json::to_string(value).unwrap())
+        .map_err(error::DecapodError::IoError)?;
+    Ok(())
+}
+
+fn read_all_events(root: &Path) -> Result<Vec<LcmEvent>, error::DecapodError> {
+    let path = lcm_events_path(root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = fs::File::open(&path).map_err(error::DecapodError::IoError)?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for line in reader.lines() {
+        let line = line.map_err(error::DecapodError::IoError)?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: LcmEvent = serde_json::from_str(trimmed)
+            .map_err(|e| error::DecapodError::ValidationError(e.to_string()))?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+/// Rough token estimate: ~4 chars per token.
+fn estimate_tokens(text: &str) -> i64 {
+    (text.len() as i64 + 3) / 4
+}
+
+// ---------------------------------------------------------------------------
+// Core operations
+// ---------------------------------------------------------------------------
+
+/// Ingest an immutable original into the append-only ledger + index.
+pub fn ingest(
+    store: &Store,
+    content: &str,
+    kind: &str,
+    actor: &str,
+    session_id: Option<&str>,
+    source: Option<&str>,
+) -> Result<serde_json::Value, error::DecapodError> {
+    let valid_kinds = ["event", "message", "artifact", "tool_result"];
+    if !valid_kinds.contains(&kind) {
+        return Err(error::DecapodError::ValidationError(format!(
+            "Invalid kind '{}'; must be one of: {}",
+            kind,
+            valid_kinds.join(", ")
+        )));
+    }
+
+    let content_hash = sha256_hex(content.as_bytes());
+    let event_id = Ulid::new().to_string();
+    let ts = now_iso();
+    let byte_size = content.len() as i64;
+
+    let mut metadata = serde_json::Map::new();
+    if let Some(sid) = session_id {
+        metadata.insert(
+            "session_id".to_string(),
+            serde_json::Value::String(sid.to_string()),
+        );
+    }
+    if let Some(src) = source {
+        metadata.insert(
+            "source".to_string(),
+            serde_json::Value::String(src.to_string()),
+        );
+    }
+
+    let event = serde_json::json!({
+        "event_id": event_id,
+        "ts": ts,
+        "actor": actor,
+        "content_hash": content_hash,
+        "kind": kind,
+        "content": content,
+        "metadata": metadata,
+    });
+
+    // 1. Append to immutable ledger
+    append_jsonl(&lcm_events_path(&store.root), &event)?;
+
+    // 2. Update derived index
+    let broker = DbBroker::new(&store.root);
+    let db_path = lcm_db_path(&store.root);
+    broker.with_conn(&db_path, "decapod", None, "lcm.ingest", |conn| {
+        conn.execute(
+            "INSERT OR IGNORE INTO originals_index(content_hash, event_id, ts, actor, kind, byte_size, session_id) VALUES(?1,?2,?3,?4,?5,?6,?7)",
+            params![content_hash, event_id, ts, actor, kind, byte_size, session_id.unwrap_or("")],
+        ).map_err(error::DecapodError::RusqliteError)?;
+        Ok(())
+    })?;
+
+    Ok(serde_json::json!({
+        "content_hash": content_hash,
+        "event_id": event_id,
+        "ts": ts,
+        "byte_size": byte_size,
+    }))
+}
+
+/// List stored originals (metadata only).
+pub fn list_originals(
+    store: &Store,
+    kind_filter: Option<&str>,
+    last_n: Option<usize>,
+) -> Result<Vec<OriginalEntry>, error::DecapodError> {
+    let broker = DbBroker::new(&store.root);
+    let db_path = lcm_db_path(&store.root);
+
+    broker.with_conn(&db_path, "decapod", None, "lcm.list", |conn| {
+        let (sql, bind_values): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match kind_filter {
+            Some(k) => {
+                let mut sql = "SELECT content_hash, event_id, ts, actor, kind, byte_size, session_id FROM originals_index WHERE kind = ?1 ORDER BY ts DESC".to_string();
+                if let Some(n) = last_n {
+                    sql.push_str(&format!(" LIMIT {}", n));
+                }
+                (sql, vec![Box::new(k.to_string())])
+            }
+            None => {
+                let mut sql = "SELECT content_hash, event_id, ts, actor, kind, byte_size, session_id FROM originals_index ORDER BY ts DESC".to_string();
+                if let Some(n) = last_n {
+                    sql.push_str(&format!(" LIMIT {}", n));
+                }
+                (sql, vec![])
+            }
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = bind_values.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt.query_map(params_refs.as_slice(), |row| {
+            let sid: String = row.get(6)?;
+            Ok(OriginalEntry {
+                content_hash: row.get(0)?,
+                event_id: row.get(1)?,
+                ts: row.get(2)?,
+                actor: row.get(3)?,
+                kind: row.get(4)?,
+                byte_size: row.get(5)?,
+                session_id: if sid.is_empty() { None } else { Some(sid) },
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(error::DecapodError::RusqliteError)?);
+        }
+        Ok(out)
+    })
+}
+
+/// Retrieve an original by content hash from the ledger.
+pub fn show_original(
+    store: &Store,
+    content_hash: &str,
+) -> Result<Option<LcmEvent>, error::DecapodError> {
+    let events = read_all_events(&store.root)?;
+    Ok(events.into_iter().find(|e| e.content_hash == content_hash))
+}
+
+/// Produce a deterministic summary from originals.
+pub fn summarize(store: &Store, scope: &str) -> Result<serde_json::Value, error::DecapodError> {
+    let events = read_all_events(&store.root)?;
+    if events.is_empty() {
+        return Ok(serde_json::json!({
+            "summary_hash": null,
+            "message": "No originals to summarize",
+        }));
+    }
+
+    // Sort by timestamp (already chronological in append-only ledger, but ensure)
+    let mut sorted = events.clone();
+    sorted.sort_by(|a, b| a.ts.cmp(&b.ts));
+
+    // Filter by scope if "session" — use the most recent session_id
+    let filtered: Vec<&LcmEvent> = if scope == "session" {
+        // Find most recent session_id
+        let last_session = sorted.iter().rev().find_map(|e| {
+            e.metadata
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        });
+        match last_session {
+            Some(sid) => sorted
+                .iter()
+                .filter(|e| {
+                    e.metadata
+                        .get("session_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s == sid)
+                        .unwrap_or(false)
+                })
+                .collect(),
+            None => sorted.iter().collect(),
+        }
+    } else {
+        sorted.iter().collect()
+    };
+
+    // Concatenate originals in timestamp order
+    let original_hashes: Vec<String> = filtered.iter().map(|e| e.content_hash.clone()).collect();
+    let concatenated: String = filtered
+        .iter()
+        .map(|e| format!("[{}:{}] {}", e.kind, e.ts, e.content))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Truncate to budget (64KB for summary text)
+    let budget = 64 * 1024;
+    let summary_text = if concatenated.len() > budget {
+        concatenated[..budget].to_string()
+    } else {
+        concatenated
+    };
+
+    // Deterministic hash: hash the concatenation of original hashes + summary text
+    let hash_input = format!("{}|{}", original_hashes.join(","), summary_text);
+    let summary_hash = sha256_hex(hash_input.as_bytes());
+    let ts = now_iso();
+    let token_estimate = estimate_tokens(&summary_text);
+
+    // Store in DB
+    let broker = DbBroker::new(&store.root);
+    let db_path = lcm_db_path(&store.root);
+    let hashes_json = serde_json::to_string(&original_hashes).unwrap();
+
+    broker.with_conn(&db_path, "decapod", None, "lcm.summarize", |conn| {
+        conn.execute(
+            "INSERT OR REPLACE INTO summaries(summary_hash, ts, scope, original_hashes, summary_text, token_estimate) VALUES(?1,?2,?3,?4,?5,?6)",
+            params![summary_hash, ts, scope, hashes_json, summary_text, token_estimate],
+        ).map_err(error::DecapodError::RusqliteError)?;
+        Ok(())
+    })?;
+
+    Ok(serde_json::json!({
+        "summary_hash": summary_hash,
+        "scope": scope,
+        "original_count": original_hashes.len(),
+        "token_estimate": token_estimate,
+        "ts": ts,
+    }))
+}
+
+/// Show a summary by hash, or the latest if no hash is given.
+pub fn show_summary(
+    store: &Store,
+    summary_hash: Option<&str>,
+) -> Result<Option<SummaryEntry>, error::DecapodError> {
+    let broker = DbBroker::new(&store.root);
+    let db_path = lcm_db_path(&store.root);
+
+    broker.with_conn(&db_path, "decapod", None, "lcm.summary.show", |conn| {
+        let (sql, bind_values): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match summary_hash {
+            Some(h) => (
+                "SELECT summary_hash, ts, scope, original_hashes, summary_text, token_estimate FROM summaries WHERE summary_hash = ?1".to_string(),
+                vec![Box::new(h.to_string())],
+            ),
+            None => (
+                "SELECT summary_hash, ts, scope, original_hashes, summary_text, token_estimate FROM summaries ORDER BY ts DESC LIMIT 1".to_string(),
+                vec![],
+            ),
+        };
+
+        let mut stmt = conn.prepare(&sql)?;
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = bind_values.iter().map(|b| b.as_ref()).collect();
+        let mut rows = stmt.query(params_refs.as_slice())?;
+        if let Some(row) = rows.next()? {
+            let hashes_json: String = row.get(3)?;
+            let original_hashes: Vec<String> = serde_json::from_str(&hashes_json)
+                .unwrap_or_default();
+            Ok(Some(SummaryEntry {
+                summary_hash: row.get(0)?,
+                ts: row.get(1)?,
+                scope: row.get(2)?,
+                original_hashes,
+                summary_text: row.get(4)?,
+                token_estimate: row.get(5)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+/// Rebuild the originals_index from the JSONL ledger.
+pub fn rebuild_index_from_ledger(store: &Store) -> Result<usize, error::DecapodError> {
+    let events = read_all_events(&store.root)?;
+    let broker = DbBroker::new(&store.root);
+    let db_path = lcm_db_path(&store.root);
+
+    broker.with_conn(&db_path, "decapod", None, "lcm.rebuild", |conn| {
+        conn.execute("DELETE FROM originals_index", [])
+            .map_err(error::DecapodError::RusqliteError)?;
+        let mut count = 0usize;
+        for event in &events {
+            let session_id = event
+                .metadata
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            conn.execute(
+                "INSERT OR IGNORE INTO originals_index(content_hash, event_id, ts, actor, kind, byte_size, session_id) VALUES(?1,?2,?3,?4,?5,?6,?7)",
+                params![
+                    event.content_hash,
+                    event.event_id,
+                    event.ts,
+                    event.actor,
+                    event.kind,
+                    event.content.len() as i64,
+                    session_id,
+                ],
+            ).map_err(error::DecapodError::RusqliteError)?;
+            count += 1;
+        }
+        Ok(count)
+    })
+}
+
+/// Validate the integrity of the LCM ledger.
+/// Returns a list of failures (empty = valid).
+pub fn validate_ledger_integrity(root: &Path) -> Result<Vec<String>, error::DecapodError> {
+    let events = read_all_events(root)?;
+    let mut failures = Vec::new();
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut prev_ts: Option<String> = None;
+
+    for (i, event) in events.iter().enumerate() {
+        // Check content hash
+        let expected = sha256_hex(event.content.as_bytes());
+        if event.content_hash != expected {
+            failures.push(format!(
+                "Line {}: content_hash mismatch (expected={}, got={})",
+                i + 1,
+                expected,
+                event.content_hash
+            ));
+        }
+
+        // Check duplicate event_ids
+        if !seen_ids.insert(&event.event_id) {
+            failures.push(format!(
+                "Line {}: duplicate event_id '{}'",
+                i + 1,
+                event.event_id
+            ));
+        }
+
+        // Check monotonic timestamps
+        if let Some(ref prev) = prev_ts {
+            if event.ts < *prev {
+                failures.push(format!(
+                    "Line {}: non-monotonic timestamp (prev={}, current={})",
+                    i + 1,
+                    prev,
+                    event.ts
+                ));
+            }
+        }
+        prev_ts = Some(event.ts.clone());
+    }
+
+    Ok(failures)
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(clap::Args, Debug)]
+pub struct LcmCli {
+    #[clap(subcommand)]
+    pub command: LcmCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LcmCommand {
+    /// Store an immutable original in the append-only ledger
+    Ingest {
+        /// Source path (reads from stdin if not provided)
+        #[clap(long)]
+        source: Option<PathBuf>,
+        /// Kind of content: event, message, artifact, tool_result
+        #[clap(long)]
+        kind: String,
+        /// Actor identifier
+        #[clap(long, default_value = "decapod")]
+        actor: String,
+        /// Session identifier
+        #[clap(long)]
+        session_id: Option<String>,
+    },
+    /// List stored originals (metadata only)
+    List {
+        /// Filter by kind
+        #[clap(long)]
+        kind: Option<String>,
+        /// Show only last N entries
+        #[clap(long)]
+        last: Option<usize>,
+    },
+    /// Retrieve an original by content hash
+    Show {
+        /// Content hash of the original
+        #[clap(long)]
+        id: String,
+    },
+    /// Produce a deterministic summary from originals
+    Summarize {
+        /// Scope: 'session' or 'all'
+        #[clap(long, default_value = "all")]
+        scope: String,
+    },
+    /// Show a summary with pointers to originals
+    #[clap(name = "summary")]
+    SummaryShow {
+        /// Summary hash (shows latest if not provided)
+        #[clap(long)]
+        id: Option<String>,
+    },
+    /// Emit subsystem schema JSON
+    Schema,
+}
+
+pub fn run_lcm_cli(store: &Store, cli: LcmCli) -> Result<(), error::DecapodError> {
+    match cli.command {
+        LcmCommand::Ingest {
+            source,
+            kind,
+            actor,
+            session_id,
+        } => {
+            let source_str = source.as_ref().map(|p| p.to_string_lossy().to_string());
+            let content = match source {
+                Some(path) => fs::read_to_string(&path).map_err(error::DecapodError::IoError)?,
+                None => {
+                    let mut buf = String::new();
+                    std::io::stdin()
+                        .read_line(&mut buf)
+                        .map_err(error::DecapodError::IoError)?;
+                    buf
+                }
+            };
+            let result = ingest(
+                store,
+                &content,
+                &kind,
+                &actor,
+                session_id.as_deref(),
+                source_str.as_deref(),
+            )?;
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+        LcmCommand::List { kind, last } => {
+            let entries = list_originals(store, kind.as_deref(), last)?;
+            println!("{}", serde_json::to_string_pretty(&entries).unwrap());
+        }
+        LcmCommand::Show { id } => {
+            let event = show_original(store, &id)?;
+            match event {
+                Some(e) => println!("{}", serde_json::to_string_pretty(&e).unwrap()),
+                None => println!("{{\"error\": \"not found\"}}"),
+            }
+        }
+        LcmCommand::Summarize { scope } => {
+            let result = summarize(store, &scope)?;
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+        LcmCommand::SummaryShow { id } => {
+            let entry = show_summary(store, id.as_deref())?;
+            match entry {
+                Some(e) => println!("{}", serde_json::to_string_pretty(&e).unwrap()),
+                None => println!("{{\"error\": \"no summary found\"}}"),
+            }
+        }
+        LcmCommand::Schema => {
+            println!("{}", serde_json::to_string_pretty(&schema()).unwrap());
+        }
+    }
+    Ok(())
+}
+
+pub fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "name": "lcm",
+        "version": "0.1.0",
+        "description": "Lossless Context Management — immutable originals + deterministic summaries",
+        "commands": [
+            { "name": "ingest", "description": "Store an immutable original in the append-only ledger" },
+            { "name": "list", "description": "List stored originals (metadata only)" },
+            { "name": "show", "description": "Retrieve an original by content hash" },
+            { "name": "summarize", "description": "Produce deterministic summary DAG from originals" },
+            { "name": "summary", "description": "Show a summary with pointers to originals" },
+            { "name": "schema", "description": "Emit subsystem schema JSON" },
+        ],
+        "storage": [schemas::LCM_DB_NAME, schemas::LCM_EVENTS_NAME],
+        "invariants": [
+            "Originals are NEVER mutated or deleted (append-only JSONL)",
+            "Content hash is SHA256 of raw content bytes — deterministic",
+            "Summaries are deterministic: same originals → same summary hash",
+            "lcm.db is always rebuildable from lcm.events.jsonl",
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn test_store() -> (tempfile::TempDir, Store) {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        initialize_lcm_db(&root).unwrap();
+        let store = Store {
+            kind: crate::core::store::StoreKind::Repo,
+            root,
+        };
+        (tmp, store)
+    }
+
+    #[test]
+    fn test_ingest_produces_correct_hash() {
+        let (_tmp, store) = test_store();
+        let content = "Hello, world!";
+        let result = ingest(&store, content, "message", "test-agent", None, None).unwrap();
+        let expected_hash = sha256_hex(content.as_bytes());
+        assert_eq!(result["content_hash"].as_str().unwrap(), expected_hash);
+    }
+
+    #[test]
+    fn test_ingest_rejects_invalid_kind() {
+        let (_tmp, store) = test_store();
+        let result = ingest(&store, "test", "bogus", "agent", None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_list_returns_ingested() {
+        let (_tmp, store) = test_store();
+        ingest(&store, "alpha", "message", "agent", None, None).unwrap();
+        ingest(&store, "beta", "event", "agent", None, None).unwrap();
+
+        let all = list_originals(&store, None, None).unwrap();
+        assert_eq!(all.len(), 2);
+
+        let msgs = list_originals(&store, Some("message"), None).unwrap();
+        assert_eq!(msgs.len(), 1);
+    }
+
+    #[test]
+    fn test_show_original_found() {
+        let (_tmp, store) = test_store();
+        let result = ingest(&store, "find me", "artifact", "agent", None, None).unwrap();
+        let hash = result["content_hash"].as_str().unwrap();
+        let event = show_original(&store, hash).unwrap().unwrap();
+        assert_eq!(event.content, "find me");
+    }
+
+    #[test]
+    fn test_validate_catches_tamper() {
+        let (_tmp, store) = test_store();
+        ingest(&store, "good content", "message", "agent", None, None).unwrap();
+
+        // Tamper with the ledger
+        let path = lcm_events_path(&store.root);
+        let mut contents = fs::read_to_string(&path).unwrap();
+        contents = contents.replace("good content", "bad content");
+        fs::write(&path, &contents).unwrap();
+
+        let failures = validate_ledger_integrity(&store.root).unwrap();
+        assert!(!failures.is_empty());
+    }
+}

--- a/src/plugins/map_ops.rs
+++ b/src/plugins/map_ops.rs
@@ -1,0 +1,415 @@
+//! Deterministic Map Operators — structured parallel processing with scope-reduction enforcement.
+//!
+//! Two operator modes:
+//! - `map llm`: Stateless parallel processing with prompt template + schema validation.
+//! - `map agentic`: Subagent delegation with mandatory scope-reduction (`--retain`).
+//!
+//! Both operators are *structural* — they define the contract and audit trail.
+//! Actual LLM/subagent dispatch is pluggable.
+
+use crate::core::error;
+use crate::core::schemas;
+use crate::core::store::Store;
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use ulid::Ulid;
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+fn map_events_path(root: &Path) -> PathBuf {
+    root.join(schemas::MAP_EVENTS_NAME)
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MapEvent {
+    pub event_id: String,
+    pub ts: String,
+    pub actor: String,
+    pub op: String,
+    pub item_count: usize,
+    pub prompt_hash: Option<String>,
+    pub schema_hash: Option<String>,
+    pub delegate_hash: Option<String>,
+    pub retain: Option<String>,
+    pub status: String,
+    pub result_hash: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct MapItemResult {
+    index: usize,
+    item_hash: String,
+    status: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn now_iso() -> String {
+    crate::core::time::now_epoch_z()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+fn append_jsonl(path: &Path, value: &serde_json::Value) -> Result<(), error::DecapodError> {
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(error::DecapodError::IoError)?;
+    writeln!(f, "{}", serde_json::to_string(value).unwrap())
+        .map_err(error::DecapodError::IoError)?;
+    Ok(())
+}
+
+fn load_items(items_str: &str) -> Result<Vec<serde_json::Value>, error::DecapodError> {
+    // Try parsing as JSON array directly
+    if let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(items_str) {
+        return Ok(arr);
+    }
+    // Try as file path
+    let path = Path::new(items_str);
+    if path.exists() {
+        let content = fs::read_to_string(path).map_err(error::DecapodError::IoError)?;
+        let arr: Vec<serde_json::Value> = serde_json::from_str(&content).map_err(|e| {
+            error::DecapodError::ValidationError(format!("Failed to parse items file: {}", e))
+        })?;
+        return Ok(arr);
+    }
+    Err(error::DecapodError::ValidationError(
+        "Items must be a valid JSON array or a path to a JSON file".to_string(),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Core operations
+// ---------------------------------------------------------------------------
+
+/// Execute a stateless map-llm operation.
+pub fn map_llm(
+    store: &Store,
+    items_str: &str,
+    prompt: &str,
+    schema_str: &str,
+    actor: &str,
+) -> Result<serde_json::Value, error::DecapodError> {
+    let items = load_items(items_str)?;
+    if items.is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "Items array must not be empty".to_string(),
+        ));
+    }
+
+    let prompt_hash = sha256_hex(prompt.as_bytes());
+    let schema_hash = sha256_hex(schema_str.as_bytes());
+
+    // Validate schema is parseable JSON
+    let _schema: serde_json::Value = serde_json::from_str(schema_str)
+        .map_err(|e| error::DecapodError::ValidationError(format!("Invalid schema JSON: {}", e)))?;
+
+    // Process each item structurally (contract definition, not execution)
+    let mut results: Vec<MapItemResult> = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        let item_json = serde_json::to_string(item).unwrap();
+        let item_hash = sha256_hex(item_json.as_bytes());
+        results.push(MapItemResult {
+            index: i,
+            item_hash,
+            status: "pending".to_string(),
+        });
+    }
+
+    // Deterministic result hash
+    let results_json = serde_json::to_string(&results).unwrap();
+    let result_hash = sha256_hex(results_json.as_bytes());
+
+    let event_id = Ulid::new().to_string();
+    let ts = now_iso();
+
+    let event = serde_json::json!({
+        "event_id": event_id,
+        "ts": ts,
+        "actor": actor,
+        "op": "map.llm",
+        "item_count": items.len(),
+        "prompt_hash": prompt_hash,
+        "schema_hash": schema_hash,
+        "status": "completed",
+        "result_hash": result_hash,
+    });
+
+    append_jsonl(&map_events_path(&store.root), &event)?;
+
+    Ok(serde_json::json!({
+        "event_id": event_id,
+        "op": "map.llm",
+        "item_count": items.len(),
+        "prompt_hash": prompt_hash,
+        "schema_hash": schema_hash,
+        "result_hash": result_hash,
+        "items": results,
+    }))
+}
+
+/// Execute a map-agentic operation with scope-reduction enforcement.
+pub fn map_agentic(
+    store: &Store,
+    items_str: &str,
+    delegate: &str,
+    retain: &str,
+    actor: &str,
+) -> Result<serde_json::Value, error::DecapodError> {
+    // Scope-reduction invariant: --retain must be non-empty
+    if retain.trim().is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "Delegation without retention violates scope-reduction invariant".to_string(),
+        ));
+    }
+
+    let items = load_items(items_str)?;
+    if items.is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "Items array must not be empty".to_string(),
+        ));
+    }
+
+    let delegate_hash = sha256_hex(delegate.as_bytes());
+
+    // Log each item delegation
+    let mut results: Vec<MapItemResult> = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        let item_json = serde_json::to_string(item).unwrap();
+        let item_hash = sha256_hex(item_json.as_bytes());
+        results.push(MapItemResult {
+            index: i,
+            item_hash,
+            status: "delegated".to_string(),
+        });
+    }
+
+    let results_json = serde_json::to_string(&results).unwrap();
+    let result_hash = sha256_hex(results_json.as_bytes());
+
+    let event_id = Ulid::new().to_string();
+    let ts = now_iso();
+
+    let event = serde_json::json!({
+        "event_id": event_id,
+        "ts": ts,
+        "actor": actor,
+        "op": "map.agentic",
+        "item_count": items.len(),
+        "delegate_hash": delegate_hash,
+        "retain": retain,
+        "status": "completed",
+        "result_hash": result_hash,
+    });
+
+    append_jsonl(&map_events_path(&store.root), &event)?;
+
+    Ok(serde_json::json!({
+        "event_id": event_id,
+        "op": "map.agentic",
+        "item_count": items.len(),
+        "delegate_hash": delegate_hash,
+        "retain": retain,
+        "result_hash": result_hash,
+        "items": results,
+    }))
+}
+
+/// Read all map events from the JSONL audit trail.
+pub fn read_map_events(root: &Path) -> Result<Vec<MapEvent>, error::DecapodError> {
+    let path = map_events_path(root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    let mut events = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: MapEvent = serde_json::from_str(trimmed)
+            .map_err(|e| error::DecapodError::ValidationError(e.to_string()))?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(clap::Args, Debug)]
+pub struct MapCli {
+    #[clap(subcommand)]
+    pub command: MapCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum MapCommand {
+    /// Stateless parallel processing: apply prompt+schema to each item
+    Llm {
+        /// JSON array or path to JSON file containing items
+        #[clap(long)]
+        items: String,
+        /// Prompt template to apply to each item
+        #[clap(long)]
+        prompt: String,
+        /// JSON schema for output validation
+        #[clap(long)]
+        schema: String,
+        /// Actor identifier
+        #[clap(long, default_value = "decapod")]
+        actor: String,
+    },
+    /// Subagent map with scope-reduction enforcement
+    Agentic {
+        /// JSON array or path to JSON file containing items
+        #[clap(long)]
+        items: String,
+        /// Delegation prompt for subagents
+        #[clap(long)]
+        delegate: String,
+        /// What the caller retains responsibility for (REQUIRED for scope-reduction)
+        #[clap(long)]
+        retain: String,
+        /// Actor identifier
+        #[clap(long, default_value = "decapod")]
+        actor: String,
+    },
+    /// Emit subsystem schema JSON
+    Schema,
+}
+
+pub fn run_map_cli(store: &Store, cli: MapCli) -> Result<(), error::DecapodError> {
+    match cli.command {
+        MapCommand::Llm {
+            items,
+            prompt,
+            schema,
+            actor,
+        } => {
+            let result = map_llm(store, &items, &prompt, &schema, &actor)?;
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+        MapCommand::Agentic {
+            items,
+            delegate,
+            retain,
+            actor,
+        } => {
+            let result = map_agentic(store, &items, &delegate, &retain, &actor)?;
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+        MapCommand::Schema => {
+            println!("{}", serde_json::to_string_pretty(&schema()).unwrap());
+        }
+    }
+    Ok(())
+}
+
+pub fn schema() -> serde_json::Value {
+    serde_json::json!({
+        "name": "map",
+        "version": "0.1.0",
+        "description": "Deterministic map operators — structured parallel processing with scope-reduction",
+        "commands": [
+            { "name": "llm", "description": "Stateless parallel processing with prompt+schema" },
+            { "name": "agentic", "description": "Subagent map with scope-reduction enforcement" },
+            { "name": "schema", "description": "Emit subsystem schema JSON" },
+        ],
+        "storage": [schemas::MAP_EVENTS_NAME],
+        "invariants": [
+            "map agentic requires --retain (scope-reduction invariant)",
+            "All operations are logged to append-only map.events.jsonl",
+            "Deterministic: same items + same prompt + same schema → same result_hash",
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn test_store() -> (tempfile::TempDir, Store) {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(&root).unwrap();
+        let store = Store {
+            kind: crate::core::store::StoreKind::Repo,
+            root,
+        };
+        (tmp, store)
+    }
+
+    #[test]
+    fn test_map_llm_rejects_empty_items() {
+        let (_tmp, store) = test_store();
+        let result = map_llm(&store, "[]", "prompt", "{}", "agent");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_map_agentic_rejects_empty_retain() {
+        let (_tmp, store) = test_store();
+        let result = map_agentic(&store, "[\"item1\"]", "delegate prompt", "", "agent");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("scope-reduction"));
+    }
+
+    #[test]
+    fn test_map_agentic_logs_delegation() {
+        let (_tmp, store) = test_store();
+        let result = map_agentic(
+            &store,
+            "[\"item1\", \"item2\"]",
+            "do the thing",
+            "orchestration",
+            "agent",
+        )
+        .unwrap();
+        assert_eq!(result["item_count"].as_u64().unwrap(), 2);
+        assert_eq!(result["retain"].as_str().unwrap(), "orchestration");
+
+        let events = read_map_events(&store.root).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].op, "map.agentic");
+    }
+
+    #[test]
+    fn test_map_llm_produces_result() {
+        let (_tmp, store) = test_store();
+        let result = map_llm(
+            &store,
+            "[\"a\", \"b\", \"c\"]",
+            "summarize: {{item}}",
+            "{\"type\": \"object\"}",
+            "agent",
+        )
+        .unwrap();
+        assert_eq!(result["item_count"].as_u64().unwrap(), 3);
+        assert!(result["result_hash"].as_str().is_some());
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,8 @@ pub mod gatling;
 pub mod health;
 pub mod heartbeat;
 pub mod knowledge;
+pub mod lcm;
+pub mod map_ops;
 pub mod policy;
 pub mod primitives;
 pub mod reflex;

--- a/tests/lcm_determinism.rs
+++ b/tests/lcm_determinism.rs
@@ -1,0 +1,266 @@
+//! Integration tests for LCM (Lossless Context Management) and Map operators.
+
+use decapod::core::store::{Store, StoreKind};
+use decapod::plugins::lcm::{
+    ingest, initialize_lcm_db, list_originals, rebuild_index_from_ledger, show_original,
+    show_summary, summarize, validate_ledger_integrity,
+};
+use decapod::plugins::map_ops::{map_agentic, map_llm, read_map_events};
+use std::fs;
+use tempfile::tempdir;
+
+fn test_store() -> (tempfile::TempDir, Store) {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    initialize_lcm_db(&root).unwrap();
+    let store = Store {
+        kind: StoreKind::Repo,
+        root,
+    };
+    (tmp, store)
+}
+
+// ---------------------------------------------------------------------------
+// LCM tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_lcm_ingest_produces_correct_content_hash() {
+    let (_tmp, store) = test_store();
+    let content = "The quick brown fox jumps over the lazy dog";
+    let result = ingest(&store, content, "message", "test-agent", None, None).unwrap();
+    let content_hash = result["content_hash"].as_str().unwrap();
+
+    // Verify SHA256
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let expected = format!("{:x}", hasher.finalize());
+    assert_eq!(content_hash, expected);
+}
+
+#[test]
+fn test_lcm_ingest_is_append_only() {
+    let (_tmp, store) = test_store();
+
+    ingest(&store, "first", "message", "agent", None, None).unwrap();
+    let ledger_path = store.root.join("lcm.events.jsonl");
+    let len1 = fs::read_to_string(&ledger_path).unwrap().lines().count();
+    assert_eq!(len1, 1);
+
+    ingest(&store, "second", "event", "agent", None, None).unwrap();
+    let len2 = fs::read_to_string(&ledger_path).unwrap().lines().count();
+    assert_eq!(len2, 2);
+
+    ingest(&store, "third", "artifact", "agent", None, None).unwrap();
+    let len3 = fs::read_to_string(&ledger_path).unwrap().lines().count();
+    assert_eq!(len3, 3);
+
+    // Verify ledger only grows
+    assert!(len3 > len2);
+    assert!(len2 > len1);
+}
+
+#[test]
+fn test_lcm_summarize_is_deterministic() {
+    let (_tmp, store) = test_store();
+
+    ingest(&store, "alpha", "message", "agent", None, None).unwrap();
+    ingest(&store, "beta", "message", "agent", None, None).unwrap();
+    ingest(&store, "gamma", "event", "agent", None, None).unwrap();
+
+    let result1 = summarize(&store, "all").unwrap();
+    let hash1 = result1["summary_hash"].as_str().unwrap().to_string();
+
+    // Summarize again — same originals should produce same hash
+    let result2 = summarize(&store, "all").unwrap();
+    let hash2 = result2["summary_hash"].as_str().unwrap().to_string();
+
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn test_lcm_index_rebuildable_from_ledger() {
+    let (_tmp, store) = test_store();
+
+    ingest(&store, "one", "message", "agent", Some("s1"), None).unwrap();
+    ingest(&store, "two", "event", "agent", Some("s1"), None).unwrap();
+    ingest(&store, "three", "artifact", "agent", None, None).unwrap();
+
+    // Get original index state
+    let original_list = list_originals(&store, None, None).unwrap();
+    assert_eq!(original_list.len(), 3);
+
+    // Delete the DB and rebuild from ledger
+    let db_path = store.root.join("lcm.db");
+    fs::remove_file(&db_path).unwrap();
+
+    // Reinitialize DB (creates empty tables)
+    initialize_lcm_db(&store.root).unwrap();
+
+    // Rebuild from ledger
+    let count = rebuild_index_from_ledger(&store).unwrap();
+    assert_eq!(count, 3);
+
+    // Verify rebuilt index matches original
+    let rebuilt_list = list_originals(&store, None, None).unwrap();
+    assert_eq!(rebuilt_list.len(), 3);
+
+    // Verify each entry hash matches
+    for orig in &original_list {
+        let found = rebuilt_list
+            .iter()
+            .find(|r| r.content_hash == orig.content_hash);
+        assert!(
+            found.is_some(),
+            "Missing content_hash {} after rebuild",
+            orig.content_hash
+        );
+    }
+}
+
+#[test]
+fn test_lcm_show_retrieves_original() {
+    let (_tmp, store) = test_store();
+    let content = "find this content";
+    let result = ingest(&store, content, "artifact", "agent", None, None).unwrap();
+    let hash = result["content_hash"].as_str().unwrap();
+
+    let event = show_original(&store, hash).unwrap().unwrap();
+    assert_eq!(event.content, content);
+    assert_eq!(event.kind, "artifact");
+}
+
+#[test]
+fn test_lcm_summary_show() {
+    let (_tmp, store) = test_store();
+    ingest(&store, "data1", "message", "agent", None, None).unwrap();
+    ingest(&store, "data2", "message", "agent", None, None).unwrap();
+
+    let summary_result = summarize(&store, "all").unwrap();
+    let summary_hash = summary_result["summary_hash"].as_str().unwrap();
+
+    let entry = show_summary(&store, Some(summary_hash)).unwrap().unwrap();
+    assert_eq!(entry.summary_hash, summary_hash);
+    assert_eq!(entry.original_hashes.len(), 2);
+    assert_eq!(entry.scope, "all");
+}
+
+// ---------------------------------------------------------------------------
+// Map operator tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_map_llm_rejects_empty_items() {
+    let (_tmp, store) = test_store();
+    let result = map_llm(&store, "[]", "prompt", "{}", "agent");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("must not be empty"), "Error was: {}", err);
+}
+
+#[test]
+fn test_map_agentic_rejects_empty_retain() {
+    let (_tmp, store) = test_store();
+    let result = map_agentic(&store, "[\"item\"]", "do it", "", "agent");
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("scope-reduction"), "Error was: {}", err);
+
+    // Also reject whitespace-only retain
+    let result2 = map_agentic(&store, "[\"item\"]", "do it", "   ", "agent");
+    assert!(result2.is_err());
+}
+
+#[test]
+fn test_map_agentic_logs_delegation() {
+    let (_tmp, store) = test_store();
+    let result = map_agentic(
+        &store,
+        "[\"task1\", \"task2\", \"task3\"]",
+        "process each task",
+        "orchestration and error handling",
+        "test-agent",
+    )
+    .unwrap();
+
+    assert_eq!(result["item_count"].as_u64().unwrap(), 3);
+    assert_eq!(
+        result["retain"].as_str().unwrap(),
+        "orchestration and error handling"
+    );
+
+    // Verify audit trail
+    let events = read_map_events(&store.root).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].op, "map.agentic");
+    assert_eq!(events[0].item_count, 3);
+    assert_eq!(
+        events[0].retain.as_deref().unwrap(),
+        "orchestration and error handling"
+    );
+}
+
+#[test]
+fn test_map_llm_processes_items() {
+    let (_tmp, store) = test_store();
+    let result = map_llm(
+        &store,
+        "[\"a\", \"b\", \"c\"]",
+        "summarize: {{item}}",
+        "{\"type\": \"object\"}",
+        "agent",
+    )
+    .unwrap();
+
+    assert_eq!(result["item_count"].as_u64().unwrap(), 3);
+    assert!(result["result_hash"].as_str().is_some());
+    assert!(result["prompt_hash"].as_str().is_some());
+    assert!(result["schema_hash"].as_str().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Immutability gate tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_lcm_immutability_gate_catches_tampered_hash() {
+    let (_tmp, store) = test_store();
+    ingest(&store, "authentic content", "message", "agent", None, None).unwrap();
+    ingest(&store, "more content", "event", "agent", None, None).unwrap();
+
+    // Tamper with a content hash in the ledger
+    let ledger_path = store.root.join("lcm.events.jsonl");
+    let contents = fs::read_to_string(&ledger_path).unwrap();
+    let tampered = contents.replacen("authentic content", "tampered content", 1);
+    fs::write(&ledger_path, &tampered).unwrap();
+
+    let failures = validate_ledger_integrity(&store.root).unwrap();
+    assert!(!failures.is_empty(), "Should detect tampered content hash");
+    assert!(
+        failures[0].contains("content_hash mismatch"),
+        "Failure message should mention hash mismatch: {}",
+        failures[0]
+    );
+}
+
+#[test]
+fn test_lcm_immutability_gate_passes_valid() {
+    let (_tmp, store) = test_store();
+    ingest(&store, "content a", "message", "agent", None, None).unwrap();
+    ingest(&store, "content b", "event", "agent", None, None).unwrap();
+
+    let failures = validate_ledger_integrity(&store.root).unwrap();
+    assert!(
+        failures.is_empty(),
+        "Valid ledger should pass: {:?}",
+        failures
+    );
+}
+
+#[test]
+fn test_lcm_ingest_rejects_invalid_kind() {
+    let (_tmp, store) = test_store();
+    let result = ingest(&store, "test", "invalid_kind", "agent", None, None);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- **`decapod lcm`** — Lossless Context Management: append-only JSONL ledger (`lcm.events.jsonl`) with SHA256 content addressing, rebuildable SQLite index (`lcm.db`), and deterministic summary DAG. Commands: `ingest`, `list`, `show`, `summarize`, `summary`, `schema`.
- **`decapod map`** — Deterministic Map operators for structured parallel processing. `map llm` defines the contract for prompt+schema application. `map agentic` enforces scope-reduction via mandatory `--retain` flag. Commands: `llm`, `agentic`, `schema`.
- **Validation gate** — `validate_lcm_immutability` verifies content hash integrity, no duplicate event IDs, and monotonic timestamps in the LCM ledger.
- **Constitution doc** — `constitution/interfaces/LCM.md` documents store model, operator contracts, determinism guarantees, and progressive disclosure.

## Files changed

| File | Change |
|------|--------|
| `src/plugins/lcm.rs` | New — LCM plugin (691 lines) |
| `src/plugins/map_ops.rs` | New — Map operators plugin (415 lines) |
| `tests/lcm_determinism.rs` | New — 13 integration tests |
| `constitution/interfaces/LCM.md` | New — Interface specification |
| `src/core/schemas.rs` | LCM/Map schema constants |
| `src/core/validate.rs` | LCM immutability validation gate |
| `src/lib.rs` | Wire `Lcm` + `Map` commands + DB init |
| `src/plugins/mod.rs` | Register new modules |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo test --lib` — 61/61 pass (9 new unit tests)
- [x] `cargo test --test lcm_determinism` — 13/13 pass
- [x] Hash correctness: SHA256 matches for ingested content
- [x] Append-only: ledger only grows, never shrinks
- [x] Deterministic summaries: same originals → same hash
- [x] Index rebuild: delete DB, rebuild from JSONL, verify identical
- [x] Scope-reduction: empty `--retain` rejected
- [x] Tamper detection: modified content caught by validation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)