### PR TITLE
Enforce canonical decapod workspaces and startup sequence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,12 @@ decapod rpc --op agent.init
 # 5. Resolve context
 decapod rpc --op context.resolve
 
-# 6. Claim your task
+# 6. Create + claim your task
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+
+# 7. Enter canonical worktree
+decapod workspace ensure
 ```
 
 If any step fails, **stop and diagnose**. Do not skip steps.
@@ -37,7 +41,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 ## Golden Rules (Non-Negotiable)
 
 1. **ALWAYS refine intent with user BEFORE inference.** Ask clarifying questions, confirm requirements, identify exceptions. Never start coding until the request is well-understood.
-2. **NEVER work on main/master.** Use `decapod workspace ensure` for isolation.
+2. **NEVER work on main/master.** Use `decapod workspace ensure` and run from `.decapod/workspaces/*`.
 3. **NEVER read/write `.decapod/` files directly.** Use `decapod` CLI exclusively.
 4. **NEVER claim done without `decapod validate` passing.**
 5. **NEVER invent parallel CLIs or state roots.** Use Decapod's command surface.
@@ -45,6 +49,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
 9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
+10. **NEVER use non-canonical worktree roots** (for example `.claude/worktrees`). Decapod work executes only in `.decapod/workspaces/*`.
 
 ---
 
@@ -52,7 +57,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 
 - **Contextualization**: Resolve context via `agent.init` and `context.resolve` before mutations.
 - **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes.
-- **Isolation**: Use `decapod workspace ensure` for worktrees. Never work on protected branches.
+- **Isolation**: Use `decapod workspace ensure` for worktrees and execute from `.decapod/workspaces/*`. Never work on protected branches.
 - **Verification**: `decapod validate` is the authoritative completion gate.
 - **Liveness**: Each command invocation refreshes your agent presence. Use `decapod todo heartbeat` for explicit heartbeat.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
 9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
-10. **NEVER use non-canonical worktree roots** (for example `.claude/worktrees`). Decapod work executes only in `.decapod/workspaces/*`.
+10. **NEVER use non-canonical worktree roots.** Decapod work executes only in `.decapod/workspaces/*`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/constitution/core/DECAPOD.md
+++ b/constitution/core/DECAPOD.md
@@ -63,9 +63,10 @@ decapod capabilities --format json
 ## Workspace Rules (Non-Negotiable)
 
 1. **Agents MUST NOT work on main/master** - Decapod validates and refuses
-2. **Use `decapod workspace ensure`** to create an isolated worktree
+2. **Use `decapod workspace ensure`** to create an isolated worktree under `.decapod/workspaces/*`
 3. **Use on-demand containers** for build/test execution (clean env)
 4. **Validate before claiming done** - `decapod validate` is the gate
+5. **Do not use non-canonical worktree roots** (for example `.claude/worktrees`)
 
 ## Worktree + On-Demand Sandbox
 

--- a/constitution/core/DECAPOD.md
+++ b/constitution/core/DECAPOD.md
@@ -66,7 +66,7 @@ decapod capabilities --format json
 2. **Use `decapod workspace ensure`** to create an isolated worktree under `.decapod/workspaces/*`
 3. **Use on-demand containers** for build/test execution (clean env)
 4. **Validate before claiming done** - `decapod validate` is the gate
-5. **Do not use non-canonical worktree roots** (for example `.claude/worktrees`)
+5. **Do not use non-canonical worktree roots**
 
 ## Worktree + On-Demand Sandbox
 

--- a/constitution/interfaces/PROCEDURAL_NORMS.md
+++ b/constitution/interfaces/PROCEDURAL_NORMS.md
@@ -222,7 +222,7 @@ This file provides concrete examples of procedural norms (team skills) that agen
   "type": "agent_expectation",
   "schema_version": "1.0.0",
   "title": "Never work on main/master directly",
-  "rule": "All implementation work must happen in isolated worktrees. Use 'decapod workspace ensure'.",
+  "rule": "All implementation work must happen in isolated worktrees under '.decapod/workspaces/*'. Use 'decapod workspace ensure'.",
   "provenance": [
     {
       "evidence_type": "doc",

--- a/constitution/specs/GIT.md
+++ b/constitution/specs/GIT.md
@@ -26,7 +26,7 @@ Git is the canonical state layer for all project work. Poor git hygiene leads to
 
 ### 1.0. Container Workspace Mandate
 
-All git-tracked implementation work MUST execute in Docker-isolated git workspaces, not by directly editing the host repository working tree (claim: `claim.git.container_workspace_required`).
+All git-tracked implementation work MUST execute in Docker-isolated git workspaces rooted at `.decapod/workspaces/*`, not by directly editing the host repository working tree (claim: `claim.git.container_workspace_required`).
 
 Required:
 - Use container workspace flows for branch creation, commits, and pushes.

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -222,6 +222,7 @@ fn validate_embedded_self_contained(
                     || line.contains("intended as")
                     || line.contains(".decapod/knowledge/")
                     || line.contains(".decapod/data/")
+                    || line.contains(".decapod/workspaces/")
                     || line.contains("repo-scoped");
                 if is_legitimate_line {
                     legitimate_ref_count += refs_on_line;
@@ -711,6 +712,48 @@ fn validate_entrypoint_invariants(
         } else {
             fail(
                 &format!("{} missing claim-before-work mandate marker", agent_file),
+                ctx,
+            );
+            all_present = false;
+        }
+
+        // Must include task creation before claim mandate
+        if agent_content.contains("decapod todo add \"<task>\"") {
+            pass(
+                &format!("{} includes task creation mandate", agent_file),
+                ctx,
+            );
+        } else {
+            fail(
+                &format!("{} missing task creation mandate marker", agent_file),
+                ctx,
+            );
+            all_present = false;
+        }
+
+        // Must include canonical Decapod workspace path mandate
+        if agent_content.contains(".decapod/workspaces") {
+            pass(
+                &format!("{} includes canonical workspace path mandate", agent_file),
+                ctx,
+            );
+        } else {
+            fail(
+                &format!(
+                    "{} missing canonical workspace path marker (`.decapod/workspaces`)",
+                    agent_file
+                ),
+                ctx,
+            );
+            all_present = false;
+        }
+
+        if agent_content.contains(".claude/worktrees") {
+            fail(
+                &format!(
+                    "{} references forbidden non-canonical worktree path `.claude/worktrees`",
+                    agent_file
+                ),
                 ctx,
             );
             all_present = false;

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -26,8 +26,12 @@ decapod rpc --op agent.init
 # 5. Resolve context
 decapod rpc --op context.resolve
 
-# 6. Claim your task
+# 6. Create + claim your task
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+
+# 7. Enter canonical worktree
+decapod workspace ensure
 ```
 
 If any step fails, **stop and diagnose**. Do not skip steps.
@@ -37,7 +41,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 ## Golden Rules (Non-Negotiable)
 
 1. **ALWAYS refine intent with user BEFORE inference.** Ask clarifying questions, confirm requirements, identify exceptions. Never start coding until the request is well-understood.
-2. **NEVER work on main/master.** Use `decapod workspace ensure` for isolation.
+2. **NEVER work on main/master.** Use `decapod workspace ensure` and run from `.decapod/workspaces/*`.
 3. **NEVER read/write `.decapod/` files directly.** Use `decapod` CLI exclusively.
 4. **NEVER claim done without `decapod validate` passing.**
 5. **NEVER invent parallel CLIs or state roots.** Use Decapod's command surface.
@@ -45,6 +49,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
 9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
+10. **NEVER use non-canonical worktree roots** (for example `.claude/worktrees`). Decapod work executes only in `.decapod/workspaces/*`.
 
 ---
 
@@ -52,7 +57,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 
 - **Contextualization**: Resolve context via `agent.init` and `context.resolve` before mutations.
 - **State Mutation**: Use `decapod` CLI/RPC exclusively for state changes.
-- **Isolation**: Use `decapod workspace ensure` for worktrees. Never work on protected branches.
+- **Isolation**: Use `decapod workspace ensure` for worktrees and execute from `.decapod/workspaces/*`. Never work on protected branches.
 - **Verification**: `decapod validate` is the authoritative completion gate.
 - **Liveness**: Each command invocation refreshes your agent presence. Use `decapod todo heartbeat` for explicit heartbeat.
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -49,7 +49,7 @@ If any step fails, **stop and diagnose**. Do not skip steps.
 7. **Claim a task before substantive work.** `decapod todo claim --id <task-id>`.
 8. **Record decisions in durable artifacts.** Not in transient conversation.
 9. **NEVER read `constitution/*` files directly.** Constitution is embedded in the Decapod binary; access it via `decapod docs show <embedded-path>`.
-10. **NEVER use non-canonical worktree roots** (for example `.claude/worktrees`). Decapod work executes only in `.decapod/workspaces/*`.
+10. **NEVER use non-canonical worktree roots.** Decapod work executes only in `.decapod/workspaces/*`.
 
 ---
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/templates/CODEX.md
+++ b/templates/CODEX.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -11,7 +11,9 @@ decapod docs ingest
 decapod session acquire
 decapod rpc --op agent.init
 decapod rpc --op context.resolve
+decapod todo add "<task>"
 decapod todo claim --id <task-id>
+decapod workspace ensure
 ```
 
 ## Operating Mode
@@ -19,7 +21,7 @@ decapod todo claim --id <task-id>
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: `decapod workspace ensure`. Never main/master.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/templates/GEMINI.md
+++ b/templates/GEMINI.md
@@ -21,7 +21,7 @@ decapod workspace ensure
 - Plan first: Non-trivial changes require a plan artifact.
 - Proof first: `decapod validate` MUST pass before claiming done.
 - Minimal changes: Only change what is directly requested.
-- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master, never `.claude/worktrees`.
+- Workspace isolation: run `decapod workspace ensure` and work only from `.decapod/workspaces/*`. Never main/master and never non-canonical worktree roots.
 - CLI only: All `.decapod/` access through `decapod` CLI.
 - Just-in-time context: load only the minimum required doc slices with `decapod docs show <path>`.
 - Embedded constitution only: never read `constitution/*` directly; use `decapod docs show <embedded-path>`.

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -512,6 +512,21 @@ fn test_entrypoints_use_embedded_docs_paths_only() {
             "{} must reference embedded docs path for operator playbook",
             file
         );
+        assert!(
+            content.contains(".decapod/workspaces"),
+            "{} must mandate canonical Decapod worktree root",
+            file
+        );
+        assert!(
+            content.contains("decapod todo add \"<task>\""),
+            "{} must require task creation before claim",
+            file
+        );
+        assert!(
+            !content.contains(".claude/worktrees"),
+            "{} must never reference non-canonical .claude/worktrees path",
+            file
+        );
     }
 }
 

--- a/tests/plan_governed_execution.rs
+++ b/tests/plan_governed_execution.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 fn run_decapod(dir: &Path, args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_decapod"))
         .current_dir(dir)
+        .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
         .args(args)
         .output()
         .expect("run decapod")


### PR DESCRIPTION
Summary:\n- enforce canonical worktree location for CLI and RPC operations requiring isolated worktrees (.decapod/workspaces/*)\n- add typed scope-violation failures for non-canonical worktree roots and non-task-scoped branches\n- harden agent entrypoint contracts (root and templates) to require sequence: validate -> docs ingest -> session acquire -> agent.init -> context.resolve -> todo add and claim -> workspace ensure\n- add validation markers and tests for canonical workspace path and todo creation-before-claim\n- update constitution docs to state canonical workspace root\n\nValidation run:\n- cargo fmt\n- cargo check\n- cargo clippy --all-targets --all-features -- -D warnings\n\nNotes:\n- decapod validate intermittently returns VALIDATE_TIMEOUT_OR_LOCK in this environment\n- local test binary linking is blocked by environment linker failure (clang/lld hidden-symbol error)