### PR TITLE
init: scaffold-v2 specs surface with operations/security semantics

### DIFF
--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -1,320 +1,98 @@
 # Architecture
 
 ## Direction
-
-Composable repository architecture with explicit boundaries and proof-backed delivery invariants. Decapod is a daemonless control plane for AI coding agents - invoked on-demand, exits immediately after, state persists locally.
+Decapod is an on-demand control-plane runtime. It enforces workflow invariants around workspace isolation, task state transitions, and proof-backed completion while preserving deterministic local-first state.
 
 ## Current Facts
-
 - Runtime/languages: rust
-- Detected surfaces/framework hints: cargo
-- Product type: service_or_library
+- Detected surfaces/framework hints: cargo, cli, rpc
+- Product type: control-plane service_or_cli
 
 ## Topology
-
 ```mermaid
-Human Intent
-  │
-  ▼
-AI Agent (Claude/Codex/Gemini/Cursor)
-  │
-  │ decapod rpc --op agent.init
-  ▼
-Decapod Runtime (On-Demand)
-  ├── Session Manager
-  ├── Workspace Isolation
-  ├── Todo Ledger
-  ├── Validate Gates
-  ├── Knowledge Store
-  └── Context Capsule
-  │
-  ▼
-Repository + Services
-  ├── Git worktree (.decapod/workspaces/*)
-  ├── SQLite ledger (.decapod/data/*.db)
-  └── Constitution embedded in binary
+flowchart LR
+  H[Human] --> A[Agent]
+  A --> C[CLI/RPC Entry]
+  C --> R[Decapod Runtime]
+  R --> P[Policy + Interlocks]
+  R --> G[Validate Gates]
+  R --> S[(Repo Store)]
+  R --> U[(User Store)]
+  G --> E[Provenance Artifacts]
 ```
 
-### System Topology with Store Boundaries
-
+## Store Boundaries
 ```mermaid
-graph TD
-    subgraph "Agent Process"
-        A[AI Agent]
-    end
-
-    subgraph "Decapod Runtime (On-Demand)"
-        R[Runtime]
-        S[Session Manager]
-        W[Workspace Isolation]
-        V[Validate Gate]
-    end
-
-    subgraph "Repo Store (<repo>/.decapod/)"
-        DB[(SQLite)]
-        J[JSONL Logs]
-        WT[Git Worktree]
-    end
-
-    subgraph "User Store (~/.decapod/)"
-        UDB[(SQLite)]
-        UJ[JSONL Logs]
-    end
-
-    A -->|"rpc --op agent.init"| R
-    R --> S
-    R --> W
-    W -->|"validate"| V
-    V -->|"receipt + hash"| A
-
-    R -->|read/write| DB
-    R -->|append| J
-    W -->|branch| WT
-
-    R -.->|"--store user"| UDB
-
-    style W fill:#f9f,stroke:#333
-    style V fill:#9f9,stroke:#333
-    style DB fill:#ff9,stroke:#333
-    style UDB fill:#ff9,stroke:#333
+flowchart LR
+  R[Runtime] --> RS[(<repo>/.decapod)]
+  R --> US[(~/.decapod)]
+  RS -. cross-write .-> V1[STORE_BOUNDARY_VIOLATION]
+  US -. cross-write .-> V1
 ```
 
-### Happy Path Sequence
-
+## Happy Path Sequence
 ```mermaid
 sequenceDiagram
-    participant Agent as AI Agent
-    participant Decapod as Decapod Runtime
-    participant Git as Git Worktree
-    participant Store as SQLite/JSONL
-
-    Note over Agent,Decapod: 1. Initialize session
-    Agent->>Decapod: decapod rpc --op agent.init
-    Decapod->>Store: Create session receipt
-    Decapod-->>Agent: session_id, allowed_next_ops
-
-    Note over Agent,Decapod: 2. Ensure workspace
-    Agent->>Decapod: decapod workspace ensure
-    Decapod->>Git: git worktree add
-    Git-->>Decapod: worktree_path
-    Decapod-->>Agent: branch_name, worktree_path
-
-    Note over Agent,Decapod: 3. Add task
-    Agent->>Decapod: decapod todo add "implement X"
-    Decapod->>Store: Append to todos.jsonl
-    Decapod-->>Agent: task_id, status=Draft
-
-    Note over Agent,Decapod: 4. Claim task
-    Agent->>Decapod: decapod todo claim --id <task_id>
-    Decapod->>Store: Update status=Claimed
-    Decapod-->>Agent: status=Claimed
-
-    Note over Agent,Decapod: 5. Do work
-    Agent->>Git: Edit files, run tests
-    Git-->>Agent: Success
-
-    Note over Agent,Decapod: 6. Validate
-    Agent->>Decapod: decapod validate
-    Decapod->>Store: Check gates
-    alt All gates pass
-        Decapod-->>Agent: receipt with hash, exit 0
-    else Gates fail
-        Decapod-->>Agent: typed error, exit non-zero
-    end
-
-    Note over Agent,Decapod: 7. Complete task
-    Agent->>Decapod: decapod todo done --id <task_id>
-    Decapod->>Store: Update status=Verified
-    Decapod-->>Agent: status=Verified
+  participant Agent
+  participant Runtime as Decapod
+  participant Git
+  participant Store
+  Agent->>Runtime: rpc --op agent.init
+  Runtime-->>Agent: session + capabilities
+  Agent->>Runtime: workspace ensure
+  Runtime->>Git: create isolated worktree
+  Agent->>Runtime: todo add/claim
+  Runtime->>Store: persist lifecycle events
+  Agent->>Runtime: validate
+  Runtime-->>Agent: gate results + receipt hash
 ```
 
-### Preflight Before Operation
-
+## Error Path
 ```mermaid
 sequenceDiagram
-    participant Agent
-    participant Decapod
-
-    Note over Agent,Decapod: BEFORE any operation
-    Agent->>Decapod: decapod preflight --op todo.add
-    Decapod->>Workspace: Check workspace status
-    Workspace-->>Decapod: git_is_protected, can_work
-    Decapod->>Capsules: Determine required context
-    Decapod-->>Agent: risk_flags[], likely_failures[], required_capsules[]
-
-    Note over Agent,Decapod: Agent decides to proceed or fix issues
-    Agent->>Decapod: decapod workspace ensure
-    Agent->>Decapod: decapod todo add "task"
-```
-
-### Impact Before Validate
-
-```mermaid
-sequenceDiagram
-    participant Agent
-    participant Decapod
-
-    Note over Agent,Decapod: AFTER changes, BEFORE validate
-    Agent->>Decapod: decapod impact --changed-files "src/a.rs,src/b.rs"
-    Decapod->>Workspace: Check workspace status
-    Decapod->>Validate: Predict gate outcomes
-    Decapod-->>Agent: will_fail_validate, predicted_failures[], recommendation
-
-    alt will_fail_validate = true
-        Agent->>Decapod: Fix issues
-    else will_fail_validate = false
-        Agent->>Decapod: decapod validate
-    end
+  participant Agent
+  participant Runtime as Decapod
+  Agent->>Runtime: mutate operation on protected branch
+  Runtime-->>Agent: WORKSPACE_REQUIRED + next action
+  Agent->>Runtime: validate with lock contention
+  Runtime-->>Agent: VALIDATE_TIMEOUT_OR_LOCK
 ```
 
 ## Execution Path
+`intent -> context.resolve -> workspace.ensure -> task lifecycle -> implementation -> validate -> evidence -> completion`
 
