### PR TITLE
feat: add safe validate diagnostics and contention gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This is the operator and integrator landing page for Decapod.
 - `README.md`: product positioning and quickstart.
 - `docs/ARCHITECTURE_OVERVIEW.md`: canonical runtime model.
 - `docs/CONTROL_PLANE_API.md`: stable CLI/RPC control-plane contract.
+- `docs/VERIFICATION.md`: operator verification commands and proof surfaces.
 - `docs/SECURITY_THREAT_MODEL.md`: security posture and limits.
 - `docs/RELEASE_PROCESS.md`: release readiness and versioning discipline.
 - `docs/MIGRATIONS.md`: forward-only schema evolution policy.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,0 +1,51 @@
+# Operator Verification Guide
+
+This guide defines how to verify Decapod behavior using reproducible commands, tests, and artifacts.
+
+## Supported Kernel Invariants
+
+| Invariant | Enforcement Surface | Verify |
+|---|---|---|
+| Validate must terminate under lock contention with a typed failure marker | `tests/validate_termination.rs` | `cargo test --all-features --test validate_termination -- --test-threads=1` |
+| RPC envelope compatibility is pinned to golden vectors | `tests/rpc_golden_vectors.rs`, `tests/golden/rpc/v1/*` | `cargo test --all-features --test rpc_golden_vectors -- --test-threads=1` |
+| Enforced claims must map to gates and KCR trend counts | `tests/canonical_evidence_gate.rs` | `cargo test --all-features --test canonical_evidence_gate -- --test-threads=1` |
+| Promotion requires provenance manifests | `src/core/workspace.rs`, `decapod workspace publish` gate | `decapod workspace publish` (fails if manifests missing) |
+
+## Proof Surfaces
+
+- RPC contract anchors: `tests/golden/rpc/v1/agent_init.request.json`, `tests/golden/rpc/v1/agent_init.response.json`
+- Validate contention semantics: `tests/validate_termination.rs`
+- Canonical evidence mapping: `tests/canonical_evidence_gate.rs`
+- Promotion provenance gate: `artifacts/provenance/artifact_manifest.json`, `artifacts/provenance/proof_manifest.json`
+
+## Validate Diagnostics (Safe Mode)
+
+Enable diagnostics only when needed:
+
+```bash
+DECAPOD_DIAGNOSTICS=1 decapod validate
+```
+
+If `VALIDATE_TIMEOUT_OR_LOCK` occurs, Decapod emits a sanitized diagnostic artifact:
+
+- `artifacts/diagnostics/validate/<run_id>.json`
+
+Expected fields:
+
+- `reason_code`
+- `elapsed_ms`
+- `timeout_secs`
+- `lock_age_ms`
+- `stale_lock_recovery_triggered`
+- `artifact_hash`
+
+Diagnostics MUST NOT include host/user/environment identifiers or absolute paths.
+
+## Repro Commands
+
+```bash
+cargo test --all-features --test validate_termination -- --test-threads=1
+cargo test --all-features --test rpc_golden_vectors -- --test-threads=1
+cargo test --all-features --test canonical_evidence_gate -- --test-threads=1
+decapod release check
+```

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -1,4 +1,6 @@
 use rusqlite::Connection;
