### PR TITLE
chore: add optional nix dev shell for contributors and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 # Cancel in-progress runs for massive time savings
 concurrency:
@@ -21,6 +22,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse       # 3x faster registry fetching
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings" # LLD linker for 2-3x faster linking
+  NIX_CONFIG: "experimental-features = nix-command flakes"
 
 jobs:
   # COMMIT LINT: Fast check, no build dependency
@@ -75,12 +77,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Format check
-        run: cargo fmt --all -- --check
+        run: nix develop .#ci -c cargo fmt --all -- --check
 
   # CLIPPY: Compiles its own analysis pass, runs in parallel with setup
   clippy:
@@ -90,19 +92,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install LLD
-        uses: ./.github/actions/install-lld
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Restore cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ci-build"
           save-if: "false"
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: nix develop .#ci -c cargo clippy --all-targets --all-features -- -D warnings
 
   # HEALTH: cargo install (release build), no dependency on setup
   health:
@@ -332,17 +332,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install LLD
-        uses: ./.github/actions/install-lld
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Restore cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ci-build"
           save-if: "false"
       - name: Run RPC suite
-        run: cargo test --all-features --test agent_rpc_suite -- --test-threads=1
+        run: nix develop .#ci -c cargo test --all-features --test agent_rpc_suite -- --test-threads=1
 
   # CHAOS: Multi-agent contention + deterministic replay gate
   chaos-replay:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
   # INTEGRATION TESTS: 20 parallel shards.
   # Each shard restores the pre-warmed cache and compiles only its assigned test harnesses.
   test-integration:
-    name: Tests (Integration ${{ matrix.shard }}/20)
+    name: Tests (Integration ${{ matrix.shard + 1 }}/20)
     runs-on: ubuntu-latest
     needs: setup
     strategy:
@@ -284,11 +284,12 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
-      - name: Run integration tests (shard ${{ matrix.shard }}/20)
+      - name: Run integration tests (shard ${{ matrix.shard + 1 }}/20)
         run: |
           set -euo pipefail
           shard=${{ matrix.shard }}
           total=20
+          display=$(( shard + 1 ))
 
           # All test targets: auto-discovered top-level tests + custom [[test]] targets
           # Build the full list from Cargo.toml to include plugins_*, core_tests, etc.
@@ -314,13 +315,13 @@ jobs:
             if [ $(( i % total )) -ne "$shard" ]; then
               continue
             fi
-            echo "Shard $shard running: $t"
+            echo "Shard $display running: $t"
             cargo test --all-features --test "$t" -- --test-threads=4
             ran=$(( ran + 1 ))
           done
 
           if [ "$ran" -eq 0 ]; then
-            echo "Shard $shard: no tests assigned"
+            echo "Shard $display: no tests assigned"
           fi
 
   # RPC SUITE: isolated to avoid contention

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,6 @@ jobs:
           set -euo pipefail
           shard=${{ matrix.shard }}
           total=20
-          shard_index=$(( shard - 1 ))
 
           # All test targets: auto-discovered top-level tests + custom [[test]] targets
           # Build the full list from Cargo.toml to include plugins_*, core_tests, etc.
@@ -312,7 +311,7 @@ jobs:
             if echo "$ISOLATED" | grep -qw "$t"; then
               continue
             fi
-            if [ $(( i % total )) -ne "$shard_index" ]; then
+            if [ $(( (i % total) + 1 )) -ne "$shard" ]; then
               continue
             fi
             echo "Shard $shard running: $t"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,53 +264,13 @@ jobs:
   # INTEGRATION TESTS: 20 parallel shards.
   # Each shard restores the pre-warmed cache and compiles only its assigned test harnesses.
   test-integration:
-    name: Tests (Integration ${{ matrix.display }}/20)
+    name: Tests (Integration ${{ matrix.shard }}/20)
     runs-on: ubuntu-latest
     needs: setup
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - shard: 0
-            display: 1
-          - shard: 1
-            display: 2
-          - shard: 2
-            display: 3
-          - shard: 3
-            display: 4
-          - shard: 4
-            display: 5
-          - shard: 5
-            display: 6
-          - shard: 6
-            display: 7
-          - shard: 7
-            display: 8
-          - shard: 8
-            display: 9
-          - shard: 9
-            display: 10
-          - shard: 10
-            display: 11
-          - shard: 11
-            display: 12
-          - shard: 12
-            display: 13
-          - shard: 13
-            display: 14
-          - shard: 14
-            display: 15
-          - shard: 15
-            display: 16
-          - shard: 16
-            display: 17
-          - shard: 17
-            display: 18
-          - shard: 18
-            display: 19
-          - shard: 19
-            display: 20
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -324,12 +284,12 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
-      - name: Run integration tests (shard ${{ matrix.display }}/20)
+      - name: Run integration tests (shard ${{ matrix.shard }}/20)
         run: |
           set -euo pipefail
           shard=${{ matrix.shard }}
           total=20
-          display=${{ matrix.display }}
+          shard_index=$(( shard - 1 ))
 
           # All test targets: auto-discovered top-level tests + custom [[test]] targets
           # Build the full list from Cargo.toml to include plugins_*, core_tests, etc.
@@ -352,16 +312,16 @@ jobs:
             if echo "$ISOLATED" | grep -qw "$t"; then
               continue
             fi
-            if [ $(( i % total )) -ne "$shard" ]; then
+            if [ $(( i % total )) -ne "$shard_index" ]; then
               continue
             fi
-            echo "Shard $display running: $t"
+            echo "Shard $shard running: $t"
             cargo test --all-features --test "$t" -- --test-threads=4
             ran=$(( ran + 1 ))
           done
 
           if [ "$ran" -eq 0 ]; then
-            echo "Shard $display: no tests assigned"
+            echo "Shard $shard: no tests assigned"
           fi
 
   # RPC SUITE: isolated to avoid contention

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,13 +264,53 @@ jobs:
   # INTEGRATION TESTS: 20 parallel shards.
   # Each shard restores the pre-warmed cache and compiles only its assigned test harnesses.
   test-integration:
-    name: Tests (Integration ${{ matrix.shard + 1 }}/20)
+    name: Tests (Integration ${{ matrix.display }}/20)
     runs-on: ubuntu-latest
     needs: setup
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        include:
+          - shard: 0
+            display: 1
+          - shard: 1
+            display: 2
+          - shard: 2
+            display: 3
+          - shard: 3
+            display: 4
+          - shard: 4
+            display: 5
+          - shard: 5
+            display: 6
+          - shard: 6
+            display: 7
+          - shard: 7
+            display: 8
+          - shard: 8
+            display: 9
+          - shard: 9
+            display: 10
+          - shard: 10
+            display: 11
+          - shard: 11
+            display: 12
+          - shard: 12
+            display: 13
+          - shard: 13
+            display: 14
+          - shard: 14
+            display: 15
+          - shard: 15
+            display: 16
+          - shard: 16
+            display: 17
+          - shard: 17
+            display: 18
+          - shard: 18
+            display: 19
+          - shard: 19
+            display: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -284,12 +324,12 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
-      - name: Run integration tests (shard ${{ matrix.shard + 1 }}/20)
+      - name: Run integration tests (shard ${{ matrix.display }}/20)
         run: |
           set -euo pipefail
           shard=${{ matrix.shard }}
           total=20
-          display=$(( shard + 1 ))
+          display=${{ matrix.display }}
 
           # All test targets: auto-discovered top-level tests + custom [[test]] targets
           # Build the full list from Cargo.toml to include plugins_*, core_tests, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,71 @@ Examples:
 
 ## Local Dev
 
+The `decapod` binary must remain independently buildable and runnable on ordinary machines. Nix is supported here only as an optional contributor shell for local testing, formatting, linting, and CI reproduction.
+
+If you do not use Nix, normal Cargo workflows are still valid:
+
 ```bash
 cargo build --locked
 cargo test --all-features
 cargo clippy --all-targets --all-features -- -D warnings
 decapod validate
 ```