-```
-Input/Event --> Contract Parse --> Session Init --> Workspace Isolation
-      |              |                  |                  |
-      +--------------+------------------+------------------+
-                        Trace + Metrics + Artifacts
-```
+## Concurrency and Runtime Model
+- Execution model: single-process daemonless command execution.
+- Isolation boundaries: per-task git worktrees and store-mode boundary.
+- Backpressure strategy: bounded validation runtime + typed timeout failures.
+- Synchronization: SQLite transaction boundaries + append-only event logs.
 
-### Detailed Data Flow
-
-```mermaid
-flowchart LR
-    subgraph Input["Input"]
-        C[CLI Command]
-        R[RPC Call]
-        E[Event/File]
-    end
-
-    subgraph Parse["Contract Parse"]
-        P[Parse & Validate]
-        A[Auth Check]
-    end
-
-    subgraph Runtime["Runtime"]
-        S[Session Manager]
-        W[Workspace Manager]
-        T[Todo Manager]
-        V[Validate Manager]
-        K[Knowledge Manager]
-    end
-
-    subgraph State["State Layer"]
-        DB[(SQLite)]
-        J[(JSONL)]
-        G[(Git)]
-    end
-
-    subgraph Output["Output"]
-        O1[Receipt Hash]
-        O2[JSON Response]
-        O3[Exit Code]
-    end
-
-    C --> P
-    R --> P
-    E --> P
-    P --> A
-    A --> S
-    A --> W
-    A --> T
-    A --> V
-    A --> K
-    
-    S --> DB
-    W --> G
-    T --> J
-    T --> DB
-    V --> DB
-    
-    S --> O1
-    W --> O2
-    T --> O1
-    V --> O1
-    V --> O2
-    V --> O3
-    
-    style P fill:#9ff,stroke:#333
-    style Runtime fill:#ff9,stroke:#333
-    style V fill:#f99,stroke:#333
-```
-
-1. **Agent Initialization**: `decapod rpc --op agent.init` creates session
-2. **Workspace Check**: `decapod workspace ensure` creates isolated worktree
-3. **Task Tracking**: `decapod todo add/claim/done` with event sourcing
-4. **Validation**: `decapod validate` produces proof receipt
-
-### Component Interaction Map
-
-```mermaid
-flowchart TB
-    S[Session<br/>Manager] -->|creates| SR[Session<br/>Receipt]
-    W[Workspace<br/>Isolation] -->|creates| WT[Worktree]
-    W -->|blocks| PB[Protected<br/>Branches]
-    T[Todo<br/>Ledger] -->|appends| J[todos.jsonl]
-    T -->|creates| TR[Task<br/>Receipt]
-    V[Validate<br/>Gate] -->|reads| J
-    V -->|reads| DB[(SQLite)]
-    V -->|emits| VR[Validation<br/>Receipt]
-    V -->|emits| EH[Exit Code]
-    K[Knowledge<br/>Store] -->|appends| KP[knowledge.jsonl]
-    C[Context<br/>Capsule] -->|queries| CE[Constitution<br/>Embed]
-    
-    SR -->|stored| DB
-    TR -->|stored| J
-    VR -->|stored| DB
-    
-    style V fill:#f99,stroke:#333
-    style W fill:#f9f,stroke:#333
-```
+## Deployment Topology
+- Runtime units: local binary invocation in developer/CI environments.
+- Environment model: repo-scoped state + optional user-global state.
+- Rollout strategy: standard branch/PR flow with validate gate before promotion.
+- Rollback trigger: any blocking gate failure or proof artifact mismatch.
 
 ## Data and Contracts
+- Inbound contracts: CLI command schema and RPC op schema.
+- Outbound dependencies: filesystem, git worktree, SQLite, JSONL ledgers.
+- Data ownership boundaries: task/session/workunit ownership explicit in repo store.
+- Schema evolution: additive-first with deterministic schema export and migration checks.
 
-### Inbound Contracts (CLI/API/events)
+## ADR Register
+| ADR | Title | Status | Rationale | Date |
+|---|---|---|---|---|
+| ADR-001 | Daemonless runtime model | Accepted | deterministic invocation and low operational burden | 2026-02-26 |
+| ADR-002 | Strict workspace interlock | Accepted | protect main/master and preserve reviewability | 2026-02-26 |
 
-- CLI: `decapod <command>` with subcommands
-- RPC: `decapod rpc --op <operation> --params <json>`
-- Events: File-based ledger appends
-
-### Outbound Dependencies (datastores/queues/external APIs)
-
-- SQLite: `.decapod/data/*.db` for persistent state
-- JSONL: `.decapod/data/*.jsonl` for event logs
-- Git: Worktree management via `git worktree`
-
-### Data Ownership Boundaries
-
-- User store: `~/.decapod/` - personal blank-slate tasks
-- Repo store: `<repo>/.decapod/` - project dogfood backlog
-- Strict separation: no cross-contamination
-
-## Service Contracts
-
-| Component | Responsibility | CLI Surface | Schema |
-|-----------|---------------|-------------|--------|
-| Session Manager | Track agent session lifecycle | `decapod session` | Session receipt |
-| Workspace Isolation | Enforce branch protection + worktree | `decapod workspace` | Branch state |
-| Todo Ledger | Event-sourced task tracking | `decapod todo` | todos.jsonl |
-| Validate Gate | Deterministic completion proof | `decapod validate` | Gate results |
-| Knowledge Store | Repository knowledge + provenance | `decapod data knowledge` | SQLite |
-| Context Capsule | Scoped constitution query | `decapod govern capsule` | Deterministic hash |
-
-## Delivery Plan
-
-1. **Slice 1**: Core session + workspace + todo + validate
-2. **Slice 2**: Knowledge store + context capsules
-3. **Slice 3**: Policy enforcement + eval gates
+## Delivery Plan (first 3 slices)
+- Slice 1: scaffold-v2 specs + validation awareness.
+- Slice 2: machine-checkable docs/diagram/changelog proof gates.
+- Slice 3: CI evidence aggregation and stricter promotion policy.
 
 ## Risks and Mitigations
-
-- **Risk**: Store contamination between user/repo
-  - **Mitigation**: Explicit --store flag, validation gates
-
-- **Risk**: Validation hangs under DB contention
-  - **Mitigation**: Bounded timeout with typed error (`VALIDATE_TIMEOUT_OR_LOCK`)
-
-- **Risk**: Agent works on main/master
-  - **Mitigation**: Workspace enforcement blocks this
-
-- **Risk**: Scope creep beyond daemonless on-demand model
-  - **Mitigation**: Constitution documents non-goals explicitly
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Spec drift from implementation | Medium | High | enforce spec-drift gate and update discipline |
+| Validation performance contention | Medium | Medium | lock-aware retries and bounded execution |
+| Interface growth complexity | Medium | High | ADR discipline + typed error taxonomy |

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -1,398 +1,70 @@
 # Interfaces
 
-## Stable Capabilities (ABI)
+## Contract Principles
+- Each interface must have explicit schema, idempotency, and typed error behavior.
+- Mutating operations return deterministic receipts when state changes.
+- Backward-compatible versioning is mandatory for stable surfaces.
 
-| Capability | Stability | Description |
-|------------|-----------|-------------|
-| `preflight.check` | stable | Before any operation, predict what will fail and what context is needed |
-| `impact.predict` | stable | Predict validation outcomes for changed files before running validate |
-| `daemonless` | stable | Decapod never runs in the background |
-| `deterministic` | stable | Same inputs produce identical outputs |
+## API / RPC Contracts
+| Interface | Method | Request Schema | Response Schema | Errors | Idempotency |
+|---|---|---|---|---|---|
+| `rpc.agent.init` | `rpc --op agent.init` | op + session context | capabilities + session envelope | `SESSION_REQUIRED` | idempotent for same active session |
+| `rpc.context.resolve` | `rpc --op context.resolve` | query/context scope | deterministic context capsule | validation errors | idempotent for same inputs |
+| `rpc.context.scope` | `rpc --op context.scope` | scoped query params | ranked scoped context list | query validation errors | idempotent for same inputs |
 
