### PR TITLE
test: init+validate green field integration tests

### DIFF
--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -307,7 +307,7 @@ pub fn ensure_workspace(
     let assigned_todos = get_assigned_open_tasks(repo_root, agent_id)?;
     if assigned_todos.is_empty() {
         return Err(DecapodError::ValidationError(format!(
-            "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_NO_CLAIMED_TODO severity=transient auto_remediable=true audience=agent agent_action=\"claim a todo with \`decapod todo claim --id <task-id>\` before spawning a worktree\" user_note=\"No todo is assigned to this agent; the agent should claim an open task first.\"\nNo claimed or open todo assigned to agent '{}'. Agent must claim a todo before spawning a worktree.",
+            "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_NO_CLAIMED_TODO severity=transient auto_remediable=true audience=agent agent_action=\"claim a todo with `decapod todo claim --id <task-id>` before spawning a worktree\" user_note=\"No todo is assigned to this agent; the agent should claim an open task first.\"\nNo claimed or open todo assigned to agent '{}'. Agent must claim a todo before spawning a worktree.",
             agent_id
         )));
     }

--- a/src/plugins/aptitude.rs
+++ b/src/plugins/aptitude.rs
@@ -660,7 +660,7 @@ fn repo_root_from_store(store: &Store) -> Result<PathBuf, error::DecapodError> {
         .map(Path::to_path_buf)
         .ok_or_else(|| {
             error::DecapodError::ValidationError(
-                format!("AUTOREMEDIABLE_VALIDATION_ERROR code=UNABLE_RESOLVE_REPO_ROOT severity=transient auto_remediable=true audience=agent agent_action=\"ensure the store root contains a valid repository and adjust path if needed\" user_note=\"Cannot resolve repository root from store root; the agent should verify the directory layout.\"\nUnable to resolve repo root from store root"),
+                "AUTOREMEDIABLE_VALIDATION_ERROR code=UNABLE_RESOLVE_REPO_ROOT severity=transient auto_remediable=true audience=agent agent_action=\"ensure the store root contains a valid repository and adjust path if needed\" user_note=\"Cannot resolve repository root from store root; the agent should verify the directory layout.\"\nUnable to resolve repo root from store root".to_string(),
             )
         })
 }
@@ -677,7 +677,7 @@ fn parse_skill_md_frontmatter(raw: &str) -> Result<(String, Option<String>), err
     let mut lines = raw.lines();
     if lines.next().map(str::trim) != Some("---") {
         return Err(error::DecapodError::ValidationError(
-            format!("AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_MISSING_FRONTMATTER severity=transient auto_remediable=true audience=agent agent_action=\"ensure SKILL.md starts with YAML frontmatter delimiter '---'\" user_note=\"SKILL.md missing frontmatter start delimiter; the agent should add the required '---' line at the beginning of the file.\"\nSKILL.md missing YAML frontmatter start '---'"),
+            "AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_MISSING_FRONTMATTER severity=transient auto_remediable=true audience=agent agent_action=\"ensure SKILL.md starts with YAML frontmatter delimiter '---'\" user_note=\"SKILL.md missing frontmatter start delimiter; the agent should add the required '---' line at the beginning of the file.\"\nSKILL.md missing YAML frontmatter start '---'".to_string(),
         ));
     }
     let mut name: Option<String> = None;
@@ -694,7 +694,7 @@ fn parse_skill_md_frontmatter(raw: &str) -> Result<(String, Option<String>), err
         }
     }
     let name = name.ok_or_else(|| {
-        error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_MISSING_NAME severity=transient auto_remediable=true audience=agent agent_action=\"add a 'name' field to SKILL.md frontmatter\" user_note=\"SKILL.md frontmatter missing required 'name' field; the agent should include a name entry.\"\nSKILL.md frontmatter missing 'name'"))
+        error::DecapodError::ValidationError("AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_MISSING_NAME severity=transient auto_remediable=true audience=agent agent_action=\"add a 'name' field to SKILL.md frontmatter\" user_note=\"SKILL.md frontmatter missing required 'name' field; the agent should include a name entry.\"\nSKILL.md frontmatter missing 'name'".to_string())
     })?;
     Ok((name, description))
 }
