### PR TITLE
fix: enforce embedded constitution path references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 6. **NEVER bypass proofs based on self-confidence.** Evidence or nothing.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
+9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`

--- a/CODEX.md
+++ b/CODEX.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ decapod init
 
 Then use your agents as normal. Decapod works on your behalf from inside the agent.
 
-Learn more about the [embedded constitution](constitution/core/DECAPOD.md).
+Learn more about the embedded constitution via the CLI:
+
+```bash
+decapod docs show core/DECAPOD.md
+```
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,11 @@ Decapod takes security seriously. This document provides an overview of our secu
 
 ## For Agents
 
-**Read the constitutional security contract:** [`constitution/specs/SECURITY.md`](constitution/specs/SECURITY.md)
+**Read the constitutional security contract via embedded docs:**
+
+```bash
+decapod docs show specs/SECURITY.md
+```
 
 This document is binding. All agents must follow the security principles outlined therein, including:
 - Credential handling (never log, never commit, always rotate)

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "7323473c31f36da0e57f5eeaaf0c4da5cd9201ea248131b087055c6a1ea4da0c"
+      "sha256": "0313d7a3079ea287d3f7516f60b8cb8865a1a6060baf6bdda63a37aa9e75773d"
     }
   ]
 }

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -8,7 +8,7 @@
 //!
 //! - **Constitution is embedded in binary**: No need for external doc files
 //! - **Use `decapod docs show <path>`**: Access docs via CLI, not direct file reads
-//! - **Override mechanism**: Projects can override docs in `.decapod/constitution/`
+//! - **Override mechanism**: Projects can override embedded docs via `.decapod/OVERRIDE.md`
 //! - **Merge semantics**: Overrides append to embedded base (see `get_merged_doc`)
 //! - **Templates for scaffolding**: CLAUDE.md, GEMINI.md, etc. are embedded here
 

--- a/src/core/docs_cli.rs
+++ b/src/core/docs_cli.rs
@@ -28,7 +28,7 @@ pub struct DocsCli {
 pub enum DocumentSource {
     /// Show only the embedded content (from the binary)
     Embedded,
-    /// Show only the override content (from .decapod/constitution/)
+    /// Show only the override content (from .decapod/OVERRIDE.md sections)
     Override,
     /// Show merged content (embedded base + project override appended)
     Merged,
@@ -70,7 +70,7 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
             for doc in docs {
                 println!("- {}", doc);
             }
-            // TODO: Also list dynamically loaded docs from .decapod/constitutions/
+            // TODO: Also list project override sections from .decapod/OVERRIDE.md
             Ok(DocsRunResult::default())
         }
         DocsCommand::Show { path, source } => {
@@ -108,7 +108,7 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
                         assets::get_embedded_doc(relative_path)
                     }
                     DocumentSource::Override => {
-                        // Show only override content from .decapod/constitution/
+                        // Show only override content from .decapod/OVERRIDE.md
                         let current_dir =
                             std::env::current_dir().map_err(error::DecapodError::IoError)?;
                         let repo_root = find_repo_root(&current_dir)?;

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -609,21 +609,32 @@ fn validate_entrypoint_invariants(
             all_present = false;
         }
 
-        // Entrypoints must reference embedded constitution docs, never legacy top-level docs/.
-        if agent_content.contains("decapod docs show docs/") {
+        // Must use embedded doc paths via CLI, never direct constitution/* file paths.
+        if agent_content.contains("decapod docs show constitution/")
+            || agent_content.contains("(constitution/")
+        {
             fail(
                 &format!(
-                    "{} references non-embedded docs path (`docs/`). Use `constitution/docs/`.",
+                    "{} references direct constitution filesystem paths; use embedded doc paths (e.g. core/*, specs/*, docs/*)",
                     agent_file
                 ),
                 ctx,
             );
             all_present = false;
-        } else if agent_content.contains("decapod docs show constitution/docs/") {
+        } else if agent_content.contains("decapod docs show docs/") {
             pass(
-                &format!("{} references embedded constitution docs path", agent_file),
+                &format!("{} references embedded docs path convention", agent_file),
                 ctx,
             );
+        } else {
+            fail(
+                &format!(
+                    "{} missing embedded docs path reference (`decapod docs show docs/...`)",
+                    agent_file
+                ),
+                ctx,
+            );
+            all_present = false;
         }
 
         // Must include explicit jail rule for .decapod access

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -44,6 +44,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 6. **NEVER bypass proofs based on self-confidence.** Evidence or nothing.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
+9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
 
 ---
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -22,6 +22,7 @@ decapod todo claim --id <task-id>
 - Workspace isolation: `decapod workspace ensure`. Never main/master.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
+- Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
 
 ## Safety Invariants
 

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -38,4 +38,4 @@ See **AGENTS.md** for the full universal contract.
 
 ## Optional Operator Guide
 
-`decapod docs show constitution/docs/PLAYBOOK.md`
+`decapod docs show docs/PLAYBOOK.md`


### PR DESCRIPTION
## Summary
Tightens constitution path semantics so operator-facing docs and entrypoints consistently use embedded doc paths through the Decapod binary.

## What changed
- Added explicit rule in `AGENTS.md` + `templates/AGENTS.md`: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.
- Updated agent entrypoints (`CLAUDE.md`, `GEMINI.md`, `CODEX.md` and templates) to include the embedded-constitution-only rule.
- Updated top-level docs:
  - `README.md` now routes constitution access through `decapod docs show core/DECAPOD.md`.
  - `SECURITY.md` now routes security contract access through `decapod docs show specs/SECURITY.md`.
- Hardened validation gate in `src/core/validate.rs`:
  - fail if agent entrypoints reference direct constitution filesystem paths.
- Added regression tests in `tests/entrypoint_correctness.rs`:
  - entrypoints/templates must use embedded docs paths
  - top-level docs must avoid direct `constitution/*` links for operator guidance.
- Corrected stale code comments around override storage path (`.decapod/OVERRIDE.md`) in `src/core/assets.rs` and `src/core/docs_cli.rs`.

## Proof
- `cargo fmt --all`
- `cargo test --test entrypoint_correctness`
- `cargo clippy --all-targets -- -D warnings`

Note: `decapod validate` in this session intermittently returned `VALIDATE_TIMEOUT_OR_LOCK` despite no live `decapod` process; this PR does not modify lock behavior.