-## CLI Command Hierarchy
-
-```mermaid
-flowchart TB
-    subgraph Root["decapod (root)"]
-        init[init]
-        session[session]
-        workspace[workspace]
-        todo[todo]
-        validate[validate]
-        govern[govern]
-        data[data]
-        auto[auto]
-        qa[qa]
-        decide[decide]
-        rpc[rpc]
-        release[release]
-    end
-
-    subgraph Session["session"]
-        sacquire[acquire]
-        sstatus[status]
-        srelease[release]
-    end
-
-    subgraph Workspace["workspace"]
-        wensure[ensure]
-        wstatus[status]
-        wpublish[publish]
-    end
-
-    subgraph Todo["todo"]
-        tadd[add]
-        tclaim[claim]
-        tdone[done]
-        tlist[list]
-    end
-
-    subgraph Govern["govern"]
-        ghealth[health]
-        gpolicy[policy]
-        gproof[proof]
-        gwatcher[watcher]
-        gfeedback[feedback]
-        gplan[plan]
-        gworkunit[workunit]
-        gcapsule[capsule]
-    end
-
-    subgraph Data["data"]
-        dknowledge[knowledge]
-        dcontext[context]
-        dschema[schema]
-        dbroker[broker]
-        daptitude[aptitude]
-        dfederation[federation]
-        dprimitives[primitives]
-    end
-
-    root --> init
-    root --> session
-    root --> workspace
-    root --> todo
-    root --> validate
-    root --> govern
-    root --> data
-    root --> auto
-    root --> qa
-    root --> decide
-    root --> rpc
-    root --> release
-
-    session --> sacquire
-    session --> sstatus
-    session --> srelease
-
-    workspace --> wensure
-    workspace --> wstatus
-    workspace --> wpublish
-
-    todo --> tadd
-    todo --> tclaim
-    todo --> tdone
-    todo --> tlist
-
-    govern --> ghealth
-    govern --> gpolicy
-    govern --> gproof
-    govern --> gwatcher
-    govern --> gfeedback
-    govern --> gplan
-    govern --> gworkunit
-    govern --> gcapsule
-
-    data --> dknowledge
-    data --> dcontext
-    data --> dschema
-    data --> dbroker
-    data --> daptitude
-    data --> dfederation
-    data --> dprimitives
-
-    style root fill:#9f9,stroke:#333
-    style session fill:#ff9,stroke:#333
-    style workspace fill:#ff9,stroke:#333
-    style todo fill:#ff9,stroke:#333
-    style validate fill:#f99,stroke:#333
-    style govern fill:#f9f,stroke:#333
-```
-
-## Inbound Contracts
-
-### CLI Surfaces
-
-| Command | Purpose | Stability |
-|---------|---------|-----------|
-| `decapod init` | Bootstrap `.decapod/` in repository | stable |
-| `decapod session acquire` | Establish agent session | stable |
-| `decapod session status` | Check current session | stable |
-| `decapod workspace ensure` | Create isolated worktree | stable |
-| `decapod workspace status` | Show current workspace/branch | stable |
-| `decapod todo add <title>` | Add task to ledger | stable |
-| `decapod todo claim --id <id>` | Claim task for current agent | stable |
-| `decapod todo done --id <id>` | Mark task complete | stable |
-| `decapod todo list` | List tasks with status | stable |
-| `decapod validate` | Run validation gates | stable |
-| `decapod capabilities --format json` | Enumerate capabilities | stable |
-| `decapod preflight --op <op>` | Predict what will fail before operation | stable |
-| `decapod impact --changed-files <files>` | Predict validation outcomes | stable |
-| `decapod data schema --format json --deterministic` | Get entity schemas | stable |
-
-### Preflight Output Schema
-
-```json
-{
-  "op": "validate",
-  "session_id": null,
-  "risk_flags": ["protected_branch"],
-  "likely_failures": [
-    {
-      "code": "WORKSPACE_REQUIRED",
-      "message": "Cannot operate on protected branch",
-      "current_branch": "master"
-    }
-  ],
-  "required_capsules": ["plugins/VERIFY.md"],
-  "next_best_actions": ["Run: decapod workspace ensure"],
-  "workspace": {
-    "git_branch": "master",
-    "git_is_protected": true,
-    "can_work": false
-  }
-}
-```
-
-### Impact Output Schema
-
-```json
-{
-  "changed_files": ["src/core/validate.rs"],
-  "will_fail_validate": true,
-  "predicted_failures": [
-    {
-      "gate": "workspace_isolation",
-      "status": "fail",
-      "code": "WORKSPACE_REQUIRED",
-      "message": "Operating on protected branch"
-    }
-  ],
-  "validation_predictions": [
-    { "gate": "workspace_isolation", "status": "pass" }
-  ],
-  "workspace": {
-    "git_branch": "master",
-    "git_is_protected": true,
-    "can_work": false
-  },
-  "recommendation": "Fix workspace issues before running validate"
-}
-```
-
-### Governance Commands
-
-| Command | Purpose |
-|---------|---------|
-| `decapod govern health summary` | System health status |
-| `decapod govern policy riskmap` | Risk classification |
-| `decapod govern watcher run` | Run safety checks |
-| `decapod govern capsule query --topic <x> --scope <y>` | Query context capsules |
-
-### Data Commands
-
-| Command | Purpose |
-|---------|---------|
-| `decapod data knowledge add --id <x> --title <y> --text <z>` | Add knowledge entry |
-| `decapod data knowledge search --query <x>` | Search knowledge |
-| `decapod data aptitude add --key <x> --value <y>` | Store preference |
-| `decapod data context audit` | Audit token usage |
+## Event Consumers
+| Consumer | Event | Ordering Requirement | Retry Policy | DLQ Policy |
+|---|---|---|---|---|
+| Todo ledger writer | `todo.add|claim|done` | per-task order | bounded retry on lock contention | append DLQ record on persistent failure |
+| Knowledge promotions | `knowledge.promote` | global append order | retry with backoff | write rejected payload to diagnostics |
 
 ## Outbound Dependencies
+| Dependency | Purpose | SLA | Timeout | Circuit-Breaker |
+|---|---|---|---|---|
+| Git worktree | workspace isolation | local op availability | 60s | fail-fast + typed error |
+| SQLite | canonical task/session state | local DB availability | 30s validate bound | lock timeout + retry policy |
+| Filesystem | artifact emission | local writeability | op-specific | fail-fast |
 
-- **SQLite**: `.decapod/data/*.db` - persistent state for todos, knowledge, sessions
-- **JSONL**: `.decapod/data/*.jsonl` - append-only event logs
-- **Git**: Worktree management via `git worktree` for workspace isolation
+## Inbound Contracts
+- CLI surfaces: `init`, `session`, `workspace`, `todo`, `validate`, `rpc`, `govern`, `data`.
+- RPC surfaces: deterministic JSON envelope with typed failure codes.
+- Event consumers: todo/workunit/provenance ledgers.
 
 ## Data Ownership
+- Source-of-truth: repo store for repo-scoped tasks/specs/proof artifacts.
+- User store: cross-repo memory and aptitude where explicitly requested.
+- Consistency model: single-writer command boundaries with durable append logs.
 
