### PR TITLE
Improve Decapod init bootstrap UX

### DIFF
--- a/.decapod/generated/artifacts/provenance/artifact_manifest.json
+++ b/.decapod/generated/artifacts/provenance/artifact_manifest.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "path": "README.md",
-      "sha256": "cff06cc06726aa58507496db67879340f30025664a608d49068205850d98a2b0"
+      "sha256": "d0ab892ca2a10f667dce19fd9c923fbb8618285f81d54c74b6722ad29d9c3e6b"
     }
   ],
   "kind": "artifact_manifest",
@@ -20,9 +20,9 @@
     ]
   },
   "policy_lineage": {
-    "capsule_hash": "b6f1500dfc743ac3a104c905a041bd165ea8cf6c31efd152a2ebcef3da217934",
+    "capsule_hash": "ae7a6d11033a9f6882f0abc2834e4712ead0e5e842e346a18bde564279ff6ad0",
     "capsule_path": ".decapod/generated/context/R_releasecheck.json",
-    "policy_hash": "b4a75518f1afed0870b27325b691d13360d99133868df1a7ef3feacc15f4f30e",
+    "policy_hash": "598e60a8e9b9586f03cbe0e7717e586d956df0d23017a59d8c0f1c9120b7b29a",
     "policy_revision": "policy.release@v1",
     "risk_tier": "medium"
   },

--- a/.decapod/generated/artifacts/provenance/intent_convergence_checklist.json
+++ b/.decapod/generated/artifacts/provenance/intent_convergence_checklist.json
@@ -19,9 +19,9 @@
   "intent": "Each merge MUST preserve user intent traceability and proof-gated completion.",
   "kind": "intent_convergence_checklist",
   "policy_lineage": {
-    "capsule_hash": "b6f1500dfc743ac3a104c905a041bd165ea8cf6c31efd152a2ebcef3da217934",
+    "capsule_hash": "ae7a6d11033a9f6882f0abc2834e4712ead0e5e842e346a18bde564279ff6ad0",
     "capsule_path": ".decapod/generated/context/R_releasecheck.json",
-    "policy_hash": "b4a75518f1afed0870b27325b691d13360d99133868df1a7ef3feacc15f4f30e",
+    "policy_hash": "598e60a8e9b9586f03cbe0e7717e586d956df0d23017a59d8c0f1c9120b7b29a",
     "policy_revision": "policy.release@v1",
     "risk_tier": "medium"
   },

--- a/.decapod/generated/artifacts/provenance/proof_manifest.json
+++ b/.decapod/generated/artifacts/provenance/proof_manifest.json
@@ -5,9 +5,9 @@
   },
   "kind": "proof_manifest",
   "policy_lineage": {
-    "capsule_hash": "b6f1500dfc743ac3a104c905a041bd165ea8cf6c31efd152a2ebcef3da217934",
+    "capsule_hash": "ae7a6d11033a9f6882f0abc2834e4712ead0e5e842e346a18bde564279ff6ad0",
     "capsule_path": ".decapod/generated/context/R_releasecheck.json",
-    "policy_hash": "b4a75518f1afed0870b27325b691d13360d99133868df1a7ef3feacc15f4f30e",
+    "policy_hash": "598e60a8e9b9586f03cbe0e7717e586d956df0d23017a59d8c0f1c9120b7b29a",
     "policy_revision": "policy.release@v1",
     "risk_tier": "medium"
   },

