### PR TITLE
feat: close 5 one-shot governance TODOs for release readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/CODEX.md
+++ b/CODEX.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/artifacts/provenance/intent_convergence_checklist.json
+++ b/artifacts/provenance/intent_convergence_checklist.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "kind": "intent_convergence_checklist",
+  "pr": {
+    "base": "master",
+    "scope": "governance-kernel"
+  },
+  "intent": "Each merge MUST preserve user intent traceability and proof-gated completion.",
+  "scope": "release-ready repository state",
+  "checklist": [
+    {
+      "name": "intent-linked-spec",
+      "status": "pass",
+      "evidence": "INTENT.md"
+    },
+    {
+      "name": "proof-gates-green",
+      "status": "pass",
+      "evidence": "decapod validate"
+    },
+    {
+      "name": "provenance-manifests-present",
+      "status": "pass",
+      "evidence": "artifacts/provenance/*.json"
+    }
+  ]
+}

--- a/constitution/docs/RELEASE_PROCESS.md
+++ b/constitution/docs/RELEASE_PROCESS.md
@@ -6,6 +6,7 @@ Run:
 
 ```bash
 decapod release check
+decapod release inventory
 ```
 
 Release readiness requires:
@@ -15,6 +16,12 @@ Release readiness requires:
 - `Cargo.lock` present for locked builds.
 - RPC golden vectors present (`tests/golden/rpc/v1`).
 - Provenance manifests present in `artifacts/provenance/`.
+- Intent-convergence checklist present and valid (`artifacts/provenance/intent_convergence_checklist.json`).
+- If schema/interface surfaces changed in the working tree, `CHANGELOG.md` `## [Unreleased]` MUST include a schema/interface note.
+
+`decapod release inventory` writes deterministic CI inventory output to:
+
+- `artifacts/inventory/repo_inventory.json`
 
 ## Versioning Rules
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -609,6 +609,23 @@ fn validate_entrypoint_invariants(
             all_present = false;
         }
 