-### Store Boundary Model
-
-```mermaid
-graph TB
-    subgraph "Decapod CLI"
-        CLI[decapod <command>]
-    end
-
-    subgraph "User Store (~/.decapod/)"
-        US[(SQLite: user.db)]
-        UJ[todos.jsonl]
-        UK[knowledge.jsonl]
-    end
-
-    subgraph "Repo Store (<repo>/.decapod/)"
-        RS[(SQLite: project.db)]
-        RJ[todos.jsonl]
-        RK[knowledge.jsonl]
-        GW[git worktrees]
-    end
-
-    CLI -->|"--store user"| US
-    CLI -->|"--store repo"| RS
-    CLI -->|default in repo| RS
-    
-    US -.->|"cross-store write"| Violate[STORE_BOUNDARY_VIOLATION]
-    RS -.->|"cross-store write"| Violate
-
-    style US fill:#9ff,stroke:#333
-    style RS fill:#ff9,stroke:#333
-    style GW fill:#f9f,stroke:#333
-    style Violate fill:#f99,stroke:#333
-```
-
-| Store | Path | Contamination Rule |
-|-------|------|-------------------|
-| `user` | `~/.decapod/` | Never seeded from repo |
-| `repo` | `<repo>/.decapod/` | Never leaks to user store |
-
-### Source-of-Truth Tables
-
-- `todos.jsonl` - Task lifecycle events (append-only)
-- `knowledge.promotions.jsonl` - Knowledge promotion events
-- `sessions/` - Agent session receipts
-- `workspaces/` - Isolated git worktrees
-
-### Cross-Boundary Read Models
-
-- `decapod capabilities --format json` - Read-only capability enumeration
-- `decapod data schema --deterministic` - Read-only schema inspection
-
-### Consistency Expectations
-
-- All writes are append-only (no updates/deletes to event logs)
-- SQLite transactions for multi-entity consistency
-- Receipt hashes for mutation verification
-
-## JSON-RPC Surface
-
-### Required Agent Initialization
-
-```bash
-decapod rpc --op agent.init
-```
-
-Returns:
-```json
-{
-  "session_id": "ulid",
-  "receipt": { "timestamp": "...", "store": "repo|user" },
-  "allowed_next_ops": ["workspace.ensure", "todo.add", ...],
-  "blocked_by": []
-}
-```
-
-### Core RPC Operations
-
-| Operation | Parameters | Returns |
-|-----------|------------|---------|
-| `agent.init` | - | Session receipt |
-| `context.resolve` | `{ "op": "todo.add" }` | Relevant constitution fragments |
-| `context.scope` | `{ "query": "validation", "limit": 8 }` | Scoped docs |
-| `validate.run` | `{ "store": "repo" }` | Gate results with pass/fail |
-| `workspace.ensure` | `{ "branch": "feature/x" }` | Worktree path |
-| `store.upsert` | `{ "entity": "todo", "data": {...} }` | Write receipt |
-| `schema.get` | `{ "entity": "todo" }` | JSON schema |
-
-### Error Response Schema
-
-All RPC errors include:
-```json
-{
-  "error": {
-    "code": "VALIDATE_TIMEOUT_OR_LOCK | WORKSPACE_REQUIRED | VERIFICATION_REQUIRED",
-    "message": "human-readable",
-    "remediation": "suggested action"
-  }
-}
-```
-
-### Error Flow
-
-```mermaid
-flowchart TD
-    subgraph Request["RPC Request"]
-        R[op: agent.init<br/>params: {...}]
-    end
-
-    subgraph Process["Runtime"]
-        P[Parse & Validate]
-        A[Auth Check]
-        E[Execute]
-    end
-
-    subgraph Response["Response"]
-        S[Success<br/>{...}]
-        F[Error<br/>{code, message, remediation}]
-    end
-
-    R --> P
-    P -->|valid| A
-    P -->|invalid| F
-    A -->|ok| E
-    A -->|no session| F
-    E -->|success| S
-    E -->|failure| F
-
-    style F fill:#f99,stroke:#333
-    style S fill:#9f9,stroke:#333
-```
-
-## Data Store Schema
-
-### Two Stores (Strictly Separated)
-
-| Store | Path | Purpose | Contamination Rule |
-|-------|------|---------|-------------------|
-| user | `~/.decapod/` | Personal blank-slate tasks | Never seeded from repo |
-| repo | `<repo>/.decapod/` | Project dogfood backlog | Never leaks to user store |
-
-### Core Entities
-
-**Todo** (`decapod data schema --subsystem todo`):
-```json
-{
-  "id": "ulid",
-  "status": "draft|claimed|executing|verified",
-  "intent": "string",
-  "spec": "string (optional)",
-  "created_by": "session_id",
-  "events": [{ "type": "created|claimed|done", "ts": "timestamp" }]
-}
-```
-
-**Knowledge Entry**:
-```json
-{
-  "id": "ulid",
-  "title": "string",
-  "text": "string",
-  "provenance": "string",
-  "claim_id": "ulid (optional)",
-  "promoted": "boolean"
+## Error Taxonomy Example (Rust)
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum InterlockError {
+    #[error("workspace required")]
+    WorkspaceRequired,
+    #[error("verification required")]
+    VerificationRequired,
+    #[error("store boundary violation")]
+    StoreBoundaryViolation,
+    #[error("validation timeout or lock")]
+    ValidateTimeoutOrLock,
 }
 ```
 
 ## Failure Semantics
+| Failure Class | Retry/Backoff | Client Contract | Observability |
+|---|---|---|---|
+| Input validation | no retry | typed non-zero response | warning log |
+| Lock contention | bounded retry + jitter | `VALIDATE_TIMEOUT_OR_LOCK` on exhaustion | error log + metric |
+| Policy interlock | no retry until condition fixed | explicit next action | policy event log |
 
-| Failure Type | Condition | Remediation |
-|--------------|-----------|-------------|
-| `VALIDATE_TIMEOUT_OR_LOCK` | DB contention > timeout | Retry with backoff |
-| `WORKSPACE_REQUIRED` | Operating on main/master | Run `decapod workspace ensure` |
-| `VERIFICATION_REQUIRED` | Claiming done without proof | Run `decapod validate` |
-| `STORE_BOUNDARY_VIOLATION` | Cross-store contamination detected | Use explicit `--store` flag |
+## Timeout Budget
+| Hop | Budget (ms) | Notes |
+|---|---|---|
+| CLI parse + preflight checks | 500 | local checks |
+| Core operation + store transaction | 5000 | per-command budget |
+| Validation full gate sweep | 30000 | hard bounded runtime |
 
