### PR TITLE
Phase 0.3: add optional validate gates for workunit/context/promotion artifacts

### DIFF
--- a/src/core/context_capsule.rs
+++ b/src/core/context_capsule.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ContextCapsuleSource {
+    pub path: String,
+    pub section: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ContextCapsuleSnippet {
+    pub source_path: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeterministicContextCapsule {
+    pub topic: String,
+    pub scope: String,
+    pub task_id: Option<String>,
+    pub workunit_id: Option<String>,
+    pub sources: Vec<ContextCapsuleSource>,
+    pub snippets: Vec<ContextCapsuleSnippet>,
+    pub capsule_hash: String,
+}
+
+impl DeterministicContextCapsule {
+    fn canonicalized_without_hash(&self) -> CanonicalCapsule {
+        let mut sources = self.sources.clone();
+        sources.sort();
+        sources.dedup();
+
+        let mut snippets = self.snippets.clone();
+        snippets.sort();
+        snippets.dedup();
+
+        CanonicalCapsule {
+            topic: self.topic.clone(),
+            scope: self.scope.clone(),
+            task_id: self.task_id.clone(),
+            workunit_id: self.workunit_id.clone(),
+            sources,
+            snippets,
+        }
+    }
+
+    pub fn canonical_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.canonicalized_without_hash())
+    }
+
+    pub fn computed_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let bytes = self.canonical_json_bytes()?;
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    pub fn with_recomputed_hash(&self) -> Result<Self, serde_json::Error> {
+        let mut out = self.clone();
+        out.capsule_hash = out.computed_hash_hex()?;
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CanonicalCapsule {
+    topic: String,
+    scope: String,
+    task_id: Option<String>,
+    workunit_id: Option<String>,
+    sources: Vec<ContextCapsuleSource>,
+    snippets: Vec<ContextCapsuleSnippet>,
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@
 pub mod assets;
 pub mod assurance;
 pub mod broker;
+pub mod context_capsule;
 pub mod coplayer;
 pub mod db;
 pub mod docs;
@@ -34,3 +35,4 @@ pub mod todo;
 pub mod trace;
 pub mod validate;
 pub mod workspace;
+pub mod workunit;

--- a/src/core/workunit.rs
+++ b/src/core/workunit.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum WorkUnitStatus {
+    Draft,
+    Executing,
+    Claimed,
+    Verified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WorkUnitProofResult {
+    pub gate: String,
+    pub status: String,
+    pub artifact_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkUnitManifest {
+    pub task_id: String,
+    pub intent_ref: String,
+    pub spec_refs: Vec<String>,
+    pub state_refs: Vec<String>,
+    pub proof_plan: Vec<String>,
+    pub proof_results: Vec<WorkUnitProofResult>,
+    pub status: WorkUnitStatus,
+}
+
+impl WorkUnitManifest {
+    pub fn canonicalized(&self) -> Self {
+        let mut out = self.clone();
+
+        out.spec_refs.sort();
+        out.spec_refs.dedup();
+
+        out.state_refs.sort();
+        out.state_refs.dedup();
+
+        out.proof_plan.sort();
+        out.proof_plan.dedup();
+
+        out.proof_results.sort();
+
+        out
+    }
+
+    pub fn canonical_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.canonicalized())
+    }
+
+    pub fn canonical_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let bytes = self.canonical_json_bytes()?;
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+}

--- a/tests/context_capsule_schema.rs
+++ b/tests/context_capsule_schema.rs
@@ -1,0 +1,69 @@
+use decapod::core::context_capsule::{
+    ContextCapsuleSnippet, ContextCapsuleSource, DeterministicContextCapsule,
+};
+
+#[test]
+fn context_capsule_canonical_serialization_is_deterministic() {
+    let capsule = DeterministicContextCapsule {
+        topic: "auth provider boundary".to_string(),
+        scope: "interfaces".to_string(),
+        task_id: Some("R_03".to_string()),
+        workunit_id: Some("R_03".to_string()),
+        sources: vec![
+            ContextCapsuleSource {
+                path: "interfaces/CONTROL_PLANE.md".to_string(),
+                section: "1. The Contract".to_string(),
+            },
+            ContextCapsuleSource {
+                path: "interfaces/CLAIMS.md".to_string(),
+                section: "2. Claims".to_string(),
+            },
+            ContextCapsuleSource {
+                path: "interfaces/CLAIMS.md".to_string(),
+                section: "2. Claims".to_string(),
+            },
+        ],
+        snippets: vec![
+            ContextCapsuleSnippet {
+                source_path: "interfaces/CLAIMS.md".to_string(),
+                text: "claim.context.capsule.deterministic".to_string(),
+            },
+            ContextCapsuleSnippet {
+                source_path: "interfaces/CONTROL_PLANE.md".to_string(),
+                text: "Control-plane operations MUST remain daemonless".to_string(),
+            },
+        ],
+        capsule_hash: String::new(),
+    };
+
+    let bytes1 = capsule.canonical_json_bytes().expect("serialize #1");
+    let bytes2 = capsule.canonical_json_bytes().expect("serialize #2");
+    assert_eq!(bytes1, bytes2, "canonical bytes must be stable");
+
+    let hash1 = capsule.computed_hash_hex().expect("hash #1");
+    let hash2 = capsule.computed_hash_hex().expect("hash #2");
+    assert_eq!(hash1, hash2, "computed hash must be stable");
+}
+
+#[test]
+fn context_capsule_with_recomputed_hash_is_stable() {
+    let base = DeterministicContextCapsule {
+        topic: "promotion firewall".to_string(),
+        scope: "interfaces".to_string(),
+        task_id: None,
+        workunit_id: None,
+        sources: vec![ContextCapsuleSource {
+            path: "interfaces/KNOWLEDGE_STORE.md".to_string(),
+            section: "Promotion Firewall".to_string(),
+        }],
+        snippets: vec![ContextCapsuleSnippet {
+            source_path: "interfaces/KNOWLEDGE_STORE.md".to_string(),
+            text: "episodic -> procedural requires explicit promotion event".to_string(),
+        }],
+        capsule_hash: "wrong".to_string(),
+    };
+
+    let normalized1 = base.with_recomputed_hash().expect("normalize #1");
+    let normalized2 = base.with_recomputed_hash().expect("normalize #2");
+    assert_eq!(normalized1.capsule_hash, normalized2.capsule_hash);
+}

--- a/tests/validate_optional_artifact_gates.rs
+++ b/tests/validate_optional_artifact_gates.rs
@@ -1,0 +1,192 @@
+use decapod::core::context_capsule::{
+    ContextCapsuleSnippet, ContextCapsuleSource, DeterministicContextCapsule,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    let decapod_init = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        decapod_init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&decapod_init.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[("DECAPOD_AGENT_ID", "unknown")],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    (tmp, dir, password)
+}
+
+#[test]
+fn validate_stubs_are_non_blocking_when_artifacts_absent() {
+    let (_tmp, dir, password) = setup_repo();
+    let validate = run_decapod(
+        &dir,
+        &["validate"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        validate.status.success(),
+        "validate should pass with no optional phase-0 artifacts; stderr:\n{}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+}
+
+#[test]
+fn validate_fails_on_invalid_workunit_manifest_if_present() {
+    let (_tmp, dir, password) = setup_repo();
+    let workunits = dir.join(".decapod").join("governance").join("workunits");
+    fs::create_dir_all(&workunits).expect("create workunits dir");
+    fs::write(workunits.join("R_BAD.json"), "{not-json").expect("write malformed workunit");
+
+    let validate = run_decapod(
+        &dir,
+        &["validate"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        !validate.status.success(),
+        "validate should fail for malformed workunit"
+    );
+    let stderr = combined_output(&validate);
+    assert!(
+        stderr.contains("invalid workunit manifest"),
+        "expected workunit parse failure in stderr, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn validate_fails_on_context_capsule_hash_mismatch_if_present() {
+    let (_tmp, dir, password) = setup_repo();
+    let capsules = dir.join(".decapod").join("generated").join("context");
+    fs::create_dir_all(&capsules).expect("create capsules dir");
+
+    let mut capsule = DeterministicContextCapsule {
+        topic: "phase0".to_string(),
+        scope: "interfaces".to_string(),
+        task_id: Some("R_1".to_string()),
+        workunit_id: Some("R_1".to_string()),
+        sources: vec![ContextCapsuleSource {
+            path: "interfaces/CLAIMS.md".to_string(),
+            section: "2. Claims".to_string(),
+        }],
+        snippets: vec![ContextCapsuleSnippet {
+            source_path: "interfaces/CLAIMS.md".to_string(),
+            text: "claim.context.capsule.deterministic".to_string(),
+        }],
+        capsule_hash: String::new(),
+    };
+    capsule.capsule_hash = "wrong_hash".to_string();
+    fs::write(
+        capsules.join("R_1.json"),
+        serde_json::to_vec_pretty(&capsule).expect("serialize capsule"),
+    )
+    .expect("write capsule");
+
+    let validate = run_decapod(
+        &dir,
+        &["validate"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        !validate.status.success(),
+        "validate should fail for capsule hash mismatch"
+    );
+    let stderr = combined_output(&validate);
+    assert!(
+        stderr.contains("Context capsule hash mismatch"),
+        "expected context capsule hash mismatch failure in stderr, got:\n{}",
+        stderr
+    );
+}
+
+#[test]
+fn validate_fails_on_invalid_knowledge_promotion_ledger_if_present() {
+    let (_tmp, dir, password) = setup_repo();
+    let data_dir = dir.join(".decapod").join("data");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::write(
+        data_dir.join("knowledge.promotions.jsonl"),
+        "{\"event_id\":\"evt_1\"}\n",
+    )
+    .expect("write promotions ledger");
+
+    let validate = run_decapod(
+        &dir,
+        &["validate"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        !validate.status.success(),
+        "validate should fail for incomplete promotion ledger entries"
+    );
+    let stderr = combined_output(&validate);
+    assert!(
+        stderr.contains("Knowledge promotion ledger missing"),
+        "expected promotion ledger schema failure in stderr, got:\n{}",
+        stderr
+    );
+}

--- a/tests/workunit_schema.rs
+++ b/tests/workunit_schema.rs
@@ -1,0 +1,67 @@
+use decapod::core::workunit::{WorkUnitManifest, WorkUnitProofResult, WorkUnitStatus};
+
+#[test]
+fn workunit_canonical_serialization_is_deterministic() {
+    let manifest = WorkUnitManifest {
+        task_id: "R_01".to_string(),
+        intent_ref: "intent://alpha".to_string(),
+        spec_refs: vec![
+            "spec://b".to_string(),
+            "spec://a".to_string(),
+            "spec://a".to_string(),
+        ],
+        state_refs: vec![
+            "state://2".to_string(),
+            "state://1".to_string(),
+            "state://1".to_string(),
+        ],
+        proof_plan: vec![
+            "validate_passes".to_string(),
+            "state_commit".to_string(),
+            "validate_passes".to_string(),
+        ],
+        proof_results: vec![
+            WorkUnitProofResult {
+                gate: "state_commit".to_string(),
+                status: "pass".to_string(),
+                artifact_ref: Some("sha256:bbb".to_string()),
+            },
+            WorkUnitProofResult {
+                gate: "validate_passes".to_string(),
+                status: "pass".to_string(),
+                artifact_ref: Some("sha256:aaa".to_string()),
+            },
+        ],
+        status: WorkUnitStatus::Claimed,
+    };
+
+    let bytes1 = manifest.canonical_json_bytes().expect("serialize #1");
+    let bytes2 = manifest.canonical_json_bytes().expect("serialize #2");
+    assert_eq!(bytes1, bytes2, "canonical bytes must be stable");
+
+    let hash1 = manifest.canonical_hash_hex().expect("hash #1");
+    let hash2 = manifest.canonical_hash_hex().expect("hash #2");
+    assert_eq!(hash1, hash2, "canonical hash must be stable");
+}
+
+#[test]
+fn workunit_canonicalization_sorts_and_dedups_contract_arrays() {
+    let manifest = WorkUnitManifest {
+        task_id: "R_02".to_string(),
+        intent_ref: "intent://beta".to_string(),
+        spec_refs: vec!["spec://b".to_string(), "spec://a".to_string()],
+        state_refs: vec!["state://2".to_string(), "state://1".to_string()],
+        proof_plan: vec!["z".to_string(), "a".to_string(), "z".to_string()],
+        proof_results: vec![WorkUnitProofResult {
+            gate: "b".to_string(),
+            status: "pass".to_string(),
+            artifact_ref: None,
+        }],
+        status: WorkUnitStatus::Draft,
+    };
+
+    let c = manifest.canonicalized();
+    assert_eq!(c.spec_refs, vec!["spec://a", "spec://b"]);
+    assert_eq!(c.state_refs, vec!["state://1", "state://2"]);
+    assert_eq!(c.proof_plan, vec!["a", "z"]);
+}


### PR DESCRIPTION
## Phase 0.3: optional artifact validate gates (no new CLI)

This PR implements Phase 0 / Task 3 as a standalone slice, branched from Phase 0.2.

### What changed
- Added optional (if-present) validate gates in `src/core/validate.rs`:
  - Work unit manifest schema parse gate
  - Context capsule integrity gate (`capsule_hash` must match deterministic recompute)
  - Knowledge promotion ledger shape gate
- Added integration tests in `tests/validate_optional_artifact_gates.rs`:
  - validate remains non-blocking when artifacts are absent
  - malformed workunit manifests fail validate deterministically
  - context capsule hash mismatches fail validate deterministically
  - incomplete promotion ledger events fail validate deterministically

### Verification
- `cargo fmt --all`
- `cargo test --test validate_optional_artifact_gates`
- `cargo test --test workunit_schema`
- `cargo test --test context_capsule_schema`

### Scope guard
- No orchestration/session/runtime control added
- No long-running process behavior
- Gate logic is stateless and repo-artifact based
