### PR TITLE
List project override sections in docs CLI

### DIFF
--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -143,6 +143,32 @@ pub fn get_override_doc(repo_root: &Path, relative_path: &str) -> Option<String>
     extract_component_override(&override_content, relative_path)
 }
 
+/// List component override section headings from .decapod/OVERRIDE.md.
+pub fn list_override_sections(repo_root: &Path) -> Vec<String> {
+    let override_path = repo_root.join(".decapod").join("OVERRIDE.md");
+    let Ok(override_content) = std::fs::read_to_string(&override_path) else {
+        return Vec::new();
+    };
+
+    extract_override_section_names(&override_content)
+}
+
+fn extract_override_section_names(override_content: &str) -> Vec<String> {
+    let Some(override_start) = override_content.find("CHANGES ARE NOT PERMITTED ABOVE THIS LINE")
+    else {
+        return Vec::new();
+    };
+    let searchable_content = &override_content[override_start..];
+
+    searchable_content
+        .lines()
+        .filter_map(|line| line.strip_prefix("### "))
+        .map(str::trim)
+        .filter(|section| !section.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 /// Extract a specific component's override content from OVERRIDE.md
 fn extract_component_override(override_content: &str, component_path: &str) -> Option<String> {
     // Only look after the "CHANGES ARE NOT PERMITTED ABOVE THIS LINE" marker

--- a/src/core/docs_cli.rs
+++ b/src/core/docs_cli.rs
@@ -122,7 +122,17 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
             for doc in docs {
                 println!("- {}", doc);
             }
-            // TODO: Also list project override sections from .decapod/OVERRIDE.md
+            if let Ok(current_dir) = std::env::current_dir()
+                && let Ok(repo_root) = find_repo_root(&current_dir)
+            {
+                let override_sections = assets::list_override_sections(&repo_root);
+                if !override_sections.is_empty() {
+                    println!("\nProject Override Sections:");
+                    for section in override_sections {
+                        println!("- {}", section);
+                    }
+                }
+            }
             Ok(DocsRunResult::default())
         }
         DocsCommand::Show { path, source } => {

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -954,6 +954,55 @@ This is a test override for CONTROL_PLANE.md
     // Should contain both embedded content and override
     assert!(merged_content.contains("## Project Overrides"));
     assert!(merged_content.contains("Custom TODO Priorities"));
+
+    let override_sections = assets::list_override_sections(root);
+    assert_eq!(
+        override_sections,
+        vec![
+            "core/DECAPOD.md",
+            "core/CONTROL_PLANE.md",
+            "plugins/TODO.md"
+        ]
+    );
+}
+
+#[test]
+fn docs_list_outputs_project_override_sections() {
+    let tmp = tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    fs::create_dir_all(root.join(".decapod")).expect("mkdir .decapod");
+    fs::write(
+        root.join(".decapod/OVERRIDE.md"),
+        r#"# OVERRIDE.md
+
+```markdown
+### core/EXAMPLE.md
+```
+
+<!-- CHANGES ARE NOT PERMITTED ABOVE THIS LINE -->
+
+## Core Overrides
+
+### core/DECAPOD.md
+
+Project override.
+"#,
+    )
+    .expect("write OVERRIDE.md");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .arg("docs")
+        .arg("list")
+        .current_dir(root)
+        .output()
+        .expect("run docs list");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    assert!(stdout.contains("Project Override Sections:"));
+    assert!(stdout.contains("- core/DECAPOD.md"));
+    assert!(!stdout.contains("core/EXAMPLE.md"));
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- list .decapod/OVERRIDE.md component sections in decapod docs list
- reuse the override marker parser behavior so template examples before the protected marker are ignored
- add parser and CLI coverage for override section output

Verification:
- cargo fmt -- --check via nix develop
- cargo test docs_list_outputs_project_override_sections --test core_tests via nix develop
- cargo test override_md_extraction_and_merging --test core_tests via nix develop
- cargo test --test core_tests via nix develop
- cargo clippy --all-targets --all-features -- -D warnings via nix shell
- DECAPOD_CONTAINER=1 decapod validate