-## Output Formats
-
-- `--format text` (default): Human-readable
-- `--format json`: Machine-parseable for automation
-- `--deterministic`: Removes volatile timestamps for reproducible outputs
+## Interface Versioning
+- Stable CLI verbs are additive-first.
+- JSON response shape changes require migration notes and docs update.
+- Removal/deprecation requires at least one release-cycle warning window.

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,0 +1,69 @@
+# Operations
+
+## Operational Readiness Checklist
+- [ ] Ownership and on-call rotation defined.
+- [ ] SLOs/SLIs defined with alert thresholds.
+- [ ] Dashboards for latency/errors/saturation active.
+- [ ] Incident runbooks linked for Sev1/Sev2 alerts.
+- [ ] Rollback policy validated.
+- [ ] Capacity assumptions reviewed.
+
+## Service Level Objectives
+| SLI | Target | Window | Owner |
+|---|---|---|---|
+| Availability | 99.9% | 30d | Core maintainers |
+| Validate latency (p95) | <= 10s | 7d | Core maintainers |
+| Gate failure false-positive rate | <= 1% | 30d | Core maintainers |
+
+## Monitoring
+| Signal | Metric | Threshold | Alert Severity |
+|---|---|---|---|
+| Throughput | command executions/min | anomaly vs baseline | Sev3 |
+| Latency | validate p95/p99 | p95 > 10s sustained | Sev2 |
+| Reliability | failed gate ratio | > 20% unexpected | Sev2 |
+| Saturation | DB lock contention | sustained contention | Sev2 |
+
+## Health Checks
+- Liveness: binary invocation and core command response.
+- Readiness: workspace/session/store checks pass.
+- Dependency: git + filesystem + SQLite reachable.
+
+## Alerting and Runbooks
+| Alert | Severity | Runbook |
+|---|---|---|
+| Validation timeout spike | Sev2 | docs/runbooks/validate-timeout.md |
+| Workspace interlock bypass regression | Sev1 | docs/runbooks/interlock-regression.md |
+| Store boundary violation increase | Sev2 | docs/runbooks/store-boundary.md |
+
+## Incident Response
+- Incident commander role rotates with core maintainers.
+- Communication channel: issue + team channel + incident notes.
+- Postmortem SLA: draft within 48h for Sev1/Sev2.
+- Corrective actions are tracked as claimed todo tasks with due dates.
+
+## Structured Logging
+- Use structured fields: `trace_id`, `task_id`, `op`, `duration_ms`, `result`, `error_code`.
+
+## Severity Definitions
+| Severity | Definition | Response Time |
+|---|---|---|
+| Sev1 | release-blocking outage or integrity risk | immediate |
+| Sev2 | major degradation or recurring gate failures | 30 minutes |
+| Sev3 | partial degradation without user-blocking impact | next business day |
+
+## Deployment Strategy
+- Branch + PR + CI validate gating.
+- Promote only with local + CI proof receipts attached.
+- Rollback by reverting offending change and revalidating.
+
+## Environment Configuration
+| Variable | Purpose | Default | Secret |
+|---|---|---|---|
+| DECAPOD_SESSION_PASSWORD | session auth gate | unset | yes |
+| RUST_LOG | log verbosity | info | no |
+| DECAPOD_STORE | store mode selection | repo | no |
+
+## Capacity Planning
+- Baseline validates command frequency in CI and local usage.
+- Track DB growth and log compaction needs over time.
+- Keep headroom for parallel agent workspaces and validate runs.

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -4,57 +4,41 @@ Canonical path: `.decapod/generated/specs/`.
 These files are the project-local contract for humans and agents.
 
 ## Snapshot
-
 - Project: decapod
-- Outcome: A daemonless control plane for AI coding agents.
+- Outcome: Daemonless control plane that drives agent convergence to user intent with proof-backed completion.
 - Detected languages: rust
-- Detected surfaces: cargo
-- Version: 0.44.3
+- Detected surfaces: cargo, cli, rpc, validation gates
 
 ## How to use this folder
-
-- `INTENT.md`: What success means, in-scope capabilities, and falsifiable non-goals.
-- `ARCHITECTURE.md`: The topology, data flow, and component responsibilities.
-- `INTERFACES.md`: CLI commands, JSON-RPC operations, and data schemas with concrete invocations.
-- `VALIDATION.md`: Proof surfaces, promotion gates, and typed error codes.
-
-## Quick Verification (Machine-Checkable)
-
-```bash
-# 1. Get capabilities
-decapod capabilities --format json
-
-# 2. Get schemas
-decapod data schema --format json --deterministic
-
-# 3. Run validation gate
-decapod validate --format json
-```
+- `INTENT.md`: product outcome, scope boundaries, and objective acceptance criteria.
+- `ARCHITECTURE.md`: topology, runtime model, deployment shape, and ADR/risk register.
+- `INTERFACES.md`: CLI/RPC/event/data contracts, timeout budgets, and failure semantics.
+- `VALIDATION.md`: promotion gate design, evidence model, and bounded execution.
+- `SEMANTICS.md`: state machines, invariants, replay semantics, and idempotency contracts.
+- `OPERATIONS.md`: SLOs, monitoring, incident response, and capacity planning.
+- `SECURITY.md`: trust boundaries, STRIDE threats, auth/authz model, and supply-chain controls.
 
 ## Canonical `.decapod/` Layout
+- `.decapod/data/`: canonical control-plane state (SQLite + ledgers).
+- `.decapod/generated/specs/`: living project specs for humans and agents.
+- `.decapod/generated/context/`: deterministic context capsules.
+- `.decapod/generated/policy/context_capsule_policy.json`: repo-native JIT context policy contract.
+- `.decapod/generated/artifacts/provenance/`: promotion manifests and convergence checklist.
+- `.decapod/generated/artifacts/inventory/`: deterministic release inventory.
+- `.decapod/generated/artifacts/diagnostics/`: opt-in diagnostics artifacts.
+- `.decapod/workspaces/`: isolated todo-scoped git worktrees.
 
-- `.decapod/data/`: Canonical control-plane state (SQLite + ledgers).
-- `.decapod/generated/specs/`: Living project specs for humans and agents.
-- `.decapod/generated/context/`: Deterministic context capsules.
-- `.decapod/generated/policy/context_capsule_policy.json`: Repo-native JIT context policy contract.
-- `.decapod/generated/artifacts/provenance/`: Promotion manifests and convergence checklist.
-- `.decapod/generated/artifacts/inventory/`: Deterministic release inventory.
-- `.decapod/generated/artifacts/diagnostics/`: Opt-in diagnostics artifacts.
-- `.decapod/workspaces/`: Isolated todo-scoped git worktrees.
+## Day-0 Onboarding Checklist
+- [ ] Confirm user-facing outcome and non-goals in `INTENT.md`.
+- [ ] Confirm architecture topology and runtime/deployment model in `ARCHITECTURE.md`.
+- [ ] Confirm all CLI/RPC interfaces and error taxonomy in `INTERFACES.md`.
+- [ ] Confirm proof surfaces and blocking gates in `VALIDATION.md`.
+- [ ] Confirm state transitions and invariants in `SEMANTICS.md`.
+- [ ] Confirm SLO/monitoring/incident ownership in `OPERATIONS.md`.
+- [ ] Confirm trust boundaries and threat mitigations in `SECURITY.md`.
+- [ ] Confirm docs + architecture diagram + changelog proof gates are defined.
+- [ ] Confirm tests pass locally and in CI.
+- [ ] Attach evidence artifacts before promotion.
 