+use serde_json::Value;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
@@ -204,5 +206,86 @@ fn validate_timeout_does_not_strand_db_for_followup_commands() {
         followup.status.success(),
         "follow-up command should succeed after lock release; stderr:\n{}",
         String::from_utf8_lossy(&followup.stderr)
+    );
+}
+
+#[test]
+fn validate_parallel_contention_emits_typed_reasoned_diagnostics() {
+    let (_tmp, dir, password) = setup_repo();
+    let db_path = dir.join(".decapod").join("data").join("todo.db");
+    assert!(db_path.exists(), "todo db should exist before lock test");
+
+    let conn = Connection::open(&db_path).expect("open todo db");
+    conn.execute_batch("BEGIN EXCLUSIVE;")
+        .expect("acquire exclusive lock");
+
+    let mut outputs = Vec::new();
+    for _ in 0..4 {
+        outputs.push(run_decapod(
+            &dir,
+            &["validate"],
+            &[
+                ("DECAPOD_AGENT_ID", "unknown"),
+                ("DECAPOD_SESSION_PASSWORD", &password),
+                ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+                ("DECAPOD_VALIDATE_TIMEOUT_SECS", "2"),
+                ("DECAPOD_DIAGNOSTICS", "1"),
+            ],
+        ));
+    }
+
+    conn.execute_batch("ROLLBACK;").expect("release lock");
+
+    for output in &outputs {
+        assert!(
+            !output.status.success(),
+            "validate should fail under forced lock contention"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("VALIDATE_TIMEOUT_OR_LOCK"),
+            "expected typed failure marker; got: {stderr}"
+        );
+        assert!(
+            stderr.contains("artifacts/diagnostics/validate/"),
+            "expected diagnostics artifact path in stderr; got: {stderr}"
+        );
+    }
+
+    let diagnostics_dir = dir.join("artifacts").join("diagnostics").join("validate");
+    assert!(
+        diagnostics_dir.exists(),
+        "diagnostics directory should be created under artifacts/diagnostics/validate"
+    );
+
+    let mut diagnostic_count = 0usize;
+    for entry in fs::read_dir(&diagnostics_dir).expect("read diagnostics dir") {
+        let entry = entry.expect("diagnostics dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        diagnostic_count += 1;
+        let raw = fs::read_to_string(&path).expect("read diagnostics artifact");
+        let payload: Value = serde_json::from_str(&raw).expect("parse diagnostics artifact");
+        assert_eq!(payload["kind"], "validate_diagnostic");
+        assert_eq!(payload["op"], "validate");
+        assert_eq!(payload["reason_code"], "timeout_acquiring_lock");
+        assert!(payload["elapsed_ms"].as_u64().is_some());
+        assert!(payload["timeout_secs"].as_u64().unwrap_or(0) > 0);
+        assert!(payload["artifact_hash"].as_str().unwrap_or("").len() >= 64);
+        assert!(
+            !raw.contains(&dir.to_string_lossy().to_string()),
+            "diagnostics should not leak absolute worktree path"
+        );
+        assert!(
+            !raw.to_ascii_lowercase().contains("hostname"),
+            "diagnostics should not leak hostname"
+        );
+    }
+
+    assert!(
+        diagnostic_count >= 4,
+        "expected at least one diagnostics artifact per failed validate run"
     );
 }


### PR DESCRIPTION
## Summary
- add opt-in sanitized validate diagnostics artifacts for  failures
- attach diagnostics path to typed validate failure output when 
- add deterministic contention stress test that asserts typed failure + diagnostics reason code
- add  as command/artifact verification runbook and index it from docs landing

## Why
- keeps kernel trust surface mechanical and observable under lock contention
- makes timeout/lock failures auditable without leaking host/user/environment metadata

## Proof
- 
- 
- 
running 4 tests
test validate_parallel_contention_emits_typed_reasoned_diagnostics ... ok
test validate_terminates_with_typed_error_under_db_contention ... ok
test validate_terminates_with_typed_error_under_immediate_lock_contention ... ok
test validate_timeout_does_not_strand_db_for_followup_commands ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 35.23s
- 
running 1 test
test rpc_agent_init_golden_vectors_are_parseable_and_stable ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 1 test
test enforced_claims_must_have_gate_mapping_and_kcr_trend_must_match ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- validate: running
validate: intent_version=0.0.2
validate: gate Four Invariants Gate
validate: summary pass=118 fail=1 warn=2 elapsed=1.34s
validate: failures 1: gate error: Validation error: SQLite open/config failed at stage='open_readonly_validate' path='/tmp/decapod-n...
validate: warnings 2: Risk map missing | Watcher audit trail missing
