### PR TITLE
Add knowledge promotion firewall ledger primitives

### DIFF
--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1211,6 +1211,57 @@ fn validate_knowledge_promotions_if_present(
                 );
             }
         }
+
+        if v.get("target_class").and_then(|x| x.as_str()) != Some("procedural") {
+            fail(
+                &format!(
+                    "Knowledge promotion ledger requires target_class='procedural' on line {} ({})",
+                    idx + 1,
+                    ledger.display()
+                ),
+                ctx,
+            );
+        }
+
+        let evidence_ok = v
+            .get("evidence_refs")
+            .and_then(|x| x.as_array())
+            .map(|arr| {
+                !arr.is_empty()
+                    && arr
+                        .iter()
+                        .all(|item| item.as_str().map(|s| !s.trim().is_empty()).unwrap_or(false))
+            })
+            .unwrap_or(false);
+        if !evidence_ok {
+            fail(
+                &format!(
+                    "Knowledge promotion ledger evidence_refs must be a non-empty string array on line {} ({})",
+                    idx + 1,
+                    ledger.display()
+                ),
+                ctx,
+            );
+        }
+
+        for key in ["approved_by", "actor", "reason"] {
+            let non_empty = v
+                .get(key)
+                .and_then(|x| x.as_str())
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false);
+            if !non_empty {
+                fail(
+                    &format!(
+                        "Knowledge promotion ledger '{}' must be a non-empty string on line {} ({})",
+                        key,
+                        idx + 1,
+                        ledger.display()
+                    ),
+                    ctx,
+                );
+            }
+        }
     }
 
     pass("Knowledge promotion ledger schema check passed", ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,6 +732,17 @@ enum KnowledgeCommand {
         #[clap(long)]
         query: String,
     },
+    /// Record explicit promotion of advisory/episodic knowledge into procedural class
+    Promote {
+        #[clap(long)]
+        source_entry_id: String,
+        #[clap(long = "evidence-ref")]
+        evidence_refs: Vec<String>,
+        #[clap(long)]
+        approved_by: String,
+        #[clap(long)]
+        reason: String,
+    },
 }
 
 #[derive(clap::Args, Debug)]
@@ -3469,6 +3480,25 @@ fn run_data_command(
                         },
                     )?;
                     println!("{}", serde_json::to_string_pretty(&results).unwrap());
+                }
+                KnowledgeCommand::Promote {
+                    source_entry_id,
+                    evidence_refs,
+                    approved_by,
+                    reason,
+                } => {
+                    let actor = current_agent_id();
+                    let event = knowledge::record_promotion_event(
+                        project_store,
+                        knowledge::KnowledgePromotionEventInput {
+                            source_entry_id: &source_entry_id,
+                            evidence_refs: &evidence_refs,
+                            approved_by: &approved_by,
+                            actor: &actor,
+                            reason: &reason,
+                        },
+                    )?;
+                    println!("{}", serde_json::to_string_pretty(&event).unwrap());
                 }
             }
         }

--- a/tests/knowledge_promotion_cli.rs
+++ b/tests/knowledge_promotion_cli.rs
@@ -1,0 +1,143 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let git_init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let init = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[("DECAPOD_AGENT_ID", "unknown")],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let password = String::from_utf8_lossy(&acquire.stdout)
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    (tmp, dir, password)
+}
+
+#[test]
+fn knowledge_promote_writes_append_only_ledger_event() {
+    let (_tmp, dir, password) = setup_repo();
+
+    let out = run_decapod(
+        &dir,
+        &[
+            "data",
+            "knowledge",
+            "promote",
+            "--source-entry-id",
+            "K_001",
+            "--evidence-ref",
+            "commit:abc123",
+            "--evidence-ref",
+            "file:docs/spec.md#L10",
+            "--approved-by",
+            "human/reviewer-1",
+            "--reason",
+            "convert episodic finding into procedural norm",
+        ],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "knowledge promote failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let payload: Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(payload["source_entry_id"], "K_001");
+    assert_eq!(payload["target_class"], "procedural");
+    assert_eq!(payload["approved_by"], "human/reviewer-1");
+
+    let ledger_path = dir
+        .join(".decapod")
+        .join("data")
+        .join("knowledge.promotions.jsonl");
+    assert!(ledger_path.exists(), "ledger should exist");
+
+    let lines = fs::read_to_string(&ledger_path).expect("read ledger");
+    let last = lines
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .next_back()
+        .expect("ledger last line");
+    let event: Value = serde_json::from_str(last).expect("valid jsonl line");
+    assert_eq!(event["source_entry_id"], "K_001");
+    assert_eq!(event["target_class"], "procedural");
+}
+
+#[test]
+fn knowledge_promote_rejects_missing_evidence_refs() {
+    let (_tmp, dir, password) = setup_repo();
+
+    let out = run_decapod(
+        &dir,
+        &[
+            "data",
+            "knowledge",
+            "promote",
+            "--source-entry-id",
+            "K_002",
+            "--approved-by",
+            "human/reviewer-2",
+            "--reason",
+            "insufficient evidence should fail",
+        ],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "promote should fail without evidence refs"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("at least one --evidence-ref is required"),
+        "unexpected error: {}",
+        stderr
+    );
+}

--- a/tests/knowledge_promotion_cli.rs
+++ b/tests/knowledge_promotion_cli.rs
@@ -99,8 +99,7 @@ fn knowledge_promote_writes_append_only_ledger_event() {
     let lines = fs::read_to_string(&ledger_path).expect("read ledger");
     let last = lines
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .next_back()
+        .rfind(|l| !l.trim().is_empty())
         .expect("ledger last line");
     let event: Value = serde_json::from_str(last).expect("valid jsonl line");
     assert_eq!(event["source_entry_id"], "K_001");


### PR DESCRIPTION
## Summary
- add `decapod data knowledge promote` to append explicit promotion-firewall events into `.decapod/data/knowledge.promotions.jsonl`
- enforce promotion event structure in `validate` (target_class must be procedural; evidence refs non-empty; approved_by/actor/reason non-empty)
- expand knowledge schema metadata to include `promote` command and promotion ledger storage surface
- add integration tests for promote command behavior and new validate gate checks

## Stack context
- includes prior Phase 2 branch stack (`feat/context-capsule-rpc`)

## Verification
- cargo fmt --all
- cargo test --test knowledge_promotion_cli --test validate_optional_artifact_gates
- cargo clippy --all-targets --all-features -- -D warnings