-## Stability Guarantees
-
-| Surface | Stability |
-|---------|-----------|
-| Core CLI commands | Stable |
-| JSON-RPC operations | Stable |
-| Validation gate | Stable |
-| Schema format | Stable |
-| Error codes | Stable |
-
-## Non-Goals (Explicitly)
-
-- No daemon mode
-- No remote/cloud dependency for core function
-- No agent framework / prompt management
-- No cross-repo state sync
+## Agent Directive
+- Specs are executable governance, not placeholders. Before coding: resolve ambiguity in these docs. Before marking done: validate, update drifted sections, and attach evidence.

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -1,0 +1,71 @@
+# Security
+
+## Threat Model
+```mermaid
+flowchart LR
+  U[Agent/User] --> B[Decapod Trust Boundary]
+  B --> S[(Repo Store)]
+  B --> US[(User Store)]
+  B --> G[Git Worktree]
+  B --> A[Artifacts]
+```
+
+## STRIDE Table
+| Threat | Surface | Mitigation | Validation |
+|---|---|---|---|
+| Spoofing | session/auth boundary | session token + password gate | session tests |
+| Tampering | task/proof artifacts | append-only logs + hash receipts | validate + hash checks |
+| Repudiation | task completion claims | claim/done audit trail | ledger review |
+| Information Disclosure | logs/artifacts | secret redaction + classification | security scan |
+| DoS | validate/store contention | bounded timeouts + retry policy | timeout gate |
+| Elevation of Privilege | protected branch/store boundaries | interlock enforcement | interlock tests |
+
+## Authentication
+- Session acquisition required for privileged operations.
+- `DECAPOD_SESSION_PASSWORD` gate enforced when configured.
+- Session lifecycle is explicit (`acquire`, `status`, `release`).
+
+## Authorization
+- Task ownership controls claim/done transitions.
+- Store mode limits write scope (repo vs user).
+- Protected branches block mutate operations.
+
+## Data Classification
+| Class | Examples | Handling |
+|---|---|---|
+| Public | docs/spec text | normal repo controls |
+| Internal | operational logs/metrics | least privilege access |
+| Sensitive | credentials/tokens/session secrets | redacted logs, restricted storage |
+
+## Sensitive Data Handling
+- Never log raw tokens/secrets.
+- Store sensitive values in env/secure stores only.
+- Redact secrets in traces and diagnostics artifacts.
+
+## Supply Chain Security
+- Rust toolchain: `cargo audit`, `cargo deny`, `cargo vet`.
+- CI must surface critical/high vulnerabilities as blockers.
+- Release artifacts should include provenance and checksums.
+
+## Secrets Management
+| Secret | Source | Rotation | Consumer |
+|---|---|---|---|
+| Session password | environment/secret manager | periodic | session gate |
+| API credentials | environment/secret manager | periodic | external dependency integrations |
+
+## Security Testing
+| Test Type | Cadence | Tooling |
+|---|---|---|
+| Dependency vulnerability scan | per PR + scheduled | cargo-audit/cargo-deny |
+| Interlock regression tests | per PR | cargo test suites |
+| Secret redaction checks | per PR | test fixtures + grep rules |
+
+## Compliance
+- Evidence artifacts must trace security-relevant gate outcomes.
+- Security exceptions require documented owner, reason, and expiry.
+
+## Pre-Promotion Security Checklist
+- [ ] Threat model updated for changed trust boundaries.
+- [ ] Auth/authz and interlock tests pass.
+- [ ] Dependency scan has no unresolved critical/high findings.
+- [ ] Sensitive data handling and redaction checks pass.

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,323 +1,58 @@
 # Semantics
 
 ## State Machines
-
-### WorkUnit Status Machine
-
 ```mermaid
 stateDiagram-v2
-    [*] --> Draft: todo add
-    Draft --> Claimed: todo claim
-    Claimed --> Verified: todo done + validate pass
-    Verified --> [*]
-    Claimed --> Draft: todo release
-    Draft --> Draft: Idempotent
-    Claimed --> Claimed: Idempotent
-    Verified --> Verified: Idempotent
+  [*] --> Draft
+  Draft --> Claimed: todo claim
+  Claimed --> Verified: todo done + validate pass
+  Claimed --> Draft: todo release
+  Verified --> [*]
 ```
 
-**States**:
-| State | Meaning | CLI Transition | Enforced By |
-|-------|---------|----------------|-------------|
-| `Draft` | Task created, not yet started | `todo add` | Binary |
-| `Claimed` | Agent has claimed this task | `todo claim` | Binary |
-| `Verified` | All proof gates passed + `todo done` | `todo done` (gated by validate) | Binary |
-| `Archived` | Task completed and archived | `todo archive` | Binary |
+| From | Event | To | Guard | Side Effect |
+|---|---|---|---|---|
+| Draft | `todo claim` | Claimed | active session + workspace | assign owner |
+| Claimed | `todo done` | Verified | blocking gates pass | persist proof receipt |
+| Claimed | `todo release` | Draft | current owner releases | clear ownership |
 
-**Actual Transitions** (from code analysis):
-- `Draft` → `Claimed` via `decapod todo claim`
-- `Claimed` → `Verified` via `decapod todo done` (requires passing `decapod validate`)
-- `Claimed` → `Draft` via `decapod todo release`
+## Invariants
+| Invariant | Type | Validation |
+|---|---|---|
+| Protected branches cannot mutate | System | workspace interlock gate |
+| Verified status requires proof | System | validate + proof_plan checks |
+| Store boundaries remain isolated | Data | store boundary checks |
+| Mutation receipts are deterministic | Data | canonical hash generation |
 
-**Note**: `Executing` is an agent-local internal state, NOT persisted in the ledger. Agents track "work in progress" locally; the ledger only knows `Claimed`.
+## Event Sourcing Schema
+| Field | Type | Meaning |
+|---|---|---|
+| event_id | ULID/string | unique event identifier |
+| task_id | string | aggregate root |
+| action | string | state transition action |
+| actor | string | who triggered change |
+| occurred_at | timestamp | ordering marker |
+| payload | json | transition metadata |
 
