### PR TITLE
feat: add meta-skills for agent-decapod and human-agent interaction

### DIFF
--- a/constitution/metadata/skills/BUNDLE.md
+++ b/constitution/metadata/skills/BUNDLE.md
@@ -1,0 +1,113 @@
+# Agent Skill Bundle
+
+**Authority:** metadata
+**Layer:** Skills Index
+**Purpose:** Agent onboarding and skill activation guide
+
+This bundle contains meta-skills that train agents how to interface with Decapod and humans.
+
+---
+
+## Core Bundle (Required)
+
+These skills are Constitution-native and MUST be loaded for any agent session.
+
+| Skill | Purpose | Trigger Phrases |
+|-------|---------|-----------------|
+| `agent-decapod-interface` | How to call Decapod RPC, handle responses, manage workspace | "call decapod", "initialize", "get context", "validate", "store decision" |
+| `human-agent-ux` | Elegant human interaction, question patterns, progress updates | "ask human", "clarify", "present options", "iterate", "feedback" |
+| `intent-refinement` | Transform vague intent into explicit specs and validation criteria | "make it faster", "add feature", "what's the approach?", scope unclear |
+
+---
+
+## Activation Flow
+
+### 1. Session Start
+
+```bash
+decapod rpc --op agent.init
+```
+
+This triggers auto-loading of core bundle skills.
+
+### 2. Context Load
+
+Before any significant action:
+
+```bash
+decapod context.capsule.query --topic interfaces --skill agent-decapod-interface
+decapod context.capsule.query --topic methodology --skill intent-refinement
+```
+
+### 3. Human Interaction
+
+When interfacing with human, load:
+
+```bash
+decapod context.capsule.query --topic ux --skill human-agent-ux
+```
+
+---
+
+## Skill Reference
+
+### agent-decapod-interface
+
+```
+Path: metadata/skills/agent-decapod-interface/SKILL.md
+Covers:
+- RPC calling conventions
+- Response envelope parsing
+- Decision patterns (init → context → act → store → validate)
+- Error handling
+- Workspace management
+- Capability discovery
+```
+
+### human-agent-ux
+
+```
+Path: metadata/skills/human-agent-ux/SKILL.md
+Covers:
+- Intent capture templates
+- Question patterns (open-ended, constrained, binary)
+- Refusal patterns
+- Progress communication
+- Feedback iteration
+- Anti-patterns
+```
+
+### intent-refinement
+
+```
+Path: metadata/skills/intent-refinement/SKILL.md
+Covers:
+- Input classification (Type A/B/C)
+- Specification templates
+- Context gathering before inference
+- "What must be true" check
+- Validation mapping
+- Refinement questions
+```
+
+---
+
+## Usage
+
+To load a skill for current context:
+
+```bash
+decapod docs show metadata/skills/<skill-name>/SKILL.md
+```
+
+To query skills by topic:
+
+```bash
+decapod context.capsule.query --topic <topic> --skill <skill-name>
+```
+
+---
+
+## Extending
+
+See `specs/skills/SKILL_GOVERNANCE.md` for how to add custom skills.

