### PR TITLE
Phase 4: Add daemonless lifecycle and kernel regression gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,11 @@ jobs:
           shared-key: "ci-setup"
           save-if: false
 
-      - name: Run integration tests (except agent_rpc_suite and chaos_replay)
+      - name: Run integration tests (except isolated suites)
         run: |
           set -euo pipefail
           for t in $(ls tests/*.rs | xargs -n1 basename | sed 's/\.rs$//'); do
-            if [ "$t" = "agent_rpc_suite" ] || [ "$t" = "chaos_replay" ]; then
+            if [ "$t" = "agent_rpc_suite" ] || [ "$t" = "chaos_replay" ] || [ "$t" = "daemonless_lifecycle" ]; then
               continue
             fi
             cargo test --all-features --test "$t" -- --test-threads=4
@@ -238,6 +238,31 @@ jobs:
 
       - name: Run chaos replay determinism test
         run: cargo test --test chaos_replay -- --test-threads=1
+
+  # DAEMONLESS: ensure commands do not leave background processes
+  daemonless-lifecycle:
+    name: Daemonless Lifecycle Gate
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install LLD
+        run: sudo apt-get update && sudo apt-get install -y lld
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci-setup"
+          save-if: false
+
+      - name: Run daemonless lifecycle test
+        run: cargo test --all-features --test daemonless_lifecycle -- --test-threads=1
 
   # HEALTH: Decapod validation and health checks
   health:
@@ -300,7 +325,7 @@ jobs:
     name: Release Build Check
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs: [fmt, clippy, test-core, test-integration, test-rpc-suite, chaos-replay, health]
+    needs: [fmt, clippy, test-core, test-integration, test-rpc-suite, chaos-replay, daemonless-lifecycle, health]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/daemonless_lifecycle.rs
+++ b/tests/daemonless_lifecycle.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let git_init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let init = run_decapod(&dir, &["init", "--force"]);
+    assert!(
+        init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    (tmp, dir)
+}
+
+fn running_decapod_pids(exe_path: &str) -> Vec<u32> {
+    let out = Command::new("ps")
+        .args(["-eo", "pid=,args="])
+        .output()
+        .expect("ps output");
+    assert!(out.status.success(), "ps command failed");
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let mut parts = trimmed.split_whitespace();
+            let pid = parts.next()?.parse::<u32>().ok()?;
+            let args = parts.collect::<Vec<_>>().join(" ");
+            if args.contains(exe_path) {
+                Some(pid)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn decapod_has_no_lingering_background_process() {
+    let (_tmp, dir) = setup_repo();
+    let exe_path = env!("CARGO_BIN_EXE_decapod");
+
+    let before = running_decapod_pids(exe_path);
+
+    for args in [
+        vec!["version"],
+        vec!["capabilities", "--format", "json"],
+        vec!["docs", "show", "core/DECAPOD.md"],
+    ] {
+        let out = run_decapod(&dir, &args);
+        assert!(
+            out.status.success(),
+            "decapod command {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    thread::sleep(Duration::from_millis(150));
+    let after = running_decapod_pids(exe_path);
+
+    assert_eq!(
+        before, after,
+        "daemonless contract violated: unexpected lingering decapod process(es)"
+    );
+}

--- a/tests/kernel_phase4_regression.rs
+++ b/tests/kernel_phase4_regression.rs
@@ -1,0 +1,225 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let git_init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let init = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        init.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[("DECAPOD_AGENT_ID", "unknown")],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let password = String::from_utf8_lossy(&acquire.stdout)
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    (tmp, dir, password)
+}
+
+#[test]
+fn phase4_kernel_surfaces_work_together() {
+    let (_tmp, dir, password) = setup_repo();
+    let auth = [
+        ("DECAPOD_AGENT_ID", "unknown"),
+        ("DECAPOD_SESSION_PASSWORD", password.as_str()),
+        ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+    ];
+
+    let init_workunit = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            "R_PHASE4",
+            "--intent-ref",
+            "intent://phase4",
+        ],
+        &auth,
+    );
+    assert!(
+        init_workunit.status.success(),
+        "workunit init failed: {}",
+        String::from_utf8_lossy(&init_workunit.stderr)
+    );
+
+    let proof_plan = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "set-proof-plan",
+            "--task-id",
+            "R_PHASE4",
+            "--gate",
+            "validate_passes",
+        ],
+        &auth,
+    );
+    assert!(
+        proof_plan.status.success(),
+        "set-proof-plan failed: {}",
+        String::from_utf8_lossy(&proof_plan.stderr)
+    );
+
+    for (gate, status) in [("validate_passes", "pass"), ("validate_passes", "pass")] {
+        let out = run_decapod(
+            &dir,
+            &[
+                "govern",
+                "workunit",
+                "record-proof",
+                "--task-id",
+                "R_PHASE4",
+                "--gate",
+                gate,
+                "--status",
+                status,
+            ],
+            &auth,
+        );
+        assert!(
+            out.status.success(),
+            "record-proof failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    for status in ["executing", "claimed", "verified"] {
+        let out = run_decapod(
+            &dir,
+            &[
+                "govern",
+                "workunit",
+                "transition",
+                "--task-id",
+                "R_PHASE4",
+                "--to",
+                status,
+            ],
+            &auth,
+        );
+        assert!(
+            out.status.success(),
+            "workunit transition {} failed: {}",
+            status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let capsule = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "capsule",
+            "query",
+            "--topic",
+            "proof gates",
+            "--scope",
+            "interfaces",
+            "--task-id",
+            "R_PHASE4",
+            "--write",
+        ],
+        &auth,
+    );
+    assert!(
+        capsule.status.success(),
+        "capsule query failed: {}",
+        String::from_utf8_lossy(&capsule.stderr)
+    );
+    let capsule_payload: Value = serde_json::from_slice(&capsule.stdout).expect("capsule payload");
+    let capsule_path = capsule_payload["path"].as_str().expect("capsule path");
+    assert!(Path::new(capsule_path).exists(), "capsule artifact missing");
+
+    let promote = run_decapod(
+        &dir,
+        &[
+            "data",
+            "knowledge",
+            "promote",
+            "--source-entry-id",
+            "K_PHASE4",
+            "--evidence-ref",
+            "commit:abc123",
+            "--approved-by",
+            "human/reviewer",
+            "--reason",
+            "phase4 regression",
+        ],
+        &auth,
+    );
+    assert!(
+        promote.status.success(),
+        "knowledge promote failed: {}",
+        String::from_utf8_lossy(&promote.stderr)
+    );
+    let promote_payload: Value = serde_json::from_slice(&promote.stdout).expect("promote payload");
+    let event_id = promote_payload["event_id"].as_str().expect("event id");
+
+    let add_proc = run_decapod(
+        &dir,
+        &[
+            "data",
+            "knowledge",
+            "add",
+            "--id",
+            "procedural/commit_norms/phase4",
+            "--title",
+            "Phase 4 Norm",
+            "--text",
+            "always prove before publish",
+            "--provenance",
+            &format!("event:{}", event_id),
+        ],
+        &auth,
+    );
+    assert!(
+        add_proc.status.success(),
+        "procedural knowledge add failed: {}",
+        String::from_utf8_lossy(&add_proc.stderr)
+    );
+
+    let validate = run_decapod(&dir, &["validate"], &auth);
+    assert!(
+        validate.status.success(),
+        "phase4 regression validate failed: {}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- add dedicated daemonless lifecycle test to prove no lingering decapod process after command completion
- add end-to-end kernel regression test covering workunit + context capsule + knowledge promotion firewall flow
- wire daemonless lifecycle into CI as an isolated job and include it in release build requirements

## Verification
- cargo test --test daemonless_lifecycle --test kernel_phase4_regression
- cargo clippy --all-targets --all-features -- -D warnings