### PR TITLE
Add workunit verified gate to workspace publish

### DIFF
--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -9,7 +9,7 @@ use crate::core::error;
 use crate::core::output;
 use crate::core::plan_governance;
 use crate::core::store::{Store, StoreKind};
-use crate::core::workunit::WorkUnitManifest;
+use crate::core::workunit::{self, WorkUnitManifest, WorkUnitStatus};
 use crate::{db, primitives, todo};
 use regex::Regex;
 use serde_json;
@@ -1079,6 +1079,15 @@ fn validate_workunit_manifests_if_present(
                 e
             ))
         })?;
+        if parsed.status == WorkUnitStatus::Verified {
+            workunit::validate_verified_manifest(&parsed).map_err(|e| {
+                error::DecapodError::ValidationError(format!(
+                    "invalid VERIFIED workunit manifest {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        }
     }
 
     pass(

--- a/src/core/workunit.rs
+++ b/src/core/workunit.rs
@@ -239,6 +239,10 @@ pub fn transition_status(
     load_workunit(project_root, task_id)
 }
 
+pub fn validate_verified_manifest(manifest: &WorkUnitManifest) -> Result<(), error::DecapodError> {
+    ensure_verified_ready(manifest)
+}
+
 fn can_transition(from: &WorkUnitStatus, to: &WorkUnitStatus) -> bool {
     use WorkUnitStatus::*;
     matches!(
@@ -265,8 +269,7 @@ fn ensure_verified_ready(manifest: &WorkUnitManifest) -> Result<(), error::Decap
         let hit = manifest
             .proof_results
             .iter()
-            .find(|r| &r.gate == gate && r.status == "pass")
-            .is_some();
+            .any(|r| &r.gate == gate && r.status == "pass");
         if !hit {
             return Err(error::DecapodError::ValidationError(format!(
                 "cannot transition to VERIFIED: missing passing proof result for gate '{}'",

--- a/tests/workunit_publish_gate.rs
+++ b/tests/workunit_publish_gate.rs
@@ -1,0 +1,86 @@
+use decapod::core::{workspace, workunit};
+use tempfile::tempdir;
+
+fn write_manifest(
+    root: &std::path::Path,
+    task_id: &str,
+    status: workunit::WorkUnitStatus,
+    proof_plan: Vec<&str>,
+    proof_results: Vec<(&str, &str)>,
+) {
+    let manifest = workunit::WorkUnitManifest {
+        task_id: task_id.to_string(),
+        intent_ref: "intent://demo".to_string(),
+        spec_refs: vec![],
+        state_refs: vec![],
+        proof_plan: proof_plan.into_iter().map(|s| s.to_string()).collect(),
+        proof_results: proof_results
+            .into_iter()
+            .map(|(gate, status)| workunit::WorkUnitProofResult {
+                gate: gate.to_string(),
+                status: status.to_string(),
+                artifact_ref: None,
+            })
+            .collect(),
+        status,
+    };
+
+    workunit::write_workunit(root, &manifest).expect("write workunit manifest");
+}
+
+#[test]
+fn publish_gate_skips_when_branch_has_no_task_ids() {
+    let dir = tempdir().expect("tempdir");
+    let result = workspace::verify_workunit_gate_for_publish(dir.path(), "feature/no-task-id");
+    assert!(result.is_ok(), "expected no-op pass for non-task branch");
+}
+
+#[test]
+fn publish_gate_fails_when_branch_task_manifest_missing() {
+    let dir = tempdir().expect("tempdir");
+    let err = workspace::verify_workunit_gate_for_publish(dir.path(), "agent/unknown/r_01ABCXYZ")
+        .expect_err("expected missing workunit manifest failure");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("missing required workunit manifest"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn publish_gate_fails_when_branch_task_not_verified() {
+    let dir = tempdir().expect("tempdir");
+    write_manifest(
+        dir.path(),
+        "R_01ABCD1",
+        workunit::WorkUnitStatus::Claimed,
+        vec!["validate_passes"],
+        vec![("validate_passes", "pass")],
+    );
+
+    let err = workspace::verify_workunit_gate_for_publish(dir.path(), "agent/codex/r_01ABCD1")
+        .expect_err("expected status gate failure");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("is not VERIFIED"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn publish_gate_passes_when_branch_task_verified() {
+    let dir = tempdir().expect("tempdir");
+    write_manifest(
+        dir.path(),
+        "R_01ABCD2",
+        workunit::WorkUnitStatus::Verified,
+        vec!["validate_passes", "test:cargo test --all"],
+        vec![
+            ("validate_passes", "pass"),
+            ("test:cargo test --all", "pass"),
+        ],
+    );
+
+    let result = workspace::verify_workunit_gate_for_publish(dir.path(), "agent/codex/r_01ABCD2");
+    assert!(result.is_ok(), "expected verified branch task to pass");
+}


### PR DESCRIPTION
## Summary
- enforce publish-time workunit gate by parsing branch task IDs and requiring matching VERIFIED manifests
- add deterministic validate check so manually edited VERIFIED manifests must still satisfy passing proof gates
- add focused integration tests for publish gate behavior and VERIFIED-manifest validation failures

## Verification
- cargo fmt --all
- cargo test --test workunit_publish_gate --test validate_optional_artifact_gates
- cargo test --test workunit_cli --test workunit_schema
- cargo clippy --all-targets --all-features -- -D warnings