-**Invariant**: Cannot transition to `Verified` without:
-1. Passing `decapod validate` first
-2. All gates in `proof_plan` have passing `proof_results`
-
-### Store Boundary Enforcement
-
-```mermaid
-graph TD
-    subgraph "Write Operation"
-        A[Agent Command] --> R{Store Flag?}
-    end
-
-    R -->|"--store repo"| Repo[Repo Store]
-    R -->|"--store user"| User[User Store]
-    R -->|none| D{Default}
-
-    D -->|"in repo context"| Repo
-    D -->|"in user context"| User
-
-    Repo -.->|"cross-store write attempt"| Violate[STORE_BOUNDARY_VIOLATION]
-    User -.->|"cross-store write attempt"| Violate
-
-    style Violate fill:#f99,stroke:#333
-    style Repo fill:#ff9,stroke:#333
-    style User fill:#9ff,stroke:#333
-```
-
-**Invariant**: Explicit `--store` flag required. Cross-store writes produce `STORE_BOUNDARY_VIOLATION`.
-
-## Invariants (Machine-Checkable)
-
-```mermaid
-flowchart TB
-    subgraph Invariant["Invariant Enforcement"]
-        I1[Protected Branch<br/>Check]
-        I2[Session Active<br/>Check]
-        I3[Proof Gates<br/>Check]
-        I4[Store Boundary<br/>Check]
-        I5[Timeout<br/>Check]
-    end
-
-    subgraph Verify["Verification Commands"]
-        V1[decapod workspace status]
-        V2[decapod session status]
-        V3[decapod validate]
-        V4[decapod validate]
-        V5[decapod validate]
-    end
-
-    subgraph Fail["Failure Codes"]
-        F1[WORKSPACE_REQUIRED]
-        F2[SESSION_REQUIRED]
-        F3[VERIFICATION_REQUIRED]
-        F4[STORE_BOUNDARY_VIOLATION]
-        F5[VALIDATE_TIMEOUT_OR_LOCK]
-    end
-
-    I1 -->|"branch matches"| V1 --> F1
-    I2 -->|"no session"| V2 --> F2
-    I3 -->|"missing proof"| V3 --> F3
-    I4 -->|"cross-store"| V4 --> F4
-    I5 -->|"timeout"| V5 --> F5
-
-    style I1 fill:#f99,stroke:#333
-    style I3 fill:#f99,stroke:#333
-    style I4 fill:#f99,stroke:#333
-```
-
-| Invariant | Verification Command | Failure Code |
-|-----------|---------------------|--------------|
-| No mutation on protected branch | `decapod workspace status` → `git_is_protected` | `WORKSPACE_REQUIRED` |
-| Verified requires passing proof gates | `decapod validate` | `VERIFICATION_REQUIRED` |
-| Store boundary not crossed | `decapod validate` | `STORE_BOUNDARY_VIOLATION` |
-| Validate terminates boundedly | `decapod validate` (30s timeout) | `VALIDATE_TIMEOUT_OR_LOCK` |
-| Session required for operations | `decapod session status` | `SESSION_REQUIRED` |
-
-## Event Log Semantics
-
-### Event Flow
-
-```mermaid
-sequenceDiagram
-    participant Agent
-    participant CLI as Decapod CLI
-    participant Parse as Command Parse
-    participant Validate as Validation
-    participant Store as JSONL/SQLite
-
-    Agent->>CLI: decapod todo add "task"
-    CLI->>Parse: validate command
-    Parse->>Validate: check session + workspace
-    Validate->>Store: BEGIN transaction
-    Store-->>Validate: lock acquired
-    Validate->>Store: APPEND event to todos.jsonl
-    Validate->>Store: WRITE to SQLite
-    Validate->>Store: COMMIT transaction
-    Store-->>Validate: success
-    Validate->>Store: COMPUTE receipt hash
-    Validate-->>CLI: receipt with hash
-    CLI-->>Agent: task_id, status=Draft, hash
-```
-
-### Append-Only Rule
-
-All state changes are logged as events in JSONL files:
-
-- `.decapod/data/todos.jsonl` - Task lifecycle events
-- `.decapod/data/knowledge.promotions.jsonl` - Knowledge promotions
-- `.decapod/data/decisions.jsonl` - Agent decisions
-
-### Receipt Hashing
-
-Every mutation produces a SHA256 receipt:
-
-```rust
-// From workunit.rs
-pub fn canonical_hash_hex(&self) -> String {
-    let bytes = self.canonical_json_bytes()?;
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    format!("{:x}", hasher.finalize())
-}
-```
-
-**Invariant**: Receipt hash is computed from canonicalized JSON (sorted keys, deduplicated arrays).
-
-### Deterministic Replay
-
-Given the same event log sequence, replay must produce identical state hashes.
-
-## Proof Surface Semantics
-
-### Validation Gate Contract
-
-```
-decapod validate --store repo --format json
-```
-
-**Output Schema**:
-```json
-{
-  "gate": "validate",
-  "timestamp": "ISO8601",
-  "results": [
-    { "name": "workspace_isolation", "status": "pass|fail", "detail": "..." }
-  ],
-  "receipt": {
-    "hash": "sha256:...",
-    "touched_paths": ["path1", "path2"]
-  }
-}
-```
-
-**Bounded Execution**: Must terminate within 30 seconds or return `VALIDATE_TIMEOUT_OR_LOCK`.
-
-### Capabilities Contract
-
-```mermaid
-flowchart LR
-    subgraph Command["CLI Command"]
-        C[decapod capabilities<br/>--format json]
-    end
-
-    subgraph Output["JSON Output"]
-        V[version]
-        CAP[capabilities]
-        SUB[subsystems]
-        INT[interlock_codes]
-        WS[workspace]
-    end
-
-    C --> Output
-    
-    V --> V1[semver]
-    CAP --> CAP1[name]
-    CAP --> CAP2[description]
-    CAP --> CAP3[stability]
-    SUB --> SUB1[name]
-    SUB --> SUB2[status]
-    SUB --> SUB3[ops]
-    INT --> INT1[workspace_required]
-    INT --> INT2[verification_required]
-    INT --> INT3[store_boundary_violation]
-    WS --> WS1[protected_patterns]
-    WS --> WS2[docker_available]
-    WS --> WS3[enforcement_available]
-
-    style C fill:#9ff,stroke:#333
-    style Output fill:#ff9,stroke:#333
-```
-
-```
-decapod capabilities --format json
-```
-
-**Output Schema**:
-```json
-{
-  "version": "semver",
-  "capabilities": [
-    { "name": "...", "description": "...", "stability": "stable|beta" }
-  ],
-  "subsystems": [
-    { "name": "...", "status": "active", "ops": ["op1", "op2"] }
-  ],
-  "interlock_codes": ["WORKSPACE_REQUIRED", "VERIFICATION_REQUIRED", ...]
-}
-```
-
-**Invariant**: Adding a new capability/subsystem/op requires updating this output.
-
-### Schema Contract
-
-```
-decapod data schema --format json --deterministic
-```
-
-**Output**: JSON schema for all entities with volatile fields (timestamps) removed when `--deterministic` is passed.
-
-**Invariant**: Schema changes are breaking changes and require version bump.
+## Replay Semantics
+- Replay uses append order from canonical JSONL logs.
+- Determinism target: same event sequence yields same task states and proof hashes.
+- Lock/contention does not reorder committed events.
 
 ## Error Code Semantics
+- `WORKSPACE_REQUIRED`: mutation attempted on protected branch.
+- `VERIFICATION_REQUIRED`: completion attempted without proof pass.
+- `STORE_BOUNDARY_VIOLATION`: cross-store write attempted.
+- `VALIDATE_TIMEOUT_OR_LOCK`: bounded execution exceeded or lock unresolved.
 
-| Code | Trigger Condition | Remediation |
-|------|------------------|--------------|
-| `WORKSPACE_REQUIRED` | Operating on protected branch | Run `decapod workspace ensure` |
-| `VERIFICATION_REQUIRED` | Claiming done without proof | Run `decapod validate` |
-| `STORE_BOUNDARY_VIOLATION` | Cross-store write detected | Use explicit `--store` flag |
-| `VALIDATE_TIMEOUT_OR_LOCK` | DB contention > timeout | Retry with backoff |
-| `SESSION_REQUIRED` | No active session | Run `decapod session acquire` |
+## Domain Rules
+- A task has exactly one active primary owner at a time.
+- Completion is invalid unless proof receipts are current.
+- Governance artifacts are append-only and auditable.
 
-## Agent Loop Semantics
-
-### Complete Agent Workflow
-
-```mermaid
-stateDiagram-v2
-    [*] --> NoSession: Agent starts
-    
-    NoSession --> Session: rpc --op agent.init
-    Session --> ProtectedBranch: workspace status
-    ProtectedBranch --> WorkspaceOk: git_is_protected=false
-    
-    WorkspaceOk --> AddTask: todo add
-    AddTask --> Draft: status=Draft
-    
-    Draft --> ClaimTask: todo claim
-    ClaimTask --> Claimed: status=Claimed
-    
-    Claimed --> Work: Agent edits files
-    Work --> Tests: Run tests
-    
-    Tests --> Validate: decapod validate
-    Validate --> Valid: exit 0
-    Valid --> Done: todo done
-    
-    Validate --> Invalid: exit non-zero
-    Invalid --> Work: Fix issues
-    
-    Done --> [*]
-    
-    ProtectedBranch --> WorkspaceOk: workspace ensure
-```
-
-### Step-by-Step Contract
-
-```
-1. decapod rpc --op agent.init
-   → Returns: session_id, allowed_next_ops, context_capsule
-
-2. decapod workspace ensure
-   → Returns: branch_name, worktree_path
-   → Invariant: Cannot be on main/master
-
-3. decapod todo add --text "..."
-   → Returns: task_id, events[]
-   → Creates: Draft status
-
-4. (repeat)
-   decapid <task_idod todo claim -->
-   → Transitions: Draft → Claimed
-
-5. decapod todo done --id <task_id>
-   → Transitions: Claimed → Verified
-   → Requires: proof_plan gates passed
-
-6. decapod validate
-   → Returns: pass/fail with receipt
-   → Invariant: Must pass before claiming done
-```
+## Idempotency Contracts
+| Operation | Idempotency Key | Duplicate Behavior |
+|---|---|---|
+| `todo claim` | task_id + agent_id | no-op if already claimed by same agent |
+| `todo done` | task_id + latest proof receipt | no-op if already verified with same proof |
+| `session acquire` | session token | returns active session envelope |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- schema/interface: expand canonical project specs set to include `SEMANTICS.md`, `OPERATIONS.md`, and `SECURITY.md`
+- docs/scaffold: scaffold-v2 project specs with adaptive topology/sequence diagrams, richer interface contracts, validation decision flow, and security/operations directives
+
+### Changed
+
+- validate: add architecture runtime/deployment section enforcement and conditional structure checks for semantics/operations/security specs
+- docs/specs: upgrade Decapod's checked-in generated specs to industry-grade operational/security semantics with explicit proof surfaces
+
 ## [0.44.6](https://github.com/DecapodLabs/decapod/compare/v0.44.5...v0.44.6) - 2026-02-25
 
 ### Fixed

