### PR TITLE
Ensure validate is clean after fresh init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,23 @@ fn write_project_config(
     Ok(())
 }
 
+fn seed_init_generated_state(target_dir: &Path, dry_run: bool) -> Result<(), error::DecapodError> {
+    if dry_run {
+        return Ok(());
+    }
+
+    let _ = docs_cli::sync_override_checksum(target_dir, false)?;
+    Ok(())
+}
+
+fn is_not_git_repository_error(err: &error::DecapodError) -> bool {
+    matches!(
+        err,
+        error::DecapodError::ValidationError(message)
+            if message.contains("Not in a git repository")
+    )
+}
+
 fn infer_repo_context(target_dir: &Path) -> RepoContext {
     let mut ctx = RepoContext {
         product_name: target_dir
@@ -940,6 +957,7 @@ pub fn run() -> Result<(), error::DecapodError> {
             let target_dir = run_init_apply(&init_with, &current_dir, &repo_ctx)?;
             let config = config_from_init_with(&init_with, repo_ctx);
             write_project_config(&target_dir, &config, init_with.dry_run)?;
+            seed_init_generated_state(&target_dir, init_with.dry_run)?;
         }
         Command::Session(session_cli) => {
             run_session_command(session_cli)?;
@@ -1016,7 +1034,9 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             // Best-effort hygiene: routinely scrub stale git worktree metadata/config.
             // This must not block primary command execution.
-            if let Err(e) = workspace::prune_stale_worktree_config(&project_root) {
+            if let Err(e) = workspace::prune_stale_worktree_config(&project_root)
+                && !is_not_git_repository_error(&e)
+            {
                 eprintln!("warn: worktree maintenance skipped: {e}");
             }
 

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -137,6 +137,31 @@ fn test_validate_passes_after_init_without_git_repo() {
         output
     );
     assert!(
+        output.contains("validation passed"),
+        "validate should emit a clean success marker. Output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Error:"),
+        "validate should not emit an error while succeeding. Output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("warn:"),
+        "validate should not emit warnings after fresh init. Output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("repair"),
+        "validate should not require self-heal/repair after fresh init. Output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("self-heal"),
+        "validate should not report self-heal after fresh init. Output:\n{}",
+        output
+    );
+    assert!(
         !output.contains("requires isolated git worktree"),
         "fresh non-git validation should not be rejected by workspace preflight. Output:\n{}",
         output


### PR DESCRIPTION
## Summary
- seed generated override checksum state during decapod init
- suppress non-git worktree maintenance warnings for standalone initialized projects
- tighten the init-then-validate regression harness to require clean success without warnings, repairs, or self-heal output

## Verification
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test test_validate_passes_after_init_without_git_repo --test entrypoint_correctness
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --test entrypoint_correctness
- nix --extra-experimental-features "nix-command flakes" shell nixpkgs#rustfmt -c cargo fmt --check
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= DECAPOD_VALIDATE_SKIP_GIT_GATES=1 cargo run -- validate