### PR TITLE
Persist deterministic context capsule artifacts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,8 @@ enum CapsuleCommand {
         workunit_id: Option<String>,
         #[clap(long, default_value_t = 6)]
         limit: usize,
+        #[clap(long, default_value_t = false)]
+        write: bool,
     },
 }
 
@@ -3115,6 +3117,7 @@ fn run_capsule_command(
             task_id,
             workunit_id,
             limit,
+            write,
         } => {
             let capsule = core::context_capsule::query_embedded_capsule(
                 project_root,
@@ -3124,7 +3127,20 @@ fn run_capsule_command(
                 workunit_id.as_deref(),
                 limit,
             )?;
-            println!("{}", serde_json::to_string_pretty(&capsule).unwrap());
+            if write {
+                let path = core::context_capsule::write_context_capsule(project_root, &capsule)?;
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "status": "ok",
+                        "path": path,
+                        "capsule": capsule,
+                    }))
+                    .unwrap()
+                );
+            } else {
+                println!("{}", serde_json::to_string_pretty(&capsule).unwrap());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add deterministic context capsule artifact path helpers under .decapod/generated/context
- add optional `--write` mode to `decapod govern capsule query` to persist capsule JSON
- normalize capsule hash before writes to ensure stable on-disk artifacts
- expand CLI tests to assert deterministic path + stable hash across repeated writes

## Verification
- cargo fmt --all
- cargo test --test context_capsule_cli --test context_capsule_schema
- cargo clippy --all-targets --all-features -- -D warnings