### PR TITLE
ux(init): polish interactive setup form and summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  Called on demand inside agent loops. No background process, no new workflow, local-first state you can verify.
+  Called on demand inside agent loops to turn intent into context, then context into explicit specifications before inference. No background process, no new workflow, local-first state you can verify.
 </p>
 
 <p align="center">

--- a/artifacts/provenance/artifact_manifest.json
+++ b/artifacts/provenance/artifact_manifest.json
@@ -17,7 +17,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "6c817430afe804ff7935c6a85084aa93c47aeea3dbc5fe3e76032c392bcda00a"
+      "sha256": "fb05033fec85ee6e57f6e1dd21c2e81eaff3e33d4a3bef30408a133de008ce2f"
     }
   ]
 }

--- a/constitution/core/DECAPOD.md
+++ b/constitution/core/DECAPOD.md
@@ -9,6 +9,8 @@ Decapod is a repo-native helper for humans that makes an agent:
 
 The human interfaces ONLY with the agent as the UX. The agent calls Decapod.
 
+Decapod is called on demand inside agent loops to turn intent into context, then context into explicit specifications before inference.
+
 ## What Decapod Is Not
 
 - Not an agent framework.
@@ -33,6 +35,7 @@ This produces a session receipt and tells you what's allowed next.
 ## Core Posture
 
 - **Local-first**: Everything is on disk, auditable, versioned
