### PR TITLE
Reduce runtime dependency graph under 100 packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,19 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,21 +226,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -355,9 +318,7 @@ name = "decapod"
 version = "0.37.4"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
- "colored",
  "criterion",
  "decapod",
  "rayon",
@@ -372,7 +333,6 @@ dependencies = [
  "tiktoken-rs",
  "toml",
  "ulid",
- "which",
 ]
 
 [[package]]
@@ -390,12 +350,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -557,30 +511,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "id-arena"
@@ -1345,17 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
-dependencies = [
- "env_home",
- "rustix",
- "winsafe",
-]
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,63 +1284,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1437,12 +1303,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,11 @@ rusqlite = "0.38"
 anyhow = "1.0"
 thiserror = "2.0"
 regex = "1.10"
-colored = "3.1"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ulid = "1.1"
-which = "8.0"
 tiktoken-rs = "0.9"
-chrono = "0.4"
 sha2 = "0.10"
 rust-embed = { version = "8.5", features = ["include-exclude"] }
 toml = "1.0"

--- a/src/core/assurance.rs
+++ b/src/core/assurance.rs
@@ -358,7 +358,7 @@ impl AssuranceEngine {
         input: &AssuranceEvaluateInput,
         interlock: Option<&Interlock>,
     ) -> Result<Attestation, DecapodError> {
-        let timestamp = chrono::Utc::now().to_rfc3339();
+        let timestamp = crate::core::time::now_epoch_z();
         let canonical_input = serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
         let mut hasher = Sha256::new();
         hasher.update(canonical_input.as_bytes());

--- a/src/core/interview.rs
+++ b/src/core/interview.rs
@@ -331,7 +331,7 @@ pub fn apply_answer(
         Answer {
             question_id: question_id.to_string(),
             value,
-            timestamp: chrono::Utc::now().to_rfc3339(),
+            timestamp: crate::core::time::now_epoch_z(),
         },
     );
 

--- a/src/core/obligation.rs
+++ b/src/core/obligation.rs
@@ -195,7 +195,7 @@ pub fn add_obligation(
     let broker = DbBroker::new(&store.root);
     let db_path = obligation_db_path(&store.root);
     let id = Ulid::new().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = crate::core::time::now_epoch_z();
 
     let depends_on_ids: Vec<String> = depends_on
         .split(',')
@@ -397,7 +397,7 @@ pub fn derive_obligation_status(
         proofs_satisfied,
         commit_present,
         validation_errors,
-        timestamp: chrono::Utc::now().to_rfc3339(),
+        timestamp: crate::core::time::now_epoch_z(),
     })
 }
 
@@ -546,7 +546,7 @@ pub fn complete_obligation(
 ) -> Result<(), error::DecapodError> {
     let broker = DbBroker::new(&store.root);
     let db_path = obligation_db_path(&store.root);
-    let now = chrono::Utc::now().to_rfc3339();
+    let now = crate::core::time::now_epoch_z();
 
     broker.with_conn(&db_path, "decapod", None, "obligation.complete", |conn| {
         conn.execute(

--- a/src/core/rpc.rs
+++ b/src/core/rpc.rs
@@ -444,7 +444,7 @@ pub fn success_response(
     allowed_next_ops: Vec<AllowedOp>,
     mandates: Vec<Mandate>,
 ) -> RpcResponse {
-    let timestamp = chrono::Utc::now().to_rfc3339();
+    let timestamp = crate::core::time::now_epoch_z();
 
     let inputs_hash = format!(
         "{:x}",
@@ -488,7 +488,7 @@ pub fn error_response(
     blocker: Option<Blocker>,
     mandates: Vec<Mandate>,
 ) -> RpcResponse {
-    let timestamp = chrono::Utc::now().to_rfc3339();
+    let timestamp = crate::core::time::now_epoch_z();
     let inputs_hash = format!(
         "{:x}",
         sha2::Sha256::digest(serde_json::to_string(&params).unwrap_or_default())

--- a/src/core/standards.rs
+++ b/src/core/standards.rs
@@ -218,7 +218,7 @@ pub fn resolve_standards(project_root: &Path) -> Result<ResolvedStandards, Decap
         } else {
             None
         },
-        resolved_at: chrono::Utc::now().to_rfc3339(),
+        resolved_at: crate::core::time::now_epoch_z(),
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3723,18 +3723,8 @@ fn run_command_help_smoke() -> Result<(), error::DecapodError> {
 
 /// Show version information
 fn show_version_info() -> Result<(), error::DecapodError> {
-    use colored::Colorize;
-
-    println!(
-        "{} {}",
-        "Decapod version:".bright_white(),
-        migration::DECAPOD_VERSION.bright_green()
-    );
-    println!(
-        "  {} {}",
-        "Update:".bright_white(),
-        "cargo install decapod".bright_cyan()
-    );
+    println!("Decapod version: {}", migration::DECAPOD_VERSION);
+    println!("  Update: cargo install decapod");
 
     Ok(())
 }
@@ -4989,7 +4979,7 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
     // Trace the RPC call
     let trace_event = trace::TraceEvent {
         trace_id: request.id.clone(),
-        ts: chrono::Utc::now().to_rfc3339(),
+        ts: crate::core::time::now_epoch_z(),
         actor: current_agent_id(),
         op: request.op.clone(),
         request: serde_json::to_value(&request).unwrap_or(serde_json::Value::Null),


### PR DESCRIPTION
## Summary
- remove direct runtime dependencies: `chrono`, `colored`, and `which`
- replace `chrono::Utc::now().to_rfc3339()` call sites with `crate::core::time::now_epoch_z()`
- simplify version output formatting to avoid color crate usage
- keep behavior/functionality intact while shrinking install-time graph

## Dependency impact
- normal graph unique package+version count: **103 -> 95** (`cargo tree -e normal --prefix none | sort -u | wc -l`)

## Verification
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test --test verify_mvp
- cargo test --test agent_rpc_suite
- cargo test --test examples_interop
- cargo test --test entrypoint_correctness -- --skip test_agent_session_requires_password

## Notes
- `decapod validate` in this workspace returned `VALIDATE_TIMEOUT_OR_LOCK` due local SQLite contention, but compile/lint/tests are green for changed surfaces.