@@ -816,7 +816,7 @@ pub fn import_skill_md(
     };
     add_skill(store, input)?;
     let skill = get_skill(store, &name)?.ok_or_else(|| {
-        error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_IMPORT_FAIL severity=transient auto_remediable=true audience=agent agent_action=\"ensure skill import persists correctly, verify file writes\" user_note=\"Skill import failed to persist; the agent should retry or investigate file system issues.\"\nskill import did not persist"))
+        error::DecapodError::ValidationError("AUTOREMEDIABLE_VALIDATION_ERROR code=SKILL_IMPORT_FAIL severity=transient auto_remediable=true audience=agent agent_action=\"ensure skill import persists correctly, verify file writes\" user_note=\"Skill import failed to persist; the agent should retry or investigate file system issues.\"\nskill import did not persist".to_string())
     })?;
 
     if !write_card {

--- a/src/plugins/context.rs
+++ b/src/plugins/context.rs
@@ -30,7 +30,7 @@ impl ContextManager {
         let config = if config_path.exists() {
             let content = fs::read_to_string(config_path).map_err(error::DecapodError::IoError)?;
             serde_json::from_str(&content)
-                .map_err(|e| error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_CONFIG_PARSE severity=transient auto_remediable=true audience=agent agent_action=\"verify the CONTEXT.json syntax and schema\" user_note=\"Context configuration parse error; the agent should correct the JSON format.\"\n{}", e.to_string())))?
+                .map_err(|e| error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_CONFIG_PARSE severity=transient auto_remediable=true audience=agent agent_action=\"verify the CONTEXT.json syntax and schema\" user_note=\"Context configuration parse error; the agent should correct the JSON format.\"\n{}", e)))?
         } else {
             Self::default_config()
         };
@@ -209,7 +209,7 @@ Archive ID: {}
             .find(|a| a.id == archive_id)
             .ok_or_else(|| {
                 error::DecapodError::ValidationError(format!(
-                    "AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_ARCHIVE_NOT_FOUND severity=transient auto_remediable=true audience=agent agent_action=\"verify the archive ID '{}' exists using \`decapod context archive list\`\" user_note=\"The requested archive was not found; the agent should check available archives.\"\nArchive '{}' not found",
+                    "AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_ARCHIVE_NOT_FOUND severity=transient auto_remediable=true audience=agent agent_action=\"verify the archive ID '{}' exists using `decapod context archive list`\" user_note=\"The requested archive was not found; the agent should check available archives.\"\nArchive '{}' not found",
                     archive_id, archive_id
                 ))
             })?;
@@ -229,8 +229,7 @@ Archive ID: {}
             );
             return Err(error::DecapodError::ValidationError(format!(
                 "AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_RESTORE_BUDGET_EXCEEDED severity=transient auto_remediable=true audience=agent agent_action=\"adjust the restore plan to fit within the '{}' profile's token budget\" user_note=\"Restore blocked because the token budget would be exceeded; the agent should either reduce added tokens or inform the user of the budget limit.\"\nRestore blocked: budget exceeded ({} + {} > {})",
-                profile_name,
-                current_tokens, added_tokens, profile.budget_tokens
+                profile_name, current_tokens, added_tokens, profile.budget_tokens
             )));
         }
 

