### PR TITLE
feat(sqlite): harden contention handling, storage preflight, and todo replay compatibility

### DIFF
--- a/tests/context_capsule_rpc.rs
+++ b/tests/context_capsule_rpc.rs
@@ -20,6 +20,14 @@ fn run_decapod_with_env(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std
     cmd.output().expect("run decapod with env")
 }
 
+fn run_git(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
 fn setup_repo() -> (TempDir, std::path::PathBuf) {
     let tmp = TempDir::new().expect("tmpdir");
     let dir = tmp.path().to_path_buf();
@@ -36,6 +44,30 @@ fn setup_repo() -> (TempDir, std::path::PathBuf) {
         decapod_init.status.success(),
         "decapod init failed: {}",
         String::from_utf8_lossy(&decapod_init.stderr)
+    );
+    let git_name = run_git(&dir, &["config", "user.name", "Decapod Test"]);
+    assert!(
+        git_name.status.success(),
+        "git config user.name failed: {}",
+        String::from_utf8_lossy(&git_name.stderr)
+    );
+    let git_email = run_git(&dir, &["config", "user.email", "test@decapod.local"]);
+    assert!(
+        git_email.status.success(),
+        "git config user.email failed: {}",
+        String::from_utf8_lossy(&git_email.stderr)
+    );
+    let git_add = run_git(&dir, &["add", "-A"]);
+    assert!(
+        git_add.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&git_add.stderr)
+    );
+    let git_commit = run_git(&dir, &["commit", "-m", "test fixture bootstrap"]);
+    assert!(
+        git_commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&git_commit.stderr)
     );
 
     let validate = run_decapod_with_env(

--- a/tests/sqlite_hardening.rs
+++ b/tests/sqlite_hardening.rs
@@ -1,0 +1,126 @@
+use decapod::core::{db, error::DecapodError, pool};
+use rusqlite::Connection;
+use std::sync::{Mutex, OnceLock};
+use tempfile::TempDir;
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[test]
+fn sqlite_pool_write_reports_busy_under_exclusive_lock_and_recovers_after_release() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("retry.db");
+
+    let setup = Connection::open(&db_path).expect("open setup");
+    setup
+        .execute(
+            "CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, v TEXT)",
+            [],
+        )
+        .expect("create table");
+
+    let lock_conn = Connection::open(&db_path).expect("open lock");
+    lock_conn
+        .execute_batch("BEGIN EXCLUSIVE;")
+        .expect("acquire exclusive lock");
+
+    let blocked = pool::global_pool().with_write(&db_path, |conn| {
+        conn.execute("INSERT INTO t(v) VALUES('blocked')", [])
+            .map_err(DecapodError::RusqliteError)?;
+        Ok(())
+    });
+    assert!(blocked.is_err(), "write must fail while lock is held");
+    let err_msg = blocked.err().unwrap().to_string();
+    assert!(
+        err_msg.contains("database is locked")
+            || err_msg.contains("DatabaseBusy")
+            || err_msg.contains("busy"),
+        "unexpected busy error: {err_msg}"
+    );
+
+    lock_conn.execute_batch("COMMIT;").expect("release lock");
+
+    let recovered = pool::global_pool().with_write(&db_path, |conn| {
+        conn.execute("INSERT INTO t(v) VALUES('ok')", [])
+            .map_err(DecapodError::RusqliteError)?;
+        Ok(())
+    });
+    assert!(
+        recovered.is_ok(),
+        "write should succeed after lock release: {recovered:?}"
+    );
+
+    let verify = Connection::open(&db_path).expect("open verify");
+    let count: i64 = verify
+        .query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))
+        .expect("count rows");
+    assert_eq!(count, 1, "exactly one successful write should be recorded");
+}
+
+#[test]
+fn sqlite_fault_injection_produces_deterministic_io_error_path() {
+    let _guard = env_lock().lock().expect("lock env");
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("fault.db");
+
+    // SAFETY: test-scoped environment mutation is serialized via env_lock.
+    unsafe { std::env::set_var("DECAPOD_SQLITE_FAULT_STAGE", "open") };
+    let err = db::db_connect(db_path.to_string_lossy().as_ref()).expect_err("fault must trigger");
+    // SAFETY: test-scoped environment mutation is serialized via env_lock.
+    unsafe { std::env::remove_var("DECAPOD_SQLITE_FAULT_STAGE") };
+
+    let msg = err.to_string();
+    assert!(msg.contains("SQLITE_FAULT_INJECTED"), "{msg}");
+    assert!(msg.contains("extended_code=522"), "{msg}");
+}
+
+#[cfg(unix)]
+#[test]
+fn storage_preflight_fails_for_non_writable_directory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let store_root = tmp.path().join("data");
+    std::fs::create_dir_all(&store_root).expect("create store root");
+
+    let mut perms = std::fs::metadata(&store_root)
+        .expect("metadata")
+        .permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&store_root, perms).expect("set readonly perms");
+
+    let err = db::storage_health_preflight(&store_root).expect_err("preflight should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("STORAGE_PREFLIGHT_FAILED"), "{msg}");
+
+    // Restore perms for cleanup.
+    let mut perms = std::fs::metadata(&store_root)
+        .expect("metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&store_root, perms).expect("restore perms");
+}
+
+#[test]
+fn sqlite_pool_read_path_remains_available_for_concurrent_queries() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("readonly.db");
+    let setup = Connection::open(&db_path).expect("open setup");
+    setup
+        .execute(
+            "CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, v TEXT)",
+            [],
+        )
+        .expect("create table");
+
+    let res = pool::global_pool().with_read(&db_path, |conn| {
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))
+            .map_err(DecapodError::RusqliteError)?;
+        assert_eq!(count, 0);
+        Ok(())
+    });
+    assert!(res.is_ok(), "read path should succeed: {res:?}");
+}