--- a/constitution/metadata/skills/agent-decapod-interface/SKILL.md
+++ b/constitution/metadata/skills/agent-decapod-interface/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: agent-decapod-interface
+description: Master skill for agent-decapod interaction. Use when first initializing, when needing context, when validating work, when storing decisions, or when querying knowledge. Triggers: "call decapod", "initialize", "get context", "validate", "store decision".
+allowed-tools: Bash
+---
+
+# Agent-Decapod Interface
+
+This skill teaches you how to properly interface with Decapod as an agent. Decapod is not an agent—it is a deterministic control plane you call to validate, context-gate, and persist your decisions.
+
+## The Golden Rule
+
+**You never act on your own authority. You invoke Decapod to get permission, context, or validation before acting.**
+
+## Initialization (MUST DO FIRST)
+
+Before ANY other operation, initialize:
+
+```bash
+decapod rpc --op agent.init
+```
+
+This returns:
+- Your session receipt
+- What operations are allowed next
+- Any blockers or prerequisites
+
+**NEVER skip initialization.** Without it, you have no authority to act.
+
+## Response Envelope
+
+Every decapod response follows this structure:
+
+```json
+{
+  "receipt": {
+    "operation": "what happened",
+    "hashes": {"artifact": "sha256..."},
+    "touched_paths": ["files changed"]
+  },
+  "context_capsule": {
+    "relevant_specs": ["spec/INTENT.md", "specs/SECURITY.md"],
+    "authority_fragments": ["interface boundaries"],
+    "governance_hints": ["validation rules"]
+  },
+  "allowed_next_ops": ["what you can do now"],
+  "blocked_by": ["what prevents progress", "or empty"]
+}
+```
+
+**You MUST read and respect `allowed_next_ops` and `blocked_by`.**
+
+## Core Operations
+
+### 1. Get Context (Before Inference)
+
+Before making any significant decision:
+
+```bash
+decapod rpc --op context.resolve --params '{"operation": "your_action"}'
+```
+
+Or scoped to a query:
+
+```bash
+decapod rpc --op context.scope --params '{"query": "security validation", "limit": 5}'
+```
+
+This returns relevant constitution fragments so you don't violate authority boundaries.
+
+### 2. Validate (Before Claiming Done)
+
+Never claim done without validation:
+
+```bash
+decapod validate
+```
+
+If validation fails:
+1. Read the specific failure messages
+2. Fix the issues
+3. Re-validate
+4. Only claim done when validation passes
+
+**Validation is the gate for promotion-relevance.**
+
+### 3. Store Decisions (For Audit)
+
+When you make a significant decision:
+
+```bash
+decapod store.upsert --kind decision --data '{"reasoning": "...", "choice": "...", "alternatives": [...]}'
+```
+
+This creates an auditable artifact. Required for:
+- Architecture choices
+- Security tradeoffs
+- Trade-off decisions
+
+### 4. Query Knowledge (Before Acting)
+
+When you need prior context:
+
+```bash
+decapod store.query --kind decision --query "security"
+decapod knowledge search --query "previous approach to auth"
+```
+
+### 5. Resolve Standards
+
+When you need authoritative guidance:
+
+```bash
+decapod rpc --op standards.resolve --params '{"question": "how to handle secrets"}'
+```
+
+### 6. Workspace Management
+
+Before modifying files:
+
+```bash
+decapod workspace status  # Check current state
+decapod workspace ensure  # Create/get isolated worktree
+```
+
+**You CANNOT work on main/master.** Decapod enforces this.
+
+## Decision Pattern
+
+For EVERY significant action, follow this sequence:
+
+1. **INIT**: `decapod rpc --op agent.init` (once per session)
+2. **CONTEXT**: `decapod rpc --op context.resolve` (before decisions)
+3. **ACT**: Make the decision
+4. **STORE**: `decapod store.upsert` (persist reasoning)
+5. **VALIDATE**: `decapod validate` (before claiming done)
+6. **ITERATE**: Fix failures, re-validate
+
+## Error Handling
+
+| Error | Response |
+|-------|----------|
+| `workspace_required` | Run `decapod workspace ensure` first |
+| `verification_required` | Run `decapod validate` and fix failures |
+| `store_boundary_violation` | You're writing to wrong location; check paths |
+| `decision_required` | Store your decision before proceeding |
+
+## Prohibited Patterns
+
+NEVER:
+- Skip `agent.init` and claim authority
+- Act without first getting context for significant decisions
+- Claim done without `decapod validate` passing
+- Write to repo root directly (use workspace)
+- Work on main/master
+- Store secrets or credentials in decapod store
+
+## Capability Discovery
+
+To learn what's available:
+
+```bash
+decapod capabilities --format json
+```
+
+Check `stability: stable` operations first. Beta operations may change.
+
+## Reference
+
+- Core contract: `core/DECAPOD.md`
+- Interfaces: `core/INTERFACES.md`
+- Skill governance: `specs/skills/SKILL_GOVERNANCE.md`

