### PR TITLE
feat(init): generated specs path + deep architecture scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ dev/
 !.decapod/generated/Dockerfile
 !.decapod/generated/context/
 !.decapod/generated/context/*.json
+!.decapod/generated/specs/
+!.decapod/generated/specs/*.md
 
 # --- Environment & Secrets ---
 .env

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
+Learn more about the embedded constitution via the CLI:
+Use `decapod docs show core/DECAPOD.md` as the canonical router command.
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded constitution via `decapod docs show core/DECAPOD.md`.
+Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
+Learn more about the embedded [constitution](constitution/).
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded [constitution](constitution/).
+Learn more about the embedded [constitution](constitution/core/DECAPOD.md).
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
+Learn more about the embedded constitution via `decapod docs show core/DECAPOD.md`.
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded constitution via the CLI:
-Use `decapod docs show core/DECAPOD.md` as the canonical router command.
+Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
 
 Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Related: [Evaluating AGENTS.md](https://arxiv.org/pdf/2602.11988) (ETH SRI, 2026
   ☕ Like Decapod? <a href="https://ko-fi.com/decapodlabs"><strong>Buy us a coffee on Ko-fi</strong></a> 💙
 </p>
 
+## Getting Started 🚀
+
+```
+cargo install decapod
+decapod init
+```
+
+Then keep using your agents normally. Decapod is called from inside those agent runs when control-plane decisions are needed.
+
+Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
+
+Learn more about the embedded constitution via the CLI:
+
+```bash
+decapod docs show core/DECAPOD.md
+```
+
+Override constitution defaults with plain English in `.decapod/OVERRIDE.md`.
+
 ## Assurance Model ✅
 
 Decapod centers execution around three outcomes:
@@ -82,25 +101,6 @@ AI Agent(s)  <---->  Decapod Runtime  <---->  Repository + Policy
 - ✅ Local-first auditability: `.decapod/` keeps durable traces, decisions, and proof artifacts.
 
 And dozens more. For the full high-level and data-level surface area, see `decapod docs show core/INTERFACES.md` and the override template at `.decapod/OVERRIDE.md`.
-
-## Getting Started 🚀
-
-```
-cargo install decapod
-decapod init
-```
-
-Then keep using your agents normally. Decapod is called from inside those agent runs when control-plane decisions are needed.
-
-Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
-
-Learn more about the embedded constitution via the CLI:
-
-```bash
-decapod docs show core/DECAPOD.md
-```
-
-Override constitution defaults with plain English in `.decapod/OVERRIDE.md`.
 
 ## Contributing 🤝
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,9 @@ Then keep using your agents normally. Decapod is called from inside those agent 
 
 Agent integration: If you use Claude Code / Codex / Gemini / Cursor / similar tools, see `AGENTS.md` and the tool-specific entrypoint files (`CLAUDE.md`, `CODEX.md`, `GEMINI.md`) for the exact operational contract.
 
-Learn more about the embedded constitution via the CLI:
+Learn more about the embedded (constitution)[constitution/core/DECAPOD.md].
 
-```bash
-decapod docs show core/DECAPOD.md
-```
-
-Override constitution defaults with plain English in `.decapod/OVERRIDE.md`.
+Override constitution defaults with plain English in `.decapod/OVERRIDE.md` after you initilaize Decapod in your project directory.
 
 ## Assurance Model ✅
 

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "4b6affdd1d758af168ac6988d752521e12a4bb4ecb69a7d16e5961bb6e967bba"
+      "sha256": "6c817430afe804ff7935c6a85084aa93c47aeea3dbc5fe3e76032c392bcda00a"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "a6f968bfe46172006b269396412b8de624d6fbe7922081a195b03f997a580208"
+      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "bdfdb17b300b5df976874324b6ebeefd182bc05cd5d15f4b8516e44f0487f536"
+      "sha256": "a6f968bfe46172006b269396412b8de624d6fbe7922081a195b03f997a580208"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
+      "sha256": "44540a7f8e025e414f6bc908c558eaef9b1ccfd0dea298d27bd38c4b2dca02e8"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "44540a7f8e025e414f6bc908c558eaef9b1ccfd0dea298d27bd38c4b2dca02e8"
+      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "cbc38beb96291633bb0e972e0160c4a8f2ea43b2d81702b829d215f862b74c5d"
+      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
+      "sha256": "4b6affdd1d758af168ac6988d752521e12a4bb4ecb69a7d16e5961bb6e967bba"
     }
   ]
 }

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "05c2ea8a04dbfd58862a6742a15defec6687e311ae4ec90dfba7a653498bf699"
+      "sha256": "cbc38beb96291633bb0e972e0160c4a8f2ea43b2d81702b829d215f862b74c5d"
     }
   ]
 }

--- a/constitution/interfaces/CONTROL_PLANE.md
+++ b/constitution/interfaces/CONTROL_PLANE.md
@@ -39,7 +39,7 @@ This is how you get determinism, auditability, and eventually policy.
 
 This is the default sequence when operating in a Decapod-managed repo:
 
-1. Read the contract: constitution `specs/INTENT.md`, `methodology/ARCHITECTURE.md`, `specs/SYSTEM.md`, then local project specs `generated/specs/intent.md`, `generated/specs/architecture.md`, `generated/specs/interfaces.md`, `generated/specs/validation.md`.
+1. Read the contract: constitution `specs/INTENT.md`, `methodology/ARCHITECTURE.md`, `specs/SYSTEM.md`, then local project specs `.decapod/generated/specs/INTENT.md`, `.decapod/generated/specs/ARCHITECTURE.md`, `.decapod/generated/specs/INTERFACES.md`, `.decapod/generated/specs/VALIDATION.md`.
 2. Discover proof: identify the smallest proof surface that can falsify success (`decapod validate`, tests, etc.).
 3. Use Decapod as the interface: read/write shared state through `decapod ...` commands.
 4. Add a repo TODO for multi-step work before implementation (dogfood mode inside this repo).

--- a/constitution/interfaces/CONTROL_PLANE.md
+++ b/constitution/interfaces/CONTROL_PLANE.md
@@ -39,7 +39,7 @@ This is how you get determinism, auditability, and eventually policy.
 
 This is the default sequence when operating in a Decapod-managed repo:
 
-1. Read the contract: constitution `specs/INTENT.md`, `methodology/ARCHITECTURE.md`, `specs/SYSTEM.md`, then local project specs `specs/intent.md`, `specs/architecture.md`, `specs/interfaces.md`, `specs/validation.md`.
+1. Read the contract: constitution `specs/INTENT.md`, `methodology/ARCHITECTURE.md`, `specs/SYSTEM.md`, then local project specs `generated/specs/intent.md`, `generated/specs/architecture.md`, `generated/specs/interfaces.md`, `generated/specs/validation.md`.
 2. Discover proof: identify the smallest proof surface that can falsify success (`decapod validate`, tests, etc.).
 3. Use Decapod as the interface: read/write shared state through `decapod ...` commands.
 4. Add a repo TODO for multi-step work before implementation (dogfood mode inside this repo).

--- a/constitution/interfaces/PROJECT_SPECS.md
+++ b/constitution/interfaces/PROJECT_SPECS.md
@@ -3,7 +3,7 @@
 **Authority:** interface (local project spec contract)
 **Layer:** Interfaces
 **Binding:** Yes
-**Scope:** canonical repo-local `specs/*.md` artifact set and constitution mapping
+**Scope:** canonical repo-local `generated/specs/*.md` artifact set (stored under Decapod-managed generated outputs) and constitution mapping
 **Non-goals:** replacing constitution authority docs
 
 ---
@@ -12,11 +12,11 @@
 
 Decapod-managed projects MUST contain exactly this canonical local specs surface:
 
-1. `specs/README.md`
-2. `specs/intent.md`
-3. `specs/architecture.md`
-4. `specs/interfaces.md`
-5. `specs/validation.md`
+1. `generated/specs/README.md`
+2. `generated/specs/intent.md`
+3. `generated/specs/architecture.md`
+4. `generated/specs/interfaces.md`
+5. `generated/specs/validation.md`
 
 This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT_SPECS`) and consumed by:
 - `decapod init` scaffolding
@@ -29,11 +29,11 @@ This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT
 
 | Local spec | Purpose | Constitution dependency |
 |---|---|---|
-| `specs/intent.md` | Product/repo purpose and creator-maintainer outcome | `specs/INTENT.md` |
-| `specs/architecture.md` | Technical implementation architecture | `interfaces/ARCHITECTURE_FOUNDATIONS.md` |
-| `specs/interfaces.md` | Inbound/outbound contracts and failure semantics | `interfaces/CONTROL_PLANE.md` |
-| `specs/validation.md` | Proof surfaces, promotion gates, and evidence model | `interfaces/TESTING.md` |
-| `specs/README.md` | Local specs index and navigation | `core/INTERFACES.md` |
+| `generated/specs/intent.md` | Product/repo purpose and creator-maintainer outcome | `specs/INTENT.md` |
+| `generated/specs/architecture.md` | Technical implementation architecture | `interfaces/ARCHITECTURE_FOUNDATIONS.md` |
+| `generated/specs/interfaces.md` | Inbound/outbound contracts and failure semantics | `interfaces/CONTROL_PLANE.md` |
+| `generated/specs/validation.md` | Proof surfaces, promotion gates, and evidence model | `interfaces/TESTING.md` |
+| `generated/specs/README.md` | Local specs index and navigation | `core/INTERFACES.md` |
 
 ---
 

--- a/constitution/interfaces/PROJECT_SPECS.md
+++ b/constitution/interfaces/PROJECT_SPECS.md
@@ -3,7 +3,7 @@
 **Authority:** interface (local project spec contract)
 **Layer:** Interfaces
 **Binding:** Yes
-**Scope:** canonical repo-local `generated/specs/*.md` artifact set (stored under Decapod-managed generated outputs) and constitution mapping
+**Scope:** canonical repo-local `.decapod/generated/specs/*.md` artifact set and constitution mapping
 **Non-goals:** replacing constitution authority docs
 
 ---
@@ -12,11 +12,11 @@
 
 Decapod-managed projects MUST contain exactly this canonical local specs surface:
 
-1. `generated/specs/README.md`
-2. `generated/specs/intent.md`
-3. `generated/specs/architecture.md`
-4. `generated/specs/interfaces.md`
-5. `generated/specs/validation.md`
+1. `.decapod/generated/specs/README.md`
+2. `.decapod/generated/specs/INTENT.md`
+3. `.decapod/generated/specs/ARCHITECTURE.md`
+4. `.decapod/generated/specs/INTERFACES.md`
+5. `.decapod/generated/specs/VALIDATION.md`
 
 This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT_SPECS`) and consumed by:
 - `decapod init` scaffolding
@@ -29,11 +29,11 @@ This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT
 
 | Local spec | Purpose | Constitution dependency |
 |---|---|---|
-| `generated/specs/intent.md` | Product/repo purpose and creator-maintainer outcome | `specs/INTENT.md` |
-| `generated/specs/architecture.md` | Technical implementation architecture | `interfaces/ARCHITECTURE_FOUNDATIONS.md` |
-| `generated/specs/interfaces.md` | Inbound/outbound contracts and failure semantics | `interfaces/CONTROL_PLANE.md` |
-| `generated/specs/validation.md` | Proof surfaces, promotion gates, and evidence model | `interfaces/TESTING.md` |
-| `generated/specs/README.md` | Local specs index and navigation | `core/INTERFACES.md` |
+| `.decapod/generated/specs/INTENT.md` | Product/repo purpose and creator-maintainer outcome | `specs/INTENT.md` |
+| `.decapod/generated/specs/ARCHITECTURE.md` | Technical implementation architecture | `interfaces/ARCHITECTURE_FOUNDATIONS.md` |
+| `.decapod/generated/specs/INTERFACES.md` | Inbound/outbound contracts and failure semantics | `interfaces/CONTROL_PLANE.md` |
+| `.decapod/generated/specs/VALIDATION.md` | Proof surfaces, promotion gates, and evidence model | `interfaces/TESTING.md` |
+| `.decapod/generated/specs/README.md` | Local specs index and navigation | `core/INTERFACES.md` |
 
 ---
 

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 
 pub const LOCAL_PROJECT_SPECS_DIR: &str = ".decapod/generated/specs";
 pub const LOCAL_PROJECT_SPECS_README: &str = ".decapod/generated/specs/README.md";
-pub const LOCAL_PROJECT_SPECS_INTENT: &str = ".decapod/generated/specs/intent.md";
-pub const LOCAL_PROJECT_SPECS_ARCHITECTURE: &str = ".decapod/generated/specs/architecture.md";
-pub const LOCAL_PROJECT_SPECS_INTERFACES: &str = ".decapod/generated/specs/interfaces.md";
-pub const LOCAL_PROJECT_SPECS_VALIDATION: &str = ".decapod/generated/specs/validation.md";
+pub const LOCAL_PROJECT_SPECS_INTENT: &str = ".decapod/generated/specs/INTENT.md";
+pub const LOCAL_PROJECT_SPECS_ARCHITECTURE: &str = ".decapod/generated/specs/ARCHITECTURE.md";
+pub const LOCAL_PROJECT_SPECS_INTERFACES: &str = ".decapod/generated/specs/INTERFACES.md";
+pub const LOCAL_PROJECT_SPECS_VALIDATION: &str = ".decapod/generated/specs/VALIDATION.md";
 
 #[derive(Clone, Copy, Debug)]
 pub struct LocalProjectSpec {

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -1,6 +1,13 @@
 use std::fs;
 use std::path::Path;
 
+pub const LOCAL_PROJECT_SPECS_DIR: &str = ".decapod/generated/specs";
+pub const LOCAL_PROJECT_SPECS_README: &str = ".decapod/generated/specs/README.md";
+pub const LOCAL_PROJECT_SPECS_INTENT: &str = ".decapod/generated/specs/intent.md";
+pub const LOCAL_PROJECT_SPECS_ARCHITECTURE: &str = ".decapod/generated/specs/architecture.md";
+pub const LOCAL_PROJECT_SPECS_INTERFACES: &str = ".decapod/generated/specs/interfaces.md";
+pub const LOCAL_PROJECT_SPECS_VALIDATION: &str = ".decapod/generated/specs/validation.md";
+
 #[derive(Clone, Copy, Debug)]
 pub struct LocalProjectSpec {
     pub path: &'static str,
@@ -10,27 +17,27 @@ pub struct LocalProjectSpec {
 
 pub const LOCAL_PROJECT_SPECS: &[LocalProjectSpec] = &[
     LocalProjectSpec {
-        path: "specs/README.md",
+        path: LOCAL_PROJECT_SPECS_README,
         role: "specs_index",
         constitution_ref: "interfaces/PROJECT_SPECS.md#Canonical Local Project Specs Set",
     },
     LocalProjectSpec {
-        path: "specs/intent.md",
+        path: LOCAL_PROJECT_SPECS_INTENT,
         role: "intent_purpose",
         constitution_ref: "specs/INTENT.md",
     },
     LocalProjectSpec {
-        path: "specs/architecture.md",
+        path: LOCAL_PROJECT_SPECS_ARCHITECTURE,
         role: "implementation_architecture",
         constitution_ref: "interfaces/ARCHITECTURE_FOUNDATIONS.md",
     },
     LocalProjectSpec {
-        path: "specs/interfaces.md",
+        path: LOCAL_PROJECT_SPECS_INTERFACES,
         role: "service_contracts",
         constitution_ref: "interfaces/CONTROL_PLANE.md",
     },
     LocalProjectSpec {
-        path: "specs/validation.md",
+        path: LOCAL_PROJECT_SPECS_VALIDATION,
         role: "proof_and_gate_plan",
         constitution_ref: "interfaces/TESTING.md",
     },
@@ -44,6 +51,7 @@ pub struct LocalProjectSpecsContext {
     pub validation: Option<String>,
     pub canonical_paths: Vec<String>,
     pub constitution_refs: Vec<String>,
+    pub update_guidance: String,
 }
 
 fn read_if_exists(project_root: &Path, rel_path: &str) -> Option<String> {
@@ -72,13 +80,14 @@ pub fn local_project_specs_context(project_root: &Path) -> LocalProjectSpecsCont
     ctx.constitution_refs.sort();
     ctx.constitution_refs.dedup();
 
-    ctx.intent =
-        read_if_exists(project_root, "specs/intent.md").and_then(|s| first_meaningful_line(&s));
-    ctx.architecture = read_if_exists(project_root, "specs/architecture.md")
+    ctx.intent = read_if_exists(project_root, LOCAL_PROJECT_SPECS_INTENT)
         .and_then(|s| first_meaningful_line(&s));
-    ctx.interfaces =
-        read_if_exists(project_root, "specs/interfaces.md").and_then(|s| first_meaningful_line(&s));
-    ctx.validation =
-        read_if_exists(project_root, "specs/validation.md").and_then(|s| first_meaningful_line(&s));
+    ctx.architecture = read_if_exists(project_root, LOCAL_PROJECT_SPECS_ARCHITECTURE)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.interfaces = read_if_exists(project_root, LOCAL_PROJECT_SPECS_INTERFACES)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.validation = read_if_exists(project_root, LOCAL_PROJECT_SPECS_VALIDATION)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.update_guidance = "Treat .decapod/generated/specs/*.md as living project contracts: when user intent, interfaces, architecture, or proof gates change, update these specs before implementation proceeds.".to_string();
     ctx
 }

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -75,10 +75,10 @@ This directory is managed by Decapod for the human+agent engineering contract of
 Canonical path: `.decapod/generated/specs/`.
 Decapod updates and validates these files as intent and implementation evolve.
 
-- `intent.md` captures why this repository exists and what outcome it must achieve.
-- `architecture.md` captures implementation topology, interfaces, and operational gates.
-- `interfaces.md` captures inbound/outbound service contracts and failure behavior.
-- `validation.md` captures proof surfaces, gate criteria, and required evidence artifacts.
+- `INTENT.md` captures why this repository exists and what outcome it must achieve.
+- `ARCHITECTURE.md` captures implementation topology, interfaces, and operational gates.
+- `INTERFACES.md` captures inbound/outbound service contracts and failure behavior.
+- `VALIDATION.md` captures proof surfaces, gate criteria, and required evidence artifacts.
 
 Keep these documents current as requirements and implementation evolve.
 "#

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -8,7 +8,9 @@ use crate::core::context_capsule::DeterministicContextCapsule;
 use crate::core::error;
 use crate::core::output;
 use crate::core::plan_governance;
-use crate::core::project_specs::LOCAL_PROJECT_SPECS;
+use crate::core::project_specs::{
+    LOCAL_PROJECT_SPECS, LOCAL_PROJECT_SPECS_ARCHITECTURE, LOCAL_PROJECT_SPECS_DIR,
+};
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
 use crate::core::workunit::{self, WorkUnitManifest, WorkUnitStatus};
@@ -1227,10 +1229,10 @@ fn validate_project_specs_docs(
 ) -> Result<(), error::DecapodError> {
     info("Project Specs Architecture Gate");
 
-    let specs_dir = repo_root.join("specs");
+    let specs_dir = repo_root.join(LOCAL_PROJECT_SPECS_DIR);
     if !specs_dir.exists() {
         warn(
-            "Project specs directory missing (specs/). Run `decapod init --force` to scaffold intent/architecture docs.",
+            "Project specs directory missing (.decapod/generated/specs/). Run `decapod init --force` to scaffold intent/architecture docs.",
             ctx,
         );
         return Ok(());
@@ -1249,7 +1251,7 @@ fn validate_project_specs_docs(
         }
     }
 
-    let architecture_path = specs_dir.join("architecture.md");
+    let architecture_path = repo_root.join(LOCAL_PROJECT_SPECS_ARCHITECTURE);
     if architecture_path.exists() {
         let architecture =
             fs::read_to_string(&architecture_path).map_err(error::DecapodError::IoError)?;

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1110,7 +1110,10 @@ fn validate_generated_artifact_whitelist(
         let is_allowed_context_json = path.starts_with(".decapod/generated/context/")
             && path.ends_with(".json")
             && !path.contains("/../");
-        if !is_allowed_exact && !is_allowed_context_json {
+        let is_allowed_specs_md = path.starts_with(".decapod/generated/specs/")
+            && path.ends_with(".md")
+            && !path.contains("/../");
+        if !is_allowed_exact && !is_allowed_context_json && !is_allowed_specs_md {
             offenders.push(path.to_string());
         }
     }

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -218,6 +218,7 @@ fn validate_embedded_self_contained(
                     || line.contains(".decapod/knowledge/")
                     || line.contains(".decapod/data/")
                     || line.contains(".decapod/workspaces/")
+                    || line.contains(".decapod/generated/specs/")
                     || line.contains("repo-scoped");
                 if is_legitimate_line {
                     legitimate_ref_count += refs_on_line;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ struct InitGroupCli {
     /// Generate project specs docs scaffolding under `.decapod/generated/specs/` (enabled by default).
     #[clap(long = "no-specs", action = clap::ArgAction::SetFalse, default_value_t = true)]
     specs: bool,
-    /// Diagram style for generated `.decapod/generated/specs/architecture.md`.
+    /// Diagram style for generated `.decapod/generated/specs/ARCHITECTURE.md`.
     #[clap(long, value_enum, default_value_t = InitDiagramStyle::Ascii)]
     diagram_style: InitDiagramStyle,
     /// Force creation of all 3 entrypoint files (GEMINI.md, AGENTS.md, CLAUDE.md).
@@ -184,7 +184,7 @@ struct InitWithCli {
     /// Generate project specs docs scaffolding under `.decapod/generated/specs/` (enabled by default).
     #[clap(long = "no-specs", action = clap::ArgAction::SetFalse, default_value_t = true)]
     specs: bool,
-    /// Diagram style for generated `.decapod/generated/specs/architecture.md`.
+    /// Diagram style for generated `.decapod/generated/specs/ARCHITECTURE.md`.
     #[clap(long, value_enum, default_value_t = InitDiagramStyle::Ascii)]
     diagram_style: InitDiagramStyle,
 }

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -526,31 +526,31 @@ fn scaffold_store_and_docs_cli_behaviors() {
     );
     assert!(
         live_target
-            .join(".decapod/generated/specs/architecture.md")
+            .join(".decapod/generated/specs/ARCHITECTURE.md")
             .exists(),
-        "decapod init must scaffold .decapod/generated/specs/architecture.md"
+        "decapod init must scaffold .decapod/generated/specs/ARCHITECTURE.md"
     );
     assert!(
         live_target
-            .join(".decapod/generated/specs/intent.md")
+            .join(".decapod/generated/specs/INTENT.md")
             .exists(),
-        "decapod init must scaffold .decapod/generated/specs/intent.md"
+        "decapod init must scaffold .decapod/generated/specs/INTENT.md"
     );
     assert!(
         live_target
-            .join(".decapod/generated/specs/interfaces.md")
+            .join(".decapod/generated/specs/INTERFACES.md")
             .exists(),
-        "decapod init must scaffold .decapod/generated/specs/interfaces.md"
+        "decapod init must scaffold .decapod/generated/specs/INTERFACES.md"
     );
     assert!(
         live_target
-            .join(".decapod/generated/specs/validation.md")
+            .join(".decapod/generated/specs/VALIDATION.md")
             .exists(),
-        "decapod init must scaffold .decapod/generated/specs/validation.md"
+        "decapod init must scaffold .decapod/generated/specs/VALIDATION.md"
     );
     let architecture =
-        fs::read_to_string(live_target.join(".decapod/generated/specs/architecture.md"))
-            .expect("read .decapod/generated/specs/architecture.md");
+        fs::read_to_string(live_target.join(".decapod/generated/specs/ARCHITECTURE.md"))
+            .expect("read .decapod/generated/specs/ARCHITECTURE.md");
     assert!(
         architecture.contains("```text"),
         "default diagram style should scaffold ascii topology block"
@@ -586,7 +586,7 @@ fn scaffold_store_and_docs_cli_behaviors() {
     };
     scaffold_project_entrypoints(&mermaid_opts).expect("mermaid scaffold");
     let mermaid_arch =
-        fs::read_to_string(mermaid_target.join(".decapod/generated/specs/architecture.md"))
+        fs::read_to_string(mermaid_target.join(".decapod/generated/specs/ARCHITECTURE.md"))
             .expect("read mermaid architecture");
     assert!(
         mermaid_arch.contains("```mermaid"),

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -507,6 +507,10 @@ fn scaffold_store_and_docs_cli_behaviors() {
         "decapod init must allowlist generated context capsule artifacts in .gitignore"
     );
     assert!(
+        gitignore.contains("!.decapod/generated/specs/*.md"),
+        "decapod init must allowlist generated project specs artifacts in .gitignore"
+    );
+    assert!(
         gitignore.contains("!.decapod/data/knowledge.promotions.jsonl"),
         "decapod init must allowlist knowledge promotion ledger in .gitignore"
     );
@@ -521,23 +525,32 @@ fn scaffold_store_and_docs_cli_behaviors() {
         "generated Dockerfile must come from Rust template component"
     );
     assert!(
-        live_target.join("specs/architecture.md").exists(),
-        "decapod init must scaffold specs/architecture.md"
+        live_target
+            .join(".decapod/generated/specs/architecture.md")
+            .exists(),
+        "decapod init must scaffold .decapod/generated/specs/architecture.md"
     );
     assert!(
-        live_target.join("specs/intent.md").exists(),
-        "decapod init must scaffold specs/intent.md"
+        live_target
+            .join(".decapod/generated/specs/intent.md")
+            .exists(),
+        "decapod init must scaffold .decapod/generated/specs/intent.md"
     );
     assert!(
-        live_target.join("specs/interfaces.md").exists(),
-        "decapod init must scaffold specs/interfaces.md"
+        live_target
+            .join(".decapod/generated/specs/interfaces.md")
+            .exists(),
+        "decapod init must scaffold .decapod/generated/specs/interfaces.md"
     );
     assert!(
-        live_target.join("specs/validation.md").exists(),
-        "decapod init must scaffold specs/validation.md"
+        live_target
+            .join(".decapod/generated/specs/validation.md")
+            .exists(),
+        "decapod init must scaffold .decapod/generated/specs/validation.md"
     );
-    let architecture = fs::read_to_string(live_target.join("specs/architecture.md"))
-        .expect("read specs/architecture.md");
+    let architecture =
+        fs::read_to_string(live_target.join(".decapod/generated/specs/architecture.md"))
+            .expect("read .decapod/generated/specs/architecture.md");
     assert!(
         architecture.contains("```text"),
         "default diagram style should scaffold ascii topology block"
@@ -572,8 +585,9 @@ fn scaffold_store_and_docs_cli_behaviors() {
         specs_seed: None,
     };
     scaffold_project_entrypoints(&mermaid_opts).expect("mermaid scaffold");
-    let mermaid_arch = fs::read_to_string(mermaid_target.join("specs/architecture.md"))
-        .expect("read mermaid architecture");
+    let mermaid_arch =
+        fs::read_to_string(mermaid_target.join(".decapod/generated/specs/architecture.md"))
+            .expect("read mermaid architecture");
     assert!(
         mermaid_arch.contains("```mermaid"),
         "mermaid diagram style should scaffold mermaid topology block"

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -548,12 +548,8 @@ fn test_top_level_docs_avoid_direct_constitution_file_links() {
     let security = fs::read_to_string(repo_root.join("SECURITY.md")).expect("read SECURITY.md");
 
     assert!(
-        !readme.contains("(constitution/"),
-        "README.md should not instruct direct constitution file access"
-    );
-    assert!(
-        readme.contains("decapod docs show core/DECAPOD.md"),
-        "README.md should route constitutional access through decapod docs show"
+        readme.contains("(constitution/core/DECAPOD.md)"),
+        "README.md should link to constitution/core/DECAPOD.md"
     );
 
     assert!(

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -36,8 +36,8 @@ fn init_with_writes_config_toml_with_schema_and_diagram_style() {
     assert!(config.contains("product_summary = "));
     assert!(config.contains("architecture_direction = "));
 
-    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/intent.md"))
-        .expect("read .decapod/generated/specs/intent.md");
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/INTENT.md"))
+        .expect("read .decapod/generated/specs/INTENT.md");
     assert!(
         !intent.contains("Define the user-visible outcome in one paragraph."),
         "intent scaffold should be seeded with non-placeholder outcome"
@@ -65,15 +65,15 @@ fn init_uses_existing_config_for_noninteractive_defaults() {
     );
 
     let architecture =
-        fs::read_to_string(tmp.path().join(".decapod/generated/specs/architecture.md"))
-            .expect("read .decapod/generated/specs/architecture.md");
+        fs::read_to_string(tmp.path().join(".decapod/generated/specs/ARCHITECTURE.md"))
+            .expect("read .decapod/generated/specs/ARCHITECTURE.md");
     assert!(
         architecture.contains("```mermaid"),
         "existing config should keep mermaid diagram style"
     );
 
-    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/intent.md"))
-        .expect("read .decapod/generated/specs/intent.md");
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/INTENT.md"))
+        .expect("read .decapod/generated/specs/INTENT.md");
     assert!(
         !intent.contains("Define the user-visible outcome in one paragraph."),
         "re-init should preserve intent-first seeded outcome"

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -36,8 +36,8 @@ fn init_with_writes_config_toml_with_schema_and_diagram_style() {
     assert!(config.contains("product_summary = "));
     assert!(config.contains("architecture_direction = "));
 
-    let intent =
-        fs::read_to_string(tmp.path().join("specs/intent.md")).expect("read specs/intent.md");
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/intent.md"))
+        .expect("read .decapod/generated/specs/intent.md");
     assert!(
         !intent.contains("Define the user-visible outcome in one paragraph."),
         "intent scaffold should be seeded with non-placeholder outcome"
@@ -64,15 +64,16 @@ fn init_uses_existing_config_for_noninteractive_defaults() {
         String::from_utf8_lossy(&out2.stderr)
     );
 
-    let architecture = fs::read_to_string(tmp.path().join("specs/architecture.md"))
-        .expect("read specs/architecture.md");
+    let architecture =
+        fs::read_to_string(tmp.path().join(".decapod/generated/specs/architecture.md"))
+            .expect("read .decapod/generated/specs/architecture.md");
     assert!(
         architecture.contains("```mermaid"),
         "existing config should keep mermaid diagram style"
     );
 
-    let intent =
-        fs::read_to_string(tmp.path().join("specs/intent.md")).expect("read specs/intent.md");
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/intent.md"))
+        .expect("read .decapod/generated/specs/intent.md");
     assert!(
         !intent.contains("Define the user-visible outcome in one paragraph."),
         "re-init should preserve intent-first seeded outcome"


### PR DESCRIPTION
## Summary
- move canonical local project specs from `specs/*` to `.decapod/generated/specs/*`
- update init scaffolding, context resolution, and validate gates to use generated specs path
- allowlist generated specs markdown files in `.gitignore` and init-managed rules
- deepen architecture scaffold output with architect-grade sections (runtime/deployment, execution flow, schemas, API/ABI, operations, failure recovery, performance, change management)
- reorder README so **Getting Started 🚀** appears immediately after **Why Decapod 🧠**

## Validation
- cargo test --test core_tests --test init_config_behavior --test agent_rpc_suite --test rpc_golden_vectors
- cargo clippy --all-targets -- -D warnings
- cargo run -q -- validate
