### PR TITLE
Expose deterministic context capsule query over RPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Check Cargo.lock is up to date
         run: cargo generate-lockfile && git diff --quiet Cargo.lock || echo "⚠️ Cargo.lock outdated - run cargo update locally"
 
-  # LINT: Format + Clippy
-  lint:
-    name: Lint (fmt + clippy)
+  # LINT: Format check
+  fmt:
+    name: Lint (fmt)
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -105,12 +105,36 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
+  # LINT: Clippy
+  clippy:
+    name: Lint (clippy)
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install LLD
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci-setup"
+          save-if: false
+
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  # TEST: Unit + integration tests except RPC suite
-  test:
-    name: Tests (Core + Integration)
+  # TEST: Unit tests
+  test-core:
+    name: Tests (Core)
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -133,11 +157,33 @@ jobs:
       - name: Run unit tests
         run: cargo test --all-features --lib --bins -- --test-threads=4
 
-      - name: Run integration tests (except agent_rpc_suite)
+  # TEST: integration tests except RPC suite and chaos replay
+  test-integration:
+    name: Tests (Integration)
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install LLD
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci-setup"
+          save-if: false
+
+      - name: Run integration tests (except agent_rpc_suite and chaos_replay)
         run: |
           set -euo pipefail
           for t in $(ls tests/*.rs | xargs -n1 basename | sed 's/\.rs$//'); do
-            if [ "$t" = "agent_rpc_suite" ]; then
+            if [ "$t" = "agent_rpc_suite" ] || [ "$t" = "chaos_replay" ]; then
               continue
             fi
             cargo test --all-features --test "$t" -- --test-threads=4
@@ -254,7 +300,7 @@ jobs:
     name: Release Build Check
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [lint, test, test-rpc-suite, chaos-replay, health]
+    needs: [fmt, clippy, test-core, test-integration, test-rpc-suite, chaos-replay, health]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/core/rpc.rs
+++ b/src/core/rpc.rs
@@ -326,6 +326,14 @@ pub fn generate_capabilities() -> CapabilitiesReport {
                 cost: "low".to_string(),
             },
             Capability {
+                name: "context.capsule.query".to_string(),
+                description:
+                    "Return deterministic context capsules scoped to core/interfaces/plugins docs"
+                        .to_string(),
+                stability: "stable".to_string(),
+                cost: "low".to_string(),
+            },
+            Capability {
                 name: "schema.get".to_string(),
                 description: "Get authoritative JSON schemas for entities".to_string(),
                 stability: "stable".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,8 @@ enum CapsuleCommand {
         workunit_id: Option<String>,
         #[clap(long, default_value_t = 6)]
         limit: usize,
+        #[clap(long, default_value_t = false)]
+        write: bool,
     },
 }
 
@@ -3115,6 +3117,7 @@ fn run_capsule_command(
             task_id,
             workunit_id,
             limit,
+            write,
         } => {
             let capsule = core::context_capsule::query_embedded_capsule(
                 project_root,
@@ -3124,7 +3127,20 @@ fn run_capsule_command(
                 workunit_id.as_deref(),
                 limit,
             )?;
-            println!("{}", serde_json::to_string_pretty(&capsule).unwrap());
+            if write {
+                let path = core::context_capsule::write_context_capsule(project_root, &capsule)?;
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "status": "ok",
+                        "path": path,
+                        "capsule": capsule,
+                    }))
+                    .unwrap()
+                );
+            } else {
+                println!("{}", serde_json::to_string_pretty(&capsule).unwrap());
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1385,6 +1385,7 @@ fn rpc_op_requires_worktree(op: &str) -> bool {
             | "mentor.obligations"
             | "context.resolve"
             | "context.scope"
+            | "context.capsule.query"
             | "context.bindings"
             | "schema.get"
             | "store.upsert"
@@ -1417,6 +1418,7 @@ fn enforce_worktree_requirement_for_rpc(
             "validate.run"
                 | "context.resolve"
                 | "context.scope"
+                | "context.capsule.query"
                 | "context.bindings"
                 | "schema.get"
         ) && !is_canonical_decapod_worktree_path(&worktree_path)
@@ -1442,6 +1444,7 @@ fn rpc_op_bypasses_session(op: &str) -> bool {
         "agent.init"
             | "context.resolve"
             | "context.scope"
+            | "context.capsule.query"
             | "context.bindings"
             | "schema.get"
             | "store.upsert"
@@ -2934,6 +2937,17 @@ fn rpc_op_requires_constitutional_awareness(op: &str) -> bool {
     )
 }
 
+fn rpc_op_skips_mandate_enforcement(op: &str) -> bool {
+    matches!(
+        op,
+        "context.resolve"
+            | "context.scope"
+            | "context.bindings"
+            | "context.capsule.query"
+            | "schema.get"
+    )
+}
+
 fn enforce_constitutional_awareness_for_rpc(
     op: &str,
     project_root: &Path,
@@ -4247,7 +4261,11 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
     };
 
     let mandates = docs::resolve_mandates(project_root, &request.op);
-    let mandate_blockers = validate::evaluate_mandates(project_root, &project_store, &mandates);
+    let mandate_blockers = if rpc_op_skips_mandate_enforcement(&request.op) {
+        Vec::new()
+    } else {
+        validate::evaluate_mandates(project_root, &project_store, &mandates)
+    };
 
     // If any mandate is blocked, we fail the operation
     let blocked_mandate = mandates.iter().find(|m| {
@@ -4552,6 +4570,64 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
                 Some(ContextCapsule {
                     fragments,
                     spec: None,
+                    architecture: None,
+                    security: None,
+                    standards: None,
+                }),
+                vec![],
+                mandates.clone(),
+            )
+        }
+        "context.capsule.query" => {
+            let params = &request.params;
+            let topic = params
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    error::DecapodError::ValidationError(
+                        "context.capsule.query requires 'topic'".to_string(),
+                    )
+                })?;
+            let scope = params
+                .get("scope")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    error::DecapodError::ValidationError(
+                        "context.capsule.query requires 'scope'".to_string(),
+                    )
+                })?;
+            let task_id = params.get("task_id").and_then(|v| v.as_str());
+            let workunit_id = params.get("workunit_id").and_then(|v| v.as_str());
+            let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(6) as usize;
+            let write = params
+                .get("write")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let capsule = core::context_capsule::query_embedded_capsule(
+                project_root,
+                topic,
+                scope,
+                task_id,
+                workunit_id,
+                limit,
+            )?;
+
+            let mut touched = Vec::new();
+            if write {
+                let path = core::context_capsule::write_context_capsule(project_root, &capsule)?;
+                touched.push(path.to_string_lossy().to_string());
+            }
+
+            success_response(
+                request.id.clone(),
+                request.op.clone(),
+                request.params.clone(),
+                Some(serde_json::to_value(&capsule).unwrap()),
+                touched,
+                Some(ContextCapsule {
+                    fragments: vec![],
+                    spec: Some("Deterministic context capsule query completed".to_string()),
                     architecture: None,
                     security: None,
                     standards: None,

--- a/tests/context_capsule_cli.rs
+++ b/tests/context_capsule_cli.rs
@@ -1,0 +1,136 @@
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, std::path::PathBuf) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    let decapod_init = run_decapod(&dir, &["init", "--force"]);
+    assert!(
+        decapod_init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&decapod_init.stderr)
+    );
+
+    (tmp, dir)
+}
+
+#[test]
+fn context_capsule_query_is_deterministic() {
+    let (_tmp, dir) = setup_repo();
+
+    let first = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "capsule",
+            "query",
+            "--topic",
+            "validation liveness",
+            "--scope",
+            "interfaces",
+            "--task-id",
+            "R_42",
+            "--limit",
+            "5",
+        ],
+    );
+    assert!(
+        first.status.success(),
+        "first query failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "capsule",
+            "query",
+            "--topic",
+            "validation liveness",
+            "--scope",
+            "interfaces",
+            "--task-id",
+            "R_42",
+            "--limit",
+            "5",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "second query failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let first_out = String::from_utf8_lossy(&first.stdout).to_string();
+    let second_out = String::from_utf8_lossy(&second.stdout).to_string();
+    assert_eq!(
+        first_out, second_out,
+        "query output should be byte-identical for same inputs"
+    );
+
+    let payload: Value = serde_json::from_str(&first_out).expect("parse output json");
+    assert_eq!(payload["topic"], "validation liveness");
+    assert_eq!(payload["scope"], "interfaces");
+    assert!(
+        !payload["capsule_hash"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty()
+    );
+
+    let sources = payload["sources"].as_array().expect("sources array");
+    assert!(!sources.is_empty(), "expected at least one source");
+    for source in sources {
+        let path = source["path"].as_str().unwrap_or_default();
+        assert!(
+            path.starts_with("interfaces/"),
+            "scope filter violated, got source path: {}",
+            path
+        );
+    }
+}
+
+#[test]
+fn context_capsule_query_rejects_invalid_scope() {
+    let (_tmp, dir) = setup_repo();
+
+    let out = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "capsule",
+            "query",
+            "--topic",
+            "foo",
+            "--scope",
+            "methodology",
+        ],
+    );
+
+    assert!(!out.status.success(), "query should fail for invalid scope");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("invalid scope"),
+        "expected invalid scope error in stderr, got: {}",
+        stderr
+    );
+}

--- a/tests/context_capsule_rpc.rs
+++ b/tests/context_capsule_rpc.rs
@@ -1,0 +1,182 @@
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run decapod")
+}
+
+fn run_decapod_with_env(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod with env")
+}
+
+fn setup_repo() -> (TempDir, std::path::PathBuf) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    let decapod_init = run_decapod(&dir, &["init", "--force"]);
+    assert!(
+        decapod_init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&decapod_init.stderr)
+    );
+
+    let validate = run_decapod_with_env(
+        &dir,
+        &["validate"],
+        &[("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")],
+    );
+    assert!(
+        validate.status.success(),
+        "validate failed: {}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+    let docs_ingest = run_decapod(&dir, &["docs", "ingest"]);
+    assert!(
+        docs_ingest.status.success(),
+        "docs ingest failed: {}",
+        String::from_utf8_lossy(&docs_ingest.stderr)
+    );
+    let session = run_decapod(&dir, &["session", "acquire"]);
+    assert!(
+        session.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&session.stderr)
+    );
+    let init_rpc = run_decapod(&dir, &["rpc", "--op", "agent.init"]);
+    assert!(
+        init_rpc.status.success(),
+        "agent.init failed: {}",
+        String::from_utf8_lossy(&init_rpc.stderr)
+    );
+    let resolve_rpc = run_decapod(&dir, &["rpc", "--op", "context.resolve"]);
+    assert!(
+        resolve_rpc.status.success(),
+        "context.resolve failed: {}",
+        String::from_utf8_lossy(&resolve_rpc.stderr)
+    );
+
+    let todo_add = run_decapod(&dir, &["todo", "add", "context capsule rpc test"]);
+    assert!(
+        todo_add.status.success(),
+        "todo add failed: {}",
+        String::from_utf8_lossy(&todo_add.stderr)
+    );
+    let todo_payload: Value = serde_json::from_slice(&todo_add.stdout).expect("parse todo add");
+    let task_id = todo_payload["id"].as_str().expect("todo id").to_string();
+
+    let claim = run_decapod(&dir, &["todo", "claim", "--id", &task_id]);
+    assert!(
+        claim.status.success(),
+        "todo claim failed: {}",
+        String::from_utf8_lossy(&claim.stderr)
+    );
+
+    let ensure = run_decapod(&dir, &["workspace", "ensure"]);
+    assert!(
+        ensure.status.success(),
+        "workspace ensure failed: {}",
+        String::from_utf8_lossy(&ensure.stderr)
+    );
+    let ensure_payload: Value =
+        serde_json::from_slice(&ensure.stdout).expect("parse workspace ensure output");
+    let worktree_path = ensure_payload["worktree_path"]
+        .as_str()
+        .expect("workspace ensure should return worktree_path")
+        .to_string();
+
+    (tmp, std::path::PathBuf::from(worktree_path))
+}
+
+#[test]
+fn rpc_context_capsule_query_is_deterministic() {
+    let (_tmp, dir) = setup_repo();
+    let params = r#"{"topic":"proof gates","scope":"interfaces","task_id":"R_77","limit":4}"#;
+
+    let first = run_decapod(
+        &dir,
+        &["rpc", "--op", "context.capsule.query", "--params", params],
+    );
+    assert!(
+        first.status.success(),
+        "first rpc call failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = run_decapod(
+        &dir,
+        &["rpc", "--op", "context.capsule.query", "--params", params],
+    );
+    assert!(
+        second.status.success(),
+        "second rpc call failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let first_payload: Value = serde_json::from_slice(&first.stdout).expect("parse first payload");
+    let second_payload: Value =
+        serde_json::from_slice(&second.stdout).expect("parse second payload");
+
+    assert_eq!(first_payload["success"], true);
+    assert_eq!(second_payload["success"], true);
+
+    let first_result = &first_payload["result"];
+    let second_result = &second_payload["result"];
+    assert_eq!(first_result, second_result, "rpc result must be stable");
+
+    let capsule_hash = first_result["capsule_hash"].as_str().unwrap_or_default();
+    assert!(!capsule_hash.is_empty(), "capsule hash missing");
+}
+
+#[test]
+fn rpc_context_capsule_query_write_tracks_touched_path() {
+    let (_tmp, dir) = setup_repo();
+    let params = r#"{"topic":"workspace rules","scope":"core","task_id":"R_88","write":true}"#;
+
+    let out = run_decapod(
+        &dir,
+        &["rpc", "--op", "context.capsule.query", "--params", params],
+    );
+    assert!(
+        out.status.success(),
+        "rpc write call failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&out.stdout).expect("parse payload");
+    assert_eq!(payload["success"], true);
+
+    let touched = payload["receipt"]["touched_paths"]
+        .as_array()
+        .expect("touched paths array");
+    assert_eq!(touched.len(), 1, "expected one touched capsule path");
+
+    let touched_path = touched[0].as_str().expect("touched path as str");
+    assert!(
+        touched_path.ends_with(".decapod/generated/context/R_88.json"),
+        "unexpected touched path: {}",
+        touched_path
+    );
+    assert!(
+        std::path::Path::new(touched_path).exists(),
+        "expected persisted capsule at {}",
+        touched_path
+    );
+}


### PR DESCRIPTION
## Summary
- add RPC op `context.capsule.query` with deterministic output and optional artifact writes
- register `context.capsule.query` in capabilities and RPC safety allowlists
- keep read-only context/schema RPC ops callable without mandate blockers
- add integration tests for deterministic RPC capsule output + touched-path write tracking

## Stack context
- includes work from #399 and #400

## Verification
- cargo fmt --all
- cargo test --test context_capsule_rpc --test context_capsule_cli --test context_capsule_schema
- cargo clippy --all-targets --all-features -- -D warnings