### PR TITLE
Phase 1.1: add workunit init/get/status CLI and persistence

### DIFF
--- a/src/core/workunit.rs
+++ b/src/core/workunit.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::core::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -56,4 +60,100 @@ impl WorkUnitManifest {
         hasher.update(&bytes);
         Ok(format!("{:x}", hasher.finalize()))
     }
+}
+
+pub fn workunits_dir(project_root: &Path) -> PathBuf {
+    project_root
+        .join(".decapod")
+        .join("governance")
+        .join("workunits")
+}
+
+pub fn validate_task_id(task_id: &str) -> Result<(), error::DecapodError> {
+    if task_id.is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "task_id cannot be empty".to_string(),
+        ));
+    }
+    if task_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        Ok(())
+    } else {
+        Err(error::DecapodError::ValidationError(format!(
+            "invalid task_id '{}': allowed characters are [A-Za-z0-9_-]",
+            task_id
+        )))
+    }
+}
+
+pub fn workunit_path(project_root: &Path, task_id: &str) -> Result<PathBuf, error::DecapodError> {
+    validate_task_id(task_id)?;
+    Ok(workunits_dir(project_root).join(format!("{task_id}.json")))
+}
+
+pub fn init_workunit(
+    project_root: &Path,
+    task_id: &str,
+    intent_ref: &str,
+) -> Result<WorkUnitManifest, error::DecapodError> {
+    let path = workunit_path(project_root, task_id)?;
+    if path.exists() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "workunit '{}' already exists",
+            task_id
+        )));
+    }
+
+    let manifest = WorkUnitManifest {
+        task_id: task_id.to_string(),
+        intent_ref: intent_ref.to_string(),
+        spec_refs: Vec::new(),
+        state_refs: Vec::new(),
+        proof_plan: Vec::new(),
+        proof_results: Vec::new(),
+        status: WorkUnitStatus::Draft,
+    };
+    write_workunit(project_root, &manifest)?;
+    Ok(manifest)
+}
+
+pub fn load_workunit(
+    project_root: &Path,
+    task_id: &str,
+) -> Result<WorkUnitManifest, error::DecapodError> {
+    let path = workunit_path(project_root, task_id)?;
+    if !path.exists() {
+        return Err(error::DecapodError::NotFound(format!(
+            "workunit '{}' not found at {}",
+            task_id,
+            path.display()
+        )));
+    }
+    let raw = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "invalid workunit manifest {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+pub fn write_workunit(
+    project_root: &Path,
+    manifest: &WorkUnitManifest,
+) -> Result<PathBuf, error::DecapodError> {
+    let path = workunit_path(project_root, &manifest.task_id)?;
+    let parent = path.parent().ok_or_else(|| {
+        error::DecapodError::ValidationError("invalid workunit parent path".to_string())
+    })?;
+    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+
+    let bytes = serde_json::to_vec_pretty(&manifest.canonicalized()).map_err(|e| {
+        error::DecapodError::ValidationError(format!("failed to serialize workunit manifest: {e}"))
+    })?;
+    fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+    Ok(path)
 }

--- a/tests/workunit_cli.rs
+++ b/tests/workunit_cli.rs
@@ -1,0 +1,186 @@
+use decapod::core::workunit;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let git_init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let init = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[("DECAPOD_AGENT_ID", "unknown")],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let password = String::from_utf8_lossy(&acquire.stdout)
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    (tmp, dir, password)
+}
+
+#[test]
+fn workunit_init_creates_manifest_file() {
+    let (_tmp, dir, password) = setup_repo();
+    let out = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            "R_001",
+            "--intent-ref",
+            "intent://test",
+        ],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "workunit init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let payload: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(payload["marker"], "WORKUNIT_INITIALIZED");
+    let manifest_path = dir
+        .join(".decapod")
+        .join("governance")
+        .join("workunits")
+        .join("R_001.json");
+    assert!(manifest_path.exists(), "manifest file should exist");
+}
+
+#[test]
+fn workunit_get_returns_expected_manifest_shape() {
+    let (_tmp, dir, password) = setup_repo();
+    let _ = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            "R_002",
+            "--intent-ref",
+            "intent://shape",
+        ],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+
+    let out = run_decapod(
+        &dir,
+        &["govern", "workunit", "get", "--task-id", "R_002"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "workunit get failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(payload["task_id"], "R_002");
+    assert_eq!(payload["intent_ref"], "intent://shape");
+    assert!(payload["spec_refs"].is_array());
+    assert!(payload["state_refs"].is_array());
+    assert!(payload["proof_plan"].is_array());
+    assert!(payload["proof_results"].is_array());
+    assert_eq!(payload["status"], "DRAFT");
+}
+
+#[test]
+fn workunit_status_returns_deterministic_manifest_hash() {
+    let (_tmp, dir, password) = setup_repo();
+    let _ = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            "R_003",
+            "--intent-ref",
+            "intent://hash",
+        ],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+
+    let out = run_decapod(
+        &dir,
+        &["govern", "workunit", "status", "--task-id", "R_003"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "workunit status failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(payload["task_id"], "R_003");
+    assert_eq!(payload["workunit_status"], "DRAFT");
+    let hash_cli = payload["manifest_hash"].as_str().expect("hash string");
+
+    let manifest = workunit::load_workunit(&dir, "R_003").expect("load workunit");
+    let hash_expected = manifest.canonical_hash_hex().expect("hash expected");
+    assert_eq!(hash_cli, hash_expected);
+
+    let path = workunit::workunit_path(&dir, "R_003").expect("path");
+    let on_disk = fs::read_to_string(path).expect("read manifest");
+    assert!(
+        !on_disk.is_empty(),
+        "manifest content should be present on disk"
+    );
+}


### PR DESCRIPTION
## Phase 1.1: Work Unit Manifest CLI (init/get/status)

This is the first Phase 1 implementation slice, branched after Phase 0.3.

### What changed
- Added persisted workunit helpers in `src/core/workunit.rs`:
  - path validation and canonical artifact location
  - create/load/write helpers
- Added `govern workunit` command surface in `src/lib.rs`:
  - `decapod govern workunit init --task-id <id> --intent-ref <ref>`
  - `decapod govern workunit get --task-id <id>`
  - `decapod govern workunit status --task-id <id>`
- Added integration tests in `tests/workunit_cli.rs`

### Artifact path
- `.decapod/governance/workunits/<task_id>.json`

### Verification
- `cargo fmt --all`
- `cargo test --test workunit_cli`
- `cargo test --test workunit_schema --test validate_optional_artifact_gates`

### Scope guard
- No daemon/session manager behavior
- No orchestration/subagent scheduling
- Stateless CLI operations over repo artifacts only
