### PR TITLE
Clarify Decapod governance kernel posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ decapod docs search --query "<problem>" --op <op> --path <path> --tag <tag>
 decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 
 # Convergence/proof surfaces (call when relevant)
-decapod workunit init --task-id <task-id> --intent-ref <intent>
+decapod govern workunit init --task-id <task-id> --intent-ref <intent>
 decapod govern capsule query --topic "<topic>" --scope interfaces --task-id <task-id>
 decapod eval plan --task-set-id <id> --task-ref <task-id> --model-id <model> --prompt-hash <hash> --judge-model-id <judge> --judge-prompt-hash <hash>
 ```
@@ -81,12 +81,12 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Decapod Governance
 
-Decapod is the repo-native control plane agents call on demand. It reduces wasted inference, prevents scope drift, enforces boundaries, and requires proof-backed completion.
+Decapod is the repo-native control plane agents call on demand. It shapes context before inference, prevents scope drift, enforces boundaries, coordinates shared state, and requires proof-backed completion.
 
 - **The agent performs the work.** Decapod does not implement or decide.
 - **Decapod governs the work.** It validates, tracks, and surfaces convergence proof.
 - **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and others more reliable by absorbing common deficiencies.
-
+- **Authority is hierarchical.** Constitution, project/spec intent, task boundaries, proof requirements, and generated artifacts outrank agent-local execution.
 Call Decapod before editing. Let Decapod validate after editing.
 
 ## Operating Notes

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ decapod init
 
 That's it.
 
-`decapod init` asks about your project and creates `.decapod/`, a local folder your agent uses to remember intent, rules, context, specs, todos, and proof.
+`decapod init` asks about your project and creates `.decapod/`, a local folder your agent uses to remember intent, rules, context, specs, task ownership, and proof.
 
 Your workflow does not change.
 
 You keep talking to your agent like normal. The agent calls Decapod when it needs project memory, intent, boundaries, specs, todos, or proof.
 
-Decapod runs, returns what the agent needs, writes explicit artifacts when useful, and exits.
+Decapod runs, rehydrates repo state, returns what the agent needs, writes explicit artifacts when useful, and exits.
 
-Decapod is a shared substrate where multiple agents, providers, and models operate against the same governed repo state concurrently.
+Decapod is the shared backhaul beneath Claude, Codex, Kilo, OpenCode, and other coding agents. Different providers get the same repo-native memory, boundaries, task ownership, and proof surface.
 
 ---
 
@@ -67,17 +67,19 @@ Decapod keeps the work bounded, remembered, specified, and provable.
 
 ---
 
-## When Decapod gets called
+## How agents use it
 
-The agent checks in with Decapod before:
+Agents invoke Decapod as a short-lived local utility:
 
-- **Acting** — clarify intent
-- **Calling the model** — resolve context
-- **Touching protected code** — enforce boundaries
-- **Changing durable instructions** — require review
-- **Committing** — produce proof
+1. Clarify intent before spending model context.
+2. Assemble bounded context instead of loading the whole repo.
+3. Claim task ownership and respect workspace boundaries.
+4. Emit specs, plans, summaries, or proof artifacts when useful.
+5. Validate the result before returning completion.
 
-Decapod is daemonless. Agents call it like `cat`, `awk`, or `grep`: short-lived, local, repo-native, and only when needed.
+If uncertainty is high, the agent should ask for clarification before inference-heavy work or irreversible edits.
+
+Decapod is daemonless. Agents call it like `cat`, `awk`, or `grep`: short-lived, host-agnostic, local, repo-native, and only when needed.
 
 See the canonical router in [constitution/core/DECAPOD.md](constitution/core/DECAPOD.md).
 
@@ -109,7 +111,7 @@ See the canonical router in [constitution/core/DECAPOD.md](constitution/core/DEC
 
 Decapod is not the agent.
 
-Decapod is the governance kernel the agent calls when intent, context, boundaries, dependencies, feedback, or proof need to become explicit.
+Decapod is the governance kernel the agent calls when intent, context, boundaries, dependencies, feedback, ownership, or proof need to become explicit.
 
 Humans mostly experience Decapod through the quality of the agent's work: clearer intent, smaller context, safer changes, better specs, and proof-backed completion.
 
@@ -119,11 +121,12 @@ Humans mostly experience Decapod through the quality of the agent's work: cleare
 
 1. **Clarifies intent** — what is the goal?
 2. **Bounds context** — what does the agent actually need?
-3. **Generates specs** — what should be built, changed, or preserved?
-4. **Tracks dependencies** — what must happen first?
-5. **Enforces boundaries** — what must not be touched?
-6. **Governs adaptation** — what feedback may change future behavior?
-7. **Requires proof** — what makes the work complete?
+3. **Defines scope** — what is in bounds for this task?
+4. **Generates specs** — what should be built, changed, or preserved?
+5. **Tracks ownership** — who owns which task or artifact?
+6. **Enforces boundaries** — what must not be touched?
+7. **Governs adaptation** — what feedback may change future behavior?
+8. **Requires proof** — what makes the work complete?
 
 Decapod resolves only what is relevant to the user's intent. Your agent gets surgical context, not the whole repo and not the entire constitution.
 
@@ -133,13 +136,15 @@ Decapod resolves only what is relevant to the user's intent. Your agent gets sur
 
 Agent workbenches improve the session.
 
-Decapod improves the shared substrate.
+Decapod improves the shared substrate behind those sessions.
 
 Agents act in private context. Decapod makes the durable parts of their work public to the repo: intent, resolved context, boundaries, todos, specs, validation, feedback-derived proposals, and proof artifacts.
 
-A task started by Claude Code should be auditable by Codex, resumable by Gemini CLI, and verifiable by Kilo. The source of truth lives in `.decapod/`, not chat history, IDE state, or provider memory.
+A task started by Claude Code should be auditable by Codex, resumable by Gemini CLI, and verifiable by Kilo or OpenCode. The source of truth lives in `.decapod/`, not chat history, IDE state, or provider memory.
 
-Decapod absorbs agent deficiencies:
+Classical acceptance pipelines made completion criteria explicit. Decapod applies that intent earlier in agent work: before inference, it shapes context and boundaries; after implementation, it requires inspectable proof. Human review still matters, but unreviewed agent-speed work needs machine-checkable governance before promotion.
+
+Decapod absorbs common agent failure modes:
 
 - ambiguity
 - context waste
@@ -251,15 +256,29 @@ Keep durable rules in `OVERRIDE.md`. Keep project shape in `config.toml`.
 
 ---
 
+## What humans inspect
+
+Humans do not need to babysit the command surface. The useful interface is the generated evidence:
+
+- specs and plans that show intended behavior
+- context summaries that explain what the agent used
+- task ownership and handoff records
+- validation output and proof artifacts
+- explicitly surfaced files in pull requests
+
+The command surface exists for agents and automation. The human-facing result is a repo that remembers why work happened and how completion was proven.
+
+---
+
 ## Proof lives in the repo
 
 Every run leaves operational evidence in `.decapod/`:
 
 - captured intent → `generated/specs/INTENT.md`
 - resolved context → `generated/context/`
-- todos and dependencies → `governance/todos.jsonl`
-- verification results → `generated/artifacts/`
-- proof artifacts → `generated/artifacts/provenance/`
+- todos and dependencies: `governance/todos.jsonl`
+- verification results: `generated/artifacts/`
+- proof artifacts: `generated/artifacts/provenance/`
 
 The generated files are the human-visible proof surface. They can be inspected locally, reviewed in pull requests, archived with the codebase, and used by the next agent invocation to re-establish state.
 
@@ -278,7 +297,7 @@ The generated files are the human-visible proof surface. They can be inspected l
 | Prompt tweaks | Reviewable instruction changes |
 | Agent improvement | Governed adaptation |
 
-Use whatever agent you already use: Claude, Codex, Gemini, Cursor, Kilo.
+Use whatever agent you already use: Claude, Codex, Gemini, Cursor, Kilo, OpenCode, or another provider.
 
 ---
 
@@ -315,6 +334,7 @@ Agent: [Decapod]
 - **Repo-native** — state lives in `.decapod/`
 - **Local-first** — no SaaS control plane required
 - **Provider-agnostic** — works across agent workbenches
+- **Agent-first** — optimized for programmatic invocation by coding agents
 - **Proof-gated** — VERIFIED means gates passed
 - **Boundary-aware** — protected paths and branches are enforced
 - **Feedback-governed** — durable behavior changes require explicit scope, review, and provenance

--- a/constitution/core/DECAPOD.md
+++ b/constitution/core/DECAPOD.md
@@ -2,19 +2,20 @@
 
 ## What Decapod Is
 
-Decapod is a repo-native helper for humans that makes an agent:
+Decapod is the daemonless, local-first, repo-native governance kernel behind AI coding agents. It makes an agent:
 1. Build what the human intends
 2. Follow the rules the human intends  
 3. Produce the quality the human intends
 
-The human interfaces ONLY with the agent as the UX. The agent calls Decapod.
+The human primarily interfaces with the agent as the UX. The agent calls Decapod.
 
-Decapod is called on demand inside agent loops to turn intent into context, then context into explicit specifications before inference.
+Decapod is called on demand inside agent loops to turn intent into context, then context into explicit specifications before inference. Each invocation rehydrates repo state, emits artifacts or proof when needed, and exits.
 
 ## What Decapod Is Not
 
 - Not an agent framework.
 - Not a prompt-pack.
+- Not a user-facing workflow app.
 - Not a daemonized control plane with hidden always-on state.
 
 ## Foundation Demands (Non-Negotiable)
@@ -25,6 +26,7 @@ Decapod is called on demand inside agent loops to turn intent into context, then
 4. **Decapod MUST remain daemonless and repo-native.** Promotion-relevant state must be auditable from repo artifacts and control-plane receipts.
 5. **Validation liveness is mandatory.** Validation must terminate boundedly with typed failure under contention, never hang indefinitely.
 6. **Operational agent guidance MUST live in entrypoint and constitution surfaces, not README.** README is human-facing product documentation.
+7. **Recursive improvement MUST respect authority hierarchy.** Agents may suggest improvements, but must not silently rewrite repository constitution, project/spec intent, task boundaries, proof requirements, or generated artifacts.
 
 ## For Agents: Quick Start
 
@@ -39,6 +41,7 @@ This produces a session receipt and tells you what's allowed next.
 - **Deterministic**: Same inputs produce same outputs
 - **Agent-native**: Designed for programmatic access via `decapod rpc`
 - **Daemonless**: No required long-lived control-plane process
+- **Host-agnostic**: Works as a local utility under different agent hosts/providers
 - **Workspace-enforced**: You cannot work on main/master - Decapod refuses
 - **Liveness-aware**: Requires **invocation heartbeat** for continuous presence tracking
 

--- a/constitution/docs/ARCHITECTURE_OVERVIEW.md
+++ b/constitution/docs/ARCHITECTURE_OVERVIEW.md
@@ -10,7 +10,31 @@ Rules:
 - Agents MUST use Decapod CLI/RPC for state mutation.
 - `.decapod` direct edits are forbidden.
 
-## 2. Artifact Model
+## 2. Execution Posture
+
+Decapod is background infrastructure for agents. It is invoked explicitly, performs a bounded control-plane action, writes auditable state or artifacts when required, and exits.
+
+Architectural constraints:
+
+- No required daemon or hidden remote coordinator.
+- No provider-specific coupling to one coding agent.
+- No human-facing workflow app as the primary interface.
+- CLI/RPC surfaces exist for agents and automation; humans primarily inspect generated artifacts and proof.
+
+## 3. Governance Hierarchy
+
+Recursive improvement and agent self-correction are governed by this authority order:
+
+1. repository constitution
+2. project/spec intent
+3. task boundaries and ownership
+4. proof requirements
+5. generated artifacts
+6. agent-local execution
+
+Agents may propose improvements at higher layers, but promotion requires explicit artifacts and proof. Agent-local execution cannot silently rewrite higher-level intent or bypass proof requirements.
+
+## 4. Artifact Model
 
 Core artifacts:
 
@@ -19,7 +43,19 @@ Core artifacts:
 - Proof artifacts: validation reports, state-commit records, verification outputs.
 - Provenance artifacts: artifact/proof manifests with hashes.
 
-## 3. Validation and Promotion
+## 5. Context Shaping
+
+Decapod reduces wasted inference as a correctness property:
+
+- clarify intent before spending model context
+- assemble bounded context capsules
+- avoid irrelevant repo sprawl
+- stop for clarification when uncertainty is high
+- validate output before completion claims
+
+Token savings are a consequence of scoped governance, not a standalone product goal.
+
+## 6. Validation and Promotion
 
 Validation semantics:
 
@@ -31,7 +67,19 @@ Promotion semantics:
 - `decapod workspace publish` is the promote path.
 - Publish MUST fail when required provenance manifests are missing.
 
-## 4. Deterministic Execution Model
+## 7. Concurrent Agent Work
+
+Concurrent work is coordinated through explicit task ownership, isolated worktrees, artifact-backed handoffs, validation, and proof before promotion.
+
+Current architecture supports local-first coordination primitives. It must not claim distributed consensus, Raft, ZooKeeper-style coordination, or global locking semantics unless those mechanisms exist and have proof surfaces.
+
+## 8. Acceptance Pipeline Lineage
+
+Acceptance-pipeline thinking made completion criteria explicit before delivery. Decapod turns that intent into an agent-mediated governance path: pre-inference context shaping, boundary enforcement, artifact-backed coordination, validation, and proof-backed completion.
+
+This complements human review. It does not make every human review obsolete; it makes agent-speed work inspectable before promotion.
+
+## 9. Deterministic Execution Model
 
 Determinism rules:
 

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -284,7 +284,7 @@ decapod docs search --query "<problem>" --op <op> --path <path> --tag <tag>
 decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 
 # Convergence/proof surfaces (call when relevant)
-decapod workunit init --task-id <task-id> --intent-ref <intent>
+decapod govern workunit init --task-id <task-id> --intent-ref <intent>
 decapod govern capsule query --topic "<topic>" --scope interfaces --task-id <task-id>
 decapod eval plan --task-set-id <id> --task-ref <task-id> --model-id <model> --prompt-hash <hash> --judge-model-id <judge> --judge-prompt-hash <hash>
 ```
