### PR TITLE
validate: soften expected gate failure output

### DIFF
--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -4898,19 +4898,36 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
         report.elapsed_ms as f64 / 1000.0
     );
 
-    if !report.failures.is_empty() {
+    if !report.failures.is_empty() && verbose {
         println!(
             "  {} {}",
-            "failures".bright_red().bold(),
-            output::preview_messages(&report.failures, 3, 120)
+            "issues".bright_red().bold(),
+            output::preview_messages(&report.failures, 10, 160)
+        );
+    } else if let Some(first_failure) = report.failures.first() {
+        println!(
+            "  {} {} found; first item: {}",
+            "issues".bright_yellow().bold(),
+            report.failures.len().to_string().bright_red(),
+            output::compact_line(first_failure, 120)
+        );
+        println!(
+            "  {} run `decapod validate -v` or `decapod validate --format json` for the full list",
+            "details".bright_blue().bold()
         );
     }
 
-    if !report.warnings.is_empty() {
+    if !report.warnings.is_empty() && verbose {
         println!(
             "  {} {}",
             "warnings".bright_yellow().bold(),
-            output::preview_messages(&report.warnings, 3, 120)
+            output::preview_messages(&report.warnings, 10, 160)
+        );
+    } else if !report.warnings.is_empty() {
+        println!(
+            "  {} {} hidden; use `-v` for warning details",
+            "warnings".bright_yellow().bold(),
+            report.warnings.len().to_string().bright_yellow()
         );
     }
 
@@ -4919,6 +4936,12 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
             "{} {}",
             "✓".bright_green().bold(),
             "validation passed".bright_green().bold()
+        );
+    } else {
+        println!(
+            "{} {}",
+            "!".bright_yellow().bold(),
+            "validation needs attention".bright_yellow().bold()
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3751,17 +3751,25 @@ fn render_validation_text(
 
     validate::render_validation_report(report, verbose);
     if !actions.is_empty() {
-        println!(
-            "  {} {}",
-            "repair".bright_blue().bold(),
-            format!("{} action(s)", actions.len()).bright_white()
-        );
-        for action in actions {
+        if verbose {
             println!(
-                "  {} {} {}",
-                "↺".bright_blue(),
-                action.action.bright_cyan(),
-                action.detail
+                "  {} {}",
+                "repair".bright_blue().bold(),
+                format!("{} action(s)", actions.len()).bright_white()
+            );
+            for action in actions {
+                println!(
+                    "  {} {} {}",
+                    "↺".bright_blue(),
+                    action.action.bright_cyan(),
+                    action.detail
+                );
+            }
+        } else {
+            println!(
+                "  {} {} action(s) applied; use `-v` for repair details",
+                "repair".bright_blue().bold(),
+                actions.len().to_string().bright_white()
             );
         }
     }
@@ -3799,14 +3807,13 @@ fn run_validate_command(
             if validate_cli.format == "json" {
                 println!("{}", serde_json::to_string_pretty(&response).unwrap());
             } else {
-                eprintln!("❌ VALIDATION FAILED: Workspace Protection Gate");
-                eprintln!("   Error: {}", blocker.message);
-                eprintln!("   Hint: {}", blocker.resolve_hint);
+                eprintln!("validation needs attention: workspace protection");
+                eprintln!("  branch: {}", workspace_status.git.current_branch);
+                eprintln!("  reason: {}", blocker.message);
+                eprintln!("  next: {}", blocker.resolve_hint);
             }
 
-            return Err(error::DecapodError::ValidationError(
-                "Workspace protection gate failed".to_string(),
-            ));
+            std::process::exit(1);
         }
     }
 
@@ -3871,10 +3878,7 @@ fn run_validate_command(
     }
 
     if report.fail_count > 0 {
-        return Err(error::DecapodError::ValidationError(format!(
-            "{} test(s) failed after self-heal.",
-            report.fail_count
-        )));
+        std::process::exit(1);
     }
     mark_validation_completed(project_root)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Render expected validation gate issues as concise needs-attention output instead of noisy error dumps
- Hide full failure/warning lists by default while preserving complete details via -v and --format json
- Exit nonzero for expected gate issues without adding the extra top-level Error wrapper

## Verification
- nix --extra-experimental-features "nix-command flakes" develop .#ci -c cargo fmt --all -- --check
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= nix --extra-experimental-features "nix-command flakes" shell nixpkgs#cargo nixpkgs#clippy nixpkgs#rustc -c cargo clippy --all-targets --all-features -- -D warnings
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --test validate_termination --test entrypoint_correctness
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo run -- validate (expected nonzero; confirms concise needs-attention output)