### PR TITLE
chore: add optional nix dev shell for contributors and CI

### DIFF
--- a/.decapod/generated/artifacts/provenance/artifact_manifest.json
+++ b/.decapod/generated/artifacts/provenance/artifact_manifest.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "8755e1e39a5738a7fa1e6740eef68fcc0534acad97ce7c561ee71783e014627f"
+      "sha256": "cff06cc06726aa58507496db67879340f30025664a608d49068205850d98a2b0"
     }
   ],
   "kind": "artifact_manifest",

--- a/README.md
+++ b/README.md
@@ -112,13 +112,11 @@ State is local and durable in `.decapod/`. Context, decisions, and traces persis
 
 ## How it works
 
-Every Decapod operation returns one of three things:
+Every Decapod operation returns some combination of three signals.
 
-| Signal | What it does | Think of it as |
-|--------|-------------|----------------|
-| **Advisory** | Tightens intent, reduces wasted loops | Guardrails |
-| **Interlock** | Hard policy boundary — blocks unsafe flow | Circuit breaker |
-| **Attestation** | Structured proof that criteria actually passed | Receipt |
+- **Advisory** narrows the problem. It helps the agent stop wasting cycles on vague intent, missing context, or weak plans.
+- **Interlock** blocks unsafe flow. It is the hard stop that says, "you are about to break policy, violate a boundary, or skip proof."
+- **Attestation** is the receipt. It records what actually happened and whether the required criteria were met.
 
 ```text
 Human Intent
@@ -149,15 +147,19 @@ The deep surface area — interfaces, capsules, eval kernel, knowledge promotion
 
 These are the things Decapod **actually enforces** — break any of these and `decapod validate` will fail:
 
-| Guarantee | Description | Enforcement |
-|-----------|-------------|-------------|
-| **Daemonless** | No background process. Invoked on-demand, exits when done. | `tests/daemonless_lifecycle.rs` |
-| **Repo-native** | All state lives in `.decapod/` as plain files. Nothing phones home. | File-based storage in `src/core/store.rs` |
-| **Proof-gated completion** | `VERIFIED` requires passing proof-plan gates, not narrative claims. | WorkUnit status machine + `tests/workunit_publish_gate.rs` |
-| **Workspace isolation** | Agents cannot mutate protected branches directly. Must use isolated worktrees. | Git worktree enforcement + `tests/workspace_interlock.rs` |
-| **Bounded validation** | `decapod validate` terminates in bounded time, never hangs. | `tests/validate_termination.rs` + timeout enforcement |
-| **Store boundary** | Agents must use CLI, not direct file access to `.decapod/*`. | Validation gates + broker |
-| **Session required** | Mutations require active session with credentials. | Session auth on mutation commands |
+Decapod stays daemonless. There is no background service to keep alive. It runs on demand and exits when the call is done. That behavior is enforced by [tests/daemonless_lifecycle.rs](tests/daemonless_lifecycle.rs).
+
+Decapod stays repo-native. State lives in `.decapod/` as plain files and local data, rather than an external control-plane service. The storage model is implemented in [src/core/store.rs](src/core/store.rs).
+
+Completion is proof-gated. `VERIFIED` is not a vibe-based status; it only exists when the proof plan passes. That path is enforced by the WorkUnit status machinery and [tests/workunit_publish_gate.rs](tests/workunit_publish_gate.rs).
+
+Workspace isolation is mandatory. Agents cannot mutate protected branches directly and are expected to work in isolated worktrees. That is enforced by the workspace interlock and [tests/workspace_interlock.rs](tests/workspace_interlock.rs).
+
+Validation is bounded. `decapod validate` must terminate in finite time instead of hanging indefinitely. That guarantee is enforced by [tests/validate_termination.rs](tests/validate_termination.rs) and the timeout logic around validation gates.
+
+The store boundary is real. Agents are expected to use Decapod command surfaces instead of mutating `.decapod/*` directly. That is enforced by validation gates and the broker layer.
+
+Mutations require a session. State-changing operations need active credentials, and session checks are part of the mutation path.
 
 These are **aspirational** (we're working on them):
 


### PR DESCRIPTION
## Summary
- add an optional flake-based contributor shell pinned in flake.lock
- route fmt, clippy, and RPC-suite CI checks through the Nix dev shell
- document the Nix workflow for contributors and simplify README language
- make integration shard labels and routing one-based

## Notes
- this does not make Nix a runtime dependency of the decapod binary
- the branch is based on current master and keeps Nix usage scoped to local development and CI