+
+## Optional Nix Dev Shell
+
+This repo includes a `flake.nix` for contributors who want a reproducible local toolchain. It is meant to remove machine-specific setup friction around Rust, `clippy`, `rustfmt`, `clang`, and `lld`.
+
+What it is for:
+
+- Reproducing CI locally.
+- Getting the expected formatter/linter/test toolchain quickly.
+- Avoiding host-specific linker/tooling drift.
+
+What it is not for:
+
+- Running the shipped `decapod` binary in production.
+- Making Nix a runtime dependency of the project.
+- Requiring contributors to adopt Nix just to use Decapod.
+
+### Nix Crash Course
+
+If you have Nix with flakes enabled, enter the shell with:
+
+```bash
+nix develop .#ci
+```
+
+That drops you into a shell with the repo's expected Rust toolchain and linker setup. From there, the normal commands work as usual:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --test agent_rpc_suite -- --test-threads=1
+decapod validate
+```
+
+If you prefer one-off commands without entering an interactive shell:
+
+```bash
+nix develop .#ci -c cargo fmt --all -- --check
+nix develop .#ci -c cargo clippy --all-targets --all-features -- -D warnings
+nix develop .#ci -c cargo test --all-features
+```
+
+### When To Use It
+
+Use the flake when:
+
+- `cargo fmt`, `clippy`, or tests fail because your host toolchain/linker differs from CI.
+- You want to reproduce the Linux CI environment closely.
+- You want a clean, disposable contributor toolchain.
+
+Skip it when:
+
+- Your local Rust setup already works.
+- You are only consuming the `decapod` binary.
+- You do not want Nix on your machine.
 
 ## Release Discipline
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1772852295,
+        "narHash": "sha256-3FB/WzLZSiU2Mc50C9q9VXU1LRUZbsU6UHKmZG1C+hU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c10801f59c68e14c308aea8fa6b0b3d81d43c61e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Optional development shell for Decapod; not required to build or run the decapod binary";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs =
+    {
+      self,
+      flake-utils,
+      nixpkgs,
+      rust-overlay,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+        toolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "clippy"
+            "rustfmt"
+          ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            clang
+            git
+            lld
+            nixfmt-rfc-style
+            openssh
+            pkg-config
+            toolchain
+          ];
+
+          shellHook = ''
+            export CARGO_TERM_COLOR=always
+            export CARGO_INCREMENTAL=0
+            export CARGO_NET_RETRY=10
+            export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+            if [ "$(uname -s)" = "Linux" ]; then
+              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
+              export RUSTFLAGS="-C link-arg=-fuse-ld=lld''${RUSTFLAGS:+ $RUSTFLAGS}"
+            fi
+          '';
+        };
+
+        devShells.ci = self.devShells.${system}.default;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
+        runtimeLibs = with pkgs; [
+          sqlite
+        ];
         toolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [
             "clippy"
@@ -37,6 +40,7 @@
             nixfmt-rfc-style
             openssh
             pkg-config
+            sqlite
             toolchain
           ];
 
@@ -45,6 +49,7 @@
             export CARGO_INCREMENTAL=0
             export CARGO_NET_RETRY=10
             export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath runtimeLibs}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             if [ "$(uname -s)" = "Linux" ]; then
               export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
               export RUSTFLAGS="-C link-arg=-fuse-ld=lld''${RUSTFLAGS:+ $RUSTFLAGS}"


### PR DESCRIPTION
## Summary
- add an optional flake-based contributor shell pinned in flake.lock
- route fmt, clippy, and RPC-suite CI checks through the Nix dev shell
- document the Nix workflow in CONTRIBUTING.md with explicit non-runtime boundaries

## Notes
- this does not make Nix a runtime dependency of the decapod binary
- the dedicated branch was fetched and rebased onto current origin/master before these changes were applied