+- **No workflow replacement**: Keep using your existing agent flow; Decapod is called inside it
 - **Deterministic**: Same inputs produce same outputs
 - **Agent-native**: Designed for programmatic access via `decapod rpc`
 - **Daemonless**: No required long-lived control-plane process

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[clap(
     name = "decapod",
     version = env!("CARGO_PKG_VERSION"),
-    about = "Decapod is the daemonless, local-first control plane that agents call on demand to align intent, enforce boundaries, and produce proof-backed completion across concurrent multi-agent work. 🦀",
+    about = "Decapod is the daemonless, local-first control plane that agents call on demand to turn intent into context, then context into explicit specifications before inference, enforce boundaries, and produce proof-backed completion across concurrent multi-agent work. 🦀",
     disable_version_flag = true
 )]
 struct Cli {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1224,8 +1224,27 @@ fn prompt_line(prompt: &str) -> Result<String, error::DecapodError> {
     Ok(buf.trim().to_string())
 }
 
-fn prompt_line_default(prompt: &str, default_value: &str) -> Result<String, error::DecapodError> {
-    let line = prompt_line(&format!("{} [{}]: ", prompt, default_value))?;
+fn print_init_block(title: &str, subtitle: &str) {
+    use colored::Colorize;
+    println!();
+    println!("{}", format!("◢ {}", title).bright_cyan().bold());
+    println!("{}", format!("  {}", subtitle).bright_black());
+}
+
+fn prompt_text_field(
+    label: &str,
+    helper: &str,
+    default_value: &str,
+) -> Result<String, error::DecapodError> {
+    use colored::Colorize;
+    println!();
+    println!("{}", format!("  {}", label).bright_white().bold());
+    println!("{}", format!("    {}", helper).bright_black());
+    println!(
+        "{}",
+        format!("    inferred: {}", default_value).bright_black()
+    );
+    let line = prompt_line(&format!("{}", "    input: ".bright_cyan().bold()))?;
     if line.trim().is_empty() {
         Ok(default_value.to_string())
     } else {
@@ -1233,9 +1252,24 @@ fn prompt_line_default(prompt: &str, default_value: &str) -> Result<String, erro
     }
 }
 
+fn prompt_line_default(prompt: &str, default_value: &str) -> Result<String, error::DecapodError> {
+    prompt_text_field(
+        prompt,
+        "Press Enter to keep inferred context.",
+        default_value,
+    )
+}
+
 fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool, error::DecapodError> {
+    use colored::Colorize;
     let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
-    let line = prompt_line(&format!("{} {} ", prompt, suffix))?;
+    println!();
+    println!("{}", format!("  {}", prompt).bright_white().bold());
+    let line = prompt_line(&format!(
+        "{} {} ",
+        "    choice:".bright_cyan().bold(),
+        suffix.bright_black()
+    ))?;
     if line.is_empty() {
         return Ok(default_yes);
     }
@@ -1320,9 +1354,10 @@ fn interactive_init_with(
     force: bool,
     dry_run: bool,
 ) -> Result<InitWithCli, error::DecapodError> {
-    println!();
-    println!("◢ Decapod Setup");
-    println!("  Existing .decapod/config.toml detected. Confirming setup profile.");
+    print_init_block(
+        "Decapod Setup",
+        "Existing .decapod/config.toml detected. Confirm your setup profile.",
+    );
     let mut next = init_with_from_config(config, target_dir, force, dry_run);
     if config.init.entrypoints.is_empty() {
         let all_entrypoints = prompt_yes_no(
@@ -1348,17 +1383,15 @@ fn interactive_init_with(
 }
 
 fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::DecapodError> {
-    println!();
-    println!("◢ Repository Context");
-    println!("  Confirm inferred product intent before generating .decapod/generated/specs/.");
+    print_init_block(
+        "Repository Context",
+        "Review inferred intent before generating .decapod/generated/specs/.",
+    );
     let current_summary = repo.product_summary.clone().unwrap_or_else(|| {
         "Deliver the repository outcome against explicit user intent with proof-backed completion."
             .to_string()
     });
-    repo.product_summary = Some(prompt_line_default(
-        "Intent outcome (beneficiary + expected change)",
-        &current_summary,
-    )?);
+    repo.product_summary = Some(prompt_line_default("Intent outcome", &current_summary)?);
 
     let refine_now = prompt_yes_no(
         "Refine architecture direction and done criteria now? (You can evolve .decapod/generated/specs/*.md later.)",
@@ -1370,7 +1403,7 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
                 .to_string()
         });
         repo.architecture_direction = Some(prompt_line_default(
-            "Architecture direction (system shape + boundaries)",
+            "Architecture direction",
             &current_arch,
         )?);
 
@@ -1378,10 +1411,7 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
             "Decapod validate passes, required tests pass, and promotion-relevant artifacts are present."
                 .to_string()
         });
-        repo.done_criteria = Some(prompt_line_default(
-            "Done criteria (evidence required for ship)",
-            &current_done,
-        )?);
+        repo.done_criteria = Some(prompt_line_default("Done criteria", &current_done)?);
     }
     Ok(())
 }
@@ -1497,8 +1527,10 @@ fn run_init_apply(
         .display()
         .to_string();
     use colored::Colorize;
-    println!();
-    println!("{}", "◢ Decapod Init Summary".bright_cyan().bold());
+    print_init_block(
+        "Decapod Init Summary",
+        "Scaffold completed with the following changes.",
+    );
     println!("  Target: {}", target_display.bright_white());
     println!(
         "  Mode: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1320,10 +1320,15 @@ fn interactive_init_with(
     force: bool,
     dry_run: bool,
 ) -> Result<InitWithCli, error::DecapodError> {
-    println!("▶ init: interactive config form (.decapod/config.toml detected)");
+    println!();
+    println!("◢ Decapod Setup");
+    println!("  Existing .decapod/config.toml detected. Confirming setup profile.");
     let mut next = init_with_from_config(config, target_dir, force, dry_run);
     if config.init.entrypoints.is_empty() {
-        let all_entrypoints = prompt_yes_no("Generate all agent entrypoint files?", true)?;
+        let all_entrypoints = prompt_yes_no(
+            "Include all default agent entrypoints (AGENTS/CLAUDE/GEMINI/CODEX)?",
+            true,
+        )?;
         if all_entrypoints {
             next.all = true;
             next.agents = true;
@@ -1343,18 +1348,20 @@ fn interactive_init_with(
 }
 
 fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::DecapodError> {
-    println!("▶ init: confirm inferred repo context before scaffolding .decapod/generated/specs/");
+    println!();
+    println!("◢ Repository Context");
+    println!("  Confirm inferred product intent before generating .decapod/generated/specs/.");
     let current_summary = repo.product_summary.clone().unwrap_or_else(|| {
         "Deliver the repository outcome against explicit user intent with proof-backed completion."
             .to_string()
     });
     repo.product_summary = Some(prompt_line_default(
-        "Intent outcome (who benefits + what changes)",
+        "Intent outcome (beneficiary + expected change)",
         &current_summary,
     )?);
 
     let refine_now = prompt_yes_no(
-        "Refine architecture direction and done criteria now? (You can evolve .decapod/generated/specs/*.md later through normal agent workflow.)",
+        "Refine architecture direction and done criteria now? (You can evolve .decapod/generated/specs/*.md later.)",
         false,
     )?;
     if refine_now {
@@ -1363,7 +1370,7 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
                 .to_string()
         });
         repo.architecture_direction = Some(prompt_line_default(
-            "Architecture direction (system shape + key boundaries)",
+            "Architecture direction (system shape + boundaries)",
             &current_arch,
         )?);
 
@@ -1372,7 +1379,7 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
                 .to_string()
         });
         repo.done_criteria = Some(prompt_line_default(
-            "Done criteria (evidence required before ship)",
+            "Done criteria (evidence required for ship)",
             &current_done,
         )?);
     }
@@ -1490,23 +1497,19 @@ fn run_init_apply(
         .display()
         .to_string();
     use colored::Colorize;
-    print!(
-        "{} {} ",
-        "▶".bright_green().bold(),
-        "init:".bright_cyan().bold(),
-    );
+    println!();
+    println!("{}", "◢ Decapod Init Summary".bright_cyan().bold());
+    println!("  Target: {}", target_display.bright_white());
     println!(
-        "target={} mode={}",
-        target_display.bright_white(),
+        "  Mode: {}",
         if init_with.dry_run {
-            "dry-run".bright_yellow()
+            "Dry Run".bright_yellow()
         } else {
-            "apply".bright_green()
+            "Apply".bright_green()
         }
     );
     println!(
-        "  {} entry+{}={}~{} cfg+{}={}~{} specs+{}={}~{} backups={}",
-        "files:".bright_cyan(),
+        "  Entrypoints: created={}, unchanged={}, preserved={}",
         scaffold_summary
             .entrypoints_created
             .to_string()
@@ -1518,21 +1521,26 @@ fn run_init_apply(
         scaffold_summary
             .entrypoints_preserved
             .to_string()
-            .bright_white(),
+            .bright_white()
+    );
+    println!(
+        "  Config: created={}, unchanged={}, preserved={}",
         scaffold_summary.config_created.to_string().bright_green(),
         scaffold_summary
             .config_unchanged
             .to_string()
             .bright_yellow(),
-        scaffold_summary.config_preserved.to_string().bright_white(),
-        scaffold_summary.specs_created.to_string().bright_green(),
-        scaffold_summary.specs_unchanged.to_string().bright_yellow(),
-        scaffold_summary.specs_preserved.to_string().bright_white(),
-        backup_count.to_string().bright_magenta()
+        scaffold_summary.config_preserved.to_string().bright_white()
     );
     println!(
-        "  {} diagram_style={}",
-        "specs:".bright_cyan(),
+        "  Specs: created={}, unchanged={}, preserved={}",
+        scaffold_summary.specs_created.to_string().bright_green(),
+        scaffold_summary.specs_unchanged.to_string().bright_yellow(),
+        scaffold_summary.specs_preserved.to_string().bright_white()
+    );
+    println!("  Backups: {}", backup_count.to_string().bright_magenta());
+    println!(
+        "  Diagram Style: {}",
         match init_with.diagram_style {
             InitDiagramStyle::Ascii => "ascii".bright_white(),
             InitDiagramStyle::Mermaid => "mermaid".bright_white(),
@@ -1541,7 +1549,7 @@ fn run_init_apply(
     println!(
         "{} {}",
         "✓".bright_green().bold(),
-        "status=ready".bright_green().bold()
+        "Ready".bright_green().bold()
     );
 
     Ok(target_dir)

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -561,3 +561,28 @@ fn test_top_level_docs_avoid_direct_constitution_file_links() {
         "SECURITY.md should route constitutional access through decapod docs show"
     );
 }
+
+#[test]
+fn test_intent_context_spec_contract_alignment() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let readme = fs::read_to_string(repo_root.join("README.md")).expect("read README.md");
+    let core_decapod = fs::read_to_string(repo_root.join("constitution/core/DECAPOD.md"))
+        .expect("read constitution/core/DECAPOD.md");
+    let lib_rs = fs::read_to_string(repo_root.join("src/lib.rs")).expect("read src/lib.rs");
+
+    let contract_phrase =
+        "turn intent into context, then context into explicit specifications before inference";
+
+    assert!(
+        readme.contains(contract_phrase),
+        "README.md must state the intent->context->specifications flow"
+    );
+    assert!(
+        core_decapod.contains(contract_phrase),
+        "constitution/core/DECAPOD.md must state the intent->context->specifications flow"
+    );
+    assert!(
+        lib_rs.contains(contract_phrase),
+        "src/lib.rs CLI about text must state the intent->context->specifications flow"
+    );
+}


### PR DESCRIPTION
## Summary
- refines ▶ init: interactive config form (.decapod/config.toml detected)
init: already initialized (.decapod exists); rerun with --force, or use `decapod init with --force` interactive copy and visual hierarchy for a more product-grade experience
- upgrades prompt flow with clearer field labeling, helper context, inferred-value visibility, and cleaner yes/no affordances
- restructures init completion output into a readable summary block (target, mode, entrypoints/config/specs/backups, diagram style)

## Scope
- no new subsystem behavior
- no command surface changes
- UX/copy/layout polish only in interactive init flow

## Validation
- cargo fmt --all
- cargo test --test entrypoint_correctness test_top_level_docs_avoid_direct_constitution_file_links -- --nocapture