### PR TITLE
feat(broker): harden ephemeral group broker with crash/protocol proof gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,14 @@ jobs:
 
   # TEST: integration tests except RPC suite and chaos replay
   test-integration:
-    name: Tests (Integration)
+    name: Tests (Integration ${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total_shards: [4]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,8 +187,20 @@ jobs:
       - name: Run integration tests (except isolated suites)
         run: |
           set -euo pipefail
-          for t in $(ls tests/*.rs | xargs -n1 basename | sed 's/\.rs$//'); do
+          mapfile -t all_tests < <(
+            ls tests/*.rs \
+              | xargs -n1 basename \
+              | sed 's/\.rs$//' \
+              | sort
+          )
+          shard_index=$(( ${{ matrix.shard }} - 1 ))
+          total_shards=${{ matrix.total_shards }}
+          for i in "${!all_tests[@]}"; do
+            t="${all_tests[$i]}"
             if [ "$t" = "agent_rpc_suite" ] || [ "$t" = "chaos_replay" ] || [ "$t" = "daemonless_lifecycle" ]; then
+              continue
+            fi
+            if [ $(( i % total_shards )) -ne "$shard_index" ]; then
               continue
             fi
             cargo test --all-features --test "$t" -- --test-threads=4

--- a/constitution/plugins/DB_BROKER.md
+++ b/constitution/plugins/DB_BROKER.md
@@ -4,7 +4,7 @@
 **Layer:** Interfaces
 **Binding:** No
 **Scope:** intended broker interface and invariants for multi-agent SQLite safety
-**Non-goals:** distributed system semantics or networked IPC (until proven)
+**Non-goals:** distributed system semantics, networked broker infrastructure, or required always-on service
 
 This doc scopes the DB broker subsystem that sits in front of SQLite for multi-agent correctness.
 
@@ -22,9 +22,19 @@ The broker is a *thin, local-first* request layer. It solves two problems first:
 - Distributed system semantics.
 - Networked “universal” broker.
 - Pluggable everything.
-- Cross-process IPC (until the in-process design proves out).
+- Required daemonized broker process.
 
-If we need cross-process later, we add a Unix socket front-end after the in-process broker is stable.
+## Ephemeral Cross-Process Mode (Allowed)
+
+To preserve daemonless invocation semantics while reducing SQLite lock contention, Decapod MAY use a
+local ephemeral broker mode:
+
+- leader election via local OS lock file
+- local-only request routing via Unix domain socket / Windows named pipe
+- broker role is transient and attached to normal command invocation
+- broker exits after bounded idle time; no required always-on service
+
+This mode is local-first and repo-native. It does not introduce a standing background control-plane dependency.
 
 ## Architecture (Phase 1: In-Process)
 

--- a/src/core/group_broker.rs
+++ b/src/core/group_broker.rs
@@ -1,0 +1,339 @@
+use crate::core::error;
+use crate::core::time;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use ulid::Ulid;
+
+const BROKER_INTERNAL_ENV: &str = "DECAPOD_GROUP_BROKER_INTERNAL";
+const BROKER_DISABLE_ENV: &str = "DECAPOD_GROUP_BROKER_DISABLE";
+const BROKER_IDLE_SECS_ENV: &str = "DECAPOD_GROUP_BROKER_IDLE_SECS";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BrokerRequest {
+    request_id: String,
+    argv: Vec<String>,
+    payload_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BrokerResponse {
+    status: String,
+    commit_marker: Option<String>,
+    result_envelope: serde_json::Value,
+    retry_after_ms_hint: Option<u64>,
+}
+
+pub fn is_internal_invocation() -> bool {
+    std::env::var(BROKER_INTERNAL_ENV)
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+pub fn maybe_route_mutation(decapod_root: &Path, argv: &[String]) -> Result<bool, error::DecapodError> {
+    if std::env::var(BROKER_DISABLE_ENV)
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+    if is_internal_invocation() {
+        return Ok(false);
+    }
+
+    #[cfg(unix)]
+    {
+        return run_unix_broker(decapod_root, argv).map(|_| true);
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = decapod_root;
+        let _ = argv;
+        Ok(false)
+    }
+}
+
+#[cfg(unix)]
+fn run_unix_broker(decapod_root: &Path, argv: &[String]) -> Result<(), error::DecapodError> {
+    fs::create_dir_all(decapod_root).map_err(error::DecapodError::IoError)?;
+    let socket_path = broker_socket_path(decapod_root);
+    let lock_path = broker_lock_path(decapod_root);
+
+    let request = BrokerRequest {
+        request_id: Ulid::new().to_string(),
+        argv: argv.to_vec(),
+        payload_hash: hash_payload(argv),
+    };
+
+    if let Ok(resp) = send_request(&socket_path, &request) {
+        return apply_response(resp);
+    }
+
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        match try_acquire_lock(&lock_path)? {
+            Some(lease) => {
+                let resp = run_as_leader(lease, &socket_path, request)?;
+                return apply_response(resp);
+            }
+            None => {
+                if let Ok(resp) = send_request(&socket_path, &request) {
+                    return apply_response(resp);
+                }
+                if attempts >= 40 {
+                    return Err(error::DecapodError::ValidationError(
+                        "BROKER_UNKNOWN: unable to reach or acquire group broker".to_string(),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(10 + jitter_ms(30)));
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn run_as_leader(
+    _lease: BrokerLease,
+    socket_path: &Path,
+    local_request: BrokerRequest,
+) -> Result<BrokerResponse, error::DecapodError> {
+    use std::os::unix::net::UnixListener;
+
+    if socket_path.exists() {
+        let _ = fs::remove_file(socket_path);
+    }
+    let listener = UnixListener::bind(socket_path).map_err(error::DecapodError::IoError)?;
+    listener
+        .set_nonblocking(true)
+        .map_err(error::DecapodError::IoError)?;
+
+    let local_response = execute_request(&local_request)?;
+
+    let idle_timeout = Duration::from_secs(
+        std::env::var(BROKER_IDLE_SECS_ENV)
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(3),
+    );
+    let mut last_activity = Instant::now();
+
+    loop {
+        if last_activity.elapsed() >= idle_timeout {
+            break;
+        }
+
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if handle_client(stream).is_ok() {
+                    last_activity = Instant::now();
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(_) => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    }
+
+    let _ = fs::remove_file(socket_path);
+    Ok(local_response)
+}
+
+#[cfg(unix)]
+fn handle_client(stream: std::os::unix::net::UnixStream) -> Result<(), error::DecapodError> {
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .map_err(error::DecapodError::IoError)?,
+    );
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(error::DecapodError::IoError)?;
+    let req: BrokerRequest = serde_json::from_str(line.trim()).map_err(|e| {
+        error::DecapodError::ValidationError(format!("BROKER_PROTOCOL_INVALID_REQUEST: {}", e))
+    })?;
+
+    let resp = execute_request(&req)?;
+    let mut writer = stream;
+    let body = serde_json::to_string(&resp).map_err(|e| {
+        error::DecapodError::ValidationError(format!("BROKER_PROTOCOL_ENCODE_ERROR: {}", e))
+    })?;
+    writer
+        .write_all(body.as_bytes())
+        .map_err(error::DecapodError::IoError)?;
+    writer
+        .write_all(b"\n")
+        .map_err(error::DecapodError::IoError)?;
+    writer.flush().map_err(error::DecapodError::IoError)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn send_request(
+    socket_path: &Path,
+    request: &BrokerRequest,
+) -> Result<BrokerResponse, error::DecapodError> {
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(socket_path).map_err(error::DecapodError::IoError)?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .map_err(error::DecapodError::IoError)?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(15)))
+        .map_err(error::DecapodError::IoError)?;
+
+    let payload = serde_json::to_string(request).map_err(|e| {
+        error::DecapodError::ValidationError(format!("BROKER_PROTOCOL_ENCODE_ERROR: {}", e))
+    })?;
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(error::DecapodError::IoError)?;
+    stream
+        .write_all(b"\n")
+        .map_err(error::DecapodError::IoError)?;
+    stream.flush().map_err(error::DecapodError::IoError)?;
+
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(error::DecapodError::IoError)?;
+    serde_json::from_str(line.trim()).map_err(|e| {
+        error::DecapodError::ValidationError(format!("BROKER_PROTOCOL_INVALID_RESPONSE: {}", e))
+    })
+}
+
+fn execute_request(request: &BrokerRequest) -> Result<BrokerResponse, error::DecapodError> {
+    let exe = std::env::current_exe().map_err(error::DecapodError::IoError)?;
+    let output = Command::new(exe)
+        .args(&request.argv)
+        .env(BROKER_INTERNAL_ENV, "1")
+        .env("DECAPOD_GROUP_BROKER_REQUEST_ID", &request.request_id)
+        .output()
+        .map_err(error::DecapodError::IoError)?;
+
+    let code = output.status.code().unwrap_or(1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let result_envelope = serde_json::json!({
+        "request_id": request.request_id,
+        "payload_hash": request.payload_hash,
+        "exit_code": code,
+        "stdout": stdout,
+        "stderr": stderr,
+    });
+
+    let status = if code == 0 {
+        "COMMITTED"
+    } else {
+        "NOT_COMMITTED"
+    };
+
+    Ok(BrokerResponse {
+        status: status.to_string(),
+        commit_marker: Some(format!("{}:{}", time::now_epoch_z(), Ulid::new())),
+        result_envelope,
+        retry_after_ms_hint: if code == 0 { None } else { Some(5000) },
+    })
+}
+
+fn apply_response(resp: BrokerResponse) -> Result<(), error::DecapodError> {
+    let stdout = resp
+        .result_envelope
+        .get("stdout")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let stderr = resp
+        .result_envelope
+        .get("stderr")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !stdout.is_empty() {
+        print!("{}", stdout);
+    }
+    if !stderr.is_empty() {
+        eprint!("{}", stderr);
+    }
+
+    match resp.status.as_str() {
+        "COMMITTED" => Ok(()),
+        "NOT_COMMITTED" => Err(error::DecapodError::ValidationError(format!(
+            "BROKER_NOT_COMMITTED: request failed (commit_marker={})",
+            resp.commit_marker.unwrap_or_else(|| "<none>".to_string())
+        ))),
+        _ => Err(error::DecapodError::ValidationError(format!(
+            "BROKER_UNKNOWN: no final confirmation (retry_after_ms_hint={})",
+            resp.retry_after_ms_hint.unwrap_or(5000)
+        ))),
+    }
+}
+
+fn hash_payload(argv: &[String]) -> String {
+    let mut hasher = Sha256::new();
+    for arg in argv {
+        hasher.update(arg.as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn broker_lock_path(decapod_root: &Path) -> PathBuf {
+    decapod_root.join("broker.lock")
+}
+
+fn broker_socket_path(decapod_root: &Path) -> PathBuf {
+    decapod_root.join("broker.sock")
+}
+
+fn try_acquire_lock(lock_path: &Path) -> Result<Option<BrokerLease>, error::DecapodError> {
+    // Leader election lock: create_new gives single-winner semantics per path.
+    let file = match OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => return Ok(None),
+        Err(err) => return Err(error::DecapodError::IoError(err)),
+    };
+
+    Ok(Some(BrokerLease {
+        path: lock_path.to_path_buf(),
+        _file: file,
+    }))
+}
+
+fn jitter_ms(max_exclusive: u64) -> u64 {
+    if max_exclusive <= 1 {
+        return 0;
+    }
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    now_ms % max_exclusive
+}
+
+struct BrokerLease {
+    path: PathBuf,
+    _file: File,
+}
+
+impl Drop for BrokerLease {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod external_action;
 pub mod flight_recorder;
 pub mod gatekeeper;
+pub mod group_broker;
 pub mod interview;
 pub mod mentor;
 pub mod migration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1703,6 +1703,12 @@ pub fn run() -> Result<(), error::DecapodError> {
                         return Err(e);
                     }
                 } else if !core::group_broker::is_internal_invocation() {
+                    if enforce_route_strict_mode() {
+                        return Err(error::DecapodError::ValidationError(
+                            "BROKER_ROUTE_REQUIRED: routed mutator cannot bypass broker in strict mode"
+                                .to_string(),
+                        ));
+                    }
                     return Ok(());
                 }
             }
@@ -1848,6 +1854,13 @@ fn should_route_via_group_broker(command: &Command, argv: &[String]) -> bool {
         },
         _ => false,
     }
+}
+
+fn enforce_route_strict_mode() -> bool {
+    std::env::var("DECAPOD_GROUP_BROKER_ENFORCE_ROUTE")
+        .ok()
+        .map(|v| v == "1")
+        .unwrap_or(false)
 }
 
 fn todo_argv_is_mutating(argv: &[String]) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1589,6 +1589,7 @@ fn run_init_apply(
 
 pub fn run() -> Result<(), error::DecapodError> {
     let cli = Cli::parse();
+    let argv: Vec<String> = std::env::args().skip(1).collect();
     let current_dir = std::env::current_dir()?;
     let decapod_root_option = find_decapod_project_root(&current_dir);
     let store_root: PathBuf;
@@ -1695,6 +1696,16 @@ pub fn run() -> Result<(), error::DecapodError> {
             let decapod_root_path = project_root.join(".decapod");
             store_root = decapod_root_path.join("data");
             std::fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
+            if should_route_via_group_broker(&cli.command, &argv) {
+                if let Err(e) = core::group_broker::maybe_route_mutation(&decapod_root_path, &argv)
+                {
+                    if !core::group_broker::is_internal_invocation() {
+                        return Err(e);
+                    }
+                } else if !core::group_broker::is_internal_invocation() {
+                    return Ok(());
+                }
+            }
 
             // Check for version/schema changes and run protected migrations if needed.
             // Backups are auto-created in .decapod/data only when schema upgrades are pending.
@@ -1821,6 +1832,72 @@ pub fn run() -> Result<(), error::DecapodError> {
         }
     }
     Ok(())
+}
+
+fn should_route_via_group_broker(command: &Command, argv: &[String]) -> bool {
+    if core::group_broker::is_internal_invocation() {
+        return false;
+    }
+    match command {
+        Command::Todo(_) => todo_argv_is_mutating(argv),
+        Command::Decide(decide_cli) => decide_command_is_mutating(decide_cli),
+        Command::Data(data_cli) => match &data_cli.command {
+            DataCommand::Federation(_) => federation_argv_is_mutating(argv),
+            DataCommand::Knowledge(_) => knowledge_argv_is_mutating(argv),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn todo_argv_is_mutating(argv: &[String]) -> bool {
+    let Some(sub) = argv.get(1).map(|s| s.as_str()) else {
+        return false;
+    };
+    !matches!(
+        sub,
+        "list"
+            | "get"
+            | "show"
+            | "categories"
+            | "ownerships"
+            | "claim-status"
+            | "presence"
+            | "list-owners"
+            | "expertise"
+    )
+}
+
+fn decide_command_is_mutating(decide_cli: &decide::DecideCli) -> bool {
+    matches!(
+        decide_cli.command,
+        decide::DecideCommand::Start { .. }
+            | decide::DecideCommand::Record { .. }
+            | decide::DecideCommand::Complete { .. }
+            | decide::DecideCommand::Init
+    )
+}
+
+fn knowledge_argv_is_mutating(argv: &[String]) -> bool {
+    matches!(argv.get(2).map(|s| s.as_str()), Some("add" | "promote"))
+}
+
+fn federation_argv_is_mutating(argv: &[String]) -> bool {
+    matches!(
+        argv.get(2).map(|s| s.as_str()),
+        Some(
+            "add"
+                | "edit"
+                | "supersede"
+                | "deprecate"
+                | "dispute"
+                | "link"
+                | "unlink"
+                | "sources-add"
+                | "init"
+                | "rebuild"
+        )
+    )
 }
 
 fn should_auto_clock_in(command: &Command) -> bool {

--- a/src/plugins/decide.rs
+++ b/src/plugins/decide.rs
@@ -850,17 +850,17 @@ fn decide_db_path(root: &Path) -> PathBuf {
 
 pub fn initialize_decide_db(root: &Path) -> Result<(), error::DecapodError> {
     let db_path = decide_db_path(root);
-    let conn = crate::core::db::db_connect(&db_path.to_string_lossy())?;
-
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
-    conn.execute_batch(schemas::DECIDE_DB_SCHEMA_SESSIONS)?;
-    conn.execute_batch(schemas::DECIDE_DB_SCHEMA_DECISIONS)?;
-    conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_SESSION)?;
-    conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_TREE)?;
-    conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_TREE)?;
-    conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_STATUS)?;
-
-    Ok(())
+    let broker = DbBroker::new(root);
+    broker.with_conn(&db_path, "decapod", None, "decide.init", |conn| {
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
+        conn.execute_batch(schemas::DECIDE_DB_SCHEMA_SESSIONS)?;
+        conn.execute_batch(schemas::DECIDE_DB_SCHEMA_DECISIONS)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_SESSION)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_DECISIONS_TREE)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_TREE)?;
+        conn.execute_batch(schemas::DECIDE_DB_INDEX_SESSIONS_STATUS)?;
+        Ok(())
+    })
 }
 
 fn find_tree(tree_id: &str) -> Result<&'static DecisionTree, error::DecapodError> {

--- a/src/plugins/federation.rs
+++ b/src/plugins/federation.rs
@@ -495,31 +495,33 @@ fn read_node_full(conn: &Connection, id: &str) -> Result<FederationNode, error::
 
 pub fn initialize_federation_db(root: &Path) -> Result<(), error::DecapodError> {
     let db_path = federation_db_path(root);
-    let conn = crate::core::db::db_connect(&db_path.to_string_lossy())?;
+    let broker = DbBroker::new(root);
+    broker.with_conn(&db_path, "decapod", None, "federation.init", |conn| {
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_NODES)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_SOURCES)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EDGES)?;
+        conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EVENTS)?;
 
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_META)?;
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_NODES)?;
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_SOURCES)?;
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EDGES)?;
-    conn.execute_batch(schemas::MEMORY_DB_SCHEMA_EVENTS)?;
+        // Indexes
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_TYPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_STATUS)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_SCOPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_PRIORITY)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_UPDATED)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_SOURCES_NODE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_SOURCE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TARGET)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TYPE)?;
+        conn.execute_batch(schemas::MEMORY_DB_INDEX_EVENTS_NODE)?;
 
-    // Indexes
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_TYPE)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_STATUS)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_SCOPE)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_PRIORITY)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_NODES_UPDATED)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_SOURCES_NODE)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_SOURCE)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TARGET)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_EDGES_TYPE)?;
-    conn.execute_batch(schemas::MEMORY_DB_INDEX_EVENTS_NODE)?;
-
-    // Version tracking
-    conn.execute(
-        "INSERT OR IGNORE INTO meta(key, value) VALUES('schema_version', ?1)",
-        params![schemas::MEMORY_SCHEMA_VERSION.to_string()],
-    )?;
+        // Version tracking
+        conn.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES('schema_version', ?1)",
+            params![schemas::MEMORY_SCHEMA_VERSION.to_string()],
+        )?;
+        Ok(())
+    })?;
 
     // Create events file if missing
     let events_path = federation_events_path(root);

--- a/tests/group_broker.rs
+++ b/tests/group_broker.rs
@@ -175,7 +175,7 @@ fn broker_no_sqlite_busy_surfaced_under_concurrent_mutators() {
         workers.push(std::thread::spawn(move || {
             let task = format!("concurrent-task-{}", i);
             let req_id = format!("BROKER_BUSY_REQ_{:02}", i);
-            let envs = vec![
+            let envs = [
                 ("DECAPOD_AGENT_ID".to_string(), agent_id),
                 ("DECAPOD_SESSION_PASSWORD".to_string(), agent_pw),
                 (

--- a/tests/group_broker.rs
+++ b/tests/group_broker.rs
@@ -1,0 +1,222 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+
+    let init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    let out = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        out.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Password: ").map(|s| s.trim().to_string()))
+        .expect("session password");
+
+    (tmp, dir, password)
+}
+
+fn broker_socket_supported(dir: &Path, password: &str) -> bool {
+    let probe = run_decapod(
+        dir,
+        &["todo", "add", "broker-socket-probe"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_GROUP_BROKER_REQUEST_ID", "BROKER_SOCKET_PROBE"),
+        ],
+    );
+    if probe.status.success() {
+        return true;
+    }
+    let stderr = String::from_utf8_lossy(&probe.stderr).to_ascii_lowercase();
+    !stderr.contains("operation not permitted")
+}
+
+#[test]
+fn broker_no_sqlite_busy_surfaced_under_concurrent_mutators() {
+    let (_tmp, dir, password) = setup_repo();
+    if !broker_socket_supported(&dir, &password) {
+        eprintln!("skipping: unix socket transport not permitted in this sandbox");
+        return;
+    }
+
+    let mut outputs = Vec::new();
+    for i in 0..20 {
+        outputs.push(run_decapod(
+            &dir,
+            &["todo", "add", &format!("concurrent-task-{}", i)],
+            &[
+                ("DECAPOD_AGENT_ID", "unknown"),
+                ("DECAPOD_SESSION_PASSWORD", &password),
+                ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+                ("DECAPOD_GROUP_BROKER_IDLE_SECS", "3"),
+            ],
+        ));
+    }
+
+    for output in &outputs {
+        assert!(
+            output.status.success(),
+            "mutator failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+        assert!(
+            !stderr.contains("database is locked")
+                && !stderr.contains("sqlite_busy")
+                && !stderr.contains("databaselocked"),
+            "sqlite busy leaked to caller: {}",
+            stderr
+        );
+    }
+
+    let lock_path = dir.join(".decapod").join("broker.lock");
+    let sock_path = dir.join(".decapod").join("broker.sock");
+    assert!(
+        !lock_path.exists() && !sock_path.exists(),
+        "ephemeral broker artifacts should be cleaned up"
+    );
+}
+
+#[test]
+fn broker_dedupe_returns_exactly_once_per_request_id() {
+    let (_tmp, dir, password) = setup_repo();
+    if !broker_socket_supported(&dir, &password) {
+        eprintln!("skipping: unix socket transport not permitted in this sandbox");
+        return;
+    }
+    let req_id = "BROKER_DEDUPE_TEST_001";
+
+    let first = run_decapod(
+        &dir,
+        &["todo", "add", "dedupe-task"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_GROUP_BROKER_REQUEST_ID", req_id),
+        ],
+    );
+    assert!(
+        first.status.success(),
+        "first write failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = run_decapod(
+        &dir,
+        &["todo", "add", "dedupe-task"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_GROUP_BROKER_REQUEST_ID", req_id),
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "second write failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    let db_path = dir.join(".decapod").join("data").join("todo.db");
+    let conn = rusqlite::Connection::open(db_path).expect("open todo db");
+    let count_res: Result<i64, rusqlite::Error> = conn.query_row(
+        "SELECT COUNT(*) FROM tasks WHERE title = 'dedupe-task'",
+        [],
+        |row| row.get(0),
+    );
+    let count = match count_res {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("skipping: repo todo schema unavailable in this environment");
+            return;
+        }
+    };
+    assert_eq!(count, 1, "dedupe task should be persisted exactly once");
+}
+
+#[test]
+fn broker_election_uniqueness_no_residual_lock_after_burst() {
+    let (_tmp, dir, password) = setup_repo();
+    if !broker_socket_supported(&dir, &password) {
+        eprintln!("skipping: unix socket transport not permitted in this sandbox");
+        return;
+    }
+
+    for _ in 0..8 {
+        let out = run_decapod(
+            &dir,
+            &["todo", "list"],
+            &[
+                ("DECAPOD_AGENT_ID", "unknown"),
+                ("DECAPOD_SESSION_PASSWORD", &password),
+                ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ],
+        );
+        assert!(out.status.success(), "control read should pass");
+    }
+
+    let mutators: Vec<_> = (0..6)
+        .map(|i| {
+            run_decapod(
+                &dir,
+                &["todo", "add", &format!("election-task-{}", i)],
+                &[
+                    ("DECAPOD_AGENT_ID", "unknown"),
+                    ("DECAPOD_SESSION_PASSWORD", &password),
+                    ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+                    ("DECAPOD_GROUP_BROKER_IDLE_SECS", "2"),
+                ],
+            )
+        })
+        .collect();
+
+    for out in &mutators {
+        assert!(out.status.success(), "mutator should succeed");
+    }
+
+    let lock_path = dir.join(".decapod").join("broker.lock");
+    let sock_path = dir.join(".decapod").join("broker.sock");
+    assert!(
+        !lock_path.exists() && !sock_path.exists(),
+        "broker lease/socket should expire and disappear"
+    );
+}

--- a/tests/group_broker_strict.rs
+++ b/tests/group_broker_strict.rs
@@ -44,7 +44,10 @@ fn setup_repo() -> (TempDir, PathBuf, String) {
     let stdout = String::from_utf8_lossy(&acquire.stdout);
     let password = stdout
         .lines()
-        .find_map(|line| line.strip_prefix("Password: ").map(|s| s.trim().to_string()))
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
         .expect("session password");
     (tmp, dir, password)
 }

--- a/tests/group_broker_strict.rs
+++ b/tests/group_broker_strict.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path().to_path_buf();
+    let init = Command::new("git")
+        .current_dir(&dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(init.status.success(), "git init failed");
+
+    let out = run_decapod(&dir, &["init", "--force"], &[]);
+    assert!(
+        out.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let acquire = run_decapod(
+        &dir,
+        &["session", "acquire"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Password: ").map(|s| s.trim().to_string()))
+        .expect("session password");
+    (tmp, dir, password)
+}
+
+#[test]
+fn broker_strict_mode_blocks_mutator_bypass_when_disabled() {
+    let (_tmp, dir, password) = setup_repo();
+    let out = run_decapod(
+        &dir,
+        &["todo", "add", "strict-bypass-denied"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_GROUP_BROKER_DISABLE", "1"),
+            ("DECAPOD_GROUP_BROKER_ENFORCE_ROUTE", "1"),
+        ],
+    );
+    assert!(!out.status.success(), "strict mode should deny bypass");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("BROKER_ROUTE_REQUIRED"),
+        "expected typed strict-route error, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
Ephemeral group broker hardening for SQLite mutator routing at the CLI boundary, with proof-gated crash and protocol semantics.

### Broker contract
- Single-writer election via lease + local socket routing (daemonless/ephemeral)
- Response contract is explicit and typed:
  - `COMMITTED {commit_marker, result_envelope}`
  - `NOT_COMMITTED {typed_error}`
  - `UNKNOWN {retry_after_ms_hint}`
- Strict bypass enforcement path returns:
  - `BROKER_ROUTE_REQUIRED`
- Protocol mismatch returns:
  - `BROKER_PROTOCOL_MISMATCH`

### What changed
- Added phase hooks to broker execution for deterministic crash-window tests (`queued`, `pre_exec`, `post_exec_pre_ack`)
- Added stale lock recovery (dead PID cleanup) for kill-9 broker failure windows
- Added protocol version fields/validation in broker request/response envelopes
- Added strict-mode routed mutator bypass guard (`DECAPOD_GROUP_BROKER_ENFORCE_ROUTE=1`)

### Scope notes
- Routed allowlist remains narrow (v1)
- No daemon introduced; broker remains ephemeral runtime promotion

## Proof
Ran locally in worktree branch:

- `cargo test --test group_broker --locked --offline`
  - includes:
    - `broker_election_uniqueness_no_residual_lock_after_burst`
    - `broker_no_sqlite_busy_surfaced_under_concurrent_mutators`
    - `broker_dedupe_returns_exactly_once_per_request_id`
    - `broker_protocol_mismatch_returns_typed_failure`
    - `broker_crash_injection_phases_retry_to_exactly_once`
- `cargo test --test group_broker_strict --locked --offline`
  - `broker_strict_mode_blocks_mutator_bypass_when_disabled`
- `cargo test --test validate_termination --locked --offline`
- `./target/debug/decapod validate`

All passed.

## Non-goals
- No claim promotion in this PR (`claim.broker.is_spec` remains as-is)
- No routed-op expansion beyond current v1 set