--- a/constitution/interfaces/PROJECT_SPECS.md
+++ b/constitution/interfaces/PROJECT_SPECS.md
@@ -17,6 +17,9 @@ Decapod-managed projects MUST contain exactly this canonical local specs surface
 3. `.decapod/generated/specs/ARCHITECTURE.md`
 4. `.decapod/generated/specs/INTERFACES.md`
 5. `.decapod/generated/specs/VALIDATION.md`
+6. `.decapod/generated/specs/SEMANTICS.md`
+7. `.decapod/generated/specs/OPERATIONS.md`
+8. `.decapod/generated/specs/SECURITY.md`
 
 This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT_SPECS`) and consumed by:
 - `decapod init` scaffolding
@@ -33,6 +36,9 @@ This set is hardcoded in the Decapod binary (`core::project_specs::LOCAL_PROJECT
 | `.decapod/generated/specs/ARCHITECTURE.md` | Technical implementation architecture | `interfaces/ARCHITECTURE_FOUNDATIONS.md` |
 | `.decapod/generated/specs/INTERFACES.md` | Inbound/outbound contracts and failure semantics | `interfaces/CONTROL_PLANE.md` |
 | `.decapod/generated/specs/VALIDATION.md` | Proof surfaces, promotion gates, and evidence model | `interfaces/TESTING.md` |
+| `.decapod/generated/specs/SEMANTICS.md` | State machines, invariants, replay semantics, and idempotency contracts | `interfaces/PROJECT_SPECS.md` |
+| `.decapod/generated/specs/OPERATIONS.md` | SLO/SLI targets, monitoring, incident operations, and deployment readiness | `interfaces/PROJECT_SPECS.md` |
+| `.decapod/generated/specs/SECURITY.md` | Threat model, trust boundaries, auth/authz, and supply-chain security posture | `interfaces/PROJECT_SPECS.md` |
 | `.decapod/generated/specs/README.md` | Local specs index and navigation | `core/INTERFACES.md` |
 
 ---

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -12,6 +12,9 @@ pub const LOCAL_PROJECT_SPECS_INTENT: &str = ".decapod/generated/specs/INTENT.md
 pub const LOCAL_PROJECT_SPECS_ARCHITECTURE: &str = ".decapod/generated/specs/ARCHITECTURE.md";
 pub const LOCAL_PROJECT_SPECS_INTERFACES: &str = ".decapod/generated/specs/INTERFACES.md";
 pub const LOCAL_PROJECT_SPECS_VALIDATION: &str = ".decapod/generated/specs/VALIDATION.md";
+pub const LOCAL_PROJECT_SPECS_SEMANTICS: &str = ".decapod/generated/specs/SEMANTICS.md";
+pub const LOCAL_PROJECT_SPECS_OPERATIONS: &str = ".decapod/generated/specs/OPERATIONS.md";
+pub const LOCAL_PROJECT_SPECS_SECURITY: &str = ".decapod/generated/specs/SECURITY.md";
 pub const LOCAL_PROJECT_SPECS_MANIFEST: &str = ".decapod/generated/specs/.manifest.json";
 pub const LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA: &str = "1.0.0";
 
@@ -48,6 +51,21 @@ pub const LOCAL_PROJECT_SPECS: &[LocalProjectSpec] = &[
         role: "proof_and_gate_plan",
         constitution_ref: "interfaces/TESTING.md",
     },
+    LocalProjectSpec {
+        path: LOCAL_PROJECT_SPECS_SEMANTICS,
+        role: "state_machines_and_invariants",
+        constitution_ref: "interfaces/PROJECT_SPECS.md",
+    },
+    LocalProjectSpec {
+        path: LOCAL_PROJECT_SPECS_OPERATIONS,
+        role: "operational_readiness",
+        constitution_ref: "interfaces/PROJECT_SPECS.md",
+    },
+    LocalProjectSpec {
+        path: LOCAL_PROJECT_SPECS_SECURITY,
+        role: "security_posture",
+        constitution_ref: "interfaces/PROJECT_SPECS.md",
+    },
 ];
 
 #[derive(Debug, Clone, Default)]
@@ -56,6 +74,9 @@ pub struct LocalProjectSpecsContext {
     pub architecture: Option<String>,
     pub interfaces: Option<String>,
     pub validation: Option<String>,
+    pub semantics: Option<String>,
+    pub operations: Option<String>,
+    pub security: Option<String>,
     pub canonical_paths: Vec<String>,
     pub constitution_refs: Vec<String>,
     pub update_guidance: String,
@@ -94,6 +115,12 @@ pub fn local_project_specs_context(project_root: &Path) -> LocalProjectSpecsCont
     ctx.interfaces = read_if_exists(project_root, LOCAL_PROJECT_SPECS_INTERFACES)
         .and_then(|s| first_meaningful_line(&s));
     ctx.validation = read_if_exists(project_root, LOCAL_PROJECT_SPECS_VALIDATION)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.semantics = read_if_exists(project_root, LOCAL_PROJECT_SPECS_SEMANTICS)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.operations = read_if_exists(project_root, LOCAL_PROJECT_SPECS_OPERATIONS)
+        .and_then(|s| first_meaningful_line(&s));
+    ctx.security = read_if_exists(project_root, LOCAL_PROJECT_SPECS_SECURITY)
         .and_then(|s| first_meaningful_line(&s));
     ctx.update_guidance = "Treat .decapod/generated/specs/*.md as living project contracts: when user intent, interfaces, architecture, or proof gates change, update these specs before implementation proceeds.".to_string();
     ctx


### PR DESCRIPTION
## Summary
- upgrade init scaffolding from v1 to scaffold-v2 with dense project-spec templates
- expand canonical specs surface from 5 to 8 files by adding `SEMANTICS.md`, `OPERATIONS.md`, and `SECURITY.md`
- add language-adaptive helpers for test criteria, error taxonomy examples, supply-chain tools, and logging hints
- add adaptive topology + happy-path diagrams based on product type
- extend validate gates to enforce new architecture sections and conditionally check new spec files (warn-only for missing files in older repos)
- update constitution mapping (`PROJECT_SPECS.md`) and Decapod's checked-in generated specs to the new quality bar
- add changelog entries for schema/interface + scaffold contract changes

## Verification
- `cargo build`
- `cargo test --test agent_rpc_suite --test examples_interop`
- `./target/debug/decapod validate` (pass=191 fail=0)
- manual smoke: fresh `decapod init --force` in temp Rust project generates all 8 dense specs

## Notes
- backward compatibility is preserved for existing repositories via `if path.exists()` checks for the newly introduced spec files