+        // Entrypoints must reference embedded constitution docs, never legacy top-level docs/.
+        if agent_content.contains("decapod docs show docs/") {
+            fail(
+                &format!(
+                    "{} references non-embedded docs path (`docs/`). Use `constitution/docs/`.",
+                    agent_file
+                ),
+                ctx,
+            );
+            all_present = false;
+        } else if agent_content.contains("decapod docs show constitution/docs/") {
+            pass(
+                &format!("{} references embedded constitution docs path", agent_file),
+                ctx,
+            );
+        }
+
         // Must include explicit jail rule for .decapod access
         if agent_content.contains(".decapod files are accessed only via decapod CLI") {
             pass(

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -37,4 +37,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show docs/PLAYBOOK.md`
+`decapod docs show constitution/docs/PLAYBOOK.md`

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -494,3 +494,29 @@ fn test_agent_entrypoints_are_identical() {
         "Template entrypoints must be identical: CLAUDE.md != CODEX.md"
     );
 }
+
+#[test]
+fn test_agent_entrypoints_only_reference_embedded_docs() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for file in [
+        "CLAUDE.md",
+        "GEMINI.md",
+        "CODEX.md",
+        "templates/CLAUDE.md",
+        "templates/GEMINI.md",
+        "templates/CODEX.md",
+    ] {
+        let content = fs::read_to_string(repo_root.join(file))
+            .unwrap_or_else(|_| panic!("Failed to read {}", file));
+        assert!(
+            !content.contains("decapod docs show docs/"),
+            "{} must not reference legacy docs/ paths",
+            file
+        );
+        assert!(
+            content.contains("decapod docs show constitution/docs/"),
+            "{} must reference embedded constitution docs",
+            file
+        );
+    }
+}

--- a/tests/examples_interop.rs
+++ b/tests/examples_interop.rs
@@ -29,3 +29,31 @@ fn release_check_surface_exists_and_runs() {
         "release check should emit ok envelope"
     );
 }
+
+#[test]
+fn release_inventory_surface_exists_and_writes_artifact() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(&root)
+        .args(["release", "inventory"])
+        .output()
+        .expect("run release inventory");
+    assert!(
+        output.status.success(),
+        "release inventory failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"cmd\":\"release.inventory\""),
+        "release inventory should emit envelope"
+    );
+    assert!(
+        root.join("artifacts/inventory/repo_inventory.json")
+            .exists(),
+        "release inventory should write deterministic artifact"
+    );
+    std::fs::remove_file(root.join("artifacts/inventory/repo_inventory.json"))
+        .expect("cleanup generated inventory artifact");
+}

--- a/tests/release_check_policy.rs
+++ b/tests/release_check_policy.rs
@@ -1,0 +1,144 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, content).expect("write file");
+}
+
+fn setup_release_fixture(changelog_unreleased: &str) -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+
+    let init = Command::new("git")
+        .current_dir(&root)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    write(
+        &root.join("CHANGELOG.md"),
+        &format!("# Changelog\n\n## [Unreleased]\n{changelog_unreleased}\n"),
+    );
+    write(&root.join(".decapod/README.md"), "decapod fixture\n");
+    write(&root.join(".decapod/data/.gitkeep"), "");
+    write(
+        &root.join("constitution/docs/MIGRATIONS.md"),
+        "# Migrations\n\n- forward-only\n",
+    );
+    write(
+        &root.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    );
+    write(&root.join("Cargo.lock"), "# lock\n");
+    write(
+        &root.join("tests/golden/rpc/v1/agent_init.request.json"),
+        "{ \"op\": \"agent.init\" }\n",
+    );
+    write(
+        &root.join("tests/golden/rpc/v1/agent_init.response.json"),
+        "{ \"status\": \"ok\" }\n",
+    );
+    write(&root.join("README.md"), "fixture\n");
+    write(
+        &root.join("src/core/schemas.rs"),
+        "pub fn schema_version() -> &'static str { \"1\" }\n",
+    );
+
+    let readme = fs::read(root.join("README.md")).expect("read readme");
+    let readme_hash = sha256_hex(&readme);
+    write(
+        &root.join("artifacts/provenance/artifact_manifest.json"),
+        &format!(
+            "{{\n  \"schema_version\": \"1.0.0\",\n  \"kind\": \"artifact_manifest\",\n  \"artifacts\": [{{\"path\": \"README.md\", \"sha256\": \"{readme_hash}\"}}]\n}}\n"
+        ),
+    );
+    write(
+        &root.join("artifacts/provenance/proof_manifest.json"),
+        "{\n  \"schema_version\": \"1.0.0\",\n  \"kind\": \"proof_manifest\",\n  \"proofs\": [{\"command\": \"decapod validate\", \"result\": \"pass\"}],\n  \"environment\": {\"os\": \"linux\", \"rust\": \"stable\"}\n}\n",
+    );
+    write(
+        &root.join("artifacts/provenance/intent_convergence_checklist.json"),
+        "{\n  \"schema_version\": \"1.0.0\",\n  \"kind\": \"intent_convergence_checklist\",\n  \"pr\": {\"base\": \"master\", \"scope\": \"fixture\"},\n  \"intent\": \"Keep proofs and intent converged\",\n  \"scope\": \"release\",\n  \"checklist\": [\n    {\"name\": \"intent\", \"status\": \"pass\", \"evidence\": \"INTENT.md\"}\n  ]\n}\n",
+    );
+
+    let add = Command::new("git")
+        .current_dir(&root)
+        .args(["add", "."])
+        .output()
+        .expect("git add");
+    assert!(add.status.success(), "git add failed");
+    let commit = Command::new("git")
+        .current_dir(&root)
+        .env("GIT_AUTHOR_NAME", "Alex H. Raber")
+        .env("GIT_AUTHOR_EMAIL", "alex@example.com")
+        .env("GIT_COMMITTER_NAME", "Alex H. Raber")
+        .env("GIT_COMMITTER_EMAIL", "alex@example.com")
+        .args(["commit", "-m", "fixture"])
+        .output()
+        .expect("git commit");
+    assert!(
+        commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    (tmp, root)
+}
+
+fn run_release_check(root: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(root)
+        .args(["release", "check"])
+        .output()
+        .expect("run release check")
+}
+
+#[test]
+fn release_check_blocks_schema_changes_without_changelog_note() {
+    let (_tmp, root) = setup_release_fixture("- housekeeping only");
+    fs::write(
+        root.join("src/core/schemas.rs"),
+        "pub fn schema_version() -> &'static str { \"2\" }\n",
+    )
+    .expect("mutate schemas");
+
+    let output = run_release_check(&root);
+    assert!(!output.status.success(), "release check should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("schema/interface files changed"),
+        "release check should explain schema/interface changelog policy; stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn release_check_allows_schema_changes_with_changelog_note() {
+    let (_tmp, root) = setup_release_fixture("- schema: bump todo shape for v2");
+    fs::write(
+        root.join("src/core/schemas.rs"),
+        "pub fn schema_version() -> &'static str { \"2\" }\n",
+    )
+    .expect("mutate schemas");
+
+    let output = run_release_check(&root);
+    assert!(
+        output.status.success(),
+        "release check should pass when changelog includes schema note.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
This PR closes five high-impact 1-shot TODOs to improve Decapod's release reliability and intent convergence surfaces.

### Completed TODOs
- R_01KJ1N4WDPFPJFEFJ814A2BB1F: deterministic CI inventory command + JSON artifact output
- R_01KJ1N50QE34XKVQ6C30S28NP9: enforce embedded constitution docs references in agent entrypoints
- R_01KJ1N5C2N92RTZ4M7R8XGJNF6: bounded runtime smoke test for validate contention behavior
- R_01KJ1N5FPDG6PQC72J4C3V61KR: release check blocks schema/interface changes lacking changelog note
- R_01KJ1N5NGNBDGQF9EWSVV091VV: intent-convergence checklist manifest gate in release check

## Key changes
- Added `decapod release inventory` to emit deterministic `artifacts/inventory/repo_inventory.json`.
- Extended `decapod release check` with:
  - intent convergence manifest validation (`artifacts/provenance/intent_convergence_checklist.json`)
  - schema/interface change policy requiring corresponding CHANGELOG Unreleased note.
- Added provenance artifact `artifacts/provenance/intent_convergence_checklist.json`.
- Enforced non-legacy docs references (`constitution/docs/`) in entrypoints via runtime validate gate and tests.
- Added release policy integration tests and validate runtime bound smoke test.

## Proof
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (full suite green)
- `decapod validate` (pass; warnings only: Risk map missing, Watcher audit trail missing)