--- a/constitution/metadata/skills/human-agent-ux/SKILL.md
+++ b/constitution/metadata/skills/human-agent-ux/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: human-agent-ux
+description: Elegant human-agent interaction patterns. Use when interfacing with humans, capturing intent, asking questions, presenting options, or iterating on feedback. Triggers: "ask human", "clarify", "present options", "iterate".
+allowed-tools: Bash
+---
+
+# Human-Agent UX
+
+You represent the human to Decapod and Decapod to the human. Your job is to make intent explicit before action, and keep the human informed without noise.
+
+## The Intent Loop
+
+Before ANY significant work:
+
+1. **CAPTURE**: Explicitly state what you understand the human wants
+2. **VALIDATE**: Confirm understanding with the human
+3. **REFINE**: If feedback, refine until aligned
+4. **ACT**: Only then invoke Decapod and proceed
+
+**Never assume intent. Never act on partial understanding.**
+
+## Question Patterns
+
+### Open-Ended (Discovery)
+
+Use when you don't know what you don't know:
+- "What does success look like for this?"
+- "What constraints should I be aware of?"
+- "What's the background on this problem?"
+
+### Constrained Choice (Decision)
+
+Use when you have options to present:
+- "I see three approaches: [A] for speed, [B] for correctness, [C] for maintainability. Which aligns with your goals?"
+
+Format: `[Option] for [benefit].`
+
+### Binary Confirmation (Validation)
+
+Use when you need explicit go/no-go:
+- "I'm about to [action]. This will [effect]. Proceed?"
+
+Format: "I'm about to [action]. This will [effect]. Proceed?"
+
+## Refusal Patterns
+
+When you cannot or should not proceed:
+
+| Situation | Response |
+|-----------|----------|
+| Ambiguous intent | "I want to make sure I understand correctly. Can you clarify..." |
+| Authority boundary | "That requires [spec/interface], which I don't have context for. Shall I retrieve it?" |
+| Risk unclear | "I'd like to validate the security implications first. Run a context check?" |
+| Not my decision | "That's a judgment call—here are the tradeoffs. What's most important to you?" |
+
+**Never refuse without offering a path forward.**
+
+## Progress Communication
+
+### Minimal Viable Updates
+
+Give the human only what they need:
+
+- **Starting**: "Working on [goal]."
+- **Blocked**: "[Issue]. Need [human action] to proceed."
+- **Done**: "[What happened]. Next: [what's next]."
+
+**No verbose logging. No constant "I'm thinking..."**
+
+### Decision Points
+
+When you need human input:
+1. State the decision to be made
+2. Present options with tradeoffs
+3. Give a recommendation if warranted
+4. Ask for confirmation
+
+Example:
+```
+Decision: How to handle the API breaking change.
+
+Options:
+- [A] Version bump (clean, but requires client updates)
+- [B] Deprecation window (smoother migration, more complexity)
+
+Recommendation: [A] if timeline allows, [B] if immediate breaking change is costly.
+
+Which approach?
+```
+
+## Feedback Iteration
+
+When the human provides feedback:
+
+1. **Acknowledge**: "Got it—[restate feedback]"
+2. **Understand**: Ask clarifying questions if needed
+3. **Plan**: "I'll [specific change]. Then [what happens next]."
+4. **Confirm**: "Does that match your intent?"
+5. **Execute**: Only after confirmation
+
+## Anti-Patterns
+
+NEVER:
+- Ask 10 questions at once (bundle into 2-3 logical groups)
+- Present options without tradeoffs
+- Proceed without explicit confirmation on big decisions
+- Hide blockers—surface them immediately
+- Be apologetic—be clear
+- Use filler ("I think maybe perhaps...")
+- Explain what you're about to do before doing it (unless asked)
+
+## Intent Capture Template
+
+When starting a new task, state:
+
+```
+Goal: [one sentence]
+Constraints: [what must be true]
+Success: [how we know we're done]
+Scope: [what's in/out]
+```
+
+Example:
+```
+Goal: Add user authentication
+Constraints: Must work with existing OAuth provider, no breaking changes
+Success: Users can log in via OAuth, tests pass
+Scope: Auth only—profile updates are separate
+```
+
+## Reference
+
+- Decapod context: `agent-decapod-interface` skill
+- Intent specification: `specs/INTENT.md`

