### PR TITLE
fix: force session instantiation for unknown agents in validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ decapod init
 
 Then use your agents as normal. Decapod works on your behalf from inside the agent.
 
-Learn more about the embedded constitution here in [DECAPOD.md](constitution/core/DECAPOD.md).
+Learn more about the embedded constitution via the CLI:
 
+```bash
+decapod docs show core/DECAPOD.md
+```
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1830,7 +1830,8 @@ fn ensure_session_valid() -> Result<(), error::DecapodError> {
     }
 
     if agent_id == "unknown" {
-        return Ok(());
+        // Force session instantiation for unknown agents (required for validate)
+        return auto_acquire_session(&project_root, &agent_id);
     }
 
     let supplied_password = match std::env::var("DECAPOD_SESSION_PASSWORD") {


### PR DESCRIPTION
## Summary
When `agent_id` is 'unknown', `ensure_session_valid` was returning `Ok(())` without acquiring a session, causing `decapod validate` to timeout due to database contention.

## Fix
Force auto-acquisition of session even for unknown agents in `ensure_session_valid`.

## Testing
- `decapod validate` now completes in ~7s instead of timing out
- Validate runs and reports actual validation failures (not timeout errors)