### PR TITLE
feat: add skills section to .decapod/README.md and move skills to .decapod/skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ dev/
 !.decapod/generated/specs/
 !.decapod/generated/specs/*.md
 !.decapod/generated/specs/.manifest.json
+# Allowlist skills - imported skill cards for reproducibility
+!.decapod/skills/
 
 # --- Environment & Secrets ---
 .env

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -346,11 +346,83 @@ It keeps Decapod-owned state, generated artifacts, and isolated workspaces separ
 7. `decapod todo add \"<task>\" && decapod todo claim --id <task-id>`
 8. `decapod workspace ensure`
 
+## Skills - Your Personal Optimization Layer
+
+**Skills are how you shape agent behavior.** Import skills to train agents how to interact with your codebase, your conventions, and your preferences.
+
+### Why Skills Matter
+
+- **Controls**: Add security reviews, code quality checks, or custom validation
+- **Optimization**: Encode your team's conventions, patterns, and best practices
+- **Context**: Give agents project-specific knowledge that persists across sessions
+
+### Quick Skills Workflow
+
+```bash
+# Import a skill from a SKILL.md file
+decapod data aptitude skill import --path path/to/your/SKILL.md
+
+# List available skills
+decapod data aptitude skill list
+
+# Resolve skills for a specific task
+decapod data aptitude skill resolve --query "how to write tests"
+
+# Query aptitude memory for learned preferences
+decapod data aptitude prompt --query "git"
+```
+
+### Creating Your Own Skills
+
+Skills are just Markdown files with YAML frontmatter:
+
+```yaml
+---
+name: my-security-review
+description: Custom security checks for our codebase
+allowed-tools: Bash
+---
+
+# Security Review Skill
+
+## Triggers
+- "check security"
+- "review for vulnerabilities"
+
+## Workflow
+1. Run `semgrep --config=auto .`
+2. Check for hardcoded secrets
+3. Validate dependency vulnerabilities
+4. Report findings
+```
+
+Place SKILL.md files in `constitution/metadata/skills/` and import them:
+
+```bash
+decapod data aptitude skill import --path constitution/metadata/skills/my-security-review/SKILL.md
+```
+
+### Aptitude Memory
+
+Decapod learns from interactions. Use aptitude to record preferences:
+
+```bash
+# Record a preference
+decapod data aptitude add --category git --key branch_prefix --value "feature/" --confidence 90
+
+# Get contextual prompts
+decapod data aptitude prompt --query "commit"
+
+# Record an observation
+decapod data aptitude observe --category code_style --content "Team prefers async/await over tokio::spawn"
+```
+
 ## Canonical Layout
 
 - `README.md`: operator onboarding and control-plane map.
 - `OVERRIDE.md`: project-local override layer for embedded constitution.
 - `data/`: canonical control-plane state (SQLite + ledgers).
+- `skills/`: imported skill cards (auto-generated, tracked for reproducibility).
 - `generated/specs/`: living project specs scaffolded by `decapod init`.
 - `generated/context/`: deterministic context capsule artifacts.
 - `generated/artifacts/provenance/`: promotion manifests and convergence checklist.

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -11,10 +11,10 @@ use crate::core::migration;
 use crate::core::output;
 use crate::core::plan_governance;
 use crate::core::project_specs::{
-    LOCAL_PROJECT_SPECS, LOCAL_PROJECT_SPECS_ARCHITECTURE, LOCAL_PROJECT_SPECS_DIR,
-    LOCAL_PROJECT_SPECS_INTENT, LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
-    LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_VALIDATION, hash_text,
-    read_specs_manifest, repo_signal_fingerprint,
+    hash_text, read_specs_manifest, repo_signal_fingerprint, LOCAL_PROJECT_SPECS,
+    LOCAL_PROJECT_SPECS_ARCHITECTURE, LOCAL_PROJECT_SPECS_DIR, LOCAL_PROJECT_SPECS_INTENT,
+    LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
+    LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_VALIDATION,
 };
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
@@ -26,8 +26,8 @@ use serde_json;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use ulid::Ulid;
 
@@ -1809,7 +1809,7 @@ fn validate_skill_cards_if_present(
 ) -> Result<(), error::DecapodError> {
     info("Skill Card Artifact Gate");
 
-    let dir = repo_root.join(".decapod").join("governance").join("skills");
+    let dir = repo_root.join(".decapod").join("skills");
     if !dir.exists() {
         skip("No skill cards found; skipping skill card gate", ctx);
         return Ok(());
@@ -3848,7 +3848,7 @@ fn validate_coplayer_policy_tightening(
 ) -> Result<(), error::DecapodError> {
     info("Co-Player Policy Tightening Gate");
 
-    use crate::core::coplayer::{CoPlayerSnapshot, derive_policy};
+    use crate::core::coplayer::{derive_policy, CoPlayerSnapshot};
 
     // Test the invariant: unknown → high → medium → low reliability
     // Each step must be equal or tighter than the next.

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -11,10 +11,10 @@ use crate::core::migration;
 use crate::core::output;
 use crate::core::plan_governance;
 use crate::core::project_specs::{
-    hash_text, read_specs_manifest, repo_signal_fingerprint, LOCAL_PROJECT_SPECS,
-    LOCAL_PROJECT_SPECS_ARCHITECTURE, LOCAL_PROJECT_SPECS_DIR, LOCAL_PROJECT_SPECS_INTENT,
-    LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
-    LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_VALIDATION,
+    LOCAL_PROJECT_SPECS, LOCAL_PROJECT_SPECS_ARCHITECTURE, LOCAL_PROJECT_SPECS_DIR,
+    LOCAL_PROJECT_SPECS_INTENT, LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
+    LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_VALIDATION, hash_text,
+    read_specs_manifest, repo_signal_fingerprint,
 };
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
@@ -26,8 +26,8 @@ use serde_json;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 use ulid::Ulid;
 
@@ -3848,7 +3848,7 @@ fn validate_coplayer_policy_tightening(
 ) -> Result<(), error::DecapodError> {
     info("Co-Player Policy Tightening Gate");
 
-    use crate::core::coplayer::{derive_policy, CoPlayerSnapshot};
+    use crate::core::coplayer::{CoPlayerSnapshot, derive_policy};
 
     // Test the invariant: unknown → high → medium → low reliability
     // Each step must be equal or tighter than the next.

--- a/src/plugins/aptitude.rs
+++ b/src/plugins/aptitude.rs
@@ -769,7 +769,7 @@ fn repo_root_from_store(store: &Store) -> Result<PathBuf, error::DecapodError> {
 }
 
 fn skills_governance_dir(repo_root: &Path) -> PathBuf {
-    repo_root.join(".decapod").join("governance").join("skills")
+    repo_root.join(".decapod").join("skills")
 }
 
 fn skills_generated_dir(repo_root: &Path) -> PathBuf {
@@ -1643,7 +1643,7 @@ pub enum SkillCommand {
         /// Path to SKILL.md
         #[clap(long)]
         path: PathBuf,
-        /// Persist deterministic skill card under .decapod/governance/skills
+        /// Persist deterministic skill card under .decapod/skills
         #[clap(long, default_value_t = true)]
         write_card: bool,
     },


### PR DESCRIPTION
## Summary

Add prominent skills documentation to `.decapod/README.md` template and restructure skill cards path.

## Changes

1. **Skills documentation in README**: Added "Skills - Your Personal Optimization Layer" section covering:
   - Why skills matter (controls, optimization, context)
   - Quick workflow commands (`decapod data aptitude skill import/list/resolve`)
   - How to create custom SKILL.md files
   - Aptitude memory for recording preferences

2. **Path refactor**: Moved skill cards from `.decapod/governance/skills/` to `.decapod/skills/` (cleaner, skills aren't governance)

3. **.gitignore**: Added `.decapod/skills/` to allowlist for reproducibility

4. **Inference payload shaping**: Previous commit added `allowed_next_ops` to `context.resolve` RPC response

## Why Skills Matter

Skills are how users shape agent behavior - adding controls, optimizations, and project-specific context that persists across sessions. This makes them prominent in the README.