--- a/.decapod/generated/context/R_releasecheck.json
+++ b/.decapod/generated/context/R_releasecheck.json
@@ -20,6 +20,10 @@
     {
       "path": "interfaces/STORE_MODEL.md",
       "section": "2. Assets (What We Protect)"
+    },
+    {
+      "path": "interfaces/CONTROL_PLANE.md",
+      "section": "6. Validate Doctrine (Proof Currency)"
     }
   ],
   "snippets": [
@@ -38,6 +42,10 @@
     {
       "source_path": "interfaces/STORE_MODEL.md",
       "text": "## 2. Assets (What We Protect)\n\n- user store privacy: a user starts blank and should not inherit repo ideology or backlog\n- repo store reproducibility: repo state should be deterministically rebuildable from repo-tracked artifacts where declared\n- derived state integrity: derived artifacts should never be treated as source-of-truth\n- provenance: every mutation should be attributable to an actor and a store context (planned: audit trail)\n\n---"
+    },
+    {
+      "source_path": "interfaces/CONTROL_PLANE.md",
+      "text": "## 6. Validate Doctrine (Proof Currency)\n\nAgents should treat proof as the control plane's currency:\n\n- if validation exists, run it\n- if validation doesn't exist, add the smallest validation gate that prevents drift\n- if something is claimed in docs, validation should be able to detect it\n\nThis is how the repo avoids \"doc reality\" diverging from \"code reality.\"\n\nValidate taxonomy (intended):"
     }
   ],
   "policy": {
@@ -47,5 +55,5 @@
     "policy_path": "",
     "repo_revision": ""
   },
