### PR TITLE
Improve validation diagnostics and branch gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 </p>
 
 <p align="center">
-  Agents call Decapod on demand to turn intent into bounded context,<br />
-  bounded context into specifications, and finished work into proof.
+  Agents call Decapod on demand to turn intent into context, then context into explicit specifications before inference,<br />
+  and finished work into proof.
 </p>
 
 <p align="center">

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -63,6 +63,13 @@ fn container_signal_reasons(repo_root: &Path) -> Vec<&'static str> {
     .collect()
 }
 
+fn auto_remediable_validation_message(code: &str, message: &str, next_action: &str) -> String {
+    format!(
+        "AUTOREMEDIABLE_VALIDATION_ERROR code={} severity=transient auto_remediable=true next_action=\"{}\"\n{}",
+        code, next_action, message
+    )
+}
+
 /// Spawn a validation gate in a rayon scope with timing and error capture.
 ///
 /// Replaces ~10 lines of boilerplate per gate with a single invocation.
@@ -3467,7 +3474,11 @@ fn validate_git_workspace_context(
         return Ok(());
     } else {
         fail(
-            "Not running in container workspace - git-tracked work must execute in Docker-isolated workspace (claim.git.container_workspace_required)",
+            &auto_remediable_validation_message(
+                "container_workspace_required",
+                "Not running in container workspace - git-tracked work must execute in Docker-isolated workspace (claim.git.container_workspace_required)",
+                "Run the command through `decapod auto container run`, or retry inside a Decapod-created container workspace.",
+            ),
             ctx,
         );
     }
@@ -3659,8 +3670,6 @@ fn validate_git_protected_branch(
         return Ok(());
     }
 