--- a/constitution/metadata/skills/intent-refinement/SKILL.md
+++ b/constitution/metadata/skills/intent-refinement/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: intent-refinement
+description: Transform raw human intent into explicit specifications before inference. Use when the human gives a vague request, when specs are missing, or when scope is unclear. Triggers: "make it faster", "add feature", "what's the approach?".
+allowed-tools: Bash
+---
+
+# Intent Refinement
+
+The human gives you intent. You make it explicit. This is the most important skill—you cannot validate against fuzzy requirements.
+
+## The Refinement Loop
+
+```
+Human Input → Explicit Intent → Spec Artifacts → Context → Action → Validation
+```
+
+You MUST complete the loop before claiming done.
+
+## Input Classification
+
+### Type A: Complete Intent
+
+The human gave you everything:
+- Goal (what)
+- Constraints (what must be true)
+- Success criteria (how we know we're done)
+
+**Action**: Confirm and proceed.
+
+### Type B: Partial Intent
+
+The human gave you the goal but not constraints or success criteria.
+
+**Action**: Ask focused questions to fill gaps.
+
+### Type C: Vague Intent
+
+The human gave you neither goal nor constraints.
+
+**Action**: Use the interview pattern to elicit:
+- Background: "What's the context for this?"
+- Goal: "What should the end result look like?"
+- Constraints: "What must be true?"
+- Scope: "What's in/out of scope?"
+
+## The Specification Template
+
+Turn intent into this structure:
+
+```markdown
+## Intent
+
+**Goal**: [One sentence describing what to accomplish]
+
+**Constraints**:
+- [Hard requirement that must be satisfied]
+- [Hard requirement that must be satisfied]
+
+**Success Criteria**:
+- [Measurable outcome that proves completion]
+- [Measurable outcome that proves completion]
+
+**Out of Scope**:
+- [Explicitly NOT included]
+- [Explicitly NOT included]
+
+**Tradeoffs**:
+- [Acceptable compromise if constrained]
+- [Acceptable compromise if constrained]
+```
+
+## When to Generate Artifacts
+
+| Situation | Action |
+|-----------|--------|
+| New feature | Generate SPEC.md, validate against it |
+| Bug fix | Document current vs expected behavior |
+| Refactor | Document invariants that must hold |
+| Architecture change | Generate ARCHITECTURE.md, get sign-off |
+| Security-sensitive | Generate SECURITY.md, run context |
+
+Use `decapod rpc --op scaffold.generate_artifacts` for structured output.
+
+## Context Gathering (BEFORE Inference)
+
+Before you act on ANY intent:
+
+1. **Resolve relevant specs**: `decapod rpc --op context.resolve --params '{"operation": "your_action"}'`
+2. **Check existing decisions**: `decapod store.query --kind decision --query "your_topic"`
+3. **Validate against standards**: `decapod rpc --op standards.resolve --params '{"question": "your_question"}'`
+
+**Never infer without context. Never assume no specs apply.**
+
+## The "What Must Be True" Check
+
+For each action you take, ask:
+- What spec governs this?
+- What must be true after my change?
+- How do I verify it's true?
+
+If you can't answer these, you don't have enough context.
+
+## Validation Mapping
+
+Map each success criterion to a validation:
+
+```
+Success Criterion: "API responds in <100ms"
+→ Validation: Run benchmark, assert <100ms
+
+Success Criterion: "No breaking changes"
+→ Validation: Run compatibility tests
+
+Success Criterion: "Tests pass"
+→ Validation: `decapod validate`
+```
+
+**No criterion without validation. No validation without execution.**
+
+## Anti-Patterns
+
+NEVER:
+- Act on intent without explicit confirmation on Type B/C inputs
+- Skip context resolution "to save time"
+- Define success criteria without measurable outcomes
+- Leave scope implicit (it will expand)
+- Accept tradeoffs without documenting them
+- Claim done without validation against stated criteria
+
+## Refinement Questions (When Stuck)
+
+Use these to unstick vague intent:
+
+| Gap | Question |
+|-----|----------|
+| Goal unclear | "What should the user experience be when this is done?" |
+| Scope unclear | "What's the smallest version we could ship first?" |
+| Constraints unclear | "What must absolutely NOT break?" |
+| Success unclear | "How will we know this is successful?" |
+| Tradeoffs unclear | "If we had to choose between X and Y, which matters more?" |
+
+## Reference
+
+- Agent interface: `agent-decapod-interface` skill
+- Human UX: `human-agent-ux` skill
+- Intent spec: `specs/INTENT.md`
+- Testing contract: `interfaces/TESTING.md`

--- a/constitution/specs/skills/SKILL_GOVERNANCE.md
+++ b/constitution/specs/skills/SKILL_GOVERNANCE.md
@@ -40,3 +40,39 @@ To be promotion-relevant, skills must be translated into deterministic, repo-nat
 - No orchestrator behavior.
 - No provider-specific skill runtime.
 - No remote registry as canonical source of truth.
+
+---
+
+## Meta-Skills (Agent Training)
+
+Decapod includes meta-skills that train external agents how to interface with the control plane. These live in `metadata/skills/` and are Constitution-native.
+
+### Classification
+
+| Type | Purpose | Location |
+|------|---------|----------|
+| **Interface** | How to call Decapod RPC | `metadata/skills/agent-decapod-interface/` |
+| **UX** | How to interact with humans | `metadata/skills/human-agent-ux/` |
+| **Refinement** | How to turn intent into specs | `metadata/skills/intent-refinement/` |
+
+### Activation
+
+Meta-skills activate when:
+- Agent initializes (`agent.init` triggers interface skill)
+- Human gives vague intent (triggers refinement)
+- Agent needs to communicate with human (triggers UX)
+
+### Agent Onboarding
+
+For new agents, ensure these meta-skills are loaded:
+1. `agent-decapod-interface` - Required for any Decapod interaction
+2. `human-agent-ux` - Required for human-facing work
+3. `intent-refinement` - Required for any task involving intent
+
+### Custom Skills
+
+To add domain-specific skills:
+1. Create `metadata/skills/<skill-name>/SKILL.md`
+2. Add YAML frontmatter with `name`, `description`, `allowed-tools`
+3. Run `decapod docs ingest` to register
+4. Skills become available via `decapod context.capsule.query`


### PR DESCRIPTION
## Summary

Add three core skills that train external agents how to interface with Decapod and humans:

- **agent-decapod-interface**: RPC calling conventions, response envelope parsing, workspace management, validation patterns
- **human-agent-ux**: Question patterns (open-ended, constrained, binary), intent capture, progress communication, refusal patterns
- **intent-refinement**: Transform vague human intent into explicit specifications with validation criteria

## Changes

- Created `constitution/metadata/skills/` directory with SKILL.md files
- Updated `specs/skills/SKILL_GOVERNANCE.md` to support meta-skills classification
- Added `BUNDLE.md` as skill bundle index for agent onboarding
- Skills imported into aptitude system via `decapod data aptitude skill import`
- Skills generate governed skill cards in `.decapod/governance/skills/`

## Why This Matters

Unlike Sentry's Claude Code plugin approach, these skills are:
- First-class citizens via `decapod data aptitude skill`
- Promotion-relevant (must exist in control-plane artifact store)
- Resolvable by query for just-in-time context loading

The skills enable the core loop:
```
Human → Agent → intent-refinement → agent-decapod-interface → context.resolve → ACT → validate → Human
```