@@ -332,12 +332,12 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 ## Decapod Governance
 
-Decapod is the repo-native control plane agents call on demand. It reduces wasted inference, prevents scope drift, enforces boundaries, and requires proof-backed completion.
+Decapod is the repo-native control plane agents call on demand. It shapes context before inference, prevents scope drift, enforces boundaries, coordinates shared state, and requires proof-backed completion.
 
 - **The agent performs the work.** Decapod does not implement or decide.
 - **Decapod governs the work.** It validates, tracks, and surfaces convergence proof.
 - **Decapod does not replace agents.** It makes Claude, Codex, OpenCode, Kilo, Pi, Cursor, Windsurf, Gemini, Aider, Devin, and others more reliable by absorbing common deficiencies.
-
+- **Authority is hierarchical.** Constitution, project/spec intent, task boundaries, proof requirements, and generated artifacts outrank agent-local execution.
 Call Decapod before editing. Let Decapod validate after editing.
 
 ## Operating Notes


### PR DESCRIPTION
## Summary
- clarify README positioning around Decapod as daemonless, agent-first governance infrastructure behind coding agents
- add stable architecture notes for execution posture, authority hierarchy, context shaping, concurrent work, and acceptance-pipeline lineage
- update the managed AGENTS.md template in src/core/assets.rs and sync generated AGENTS.md output
- correct the generated AGENTS proof-surface command to the exposed decapod govern workunit path

## Verification
- decapod impact --predict --changed-files README.md,AGENTS.md,src/core/assets.rs,constitution/core/DECAPOD.md,constitution/docs/ARCHITECTURE_OVERVIEW.md
- decapod preflight --op validate
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --test entrypoint_correctness
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS= cargo test --test constitution_claims --test contract_conformance
- env DECAPOD_CONTAINER=1 decapod validate

## Notes
- AGENTS.md is generated; the source change is in src/core/assets.rs.
- Plain host decapod validate reports container_workspace_required in this environment; validation passed with the container marker used by the validation gate.