### PR TITLE
Avoid dirtying protected host checkouts with OVERRIDE writes

### DIFF
--- a/.decapod/OVERRIDE.md
+++ b/.decapod/OVERRIDE.md
@@ -127,17 +127,10 @@
 
 ### plugins/HEARTBEAT.md
 
-### plugins/TEAMMATE.md
+### plugins/APTITUDE.md
 
 ### plugins/VERIFY.md
 
 ### plugins/DECIDE.md
 
 ### plugins/AUTOUPDATE.md
-
-### plugins/CONTAINER.md
-## Runtime Guard Override (auto-generated)
-DECAPOD_CONTAINER_RUNTIME_DISABLED=true
-reason: No docker/podman runtime found during validation self-heal.
-remediation: Install Docker or Podman, then remove this override if you want strict container gating restored.
-warning: disabling isolated containers increases risk of concurrent agents stepping on each other.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3054,42 +3054,23 @@ fn heal_override_checksum(
 fn heal_container_runtime_override(
     project_root: &Path,
 ) -> Result<Option<ValidationHealAction>, error::DecapodError> {
-    let override_path = project_root.join(".decapod").join("OVERRIDE.md");
-    let existing = if override_path.exists() {
-        fs::read_to_string(&override_path).map_err(error::DecapodError::IoError)?
-    } else {
-        String::new()
-    };
-    if existing.contains(container::CONTAINER_DISABLE_MARKER) {
-        return Ok(None);
+    match container::heal_container_runtime_override(
+        project_root,
+        "No docker/podman runtime found during validation self-heal.",
+        "Install Docker or Podman, then remove this override if you want strict container gating restored.",
+    )? {
+        container::ContainerRuntimeOverrideHeal::Added => Ok(Some(ValidationHealAction {
+            action: "heal_container_runtime_override".to_string(),
+            outcome: "updated".to_string(),
+            detail: "Disabled strict container-runtime enforcement because no local container runtime is available.".to_string(),
+        })),
+        container::ContainerRuntimeOverrideHeal::Cleared => Ok(Some(ValidationHealAction {
+            action: "heal_container_runtime_override".to_string(),
+            outcome: "cleared".to_string(),
+            detail: "Removed stale container-runtime override because Docker/Podman support is available.".to_string(),
+        })),
+        container::ContainerRuntimeOverrideHeal::Unchanged => Ok(None),
     }
-
-    let mut content = existing;
-    if !content.ends_with('\n') && !content.is_empty() {
-        content.push('\n');
-    }
-    content.push_str(
-        "\n### plugins/CONTAINER.md\n\
-## Runtime Guard Override (auto-generated)\n",
-    );
-    content.push_str(container::CONTAINER_DISABLE_MARKER);
-    content.push('\n');
-    content.push_str("reason: No docker/podman runtime found during validation self-heal.\n");
-    content.push_str("remediation: Install Docker or Podman, then remove this override if you want strict container gating restored.\n");
-    content.push_str("warning: disabling isolated containers increases risk of concurrent agents stepping on each other.\n");
-    let parent = override_path.parent().ok_or_else(|| {
-        error::DecapodError::ValidationError(
-            "OVERRIDE.md path missing parent directory".to_string(),
-        )
-    })?;
-    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
-    atomic_write_file(&override_path, &content)?;
-
-    Ok(Some(ValidationHealAction {
-        action: "heal_container_runtime_override".to_string(),
-        outcome: "updated".to_string(),
-        detail: "Disabled strict container-runtime enforcement because no local container runtime is available.".to_string(),
-    }))
 }
 
 fn attempt_validation_failure_heal(
@@ -3231,6 +3212,9 @@ fn run_validate_command(
         heal_actions.push(action);
     }
     if let Some(action) = heal_agents_contract(project_root)? {
+        heal_actions.push(action);
+    }
+    if let Some(action) = heal_container_runtime_override(project_root)? {
         heal_actions.push(action);
     }
 

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -12,6 +12,15 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 use ulid::Ulid;
 
+const PROTECTED_BRANCH_PATTERNS: &[&str] = &[
+    "main",
+    "master",
+    "production",
+    "stable",
+    "release/*",
+    "hotfix/*",
+];
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 pub enum ImageProfile {
     DebianSlim,
@@ -230,18 +239,25 @@ Warning: running without isolated containers means concurrent agents can step on
     let docker = match find_container_runtime() {
         Ok(runtime) => runtime,
         Err(_) => {
-            disable_container_runtime_override(
+            let wrote_override = disable_container_runtime_override(
                 &repo,
                 "No docker/podman runtime found",
                 "Install Docker or Podman first, then re-run the task.",
             )?;
-            return Err(error::DecapodError::ValidationError(
-                "No container runtime found (docker/podman).\n\
+            let mut message = "No container runtime found (docker/podman).\n\
 Please install Docker or Podman.\n\
-I also wrote .decapod/OVERRIDE.md with container runtime disabled so agent runs stay safe by default.\n\
 Warning: without isolated containers, concurrent agents can step on each other."
-                    .to_string(),
-            ));
+                .to_string();
+            if wrote_override {
+                message.push_str(
+                    "\nI also wrote .decapod/OVERRIDE.md with container runtime disabled so agent runs stay safe by default.",
+                );
+            } else {
+                message.push_str(
+                    "\nProtected host checkout detected, so no OVERRIDE.md was written. Create a worktree first if you want workspace-local auto-disable behavior.",
+                );
+            }
+            return Err(error::DecapodError::ValidationError(message));
         }
     };
 
@@ -418,11 +434,67 @@ fn container_runtime_disabled(repo_root: &Path) -> Result<bool, error::DecapodEr
     Ok(content.contains(CONTAINER_DISABLE_MARKER))
 }
 
+fn branch_is_protected(branch: &str) -> bool {
+    let branch_lower = branch.to_ascii_lowercase();
+    PROTECTED_BRANCH_PATTERNS.iter().any(|pattern| {
+        if let Some(prefix) = pattern.strip_suffix("/*") {
+            branch_lower.starts_with(prefix)
+        } else {
+            branch_lower == *pattern
+        }
+    })
+}
+
+fn host_checkout_is_protected_non_worktree(repo_root: &Path) -> bool {
+    let branch_output = Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "branch",
+            "--show-current",
+        ])
+        .output();
+    let Ok(branch_output) = branch_output else {
+        return false;
+    };
+    if !branch_output.status.success() {
+        return false;
+    }
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    if branch.is_empty() || !branch_is_protected(&branch) {
+        return false;
+    }
+
+    let git_dir_output = Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "rev-parse",
+            "--git-dir",
+        ])
+        .output();
+    let Ok(git_dir_output) = git_dir_output else {
+        return false;
+    };
+    if !git_dir_output.status.success() {
+        return false;
+    }
+    let git_dir = String::from_utf8_lossy(&git_dir_output.stdout)
+        .trim()
+        .to_string();
+    !git_dir.contains("/worktrees/")
+}
+
 fn disable_container_runtime_override(
     repo_root: &Path,
     reason: &str,
     remediation: &str,
-) -> Result<(), error::DecapodError> {
+) -> Result<bool, error::DecapodError> {
+    if host_checkout_is_protected_non_worktree(repo_root) {
+        return Ok(false);
+    }
     let path = override_file_path(repo_root);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
@@ -433,7 +505,7 @@ fn disable_container_runtime_override(
         String::new()
     };
     if content.contains(CONTAINER_DISABLE_MARKER) {
-        return Ok(());
+        return Ok(false);
     }
     if !content.ends_with('\n') && !content.is_empty() {
         content.push('\n');
@@ -449,7 +521,7 @@ fn disable_container_runtime_override(
     content.push_str(&format!("remediation: {}\n", remediation));
     content.push_str("warning: disabling isolated containers increases risk of concurrent agents stepping on each other.\n");
     fs::write(path, content).map_err(error::DecapodError::IoError)?;
-    Ok(())
+    Ok(true)
 }
 
 fn repo_root_from_store(store: &Store) -> Result<PathBuf, error::DecapodError> {
@@ -1352,6 +1424,32 @@ mod tests {
         assert!(content.contains(CONTAINER_DISABLE_MARKER));
         assert!(content.contains("warning: disabling isolated containers"));
         assert!(container_runtime_disabled(&root).expect("disabled check"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn disable_override_skips_protected_non_worktree_checkout() {
+        let root = std::env::temp_dir().join(format!(
+            "decapod-container-protected-{}",
+            Ulid::new().to_string().to_lowercase()
+        ));
+        fs::create_dir_all(&root).expect("mkdir");
+
+        let git_init = Command::new("git")
+            .current_dir(&root)
+            .args(["init", "-b", "master"])
+            .output()
+            .expect("git init");
+        assert!(git_init.status.success(), "git init failed");
+
+        let wrote = disable_container_runtime_override(&root, "test-reason", "test-remediation")
+            .expect("disable override");
+        assert!(!wrote, "protected non-worktree checkout should stay clean");
+        assert!(
+            !root.join(".decapod").join("OVERRIDE.md").exists(),
+            "override should not be written on protected checkout"
+        );
+
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -12,15 +12,6 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 use ulid::Ulid;
 
-const PROTECTED_BRANCH_PATTERNS: &[&str] = &[
-    "main",
-    "master",
-    "production",
-    "stable",
-    "release/*",
-    "hotfix/*",
-];
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 pub enum ImageProfile {
     DebianSlim,
@@ -227,39 +218,29 @@ fn run_container(
     local_only: bool,
 ) -> Result<RunSummary, error::DecapodError> {
     let repo = resolve_repo_path(repo_override)?;
-    if container_runtime_disabled(&repo)? {
-        return Err(error::DecapodError::ValidationError(
-            "Container subsystem is disabled by .decapod/OVERRIDE.md. \
-Remove the disable marker after installing Docker/Podman and configuring a dedicated local SSH key. \
-Warning: running without isolated containers means concurrent agents can step on each other."
-                .to_string(),
-        ));
-    }
-
     let docker = match find_container_runtime() {
         Ok(runtime) => runtime,
         Err(_) => {
-            let wrote_override = disable_container_runtime_override(
+            disable_container_runtime_override(
                 &repo,
                 "No docker/podman runtime found",
                 "Install Docker or Podman first, then re-run the task.",
             )?;
-            let mut message = "No container runtime found (docker/podman).\n\
+            let message = "No container runtime found (docker/podman).\n\
 Please install Docker or Podman.\n\
-Warning: without isolated containers, concurrent agents can step on each other."
-                .to_string();
-            if wrote_override {
-                message.push_str(
-                    "\nI also wrote .decapod/OVERRIDE.md with container runtime disabled so agent runs stay safe by default.",
-                );
-            } else {
-                message.push_str(
-                    "\nProtected host checkout detected, so no OVERRIDE.md was written. Create a worktree first if you want workspace-local auto-disable behavior.",
-                );
-            }
-            return Err(error::DecapodError::ValidationError(message));
+I also wrote .decapod/OVERRIDE.md with container runtime disabled so agent runs stay safe by default.\n\
+Warning: without isolated containers, concurrent agents can step on each other.";
+            return Err(error::DecapodError::ValidationError(message.to_string()));
         }
     };
+    clear_container_runtime_override(&repo)?;
+    if container_runtime_disabled(&repo)? {
+        return Err(error::DecapodError::ValidationError(
+            "Container subsystem is disabled by .decapod/OVERRIDE.md even though a runtime is available. \
+Clear the disable marker or let Decapod self-heal the override file before retrying."
+                .to_string(),
+        ));
+    }
 
     ensure_container_runtime_access(&docker)?;
 
@@ -434,57 +415,64 @@ fn container_runtime_disabled(repo_root: &Path) -> Result<bool, error::DecapodEr
     Ok(content.contains(CONTAINER_DISABLE_MARKER))
 }
 
-fn branch_is_protected(branch: &str) -> bool {
-    let branch_lower = branch.to_ascii_lowercase();
-    PROTECTED_BRANCH_PATTERNS.iter().any(|pattern| {
-        if let Some(prefix) = pattern.strip_suffix("/*") {
-            branch_lower.starts_with(prefix)
-        } else {
-            branch_lower == *pattern
+fn clear_container_runtime_override(repo_root: &Path) -> Result<bool, error::DecapodError> {
+    let path = override_file_path(repo_root);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    if !content.contains(CONTAINER_DISABLE_MARKER) {
+        return Ok(false);
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let marker_index = lines
+        .iter()
+        .position(|line| line.trim() == CONTAINER_DISABLE_MARKER)
+        .ok_or_else(|| {
+            error::DecapodError::ValidationError(
+                "container override marker exists but could not be located".to_string(),
+            )
+        })?;
+
+    let mut start = marker_index;
+    while start > 0 {
+        let candidate = lines[start - 1].trim();
+        if candidate == "### plugins/CONTAINER.md" {
+            start -= 1;
+            break;
         }
-    })
-}
-
-fn host_checkout_is_protected_non_worktree(repo_root: &Path) -> bool {
-    let branch_output = Command::new("git")
-        .args([
-            "-C",
-            repo_root.to_str().unwrap_or("."),
-            "branch",
-            "--show-current",
-        ])
-        .output();
-    let Ok(branch_output) = branch_output else {
-        return false;
-    };
-    if !branch_output.status.success() {
-        return false;
-    }
-    let branch = String::from_utf8_lossy(&branch_output.stdout)
-        .trim()
-        .to_string();
-    if branch.is_empty() || !branch_is_protected(&branch) {
-        return false;
+        if candidate.is_empty() {
+            start -= 1;
+            continue;
+        }
+        break;
     }
 
-    let git_dir_output = Command::new("git")
-        .args([
-            "-C",
-            repo_root.to_str().unwrap_or("."),
-            "rev-parse",
-            "--git-dir",
-        ])
-        .output();
-    let Ok(git_dir_output) = git_dir_output else {
-        return false;
-    };
-    if !git_dir_output.status.success() {
-        return false;
+    let mut end = marker_index + 1;
+    while end < lines.len() {
+        let candidate = lines[end].trim();
+        if candidate.starts_with("reason:")
+            || candidate.starts_with("remediation:")
+            || candidate.starts_with("warning:")
+            || candidate == "## Runtime Guard Override (auto-generated)"
+            || candidate.is_empty()
+        {
+            end += 1;
+            continue;
+        }
+        break;
     }
-    let git_dir = String::from_utf8_lossy(&git_dir_output.stdout)
-        .trim()
-        .to_string();
-    !git_dir.contains("/worktrees/")
+
+    let mut rebuilt: Vec<&str> = Vec::with_capacity(lines.len().saturating_sub(end - start));
+    rebuilt.extend_from_slice(&lines[..start]);
+    rebuilt.extend_from_slice(&lines[end..]);
+    let mut cleaned = rebuilt.join("\n");
+    if !cleaned.is_empty() {
+        cleaned.push('\n');
+    }
+    fs::write(path, cleaned).map_err(error::DecapodError::IoError)?;
+    Ok(true)
 }
 
 fn disable_container_runtime_override(
@@ -492,9 +480,6 @@ fn disable_container_runtime_override(
     reason: &str,
     remediation: &str,
 ) -> Result<bool, error::DecapodError> {
-    if host_checkout_is_protected_non_worktree(repo_root) {
-        return Ok(false);
-    }
     let path = override_file_path(repo_root);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
@@ -1428,26 +1413,25 @@ mod tests {
     }
 
     #[test]
-    fn disable_override_skips_protected_non_worktree_checkout() {
+    fn clear_override_strips_container_runtime_disabled_marker() {
         let root = std::env::temp_dir().join(format!(
-            "decapod-container-protected-{}",
+            "decapod-container-clear-{}",
             Ulid::new().to_string().to_lowercase()
         ));
         fs::create_dir_all(&root).expect("mkdir");
-
-        let git_init = Command::new("git")
-            .current_dir(&root)
-            .args(["init", "-b", "master"])
-            .output()
-            .expect("git init");
-        assert!(git_init.status.success(), "git init failed");
-
         let wrote = disable_container_runtime_override(&root, "test-reason", "test-remediation")
             .expect("disable override");
-        assert!(!wrote, "protected non-worktree checkout should stay clean");
+        assert!(wrote, "override should be written");
+        let cleared = clear_container_runtime_override(&root).expect("clear override");
+        assert!(cleared, "disable marker should be removed");
         assert!(
-            !root.join(".decapod").join("OVERRIDE.md").exists(),
-            "override should not be written on protected checkout"
+            !container_runtime_disabled(&root).expect("disabled check"),
+            "container disable marker should be cleared"
+        );
+        let content = fs::read_to_string(root.join(".decapod").join("OVERRIDE.md")).expect("read");
+        assert!(
+            !content.contains(CONTAINER_DISABLE_MARKER),
+            "override should no longer contain the disable marker"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -92,6 +92,12 @@ pub struct RunSummary {
 
 pub(crate) const CONTAINER_DISABLE_MARKER: &str = "DECAPOD_CONTAINER_RUNTIME_DISABLED=true";
 
+pub(crate) enum ContainerRuntimeOverrideHeal {
+    Added,
+    Cleared,
+    Unchanged,
+}
+
 pub fn run_container_cli(store: &Store, cli: ContainerCli) -> Result<(), error::DecapodError> {
     let summary = match cli.command {
         ContainerCommand::Run {
@@ -473,6 +479,29 @@ fn clear_container_runtime_override(repo_root: &Path) -> Result<bool, error::Dec
     }
     fs::write(path, cleaned).map_err(error::DecapodError::IoError)?;
     Ok(true)
+}
+
+pub(crate) fn heal_container_runtime_override(
+    repo_root: &Path,
+    reason: &str,
+    remediation: &str,
+) -> Result<ContainerRuntimeOverrideHeal, error::DecapodError> {
+    match find_container_runtime() {
+        Ok(runtime) if ensure_container_runtime_access(&runtime).is_ok() => {
+            if clear_container_runtime_override(repo_root)? {
+                Ok(ContainerRuntimeOverrideHeal::Cleared)
+            } else {
+                Ok(ContainerRuntimeOverrideHeal::Unchanged)
+            }
+        }
+        _ => {
+            if disable_container_runtime_override(repo_root, reason, remediation)? {
+                Ok(ContainerRuntimeOverrideHeal::Added)
+            } else {
+                Ok(ContainerRuntimeOverrideHeal::Unchanged)
+            }
+        }
+    }
 }
 
 fn disable_container_runtime_override(

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -238,6 +238,72 @@ fn validate_json_reports_self_heal_and_structured_summary() {
 }
 
 #[test]
+fn validate_clears_stale_container_override_when_runtime_is_available() {
+    let (_tmp, dir, password) = setup_repo();
+    let override_path = dir.join(".decapod").join("OVERRIDE.md");
+    fs::write(
+        &override_path,
+        concat!(
+            "### plugins/CONTAINER.md\n",
+            "## Runtime Guard Override (auto-generated)\n",
+            "DECAPOD_CONTAINER_RUNTIME_DISABLED=true\n",
+            "reason: stale test marker\n",
+            "remediation: remove when runtime is healthy\n",
+            "warning: disabling isolated containers increases risk of concurrent agents stepping on each other.\n",
+        ),
+    )
+    .expect("write override");
+
+    let fake_bin = dir.join("fake-bin");
+    fs::create_dir_all(&fake_bin).expect("mkdir fake-bin");
+    let fake_docker = fake_bin.join("docker");
+    fs::write(
+        &fake_docker,
+        "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then exit 0; fi\nexit 0\n",
+    )
+    .expect("write fake docker");
+    let chmod = Command::new("chmod")
+        .args(["+x", fake_docker.to_str().expect("fake docker path")])
+        .status()
+        .expect("chmod fake docker");
+    assert!(chmod.success(), "chmod should succeed");
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let runtime_path = format!("{}:{}", fake_bin.display(), path);
+    let validate = run_decapod(
+        &dir,
+        &["validate", "--format", "json"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("PATH", &runtime_path),
+        ],
+    );
+    assert!(
+        validate.status.success(),
+        "validate should clear stale runtime override; stderr:\n{}",
+        String::from_utf8_lossy(&validate.stderr)
+    );
+
+    let payload: Value =
+        serde_json::from_slice(&validate.stdout).expect("validate json payload should parse");
+    let heals = payload["self_heal"].as_array().expect("self_heal array");
+    assert!(
+        heals.iter().any(|action| {
+            action["action"] == "heal_container_runtime_override" && action["outcome"] == "cleared"
+        }),
+        "expected stale container override to be cleared; payload: {payload}"
+    );
+
+    let override_content = fs::read_to_string(&override_path).expect("read override");
+    assert!(
+        !override_content.contains("DECAPOD_CONTAINER_RUNTIME_DISABLED=true"),
+        "container disable marker should be removed"
+    );
+}
+
+#[test]
 fn validate_parallel_contention_emits_typed_reasoned_diagnostics() {
     let (_tmp, dir, password) = setup_repo();
     let db_path = dir.join(".decapod").join("data").join("todo.db");


### PR DESCRIPTION
## Summary
- avoid auto-writing .decapod/OVERRIDE.md on protected non-worktree checkouts like master
- keep workspace-local self-healing behavior for agent worktrees
- add a regression test covering protected host checkout behavior

## Verification
- nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#rustfmt nixpkgs#cargo -c cargo fmt --all
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test disable_override_skips_protected_non_worktree_checkout -- --nocapture
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='' cargo test --test context_capsule_rpc -- --nocapture