### PR TITLE
Enhance universal agent contract template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-This contract applies equally to Claude, Codex, Gemini, Cursor, Kilo, and any other agent operating here.
+This contract applies equally to Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and future agents.
 
 ## Mandatory Initialization
 
@@ -71,11 +71,11 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Universal Agent Operating Contract
 
-**Doctrine:** Establish intent, shape context, bound mutation, and define proof before implementation.
+**Doctrine:** Agents should establish intent, shape context, bound mutation, and define proof before implementation.
 
-**Before:** Determine what's asked; identify files/modules; define scope; surface assumptions; create dependency-aware todos.
+**Before:** Determine what's asked; identify files/commands/modules/artifacts; define in/out scope; surface assumptions/clarifications; create dependency-aware todos.
 
-**During:** Avoid opportunistic rewrites; preserve behavior unless task requires change; stop before crossing subsystem boundaries; verify before completion.
+**During:** Avoid opportunistic rewrites; preserve behavior unless required; stop before crossing subsystem boundaries; run the strongest practical verification.
 
 **After:** Report what changed, tested, not tested, and uncertainty. Ensure `decapod validate` passes.
 
@@ -85,7 +85,7 @@ Decapod is the repo-native control plane agents call on demand. It reduces waste
 
 - **The agent performs the work.** Decapod does not implement or decide.
 - **Decapod governs the work.** It validates, tracks, and surfaces convergence proof.
-- **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, and others more reliable by absorbing common deficiencies.
+- **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and others more reliable by absorbing common deficiencies.
 
 Call Decapod before editing. Let Decapod validate after editing.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  Agents call Decapod on demand to turn intent into context, context into explicit specifications,<br />
+  Agents call Decapod on demand to turn intent into context, then context into explicit specifications before inference,<br />
   and finished work into proof.
 </p>
 

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -253,7 +253,7 @@ fn template_agents() -> String {
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod control plane.**
 
-This contract applies equally to Claude, Codex, Gemini, Cursor, Kilo, and any other agent operating here.
+This contract applies equally to Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and future agents.
 
 ## Mandatory Initialization
 
@@ -322,11 +322,11 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Universal Agent Operating Contract
 
-**Doctrine:** Establish intent, shape context, bound mutation, and define proof before implementation.
+**Doctrine:** Agents should establish intent, shape context, bound mutation, and define proof before implementation.
 
-**Before:** Determine what's asked; identify files/modules; define scope; surface assumptions; create dependency-aware todos.
+**Before:** Determine what's asked; identify files/commands/modules/artifacts; define in/out scope; surface assumptions/clarifications; create dependency-aware todos.
 
-**During:** Avoid opportunistic rewrites; preserve behavior unless task requires change; stop before crossing subsystem boundaries; verify before completion.
+**During:** Avoid opportunistic rewrites; preserve behavior unless required; stop before crossing subsystem boundaries; run the strongest practical verification.
 
 **After:** Report what changed, tested, not tested, and uncertainty. Ensure `decapod validate` passes.
 
@@ -336,7 +336,7 @@ Decapod is the repo-native control plane agents call on demand. It reduces waste
 
 - **The agent performs the work.** Decapod does not implement or decide.
 - **Decapod governs the work.** It validates, tracks, and surfaces convergence proof.
-- **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, and others more reliable by absorbing common deficiencies.
+- **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and others more reliable by absorbing common deficiencies.
 
 Call Decapod before editing. Let Decapod validate after editing.
 


### PR DESCRIPTION
## Summary
- update the AGENTS.md source template in src/core/assets.rs with the universal operating contract wording and requested provider coverage
- sync the generated AGENTS.md output with the managed template
- align README language with the enforced intent -> context -> specifications before inference contract

## Verification
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --test entrypoint_correctness
- env DECAPOD_CONTAINER=1 decapod validate

## Notes
- AGENTS.md is generated; the source change is in src/core/assets.rs.
- Plain decapod validate outside a container still reports container_workspace_required in this environment.