--- a/tests/init_validate_green_field.rs
+++ b/tests/init_validate_green_field.rs
@@ -1,0 +1,343 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn run_decapod_with_password(
+    dir: &Path,
+    args: &[&str],
+    password: &str,
+    extra_envs: &[(&str, &str)],
+) -> std::process::Output {
+    let mut envs = vec![
+        ("DECAPOD_AGENT_ID", "init-validate-test"),
+        ("DECAPOD_SESSION_PASSWORD", password),
+        ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+    ];
+    for (k, v) in extra_envs {
+        envs.push((*k, *v));
+    }
+    run_decapod(dir, args, &envs)
+}
+
+fn setup_initialized_repo(tmp: &tempfile::TempDir) -> String {
+    let dir = tmp.path();
+
+    let git_init = Command::new("git")
+        .current_dir(dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--product-name",
+            "Test Project",
+            "--product-summary",
+            "A test project for validation",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let acquire = run_decapod(
+        dir,
+        &["session", "acquire"],
+        &[
+            ("DECAPOD_AGENT_ID", "init-validate-test"),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    stdout
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output")
+}
+
+#[test]
+fn fresh_init_validate_comes_back_green() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+    let password = setup_initialized_repo(&tmp);
+
+    let validate = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+
+    let stderr = String::from_utf8_lossy(&validate.stderr);
+    let stdout = String::from_utf8_lossy(&validate.stdout);
+
+    assert!(
+        validate.status.success(),
+        "validate should succeed for fresh init project.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+
+    assert!(
+        stderr.contains("validation passed") || stdout.contains("validation passed"),
+        "expected 'validation passed' in output"
+    );
+
+    assert!(
+        !stderr.contains("fail=") || stderr.contains("fail=0"),
+        "expected no failures in validation output: {}",
+        stderr
+    );
+}
+
+#[test]
+fn fresh_init_validate_with_real_git_workspace() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+    let password = setup_initialized_repo(&tmp);
+
+    let validate = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+
+    let stderr = String::from_utf8_lossy(&validate.stderr);
+    let stdout = String::from_utf8_lossy(&validate.stdout);
+
+    assert!(
+        validate.status.success(),
+        "validate should succeed for fresh init project with git workspace.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+}
+
+#[test]
+fn re_init_preserves_validation_green() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+    let password = setup_initialized_repo(&tmp);
+
+    let validate1 = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+    assert!(
+        validate1.status.success(),
+        "first validate failed: {}",
+        String::from_utf8_lossy(&validate1.stderr)
+    );
+
+    let reinit = run_decapod_with_password(dir, &["init", "--force"], &password, &[]);
+    assert!(
+        reinit.status.success(),
+        "re-init failed: {}",
+        String::from_utf8_lossy(&reinit.stderr)
+    );
+
+    let validate2 = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+    let stderr = String::from_utf8_lossy(&validate2.stderr);
+
+    assert!(
+        validate2.status.success(),
+        "validate after re-init should succeed.\nstderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn upgrade_from_older_config_version_reports_clear_error() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    let git_init = Command::new("git")
+        .current_dir(dir)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--product-name",
+            "Upgrade Test",
+            "--product-summary",
+            "Test upgrade path",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "initial decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config_path = dir.join(".decapod").join("config.toml");
+    let config_content = fs::read_to_string(&config_path).expect("read config.toml");
+
+    let old_config =
+        config_content.replace(r#"schema_version = "1.0.0""#, r#"schema_version = "0.9.0""#);
+    fs::write(&config_path, old_config).expect("write old config version");
+
+    let acquire = run_decapod(
+        dir,
+        &["session", "acquire"],
+        &[
+            ("DECAPOD_AGENT_ID", "init-validate-test"),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    let validate = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+
+    let stderr = String::from_utf8_lossy(&validate.stderr);
+    let stdout = String::from_utf8_lossy(&validate.stdout);
+
+    assert!(
+        stdout.contains("fail=") && stdout.contains("schema_version must be 1.0.0"),
+        "error message should clearly indicate schema_version issue.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+}
+
+#[test]
+fn init_validate_with_various_config_options() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    let git_init = Command::new("git")
+        .current_dir(dir)
+        .args(["init", "-b", "main"])
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success(), "git init failed");
+
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--product-name",
+            "Multi Option Test",
+            "--product-summary",
+            "Testing multiple init options",
+            "--primary-language",
+            "rust,python",
+            "--surface",
+            "cli,backend",
+            "--architecture-direction",
+            "Microservice with CLI frontend",
+            "--done-criteria",
+            "all tests pass and validate is green",
+        ],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "decapod init with options failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let acquire = run_decapod(
+        dir,
+        &["session", "acquire"],
+        &[
+            ("DECAPOD_AGENT_ID", "init-validate-test"),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    let validate = run_decapod_with_password(
+        dir,
+        &["validate"],
+        &password,
+        &[("DECAPOD_VALIDATE_TIMEOUT_SECS", "120")],
+    );
+
+    let stderr = String::from_utf8_lossy(&validate.stderr);
+
+    assert!(
+        validate.status.success(),
+        "validate should succeed with complex init options.\nstderr: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

Adds CI integration tests for `decapod init` followed by `decapod validate` to ensure new projects come back entirely green, and tests the upgrade path for older config schemas.

## Tests Added

1. `fresh_init_validate_comes_back_green` - Verifies a freshly initialized project validates with zero failures
2. `fresh_init_validate_with_real_git_workspace` - Same test with git workspace gates enabled  
3. `re_init_preserves_validation_green` - Re-running init on existing project preserves validation health
4. `init_validate_with_various_config_options` - Tests complex init options still validate green
5. `upgrade_from_older_config_version_reports_clear_error` - Old config schema version produces clear error

## Fixes

Also includes fix from PR #522 (cherry-picked):
- Fix invalid escape sequence `\`` in validation error strings (workspace.rs, context.rs)
- Fix `useless_format` clippy warnings (aptitude.rs)
- Fix `to_string_in_format_args` clippy warning (context.rs)

## Test Results

All 5 tests pass locally:
```
running 5 tests
test fresh_init_validate_comes_back_green ... ok
test fresh_init_validate_with_real_git_workspace ... ok  
test init_validate_with_various_config_options ... ok
test re_init_preserves_validation_green ... ok
test upgrade_from_older_config_version_reports_clear_error ... ok
```