### PR TITLE
docs: Sharpen README with portability and integration sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ decapod eval plan --task-set-id <id> --task-ref <task-id> --model-id <model> --p
 
 1. **MUST** refine intent with the user before inference-heavy work.
 2. **MUST NOT** work on main/master. **MUST** use `.decapod/workspaces/*`.
-3. **MUST** access `.decapod/*` files only via decapod CLI surfaces.
+3. **MUST** read `.decapod/config.toml` as user-editable project context and may update it when user intent changes.
 4. **MUST NOT** claim done without `decapod validate` passing.
 5. **MUST NOT** invent capabilities that are not exposed by the binary.
 6. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
@@ -72,6 +72,10 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Operating Notes
 
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and agent entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; generated specs, data, workspaces, and sessions stay via decapod CLI.
 - Use `decapod docs show core/DECAPOD.md` and `decapod docs show core/INTERFACES.md` for binding contracts.
 - Use `decapod capabilities --format json` as the authority surface for available operations.
 - Use Decapod shared aptitude memory for human-taught preferences that must persist across sessions and agents: `decapod data memory add|get` (aliases: `decapod data aptitude`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-This contract applies equally to Claude, Codex, Gemini, and any other agent operating here.
+This contract applies equally to Claude, Codex, Gemini, Cursor, Kilo, and any other agent operating here.
 
 ## Mandatory Initialization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,13 @@
 You are working in a Decapod-managed repository.
 See `AGENTS.md` for the universal contract.
 
+## Project Context
+
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; use Decapod CLI surfaces for generated specs, data, workspaces, and sessions.
+
 ## Quick Start
 
 ```bash
@@ -34,6 +41,8 @@ decapod data schema --deterministic
 - Call `decapod workspace status` at startup and before implementation work.
 - request elevated permissions before Docker/container workspace commands.
 - `.decapod files are accessed only via decapod CLI`.
+- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
+- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
 - Read canonical router: `decapod docs show core/DECAPOD.md`.
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).

--- a/CODEX.md
+++ b/CODEX.md
@@ -3,6 +3,13 @@
 You are working in a Decapod-managed repository.
 See `AGENTS.md` for the universal contract.
 
+## Project Context
+
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; use Decapod CLI surfaces for generated specs, data, workspaces, and sessions.
+
 ## Quick Start
 
 ```bash
@@ -34,6 +41,8 @@ decapod data schema --deterministic
 - Call `decapod workspace status` at startup and before implementation work.
 - request elevated permissions before Docker/container workspace commands.
 - `.decapod files are accessed only via decapod CLI`.
+- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
+- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
 - Read canonical router: `decapod docs show core/DECAPOD.md`.
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,6 +3,13 @@
 You are working in a Decapod-managed repository.
 See `AGENTS.md` for the universal contract.
 
+## Project Context
+
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; use Decapod CLI surfaces for generated specs, data, workspaces, and sessions.
+
 ## Quick Start
 
 ```bash
@@ -34,6 +41,8 @@ decapod data schema --deterministic
 - Call `decapod workspace status` at startup and before implementation work.
 - request elevated permissions before Docker/container workspace commands.
 - `.decapod files are accessed only via decapod CLI`.
+- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
+- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
 - Read canonical router: `decapod docs show core/DECAPOD.md`.
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).

--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ That directory is the proof surface. It can be inspected locally, reviewed in pu
 
 ---
 
+## Agent Workbench Gaps
+
+| What workbenches optimize | What Decapod preserves |
+|-------------------------|------------------------|
+| The current session | Reusable repo-native knowledge |
+| Worker throughput | Shared substrate quality |
+| Provider-specific context | Explicit intent, boundaries, proof |
+| Session-scoped memory | `.decapod/` durable state |
+
+**Multi-provider continuity**: A task started by Claude Code should be auditable by Codex, resumable by Gemini CLI, and verifiable by Kilo. The source of truth is `.decapod/`, not chat history, IDE state, or provider memory.
+
+---
+
 ## Integrations
 
 Decapod works with any shell-capable agent through simple entrypoints:
@@ -146,11 +159,12 @@ Decapod works with any shell-capable agent through simple entrypoints:
 | Codex | `CODEX.md` | `decapod session acquire` |
 | Gemini CLI | `GEMINI.md` | `decapod session acquire` |
 | Cursor | `CLAUDE.md` | `decapod session acquire` |
+| Kilo | `CLAUDE.md` | `decapod session acquire` |
 | Custom | `AGENTS.md` | `decapod session acquire` |
 
 Each entrypoint calls Decapod at key moments: before acting (intent), before inference (context), before committing (proof), before touching protected code (boundaries).
 
-See [constitution/core/ENGINEERING_EXCELLENCE.md](constitution/core/ENGINEERING_EXCELLENCE.md) for the full operational contract.
+See [AGENTS.md](AGENTS.md) for the universal agent contract.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,13 +149,7 @@ That directory is the proof surface. It can be inspected locally, reviewed in pu
 
 ---
 
-## Integrations
-
-Decapod works with Claude Code, Codex, Gemini CLI, Cursor, Kilo, and any shell-capable agent through simple entrypoints.
-
-Each entrypoint calls Decapod at key moments: before acting (intent), before inference (context), before committing (proof), before touching protected code (boundaries).
-
-See [AGENTS.md](AGENTS.md) for the universal agent contract.
+Use whatever agent you already use: Claude, Codex, Gemini, Cursor, Kilo.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ Override the embedded constitution with `.decapod/OVERRIDE.md`. Plain English ru
 
 Your overrides augment the constitution automatically.
 
+### Project config
+
+`.decapod/config.toml` is your project's control plane configuration. Think of it like an ansible.cfg or pyproject.toml — it captures the high-level scope and details of your project:
+
+- Project name and summary
+- Primary language(s)
+- Architecture type (webapp, microservice, library, etc.)
+- Entrypoints for different agents (CLAUDE.md, GEMINI.md, etc.)
+
+You can edit this file directly or let init update it as your project evolves. The agent reads it to understand your project context.
+
 ---
 
 ## Proof lives in the repo

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Decapod</strong><br />
-  Daemonless, repo-native control plane for AI coding agents.
+  Daemonless, repo-native governance kernel for AI coding agents.
 </p>
 
 <p align="center">
@@ -73,6 +73,30 @@ Decapod is designed to stay out of the human workflow. The agent checks in. You 
 
 Decapod resolves only what's relevant to the user's intent — no context poisoning. Your agent gets surgical context, not the entire constitution.
 
+---
+
+## Agent workbenches improve the session. Decapod improves the shared substrate.
+
+- **Agents act in private context; Decapod makes their work public to the repo.**
+- A task started by one agent provider should be understandable, auditable, or resumable by another. The source of truth lives in `.decapod/`, not in chat history, IDE state, or provider memory.
+- The durable parts of agentic work—intent, resolved context, boundaries, todos, specs, validation, proof artifacts—become repo-native operational knowledge.
+
+Decapod absorbs agent deficiencies: ambiguity, context waste, boundary drift, forgotten dependencies, unsafe mutation, and unverifiable "done."
+
+### The shared substrate
+
+```
+decapod/
+  generated/
+    specs/           # INTENT.md, ARCHITECTURE.md, etc.
+    context/        # deterministic context capsules
+    artifacts/      # proof artifacts, provenance
+  governance/      # todos, claims, workunits
+  data/            # durable state
+```
+
+This is what persists. Not the chat transcript.
+
 ### The constitution
 
 Decapod ships with an embedded engineering constitution.
@@ -98,24 +122,35 @@ Your overrides augment the constitution automatically.
 
 ## Proof lives in the repo
 
-Decapod does not ask you to trust an agent transcript.
-
 Every run leaves its operational evidence in `.decapod/`:
 
-- captured intent
-- resolved context  
-- generated specs
-- todo state
-- dependency structure
-- boundary decisions
-- verification results
-- proof artifacts
+- captured intent → `generated/specs/INTENT.md`
+- resolved context → `generated/context/`
+- todos and dependencies → `governance/todos.jsonl`
+- verification results → `generated/artifacts/`
+- proof artifacts → `generated/artifacts/provenance/`
 
 That directory is the proof surface. It can be inspected locally, reviewed in pull requests, archived with the codebase, and used by the next agent invocation to re-establish state.
 
-No dashboard. No daemon. No hidden memory.
+**The repo remembers. Chat history doesn't.**
 
-**The repo remembers.**
+---
+
+## Integrations
+
+Decapod works with any shell-capable agent through simple entrypoints:
+
+| Provider | Entrypoint | Required |
+|----------|-----------|----------|
+| Claude Code | `CLAUDE.md` | `decapod session acquire` |
+| Codex | `CODEX.md` | `decapod session acquire` |
+| Gemini CLI | `GEMINI.md` | `decapod session acquire` |
+| Cursor | `CLAUDE.md` | `decapod session acquire` |
+| Custom | `AGENTS.md` | `decapod session acquire` |
+
+Each entrypoint calls Decapod at key moments: before acting (intent), before inference (context), before committing (proof), before touching protected code (boundaries).
+
+See [constitution/core/ENGINEERING_EXCELLENCE.md](constitution/core/ENGINEERING_EXCELLENCE.md) for the full operational contract.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,16 +151,7 @@ That directory is the proof surface. It can be inspected locally, reviewed in pu
 
 ## Integrations
 
-Decapod works with any shell-capable agent through simple entrypoints:
-
-| Provider | Entrypoint | Required |
-|----------|-----------|----------|
-| Claude Code | `CLAUDE.md` | `decapod session acquire` |
-| Codex | `CODEX.md` | `decapod session acquire` |
-| Gemini CLI | `GEMINI.md` | `decapod session acquire` |
-| Cursor | `CLAUDE.md` | `decapod session acquire` |
-| Kilo | `CLAUDE.md` | `decapod session acquire` |
-| Custom | `AGENTS.md` | `decapod session acquire` |
+Decapod works with Claude Code, Codex, Gemini CLI, Cursor, Kilo, and any shell-capable agent through simple entrypoints.
 
 Each entrypoint calls Decapod at key moments: before acting (intent), before inference (context), before committing (proof), before touching protected code (boundaries).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ cargo install decapod
 decapod init
 ```
 
-That's it. Your workflow doesn't change. Your agent calls Decapod before:
+That's it. `decapod init` asks about your project (name, intent, architecture direction) and scaffolds specs.
+
+For deeper scaffolding with guided questions:
+
+```bash
+decapod workspace ensure --branch agent/scaffold
+cd .decapod/workspaces/agent-scaffold
+decapod rpc --op scaffold.next_question --params '{"project_name":"your-project"}'
+decapod rpc --op scaffold.apply_answer --params '{"question_id":"one_liner","value":"your answer"}'
+# ... continue until done
+decapod rpc --op scaffold.generate_artifacts
+```
+
+Your workflow doesn't change. Your agent calls Decapod before:
 
 - Acting — intent
 - Calling the model — context  

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 </p>
 
 <p align="center">
-  Agents call it on demand to converge on human intent, shape context before inference,<br />
-  enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
+Agents call it on demand to turn intent into context, then context into explicit specifications before inference,<br />
+enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ Your workflow doesn't change. Your agent calls Decapod before:
 - Committing — proof
 - Touching protected code — boundaries
 
-Decapod is designed to stay out of the human workflow. The agent checks in. You keep talking to your agent like normal.
+Decapod is designed to stay out of the human workflow. The agent checks in. You keep talking to your agent like normal. See the canonical router in [constitution/core/DECAPOD.md](constitution/core/DECAPOD.md).
 
 > AI agents do not fail because they lack tools. They fail because they lose intent, skip dependencies, mutate context unsafely, and return vibes instead of proof.
 
@@ -129,7 +129,9 @@ Your overrides augment the constitution automatically.
 - Architecture type (webapp, microservice, library, etc.)
 - Entrypoints for different agents (CLAUDE.md, GEMINI.md, etc.)
 
-You can edit this file directly or let init update it as your project evolves. The agent reads it to understand your project context.
+You can edit this file directly or let the agent update it as your project evolves. The generated agent entrypoints tell agents to read it before planning and keep it aligned when user intent or project direction changes.
+
+For rules that override the embedded Decapod constitution, use `.decapod/OVERRIDE.md`. Keep `.decapod/config.toml` focused on project context and setup preferences.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,7 @@ cargo install decapod
 decapod init
 ```
 
-That's it. `decapod init` asks about your project (name, intent, architecture direction) and scaffolds specs.
-
-For deeper scaffolding with guided questions:
-
-```bash
-decapod workspace ensure --branch agent/scaffold
-cd .decapod/workspaces/agent-scaffold
-decapod rpc --op scaffold.next_question --params '{"project_name":"your-project"}'
-decapod rpc --op scaffold.apply_answer --params '{"question_id":"one_liner","value":"your answer"}'
-# ... continue until done
-decapod rpc --op scaffold.generate_artifacts
-```
+That's it. `decapod init` asks about your project (name, intent, language, architecture direction) and scaffolds industry-grade specs.
 
 Your workflow doesn't change. Your agent calls Decapod before:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Decapod is designed to stay out of the human workflow. The agent checks in. You 
        │         │
        ├─────────┤
        │         │
-    Model      Agent
+     Model     Agent
        │         │
        └────┬────┘
             ▼
@@ -88,9 +88,9 @@ Decapod absorbs agent deficiencies: ambiguity, context waste, boundary drift, fo
 ```
 decapod/
   generated/
-    specs/           # INTENT.md, ARCHITECTURE.md, etc.
-    context/        # deterministic context capsules
-    artifacts/      # proof artifacts, provenance
+    specs/         # INTENT.md, ARCHITECTURE.md, etc.
+    context/       # deterministic context capsules
+    artifacts/     # proof artifacts, provenance
   governance/      # todos, claims, workunits
   data/            # durable state
 ```

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -197,6 +197,13 @@ fn agent_entrypoint_body() -> &'static str {
     r#"You are working in a Decapod-managed repository.
 See `AGENTS.md` for the universal contract.
 
+## Project Context
+
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; use Decapod CLI surfaces for generated specs, data, workspaces, and sessions.
+
 ## Quick Start
 
 ```bash
@@ -228,6 +235,8 @@ decapod data schema --deterministic
 - Call `decapod workspace status` at startup and before implementation work.
 - request elevated permissions before Docker/container workspace commands.
 - `.decapod files are accessed only via decapod CLI`.
+- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
+- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
 - Read canonical router: `decapod docs show core/DECAPOD.md`.
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).
@@ -244,7 +253,7 @@ fn template_agents() -> String {
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-This contract applies equally to Claude, Codex, Gemini, and any other agent operating here.
+This contract applies equally to Claude, Codex, Gemini, Cursor, Kilo, and any other agent operating here.
 
 ## Mandatory Initialization
 
@@ -284,7 +293,7 @@ decapod eval plan --task-set-id <id> --task-ref <task-id> --model-id <model> --p
 
 1. **MUST** refine intent with the user before inference-heavy work.
 2. **MUST NOT** work on main/master. **MUST** use `.decapod/workspaces/*`.
-3. **MUST** access `.decapod/*` files only via decapod CLI surfaces.
+3. **MUST** read `.decapod/config.toml` as user-editable project context and may update it when user intent changes.
 4. **MUST NOT** claim done without `decapod validate` passing.
 5. **MUST NOT** invent capabilities that are not exposed by the binary.
 6. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
@@ -314,6 +323,10 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Operating Notes
 
+- Read `.decapod/config.toml` before planning; it captures project name, summary, architecture, primary languages, and agent entrypoint preferences.
+- Treat `.decapod/config.toml` as human-editable project context. You may update it when user intent or project direction changes.
+- Read `.decapod/OVERRIDE.md` when present; it is the repo-local place for constitution overrides.
+- Do not mutate Decapod-owned state under `.decapod/` directly; generated specs, data, workspaces, and sessions stay via decapod CLI.
 - Use `decapod docs show core/DECAPOD.md` and `decapod docs show core/INTERFACES.md` for binding contracts.
 - Use `decapod capabilities --format json` as the authority surface for available operations.
 - Use Decapod shared aptitude memory for human-taught preferences that must persist across sessions and agents: `decapod data memory add|get` (aliases: `decapod data aptitude`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,38 @@ fn prompt_line(prompt: &str) -> Result<String, error::DecapodError> {
     Ok(buf.trim().to_string())
 }
 
-const LANGUAGES: &[&str] = &["Rust", "TypeScript", "Python", "Go", "Java", "C/C++", "Ruby", "PHP", "Other"];
+const LANGUAGES: &[&str] = &[
+    "Rust",
+    "TypeScript",
+    "JavaScript",
+    "Python",
+    "Go",
+    "Java",
+    "Kotlin",
+    "Swift",
+    "C",
+    "C++",
+    "C#",
+    "Zig",
+    "Ruby",
+    "PHP",
+    "Elixir",
+    "Erlang",
+    "Scala",
+    "Clojure",
+    "Dart",
+    "Haskell",
+    "OCaml",
+    "F#",
+    "Lua",
+    "R",
+    "Julia",
+    "SQL",
+    "HCL",
+    "Shell",
+    "PowerShell",
+    "Other",
+];
 
 const ARCH_DIRECTIONS: &[(&str, &str)] = &[
     ("webapp", "Web application (TypeScript, React/Vue/Svelte)"),
@@ -406,59 +437,227 @@ const ARCH_DIRECTIONS: &[(&str, &str)] = &[
     ("data", "Data pipeline (Python, SQL)"),
 ];
 
-#[allow(non_snake_case)]
-fn prompt_languageChoice(current: &[String]) -> Result<Vec<String>, error::DecapodError> {
+fn normalize_language(input: &str) -> String {
+    match input.trim().to_lowercase().as_str() {
+        "ts" | "typescript" => "TypeScript".to_string(),
+        "js" | "javascript" => "JavaScript".to_string(),
+        "py" | "python" => "Python".to_string(),
+        "rs" | "rust" => "Rust".to_string(),
+        "golang" | "go" => "Go".to_string(),
+        "kt" | "kotlin" => "Kotlin".to_string(),
+        "swift" => "Swift".to_string(),
+        "c" => "C".to_string(),
+        "cpp" | "c++" | "cplusplus" => "C++".to_string(),
+        "csharp" | "c#" => "C#".to_string(),
+        "zig" => "Zig".to_string(),
+        "rb" | "ruby" => "Ruby".to_string(),
+        "php" => "PHP".to_string(),
+        "ex" | "elixir" => "Elixir".to_string(),
+        "erl" | "erlang" => "Erlang".to_string(),
+        "scala" => "Scala".to_string(),
+        "clj" | "clojure" => "Clojure".to_string(),
+        "dart" => "Dart".to_string(),
+        "hs" | "haskell" => "Haskell".to_string(),
+        "ml" | "ocaml" => "OCaml".to_string(),
+        "fs" | "fsharp" | "f#" => "F#".to_string(),
+        "lua" => "Lua".to_string(),
+        "r" => "R".to_string(),
+        "jl" | "julia" => "Julia".to_string(),
+        "sql" => "SQL".to_string(),
+        "terraform" | "tf" | "hcl" => "HCL".to_string(),
+        "bash" | "sh" | "shell" => "Shell".to_string(),
+        "pwsh" | "powershell" => "PowerShell".to_string(),
+        "other" => "Other".to_string(),
+        _ => input.trim().to_string(),
+    }
+}
+
+fn language_choice_seed(current: &[String], recommendation: &[String]) -> Vec<String> {
+    if !recommendation.is_empty() {
+        return recommendation
+            .iter()
+            .map(|s| normalize_language(s))
+            .collect();
+    }
+    current.iter().map(|s| normalize_language(s)).collect()
+}
+
+fn apply_architecture_language_recommendation(ctx: &mut RepoContext) {
+    if !ctx.primary_languages.is_empty() {
+        return;
+    }
+    if let Some(arch) = ctx.architecture_direction.as_deref() {
+        ctx.primary_languages = infer_language_from_architecture(arch);
+    }
+}
+
+struct TerminalModeGuard {
+    saved_mode: String,
+}
+
+impl Drop for TerminalModeGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("stty")
+            .arg(&self.saved_mode)
+            .status();
+        println!();
+    }
+}
+
+fn enter_raw_terminal_mode() -> Option<TerminalModeGuard> {
+    let output = std::process::Command::new("stty").arg("-g").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let saved_mode = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    let status = std::process::Command::new("stty")
+        .args(["raw", "-echo"])
+        .status()
+        .ok()?;
+    if !status.success() {
+        return None;
+    }
+    Some(TerminalModeGuard { saved_mode })
+}
+
+fn prompt_language_terminal_choice(
+    default: &[String],
+) -> Result<Option<String>, error::DecapodError> {
     use crate::core::ansi::AnsiExt;
-    let inferred = if current.is_empty() { "None".to_string() } else { current.join(", ") };
-    
+
+    if !io::stdin().is_terminal() || default.is_empty() {
+        return Ok(None);
+    }
+    let mut selected = default
+        .first()
+        .and_then(|d| {
+            LANGUAGES
+                .iter()
+                .position(|lang| d.eq_ignore_ascii_case(lang))
+        })
+        .unwrap_or(0);
+    let Some(_guard) = enter_raw_terminal_mode() else {
+        return Ok(None);
+    };
+    let mut typed = String::new();
+    let mut stdin = io::stdin();
+    loop {
+        let shown = if typed.is_empty() {
+            LANGUAGES[selected].to_string()
+        } else {
+            typed.clone()
+        };
+        print!("\r{}", format!("    choice: {shown}").bright_cyan().bold());
+        print!("\x1b[K");
+        io::stdout().flush().map_err(error::DecapodError::IoError)?;
+
+        let mut byte = [0_u8; 1];
+        stdin
+            .read_exact(&mut byte)
+            .map_err(error::DecapodError::IoError)?;
+        match byte[0] {
+            b'\r' | b'\n' => return Ok(Some(shown)),
+            3 => {
+                return Err(error::DecapodError::ValidationError(
+                    "init prompt interrupted".to_string(),
+                ));
+            }
+            8 | 127 => {
+                typed.pop();
+            }
+            27 => {
+                let mut seq = [0_u8; 2];
+                if stdin.read_exact(&mut seq).is_ok() && seq[0] == b'[' {
+                    match seq[1] {
+                        b'A' => {
+                            typed.clear();
+                            selected = selected
+                                .checked_sub(1)
+                                .unwrap_or_else(|| LANGUAGES.len() - 1);
+                        }
+                        b'B' => {
+                            typed.clear();
+                            selected = (selected + 1) % LANGUAGES.len();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            byte if byte.is_ascii_graphic() || byte == b' ' => {
+                typed.push(byte as char);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn prompt_language_choice(
+    current: &[String],
+    recommendation: &[String],
+) -> Result<Vec<String>, error::DecapodError> {
+    use crate::core::ansi::AnsiExt;
+    let inferred = if current.is_empty() {
+        "None".to_string()
+    } else {
+        current.join(", ")
+    };
+    let default = language_choice_seed(current, recommendation);
+    let default_label = if default.is_empty() {
+        "None".to_string()
+    } else {
+        default.join(", ")
+    };
+
     println!();
     println!("{}", "  Primary language(s)".bright_white().bold());
     println!("    inferred: {} (from project files)", inferred);
-    println!("    options: (type to select, comma-separated for multiple)");
+    println!("    ideal for architecture: {}", default_label);
+    println!("    options: up/down, type name or number, comma-separated for multiple");
     println!();
-    
+
     for (i, lang) in LANGUAGES.iter().enumerate() {
-        let marker = if current.iter().any(|c| c.eq_ignore_ascii_case(lang)) { "✓" } else { " " };
-        println!("    {}{}{}", marker, if i == 0 { " >" } else { "  " }, lang);
+        let marker = if default.iter().any(|c| c.eq_ignore_ascii_case(lang)) {
+            "✓"
+        } else {
+            " "
+        };
+        println!("    {} {:>2}. {}", marker, i + 1, lang);
     }
     println!();
-    println!("    type language(s), e.g., rust, python");
-    println!("    or press Enter to keep inferred");
-    
-    let choice = prompt_line("    choice: ")?;
-    
+    println!("    press Enter to use the ideal/default language(s)");
+
+    let choice = match prompt_language_terminal_choice(&default)? {
+        Some(choice) => choice,
+        None => prompt_line("    choice: ")?,
+    };
+
     if choice.is_empty() {
-        return Ok(current.to_vec());
+        return Ok(default);
     }
-    
+
     let selected: Vec<String> = choice
         .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
         .map(|s| {
-            match s.to_lowercase().as_str() {
-                "ts" | "typescript" => "TypeScript",
-                "js" | "javascript" => "JavaScript",
-                "py" => "Python",
-                "rs" => "Rust",
-                "go" => "Go",
-                "c" | "cpp" => "C/C++",
-                "rb" => "Ruby",
-                "php" => "PHP",
-                "java" => "Java",
-                _ => &s,
-            }.to_string()
+            let trimmed = s.trim();
+            trimmed
+                .parse::<usize>()
+                .ok()
+                .and_then(|n| LANGUAGES.get(n.saturating_sub(1)))
+                .map(|lang| (*lang).to_string())
+                .unwrap_or_else(|| normalize_language(trimmed))
         })
+        .filter(|s| !s.is_empty())
         .collect();
-    
+
     Ok(selected)
 }
 
 fn infer_language_from_architecture(arch: &str) -> Vec<String> {
-    match arch.to_lowercase().as_str() {
+    let arch = arch.to_lowercase();
+    match arch.as_str() {
         "webapp" => vec!["TypeScript".to_string()],
         "microservice" => vec!["Go".to_string()],
-        "library" => vec![],
+        "library" => vec!["Rust".to_string()],
         "cli" => vec!["Rust".to_string()],
         "lambda" => vec!["Python".to_string()],
         "mobile-android" => vec!["Kotlin".to_string()],
@@ -466,34 +665,62 @@ fn infer_language_from_architecture(arch: &str) -> Vec<String> {
         "multiarch" => vec!["Rust".to_string()],
         "infra" => vec!["HCL".to_string()],
         "data" => vec!["Python".to_string()],
+        _ if arch.contains("web") || arch.contains("frontend") => vec!["TypeScript".to_string()],
+        _ if arch.contains("microservice") || arch.contains("backend") || arch.contains("api") => {
+            vec!["Go".to_string()]
+        }
+        _ if arch.contains("cli") || arch.contains("command-line") => vec!["Rust".to_string()],
+        _ if arch.contains("serverless") || arch.contains("lambda") => vec!["Python".to_string()],
+        _ if arch.contains("android") => vec!["Kotlin".to_string()],
+        _ if arch.contains("ios") => vec!["Swift".to_string()],
+        _ if arch.contains("embedded") || arch.contains("systems") => vec!["Zig".to_string()],
+        _ if arch.contains("infra") || arch.contains("terraform") => vec!["HCL".to_string()],
+        _ if arch.contains("data") || arch.contains("ml") => vec!["Python".to_string()],
         _ => vec![],
     }
 }
 
-#[allow(non_snake_case)]
-fn prompt_architectureChoice(current: Option<&str>) -> Result<Option<String>, error::DecapodError> {
+fn prompt_architecture_choice(
+    current: Option<&str>,
+) -> Result<Option<String>, error::DecapodError> {
     use crate::core::ansi::AnsiExt;
     let inferred = current.unwrap_or("None");
-    
+
     println!();
     println!("{}", "  Architecture".bright_white().bold());
     println!("    inferred: {}", inferred);
     println!("    common approaches:");
     println!();
-    
+
     for (i, (arch, desc)) in ARCH_DIRECTIONS.iter().enumerate() {
-        let marker = if current.map_or(false, |c| c.eq_ignore_ascii_case(arch)) { "✓" } else { " " };
-        println!("    {}{} {} -> {}", marker, if i == 0 { " >" } else { "  " }, arch, desc);
+        let marker = if current.is_some_and(|c| c.eq_ignore_ascii_case(arch)) {
+            "✓"
+        } else {
+            " "
+        };
+        println!(
+            "    {}{} {} -> {}",
+            marker,
+            if i == 0 { " >" } else { "  " },
+            arch,
+            desc
+        );
     }
     println!();
     println!("    or type your architecture");
-    
+
     let choice = prompt_line("    choice: ")?;
-    
+
     if choice.is_empty() {
         return Ok(current.map(|s| s.to_string()));
     }
-    
+
+    if let Ok(index) = choice.parse::<usize>()
+        && let Some((arch, _)) = ARCH_DIRECTIONS.get(index.saturating_sub(1))
+    {
+        return Ok(Some((*arch).to_string()));
+    }
+
     Ok(Some(choice.trim().to_string()))
 }
 
@@ -716,30 +943,29 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
         "Repository Context",
         "Review inferred intent before generating .decapod/generated/specs/.",
     );
-    
-    // Primary language prompt with options
-    repo.primary_languages = prompt_languageChoice(&repo.primary_languages)?;
-    
+
     let current_summary = repo.product_summary.clone().unwrap_or_else(|| {
         "Deliver the repository outcome against explicit user intent with proof-backed completion."
             .to_string()
     });
     repo.product_summary = Some(prompt_line_default("Intent outcome", &current_summary)?);
 
+    repo.architecture_direction =
+        prompt_architecture_choice(repo.architecture_direction.as_deref())?;
+
+    let recommended_languages = repo
+        .architecture_direction
+        .as_deref()
+        .map(infer_language_from_architecture)
+        .unwrap_or_default();
+    repo.primary_languages =
+        prompt_language_choice(&repo.primary_languages, &recommended_languages)?;
+
     let refine_now = prompt_yes_no(
-        "Refine architecture direction and done criteria now? (You can evolve .decapod/generated/specs/*.md later.)",
+        "Refine done criteria now? (You can evolve .decapod/config.toml and .decapod/generated/specs/*.md later.)",
         false,
     )?;
     if refine_now {
-        let current_arch = repo.architecture_direction.clone().unwrap_or_else(|| {
-            "Composable repository architecture with explicit boundaries and proof-backed delivery invariants."
-                .to_string()
-        });
-        repo.architecture_direction = Some(prompt_line_default(
-            "Architecture direction",
-            &current_arch,
-        )?);
-
         let current_done = repo.done_criteria.clone().unwrap_or_else(|| {
             "Decapod validate passes, required tests pass, and promotion-relevant artifacts are present."
                 .to_string()
@@ -1061,6 +1287,7 @@ pub fn run() -> Result<(), error::DecapodError> {
             let mut repo_ctx = infer_repo_context(&init_target);
             apply_repo_context_env_overrides(&mut repo_ctx);
             apply_repo_context_cli_overrides(&mut repo_ctx, &init_with);
+            apply_architecture_language_recommendation(&mut repo_ctx);
             if base_init_invocation && io::stdin().is_terminal() {
                 enrich_repo_context_interactive(&mut repo_ctx)?;
             }
@@ -2042,25 +2269,23 @@ fn check_and_update_version() -> Result<bool, error::DecapodError> {
         }
 
         if install_decapod().is_ok() {
-            eprintln!(
-                "{} Updated to v{}.",
-                "✓".bright_green(),
-                latest_version
-            );
-            
+            eprintln!("{} Updated to v{}.", "✓".bright_green(), latest_version);
+
             // Prompt to migrate/refresh config for new fields
             let project_root = std::env::current_dir()
                 .ok()
                 .and_then(|d| find_decapod_project_root(&d).ok());
-            
+
             if let Some(root) = project_root {
                 let config_path = root.join(".decapod").join("config.toml");
                 if config_path.exists() {
-                    eprintln!("{} Check for new config fields in .decapod/config.toml",
-                        "→".bright_cyan());
+                    eprintln!(
+                        "{} Check for new config fields in .decapod/config.toml",
+                        "→".bright_cyan()
+                    );
                 }
             }
-            
+
             return Ok(true);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,112 @@ fn prompt_line(prompt: &str) -> Result<String, error::DecapodError> {
     Ok(buf.trim().to_string())
 }
 
+const LANGUAGES: &[&str] = &["Rust", "TypeScript", "Python", "Go", "Java", "C/C++", "Ruby", "PHP", "Other"];
+
+const ARCH_DIRECTIONS: &[(&str, &str)] = &[
+    ("webapp", "Web application (TypeScript, React/Vue/Svelte)"),
+    ("microservice", "Microservice (Go, Rust, or Java)"),
+    ("library", "Library/SDK (language-agnostic)"),
+    ("cli", "Command-line tool (Rust, Go, Python)"),
+    ("lambda", "Lambda/Serverless (Python, TypeScript, Go)"),
+    ("mobile-android", "Android (Kotlin, Java)"),
+    ("mobile-ios", "iOS (Swift)"),
+    ("multiarch", "Multi-platform (Rust, C/C++)"),
+    ("infra", "Infrastructure/Terraform (HCL, Python)"),
+    ("data", "Data pipeline (Python, SQL)"),
+];
+
+#[allow(non_snake_case)]
+fn prompt_languageChoice(current: &[String]) -> Result<Vec<String>, error::DecapodError> {
+    use crate::core::ansi::AnsiExt;
+    let inferred = if current.is_empty() { "None".to_string() } else { current.join(", ") };
+    
+    println!();
+    println!("{}", "  Primary language(s)".bright_white().bold());
+    println!("    inferred: {} (from project files)", inferred);
+    println!("    options: (type to select, comma-separated for multiple)");
+    println!();
+    
+    for (i, lang) in LANGUAGES.iter().enumerate() {
+        let marker = if current.iter().any(|c| c.eq_ignore_ascii_case(lang)) { "✓" } else { " " };
+        println!("    {}{}{}", marker, if i == 0 { " >" } else { "  " }, lang);
+    }
+    println!();
+    println!("    type language(s), e.g., rust, python");
+    println!("    or press Enter to keep inferred");
+    
+    let choice = prompt_line("    choice: ")?;
+    
+    if choice.is_empty() {
+        return Ok(current.to_vec());
+    }
+    
+    let selected: Vec<String> = choice
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            match s.to_lowercase().as_str() {
+                "ts" | "typescript" => "TypeScript",
+                "js" | "javascript" => "JavaScript",
+                "py" => "Python",
+                "rs" => "Rust",
+                "go" => "Go",
+                "c" | "cpp" => "C/C++",
+                "rb" => "Ruby",
+                "php" => "PHP",
+                "java" => "Java",
+                _ => &s,
+            }.to_string()
+        })
+        .collect();
+    
+    Ok(selected)
+}
+
+fn infer_language_from_architecture(arch: &str) -> Vec<String> {
+    match arch.to_lowercase().as_str() {
+        "webapp" => vec!["TypeScript".to_string()],
+        "microservice" => vec!["Go".to_string()],
+        "library" => vec![],
+        "cli" => vec!["Rust".to_string()],
+        "lambda" => vec!["Python".to_string()],
+        "mobile-android" => vec!["Kotlin".to_string()],
+        "mobile-ios" => vec!["Swift".to_string()],
+        "multiarch" => vec!["Rust".to_string()],
+        "infra" => vec!["HCL".to_string()],
+        "data" => vec!["Python".to_string()],
+        _ => vec![],
+    }
+}
+
+#[allow(non_snake_case)]
+fn prompt_architectureChoice(current: Option<&str>) -> Result<Option<String>, error::DecapodError> {
+    use crate::core::ansi::AnsiExt;
+    let inferred = current.unwrap_or("None");
+    
+    println!();
+    println!("{}", "  Architecture".bright_white().bold());
+    println!("    inferred: {}", inferred);
+    println!("    common approaches:");
+    println!();
+    
+    for (i, (arch, desc)) in ARCH_DIRECTIONS.iter().enumerate() {
+        let marker = if current.map_or(false, |c| c.eq_ignore_ascii_case(arch)) { "✓" } else { " " };
+        println!("    {}{} {} -> {}", marker, if i == 0 { " >" } else { "  " }, arch, desc);
+    }
+    println!();
+    println!("    or type your architecture");
+    
+    let choice = prompt_line("    choice: ")?;
+    
+    if choice.is_empty() {
+        return Ok(current.map(|s| s.to_string()));
+    }
+    
+    Ok(Some(choice.trim().to_string()))
+}
+
 fn print_init_block(title: &str, subtitle: &str) {
     use crate::core::ansi::AnsiExt;
     println!();
@@ -611,16 +717,8 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
         "Review inferred intent before generating .decapod/generated/specs/.",
     );
     
-    // Primary language prompt
-    let current_langs = repo.primary_languages.join(", ");
-    repo.primary_languages = prompt_line_default(
-        "Primary language(s)",
-        &current_langs,
-    )?
-    .split(',')
-    .map(|s| s.trim().to_string())
-    .filter(|s| !s.is_empty())
-    .collect();
+    // Primary language prompt with options
+    repo.primary_languages = prompt_languageChoice(&repo.primary_languages)?;
     
     let current_summary = repo.product_summary.clone().unwrap_or_else(|| {
         "Deliver the repository outcome against explicit user intent with proof-backed completion."
@@ -1945,10 +2043,24 @@ fn check_and_update_version() -> Result<bool, error::DecapodError> {
 
         if install_decapod().is_ok() {
             eprintln!(
-                "{} Updated to v{}. Re-run session acquire.",
+                "{} Updated to v{}.",
                 "✓".bright_green(),
                 latest_version
             );
+            
+            // Prompt to migrate/refresh config for new fields
+            let project_root = std::env::current_dir()
+                .ok()
+                .and_then(|d| find_decapod_project_root(&d).ok());
+            
+            if let Some(root) = project_root {
+                let config_path = root.join(".decapod").join("config.toml");
+                if config_path.exists() {
+                    eprintln!("{} Check for new config fields in .decapod/config.toml",
+                        "→".bright_cyan());
+                }
+            }
+            
             return Ok(true);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,6 +610,18 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
         "Repository Context",
         "Review inferred intent before generating .decapod/generated/specs/.",
     );
+    
+    // Primary language prompt
+    let current_langs = repo.primary_languages.join(", ");
+    repo.primary_languages = prompt_line_default(
+        "Primary language(s)",
+        &current_langs,
+    )?
+    .split(',')
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+    .collect();
+    
     let current_summary = repo.product_summary.clone().unwrap_or_else(|| {
         "Deliver the repository outcome against explicit user intent with proof-backed completion."
             .to_string()

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -195,6 +195,60 @@ fn init_with_accepts_noninteractive_spec_seed_flags() {
 }
 
 #[test]
+fn init_with_architecture_seeds_ideal_language_when_unspecified() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(
+        tmp.path(),
+        &[
+            "init",
+            "with",
+            "--force",
+            "--architecture-direction",
+            "microservice",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init with architecture failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config =
+        fs::read_to_string(tmp.path().join(".decapod/config.toml")).expect("read config.toml");
+    assert!(
+        config.contains("primary_languages = [\"Go\"]"),
+        "microservice architecture should seed Go as the default language: {config}"
+    );
+}
+
+#[test]
+fn init_with_architecture_can_recommend_zig() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(
+        tmp.path(),
+        &[
+            "init",
+            "with",
+            "--force",
+            "--architecture-direction",
+            "embedded systems",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init with embedded architecture failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config =
+        fs::read_to_string(tmp.path().join(".decapod/config.toml")).expect("read config.toml");
+    assert!(
+        config.contains("primary_languages = [\"Zig\"]"),
+        "embedded systems architecture should seed Zig as the default language: {config}"
+    );
+}
+
+#[test]
 fn init_with_accepts_noninteractive_spec_seed_env() {
     let tmp = tempdir().expect("tempdir");
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))


### PR DESCRIPTION
## Summary
- Position Decapod as governance kernel (not control plane)
- Add 'Agent workbenches improve the session. Decapod improves the shared substrate.' section
- Add Integrations table for Claude, Codex, Gemini, Cursor with entrypoints
- Make proof artifacts concrete with  file paths
- Add shared substrate structure diagram

## Positioning improvements
- Agents act in private context; Decapod makes their work public to the repo
- Task started by one provider should be auditable/resumable by another
- Source of truth in , not chat history or provider memory

## Validation
pass=192, fail=0