-  "capsule_hash": "b6f1500dfc743ac3a104c905a041bd165ea8cf6c31efd152a2ebcef3da217934"
+  "capsule_hash": "ae7a6d11033a9f6882f0abc2834e4712ead0e5e842e346a18bde564279ff6ad0"
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,9 @@ pub(crate) struct InitGroupCli {
     /// Directory to initialize (defaults to current working directory).
     #[clap(short, long)]
     pub dir: Option<PathBuf>,
+    /// Create this project directory if needed, enter it for initialization, and scaffold there.
+    #[clap(long)]
+    pub project_dir: Option<PathBuf>,
     /// Overwrite existing files by archiving them under `<dir>/.decapod_archive/`.
     #[clap(long)]
     pub force: bool,
@@ -161,6 +164,9 @@ pub(crate) struct InitWithCli {
     /// Directory to initialize (defaults to current working directory).
     #[clap(short, long)]
     pub dir: Option<PathBuf>,
+    /// Create this project directory if needed, enter it for initialization, and scaffold there.
+    #[clap(long)]
+    pub project_dir: Option<PathBuf>,
     /// Overwrite existing files by archiving them under `<dir>/.decapod_archive/`.
     #[clap(long)]
     pub force: bool,

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -33,6 +33,15 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
+fn is_inside_git_work_tree(repo_root: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(repo_root)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 /// Spawn a validation gate in a rayon scope with timing and error capture.
 ///
 /// Replaces ~10 lines of boilerplate per gate with a single invocation.
@@ -3416,6 +3425,14 @@ fn validate_git_workspace_context(
         return Ok(());
     }
 
+    if !is_inside_git_work_tree(repo_root) {
+        skip(
+            "Git workspace gates skipped: initialized project is not a git repository",
+            ctx,
+        );
+        return Ok(());
+    }
+
     let signals_container = [
         (
             std::env::var("DECAPOD_CONTAINER").ok().as_deref() == Some("1"),
@@ -3620,6 +3637,14 @@ fn validate_git_protected_branch(
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         skip(
             "Git protected branch gate skipped (DECAPOD_VALIDATE_SKIP_GIT_GATES set)",
+            ctx,
+        );
+        return Ok(());
+    }
+
+    if !is_inside_git_work_tree(repo_root) {
+        skip(
+            "Git protected branch gate skipped: initialized project is not a git repository",
             ctx,
         );
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,54 @@ fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool, error::Decapod
     Ok(matches!(normalized.as_str(), "y" | "yes"))
 }
 
+fn resolve_existing_init_dir(raw: &Path) -> Result<PathBuf, error::DecapodError> {
+    std::fs::canonicalize(raw).map_err(error::DecapodError::IoError)
+}
+
+fn resolve_or_create_project_dir(
+    current_dir: &Path,
+    raw: &Path,
+    dry_run: bool,
+) -> Result<PathBuf, error::DecapodError> {
+    let candidate = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        current_dir.join(raw)
+    };
+    if candidate.exists() && !candidate.is_dir() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "project directory target '{}' exists but is not a directory",
+            candidate.display()
+        )));
+    }
+    if !dry_run {
+        std::fs::create_dir_all(&candidate).map_err(error::DecapodError::IoError)?;
+    }
+    if candidate.exists() {
+        std::fs::canonicalize(&candidate).map_err(error::DecapodError::IoError)
+    } else {
+        Ok(candidate)
+    }
+}
+
+fn prompt_init_target_dir(current_dir: &Path) -> Result<PathBuf, error::DecapodError> {
+    if prompt_yes_no("Initialize the existing current directory?", true)? {
+        return resolve_existing_init_dir(current_dir);
+    }
+    let project_name = prompt_text_field(
+        "Project directory name",
+        "Decapod will create this directory and initialize inside it.",
+        "my-project",
+    )?;
+    let project_name = project_name.trim();
+    if project_name.is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "Project directory name cannot be empty".to_string(),
+        ));
+    }
+    resolve_or_create_project_dir(current_dir, Path::new(project_name), false)
+}
+
 fn prompt_diagram_style(
     default_style: InitDiagramStyle,
 ) -> Result<InitDiagramStyle, error::DecapodError> {
@@ -461,6 +509,7 @@ fn init_with_from_config(
         has("AGENTS.md") && has("CLAUDE.md") && has("GEMINI.md") && has("CODEX.md");
     InitWithCli {
         dir: Some(target_dir),
+        project_dir: None,
         force,
         dry_run,
         all: all_entrypoints,
@@ -582,7 +631,11 @@ fn run_init_apply(
         Some(d) => d.clone(),
         None => current_dir.to_path_buf(),
     };
-    let target_dir = std::fs::canonicalize(&target_dir).map_err(error::DecapodError::IoError)?;
+    let target_dir = if target_dir.exists() {
+        std::fs::canonicalize(&target_dir).map_err(error::DecapodError::IoError)?
+    } else {
+        target_dir
+    };
 
     let setup_decapod_root = target_dir.join(".decapod");
     if setup_decapod_root.exists() && !init_with.force {
@@ -766,13 +819,24 @@ pub fn run() -> Result<(), error::DecapodError> {
                 }
                 Some(InitCommand::With(with)) => with,
                 None => {
-                    let target = std::fs::canonicalize(
-                        init_group
-                            .dir
-                            .clone()
-                            .unwrap_or_else(|| current_dir.clone()),
-                    )
-                    .map_err(error::DecapodError::IoError)?;
+                    if init_group.dir.is_some() && init_group.project_dir.is_some() {
+                        return Err(error::DecapodError::ValidationError(
+                            "Use either --dir for an existing directory or --project-dir to create/select a project directory, not both.".to_string(),
+                        ));
+                    }
+                    let target = if let Some(project_dir) = init_group.project_dir.as_ref() {
+                        resolve_or_create_project_dir(
+                            &current_dir,
+                            project_dir,
+                            init_group.dry_run,
+                        )?
+                    } else if let Some(dir) = init_group.dir.as_ref() {
+                        resolve_existing_init_dir(dir)?
+                    } else if io::stdin().is_terminal() {
+                        prompt_init_target_dir(&current_dir)?
+                    } else {
+                        resolve_existing_init_dir(&current_dir)?
+                    };
                     let maybe_cfg = load_project_config_if_present(&target)?;
                     if let Some(cfg) = maybe_cfg {
                         let mut with = if io::stdin().is_terminal() {
@@ -831,6 +895,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                     } else {
                         InitWithCli {
                             dir: Some(target),
+                            project_dir: None,
                             force: init_group.force,
                             dry_run: init_group.dry_run,
                             all: init_group.all,
@@ -851,9 +916,21 @@ pub fn run() -> Result<(), error::DecapodError> {
                 }
             };
 
-            let init_target =
-                std::fs::canonicalize(init_with.dir.clone().unwrap_or_else(|| current_dir.clone()))
-                    .map_err(error::DecapodError::IoError)?;
+            if init_with.dir.is_some() && init_with.project_dir.is_some() {
+                return Err(error::DecapodError::ValidationError(
+                    "Use either --dir for an existing directory or --project-dir to create/select a project directory, not both.".to_string(),
+                ));
+            }
+            let init_target = if let Some(project_dir) = init_with.project_dir.as_ref() {
+                resolve_or_create_project_dir(&current_dir, project_dir, init_with.dry_run)?
+            } else if let Some(dir) = init_with.dir.as_ref() {
+                resolve_existing_init_dir(dir)?
+            } else {
+                resolve_existing_init_dir(&current_dir)?
+            };
+            let mut init_with = init_with;
+            init_with.dir = Some(init_target.clone());
+            init_with.project_dir = None;
             let mut repo_ctx = infer_repo_context(&init_target);
             apply_repo_context_env_overrides(&mut repo_ctx);
             apply_repo_context_cli_overrides(&mut repo_ctx, &init_with);
@@ -1138,6 +1215,7 @@ fn command_requires_worktree(command: &Command) -> bool {
         | Command::Setup(_)
         | Command::Session(_)
         | Command::Version
+        | Command::Validate(_)
         | Command::Workspace(_)
         | Command::Capabilities(_)
         | Command::Trace(_)

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -113,6 +113,37 @@ fn test_validate_passes_after_init() {
 }
 
 #[test]
+fn test_validate_passes_after_init_without_git_repo() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+
+    let init = run_raw(&temp_path, &["init", "--force"], &[]);
+    assert!(
+        init.status.success(),
+        "decapod init should succeed. Output:\n{}{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let validate = run_raw(&temp_path, &["validate"], &[]);
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+    assert!(
+        validate.status.success(),
+        "decapod validate should pass immediately after init in a non-git directory. Output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("requires isolated git worktree"),
+        "fresh non-git validation should not be rejected by workspace preflight. Output:\n{}",
+        output
+    );
+}
+
+#[test]
 fn test_agent_session_requires_password() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -52,6 +52,69 @@ fn init_with_writes_config_toml_with_schema_and_diagram_style() {
 }
 
 #[test]
+fn init_project_dir_creates_directory_and_initializes_inside_it() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(
+        tmp.path(),
+        &[
+            "init",
+            "--project-dir",
+            "pincher",
+            "--product-name",
+            "pincher",
+            "--force",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init --project-dir failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let project = tmp.path().join("pincher");
+    assert!(project.is_dir(), "expected project directory to be created");
+    assert!(
+        project.join(".decapod/config.toml").exists(),
+        "expected .decapod/config.toml in project directory"
+    );
+    assert!(
+        !tmp.path().join(".decapod").exists(),
+        "parent directory should not be initialized"
+    );
+}
+
+#[test]
+fn init_with_project_dir_creates_directory_and_initializes_inside_it() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(
+        tmp.path(),
+        &[
+            "init",
+            "with",
+            "--project-dir",
+            "pincher-with",
+            "--product-summary",
+            "Initialize a named project directory.",
+            "--force",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init with --project-dir failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let project = tmp.path().join("pincher-with");
+    assert!(project.is_dir(), "expected project directory to be created");
+    let intent = fs::read_to_string(project.join(".decapod/generated/specs/INTENT.md"))
+        .expect("read .decapod/generated/specs/INTENT.md");
+    assert!(
+        intent.contains("Initialize a named project directory."),
+        "intent spec should be written under the created project directory"
+    );
+}
+
+#[test]
 fn init_uses_existing_config_for_noninteractive_defaults() {
     let tmp = tempdir().expect("tempdir");
     let out1 = run_decapod(


### PR DESCRIPTION
## Summary
- allow fresh non-git decapod init directories to validate without being rejected by workspace preflight
- add --project-dir to decapod init and decapod init with to create/select a named project directory before scaffolding
- add regression coverage for non-git init validation and project-directory initialization

## Tests
- cargo test --test init_config_behavior
- cargo test test_validate_passes_after_init --test entrypoint_correctness
- cargo fmt --check via Nix rustfmt