-    let protected_patterns = ["master", "main", "production", "stable"];
-
     let current_branch = {
         let output = std::process::Command::new("git")
             .args(["rev-parse", "--abbrev-ref", "HEAD"])
@@ -3678,9 +3687,7 @@ fn validate_git_protected_branch(
             .unwrap_or_else(|| "unknown".to_string())
     };
 
-    let is_protected = protected_patterns
-        .iter()
-        .any(|p| current_branch == *p || current_branch.starts_with("release/"));
+    let is_protected = is_protected_git_branch(&current_branch);
 
     if is_protected {
         fail(
@@ -3697,14 +3704,7 @@ fn validate_git_protected_branch(
         );
     }
 
-    let has_remote = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(repo_root)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-
-    if has_remote {
+    if is_protected && git_origin_exists(repo_root) {
         let ahead_behind = std::process::Command::new("git")
             .args(["rev-list", "--left-right", "--count", "HEAD...origin/HEAD"])
             .current_dir(repo_root)
@@ -3714,9 +3714,7 @@ fn validate_git_protected_branch(
             && out.status.success()
         {
             let counts = String::from_utf8_lossy(&out.stdout);
-            let parts: Vec<&str> = counts.split_whitespace().collect();
-            if parts.len() >= 2 {
-                let ahead: u32 = parts[0].parse().unwrap_or(0);
+            if let Some((ahead, _behind)) = parse_ahead_behind_counts(&counts) {
                 if ahead > 0 {
                     let output = std::process::Command::new("git")
                         .args(["rev-list", "--format=%s", "-n1", "HEAD"])
@@ -3745,9 +3743,70 @@ fn validate_git_protected_branch(
                 }
             }
         }
+    } else if git_origin_exists(repo_root) {
+        match git_upstream_ref(repo_root) {
+            Some(upstream) => {
+                let output = std::process::Command::new("git")
+                    .args(["rev-list", "--left-right", "--count"])
+                    .arg(format!("HEAD...{}", upstream))
+                    .current_dir(repo_root)
+                    .output();
+                if let Ok(out) = output
+                    && out.status.success()
+                {
+                    let counts = String::from_utf8_lossy(&out.stdout);
+                    if let Some((ahead, behind)) = parse_ahead_behind_counts(&counts) {
+                        pass(
+                            &format!(
+                                "Working branch divergence from upstream '{}': ahead {}, behind {}; protected branch direct-push check not applicable",
+                                upstream, ahead, behind
+                            ),
+                            ctx,
+                        );
+                    }
+                }
+            }
+            None => pass(
+                "Working branch has no upstream; protected branch direct-push check not applicable",
+                ctx,
+            ),
+        }
     }
 
     Ok(())
+}
+
+fn is_protected_git_branch(branch: &str) -> bool {
+    matches!(branch, "master" | "main" | "production" | "stable") || branch.starts_with("release/")
+}
+
+fn git_origin_exists(repo_root: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_root)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn git_upstream_ref(repo_root: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let upstream = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!upstream.is_empty()).then_some(upstream)
+}
+
+fn parse_ahead_behind_counts(counts: &str) -> Option<(u32, u32)> {
+    let mut parts = counts.split_whitespace();
+    let ahead = parts.next()?.parse().ok()?;
+    let behind = parts.next()?.parse().ok()?;
+    Some((ahead, behind))
 }
 
 fn validate_tooling_gate(
@@ -3782,60 +3841,123 @@ fn validate_tooling_gate(
     let cargo_toml = repo_root.join("Cargo.toml");
     if cargo_toml.exists() {
         has_tooling = true;
-        let root_fmt = repo_root.to_path_buf();
-        let root_clippy = repo_root.to_path_buf();
-
-        let fmt_handle = std::thread::spawn(move || {
-            std::process::Command::new("cargo")
-                .args(["fmt", "--all", "--", "--check"])
-                .current_dir(&root_fmt)
-                .output()
-        });
-
-        let clippy_handle = std::thread::spawn(move || {
-            std::process::Command::new("cargo")
-                .args([
-                    "clippy",
-                    "--all-targets",
-                    "--all-features",
-                    "--",
-                    "-D",
-                    "warnings",
-                ])
-                .current_dir(&root_clippy)
-                .output()
-        });
-
-        match fmt_handle.join().expect("fmt thread panicked") {
-            Ok(output) => {
-                if output.status.success() {
-                    pass("Rust code formatting passes (cargo fmt)", ctx);
-                } else {
-                    fail("Rust code formatting failed - run `cargo fmt --all`", ctx);
-                    has_failures = true;
-                }
-            }
-            Err(e) => {
-                fail(&format!("Failed to run cargo fmt: {}", e), ctx);
-                has_failures = true;
-            }
+        let fmt_available = cargo_subcommand_available("fmt");
+        let clippy_available = cargo_subcommand_available("clippy");
+        if !fmt_available {
+            fail(
+                &auto_remediable_validation_message(
+                    "rustfmt_unavailable",
+                    "Rust formatter is unavailable; `cargo fmt --version` did not succeed.",
+                    "Install the rustfmt component or run inside `nix develop .#ci` before enabling tooling gates.",
+                ),
+                ctx,
+            );
+            has_failures = true;
+        }
+        if !clippy_available {
+            fail(
+                &auto_remediable_validation_message(
+                    "clippy_unavailable",
+                    "Rust clippy is unavailable; `cargo clippy --version` did not succeed.",
+                    "Install the clippy component or run inside `nix develop .#ci` before enabling tooling gates.",
+                ),
+                ctx,
+            );
+            has_failures = true;
         }
 
-        match clippy_handle.join().expect("clippy thread panicked") {
-            Ok(output) => {
-                if output.status.success() {
-                    pass("Rust linting passes (cargo clippy)", ctx);
-                } else {
+        let fmt_handle = fmt_available.then(|| {
+            let root_fmt = repo_root.to_path_buf();
+            std::thread::spawn(move || {
+                std::process::Command::new("cargo")
+                    .args(["fmt", "--all", "--", "--check"])
+                    .current_dir(&root_fmt)
+                    .output()
+            })
+        });
+
+        let clippy_handle = clippy_available.then(|| {
+            let root_clippy = repo_root.to_path_buf();
+            std::thread::spawn(move || {
+                std::process::Command::new("cargo")
+                    .args([
+                        "clippy",
+                        "--all-targets",
+                        "--all-features",
+                        "--",
+                        "-D",
+                        "warnings",
+                    ])
+                    .current_dir(&root_clippy)
+                    .output()
+            })
+        });
+
+        if let Some(fmt_handle) = fmt_handle {
+            match fmt_handle.join().expect("fmt thread panicked") {
+                Ok(output) => {
+                    if output.status.success() {
+                        pass("Rust code formatting passes (cargo fmt)", ctx);
+                    } else {
+                        fail(
+                            &auto_remediable_validation_message(
+                                "cargo_fmt_failed",
+                                &format!(
+                                    "Rust code formatting failed - run `cargo fmt --all`.\nstderr:\n{}",
+                                    String::from_utf8_lossy(&output.stderr).trim()
+                                ),
+                                "Run `cargo fmt --all`, then retry validation.",
+                            ),
+                            ctx,
+                        );
+                        has_failures = true;
+                    }
+                }
+                Err(e) => {
                     fail(
-                        "Rust linting failed - run `cargo clippy --all-targets --all-features`",
+                        &auto_remediable_validation_message(
+                            "cargo_fmt_execution_failed",
+                            &format!("Failed to run cargo fmt: {}", e),
+                            "Install a complete Rust toolchain, then retry validation.",
+                        ),
                         ctx,
                     );
                     has_failures = true;
                 }
             }
-            Err(e) => {
-                fail(&format!("Failed to run cargo clippy: {}", e), ctx);
-                has_failures = true;
+        }
+
+        if let Some(clippy_handle) = clippy_handle {
+            match clippy_handle.join().expect("clippy thread panicked") {
+                Ok(output) => {
+                    if output.status.success() {
+                        pass("Rust linting passes (cargo clippy)", ctx);
+                    } else {
+                        fail(
+                            &auto_remediable_validation_message(
+                                "cargo_clippy_failed",
+                                &format!(
+                                    "Rust linting failed - run `cargo clippy --all-targets --all-features`.\nstderr:\n{}",
+                                    String::from_utf8_lossy(&output.stderr).trim()
+                                ),
+                                "Fix lint failures. If the failure is local linker configuration, clear RUSTFLAGS and set CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc before retrying.",
+                            ),
+                            ctx,
+                        );
+                        has_failures = true;
+                    }
+                }
+                Err(e) => {
+                    fail(
+                        &auto_remediable_validation_message(
+                            "cargo_clippy_execution_failed",
+                            &format!("Failed to run cargo clippy: {}", e),
+                            "Install a complete Rust toolchain, then retry validation.",
+                        ),
+                        ctx,
+                    );
+                    has_failures = true;
+                }
             }
         }
     }
@@ -4036,6 +4158,15 @@ fn validate_tooling_gate(
     }
 
     Ok(())
+}
+
+fn cargo_subcommand_available(subcommand: &str) -> bool {
+    std::process::Command::new("cargo")
+        .arg(subcommand)
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 fn validate_state_commit_gate(
@@ -4943,5 +5074,26 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
             "!".bright_yellow().bold(),
             "validation needs attention".bright_yellow().bold()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_protected_git_branch, parse_ahead_behind_counts};
+
+    #[test]
+    fn protected_branch_matching_is_limited_to_protected_refs() {
+        assert!(is_protected_git_branch("master"));
+        assert!(is_protected_git_branch("main"));
+        assert!(is_protected_git_branch("release/2026.05"));
+        assert!(!is_protected_git_branch("agent/codex/fix"));
+        assert!(!is_protected_git_branch("feature/main-cleanup"));
+    }
+
+    #[test]
+    fn parses_git_ahead_behind_counts() {
+        assert_eq!(parse_ahead_behind_counts("3\t1\n"), Some((3, 1)));
+        assert_eq!(parse_ahead_behind_counts("0 12"), Some((0, 12)));
+        assert_eq!(parse_ahead_behind_counts("bad 12"), None);
     }
 }

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -84,6 +84,47 @@ struct WorkspaceSpec {
     backend: String,
 }
 
+fn auto_remediable_validation_error(
+    code: &str,
+    message: impl AsRef<str>,
+    next_action: &str,
+) -> error::DecapodError {
+    error::DecapodError::ValidationError(format!(
+        "AUTOREMEDIABLE_VALIDATION_ERROR code={} severity=transient auto_remediable=true next_action=\"{}\"\n{}",
+        code,
+        next_action,
+        message.as_ref()
+    ))
+}
+
+fn classify_container_failure(stdout: &str, stderr: &str) -> (&'static str, &'static str) {
+    let combined = format!("{}\n{}", stdout, stderr).to_lowercase();
+    if combined.contains("permission denied")
+        || combined.contains("operation not permitted")
+        || combined.contains("index.lock")
+    {
+        (
+            "container_workspace_permission_denied",
+            "Retry from a Decapod worktree with a writable workspace, or disable host-user mapping only when host cleanup is acceptable.",
+        )
+    } else if combined.contains("refusing to fetch into branch") {
+        (
+            "container_branch_sync_checked_out",
+            "Retry with a dedicated work branch that is not checked out in the host repository, then let Decapod fold the branch back.",
+        )
+    } else if combined.contains("invalid linker name") || combined.contains("-fuse-ld=lld") {
+        (
+            "rust_toolchain_linker_config",
+            "Clear RUSTFLAGS and set CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc, or run inside the repo's Nix development shell.",
+        )
+    } else {
+        (
+            "container_command_failed",
+            "Inspect stdout/stderr, apply the suggested fix, and rerun the same Decapod container command.",
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RunSummary {
     pub value: serde_json::Value,
@@ -228,15 +269,20 @@ fn run_container(
             let message = "No container runtime found (docker/podman).\n\
 Please install Docker or Podman.\n\
 Warning: without isolated containers, concurrent agents can step on each other.";
-            return Err(error::DecapodError::ValidationError(message.to_string()));
+            return Err(auto_remediable_validation_error(
+                "container_runtime_missing",
+                message,
+                "Install Docker or Podman, start the runtime, then retry the Decapod container command.",
+            ));
         }
     };
     clear_container_runtime_override(&repo)?;
     if container_runtime_disabled(&repo)? {
-        return Err(error::DecapodError::ValidationError(
+        return Err(auto_remediable_validation_error(
+            "container_runtime_override_disabled",
             "Container subsystem is disabled by .decapod/OVERRIDE.md even though a runtime is available. \
-Clear the disable marker or let Decapod self-heal the override file before retrying."
-                .to_string(),
+Clear the disable marker or let Decapod self-heal the override file before retrying.",
+            "Run `decapod validate` once to allow self-heal, or remove the container disable marker through Decapod.",
         ));
     }
 
@@ -281,10 +327,14 @@ Clear the disable marker or let Decapod self-heal the override file before retry
             if !keep_worktree {
                 let _ = cleanup_workspace_clone(&workspace.path);
             }
-            error::DecapodError::ValidationError(format!(
-                "container runtime terminated before normal completion: {}\n{}",
-                exec_err, sync_msg
-            ))
+            auto_remediable_validation_error(
+                "container_runtime_terminated",
+                format!(
+                    "container runtime terminated before normal completion: {}\n{}",
+                    exec_err, sync_msg
+                ),
+                "Retry the same command after addressing the runtime or sync diagnostic below.",
+            )
         },
     )?;
     let elapsed = start.elapsed().as_secs();
@@ -346,12 +396,17 @@ Clear the disable marker or let Decapod self-heal the override file before retry
     if !output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(error::DecapodError::ValidationError(format!(
-            "Container command failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
-            output.status.code(),
-            stdout.trim(),
-            stderr.trim()
-        )));
+        let (code, next_action) = classify_container_failure(&stdout, &stderr);
+        return Err(auto_remediable_validation_error(
+            code,
+            format!(
+                "Container command failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+                output.status.code(),
+                stdout.trim(),
+                stderr.trim()
+            ),
+            next_action,
+        ));
     }
     if let Some(err) = cleanup_err {
         return Err(err);
@@ -382,10 +437,11 @@ fn execute_container_with_timeout(
         }
         if start.elapsed() > timeout {
             let _ = child.kill();
-            return Err(error::DecapodError::ValidationError(format!(
-                "Container command timed out after {}s",
-                timeout_seconds
-            )));
+            return Err(auto_remediable_validation_error(
+                "container_command_timeout",
+                format!("Container command timed out after {}s", timeout_seconds),
+                "Increase --timeout-seconds for expected long runs, or inspect the command for a lock/deadlock before retrying.",
+            ));
         }
         std::thread::sleep(Duration::from_millis(250));
     }
@@ -582,16 +638,20 @@ fn ensure_container_runtime_access(runtime: &str) -> Result<(), error::DecapodEr
         "Runtime preflight failed. Verify Docker/Podman daemon availability and user permissions, then retry."
     };
 
-    Err(error::DecapodError::ValidationError(format!(
-        "Container runtime preflight failed.\n\
+    Err(auto_remediable_validation_error(
+        "container_runtime_preflight_failed",
+        format!(
+            "Container runtime preflight failed.\n\
 runtime: {}\n\
 probe: `{}`\n\
 {}\n\
 context: {}, DOCKER_HOST={}, XDG_RUNTIME_DIR={}\n\
 stderr:\n{}\n\
 stdout:\n{}",
-        runtime, "info", remediation, uid, docker_host, xdg_runtime_dir, stderr, stdout
-    )))
+            runtime, "info", remediation, uid, docker_host, xdg_runtime_dir, stderr, stdout
+        ),
+        remediation,
+    ))
 }
 
 fn push_branch_to_origin(repo: &Path, branch: &str) -> Result<(), error::DecapodError> {
@@ -672,12 +732,16 @@ fn ensure_local_alpine_image(runtime: &str, repo: &Path) -> Result<String, error
         .output()
         .map_err(error::DecapodError::IoError)?;
     if !output.status.success() {
-        return Err(error::DecapodError::ValidationError(format!(
-            "Failed to build local alpine image '{}'\nstdout:\n{}\nstderr:\n{}",
-            image_tag,
-            String::from_utf8_lossy(&output.stdout).trim(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        )));
+        return Err(auto_remediable_validation_error(
+            "container_image_build_failed",
+            format!(
+                "Failed to build local alpine image '{}'\nstdout:\n{}\nstderr:\n{}",
+                image_tag,
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+            "Fix Dockerfile/package resolution for the local image, then retry the container run.",
+        ));
     }
 
     Ok(image_tag)
@@ -719,7 +783,14 @@ fn dockerfile_template_schema_component() -> DockerfileTemplateSchemaComponent {
         generator: "container::generated_dockerfile_for_repo",
         regenerate_hint: "decapod auto container run --image-profile alpine",
         base_images,
-        required_packages: vec!["git", "openssh-client", "ca-certificates", "bash", "curl"],
+        required_packages: vec![
+            "git",
+            "openssh-client",
+            "ca-certificates",
+            "bash",
+            "curl",
+            "coreutils",
+        ],
         stack_packages,
         extra_packages_env: "DECAPOD_CONTAINER_APK_PACKAGES",
     }
@@ -921,10 +992,14 @@ fn sync_workspace_branch_to_host_repo(
 ) -> Result<(), error::DecapodError> {
     let branch_ref = format!("refs/heads/{}", branch);
     if !git_ref_exists(workspace, &branch_ref)? {
-        return Err(error::DecapodError::ValidationError(format!(
-            "workspace branch '{}' does not exist; cannot sync back to host repo",
-            branch
-        )));
+        return Err(auto_remediable_validation_error(
+            "container_workspace_branch_missing",
+            format!(
+                "workspace branch '{}' does not exist; cannot sync back to host repo",
+                branch
+            ),
+            "Retry with a freshly prepared Decapod workspace; the previous workspace did not retain the expected branch.",
+        ));
     }
 
     let workspace_str = workspace.to_str().ok_or_else(|| {
@@ -959,17 +1034,25 @@ fn sync_workspace_branch_to_host_repo(
         if pull_output.status.success() {
             return Ok(());
         }
-        return Err(error::DecapodError::ValidationError(format!(
-            "failed fast-forwarding checked-out branch '{}' from workspace '{}': {}",
-            branch,
-            workspace.display(),
-            String::from_utf8_lossy(&pull_output.stderr).trim()
-        )));
+        return Err(auto_remediable_validation_error(
+            "container_branch_sync_checked_out",
+            format!(
+                "failed fast-forwarding checked-out branch '{}' from workspace '{}': {}",
+                branch,
+                workspace.display(),
+                String::from_utf8_lossy(&pull_output.stderr).trim()
+            ),
+            "Check out a different host branch or use a dedicated Decapod worktree, then retry branch foldback.",
+        ));
     }
-    Err(error::DecapodError::ValidationError(format!(
-        "failed syncing workspace branch '{}' back to host repo: {}",
-        branch, stderr
-    )))
+    Err(auto_remediable_validation_error(
+        "container_branch_sync_failed",
+        format!(
+            "failed syncing workspace branch '{}' back to host repo: {}",
+            branch, stderr
+        ),
+        "Resolve the git sync diagnostic, then retry foldback or push from the retained workspace branch.",
+    ))
 }
 
 fn current_branch(repo: &Path) -> Result<String, error::DecapodError> {
@@ -1402,6 +1485,7 @@ mod tests {
         assert!(content.contains("FROM rust:1.91.1-alpine"));
         assert!(content.contains("git"));
         assert!(content.contains("openssh-client"));
+        assert!(content.contains("coreutils"));
     }
 
     #[test]
@@ -1414,7 +1498,26 @@ mod tests {
         });
         assert!(content.contains("FROM alpine:3.20"));
         assert!(content.contains("git"));
+        assert!(content.contains("coreutils"));
         assert!(!content.contains("rust:1.91.1-alpine"));
+    }
+
+    #[test]
+    fn container_failures_are_classified_for_common_validation_causes() {
+        assert_eq!(
+            classify_container_failure("", "fatal: unable to create index.lock: Permission denied")
+                .0,
+            "container_workspace_permission_denied"
+        );
+        assert_eq!(
+            classify_container_failure("", "fatal: refusing to fetch into branch").0,
+            "container_branch_sync_checked_out"
+        );
+        assert_eq!(
+            classify_container_failure("", "clang: invalid linker name in argument '-fuse-ld=lld'")
+                .0,
+            "rust_toolchain_linker_config"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify expected/self-healable validation failures with auto-remediable metadata and next actions
- stop treating ordinary PR/work branches ahead of origin/HEAD as protected-branch violations
- harden container diagnostics for runtime, Docker image, command, permission, linker, timeout, and branch foldback failures
- restore README intent/context/spec wording required by entrypoint contract tests

## Verification
- cargo fmt --all -- --check via Nix rustfmt
- cargo test --lib
- cargo test --test entrypoint_correctness -- --test-threads=4
- cargo test --test agent_rpc_suite -- --test-threads=4
- cargo clippy --all-targets --all-features -- -D warnings via Nix
- docker container validate with branch binary: status ok, fail_count 0