--- a/tests/todo_rebuild_compat.rs
+++ b/tests/todo_rebuild_compat.rs
@@ -1,0 +1,52 @@
+use decapod::core::todo;
+use rusqlite::Connection;
+use serde_json::json;
+use tempfile::TempDir;
+
+#[test]
+fn todo_rebuild_accepts_task_proof_claimed_events() {
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+    std::fs::create_dir_all(root).expect("create root");
+
+    let events_path = root.join("todo.events.jsonl");
+    let add_event = json!({
+        "ts": "1770000001Z",
+        "event_id": "E_ADD_1",
+        "event_type": "task.add",
+        "status": "success",
+        "task_id": "T_1",
+        "payload": {
+            "title": "Compatibility task"
+        },
+        "actor": "test"
+    });
+    let proof_claimed = json!({
+        "ts": "1770000002Z",
+        "event_id": "E_PROOF_1",
+        "event_type": "task.proof.claimed",
+        "status": "success",
+        "task_id": "T_1",
+        "payload": {
+            "last_verified_status": "CLAIMED",
+            "last_verified_notes": "Proof hooks pending verification"
+        },
+        "actor": "test"
+    });
+
+    std::fs::write(&events_path, format!("{}\n{}\n", add_event, proof_claimed))
+        .expect("write events");
+
+    let out_db = root.join("todo.db");
+    let count =
+        todo::rebuild_db_from_events(&events_path, &out_db).expect("rebuild should succeed");
+    assert_eq!(count, 2, "expected both events to replay");
+
+    let conn = Connection::open(out_db).expect("open rebuilt db");
+    let task_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM tasks WHERE id='T_1'", [], |row| {
+            row.get(0)
+        })
+        .expect("query tasks");
+    assert_eq!(task_count, 1, "task must exist after rebuild");
+}

--- a/tests/workspace_interlock.rs
+++ b/tests/workspace_interlock.rs
@@ -1,0 +1,63 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn workspace_ensure_blocks_on_protected_branch_with_local_mods() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path();
+
+    Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(dir)
+        .status()
+        .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .status()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .status()
+        .expect("git config name");
+
+    std::fs::write(dir.join("README.md"), "# test\n").expect("write readme");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir)
+        .status()
+        .expect("git commit");
+
+    let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--force"])
+        .current_dir(dir)
+        .output()
+        .expect("decapod init");
+    assert!(init_out.status.success(), "init failed");
+
+    // Dirty the protected branch checkout.
+    std::fs::write(dir.join("README.md"), "# changed\n").expect("mutate readme");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["workspace", "ensure"])
+        .current_dir(dir)
+        .output()
+        .expect("workspace ensure");
+
+    assert!(
+        !out.status.success(),
+        "workspace ensure should block for protected+dirty checkout"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("WORKSPACE_INTERLOCK_DIRTY_PROTECTED"),
+        "unexpected stderr: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Why
Decapod was intermittently failing with SQLite contention (`DatabaseBusy`) and transient `SystemIoFailure(522)` paths, and repo-store validation could deterministically fail on `Unknown event_type 'task.proof.claimed'`.

## What changed
- `src/core/db.rs`
  - added storage preflight (`storage_health_preflight`) with typed failures and actionable remediation
  - added unsupported filesystem detection (`nfs/nfs4/cifs/smbfs/9p/vboxsf`)
  - added write probe check before open/config stages
  - added bounded retry jitter and deterministic fault injection (`DECAPOD_SQLITE_FAULT_STAGE`) for I/O-path tests
- `src/core/todo.rs`
  - added replay compatibility handler for `task.proof.claimed` in `rebuild_db_from_events`
- `src/core/workspace.rs`
  - run storage preflight at `workspace ensure` entry
  - enforce protected-branch+dirty-tree interlock with typed failure marker (`WORKSPACE_INTERLOCK_DIRTY_PROTECTED`)

## Tests added
- `tests/sqlite_hardening.rs`
  - deterministic busy-lock behavior
  - deterministic fault-injection for I/O path
  - storage preflight failure behavior
- `tests/todo_rebuild_compat.rs`
  - proves rebuild accepts `task.proof.claimed`
- `tests/workspace_interlock.rs`
  - proves workspace ensure blocks on protected+dirty

## Validation
- `cargo test --test sqlite_hardening -- --nocapture`
- `cargo test --test todo_rebuild_compat -- --nocapture`
- `cargo test --test workspace_interlock -- --nocapture`
- `cargo test --test validate_termination -- --nocapture`

## Release
Please merge before release cut so this ships in `v0.42.0` (not yet published to crates.io).
