### PR TITLE
ci: share decapod binary across test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,25 +104,29 @@ jobs:
       - name: Clippy
         run: nix develop .#ci -c cargo clippy --all-targets --all-features -- -D warnings
 
-  # HEALTH: cargo install (release build), no dependency on setup
+  # HEALTH: consumes the shared decapod binary from setup
   health:
     name: Health Checks
     runs-on: ubuntu-latest
+    needs: setup
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install LLD
-        uses: ./.github/actions/install-lld
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
       - name: Restore cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ci-build"
           save-if: "false"
-      - name: Build and install decapod
-        run: cargo install --path . --locked
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Install shared decapod binary
+        run: |
+          chmod +x target/debug/decapod
+          echo "$PWD/target/debug" >> "$GITHUB_PATH"
       - name: Initialize Decapod
         run: decapod init --force
         env:
@@ -209,11 +213,11 @@ jobs:
           fi
           echo "✅ No network dependencies"
 
-  # SETUP: Compile the library once, save to Swatinem cache.
-  # Test shards restore this cache and only compile their own small test harness (~15-30s).
-  # No binary artifact upload — cache is ~100-200MB of compiled objects, not linked binaries.
+  # SETUP: Compile the shared decapod binary once and save both cache + binary artifact.
+  # Test jobs restore this cache and download the same target/debug/decapod executable
+  # so integration tests that use CARGO_BIN_EXE_decapod do not independently rebuild it.
   setup:
-    name: Setup & Warm Cache
+    name: Setup & Build Shared Binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -235,10 +239,15 @@ jobs:
           cache-all-crates: true
       - name: Check Cargo.lock is up to date
         run: cargo generate-lockfile && git diff --quiet Cargo.lock || echo "⚠️ Cargo.lock outdated - run cargo update locally"
-      - name: Compile library and binary (warm cache, no test harnesses)
-        # cargo build --all-features compiles the lib+bin but not test harnesses,
-        # keeping the cache small. Each test shard compiles only its own harness file.
-        run: cargo build --all-features
+      - name: Compile shared decapod binary
+        run: cargo build --all-features --bin decapod
+      - name: Upload shared decapod binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug/decapod
+          retention-days: 1
+          compression-level: 0
 
   # TEST: Unit tests
   test-core:
@@ -258,6 +267,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run unit tests
         run: cargo test --all-features --lib --bins -- --test-threads=4
 
@@ -284,6 +300,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run integration tests (shard ${{ matrix.shard }}/20)
         run: |
           set -euo pipefail
@@ -341,6 +364,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run RPC suite
         run: nix develop .#ci -c cargo test --all-features --test agent_rpc_suite -- --test-threads=1
 
@@ -362,6 +392,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run chaos replay determinism test
         run: cargo test --test chaos_replay -- --test-threads=1
 
@@ -383,6 +420,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run daemonless lifecycle test
         run: cargo test --all-features --test daemonless_lifecycle -- --test-threads=1
 
@@ -404,6 +448,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run contract conformance tests
         run: |
           cargo test --all-features --test contract_conformance -- --test-threads=1
@@ -430,6 +481,13 @@ jobs:
         with:
           shared-key: "ci-build"
           save-if: "false"
+      - name: Download shared decapod binary
+        uses: actions/download-artifact@v4
+        with:
+          name: decapod-debug-linux-${{ github.sha }}
+          path: target/debug
+      - name: Make shared decapod binary executable
+        run: chmod +x target/debug/decapod
       - name: Run migration tests
         run: cargo test --all-features --test core_tests migration_ -- --ignored --test-threads=1
 


### PR DESCRIPTION
## Summary
- build the debug decapod binary once in the setup job
- upload the binary as a short-lived workflow artifact
- download the shared binary in health and test jobs before invoking decapod or cargo tests that need CARGO_BIN_EXE_decapod
- remove per-job cargo install from health checks

## Validation
- yq parsed .github/workflows/ci.yml successfully
- DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate