### PR TITLE
feat(init): track active row in raw-mode selector prompt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,6 +671,28 @@ fn selector_shown(options: &[&str], selected: usize, typed: &str) -> String {
         .unwrap_or_else(|| typed.to_string())
 }
 
+fn selector_active_line(
+    options: &[&str],
+    default: &[String],
+    selected: usize,
+    typed: &str,
+) -> String {
+    let shown = selector_shown(options, selected, typed);
+    let typed_match = find_selector_match(options, typed);
+    let matched = typed_match.unwrap_or(selected);
+    let marker = if default.iter().any(|d| d.eq_ignore_ascii_case(&shown)) {
+        "✓"
+    } else {
+        " "
+    };
+
+    if typed.trim().is_empty() || typed_match.is_some() {
+        format!("    active: > {} {:>2}. {}", marker, matched + 1, shown)
+    } else {
+        format!("    active: >   {}", shown)
+    }
+}
+
 fn update_selector_from_byte(options: &[&str], selected: &mut usize, typed: &mut String, byte: u8) {
     match byte {
         8 | 127 => {
@@ -749,11 +771,21 @@ fn prompt_terminal_selector(
     };
     let mut typed = String::new();
     let mut stdin = io::stdin();
+    let mut rendered = false;
     loop {
         let shown = selector_shown(options, selected, &typed);
-        print!("\r{}", format!("{prompt}{shown}").bright_cyan().bold());
+        let active = selector_active_line(options, default, selected, &typed);
+        if rendered {
+            print!("\x1b[1A");
+        }
+        print!(
+            "\r{}\x1b[K\n\r{}\x1b[K",
+            active.bright_white().bold(),
+            format!("{prompt}{shown}").bright_cyan().bold()
+        );
         print!("\x1b[K");
         io::stdout().flush().map_err(error::DecapodError::IoError)?;
+        rendered = true;
 
         let mut byte = [0_u8; 1];
         stdin
@@ -767,7 +799,7 @@ fn prompt_terminal_selector(
                 ));
             }
             8 | 127 => {
-                typed.pop();
+                update_selector_from_byte(options, &mut selected, &mut typed, byte[0]);
             }
             27 => {
                 let mut seq = [0_u8; 2];
@@ -7731,6 +7763,24 @@ mod init_prompt_tests {
         assert_eq!(selected, "TypeScript");
         assert!(!selected.contains("\x1b"));
         assert!(!selected.contains("[B"));
+    }
+
+    #[test]
+    fn active_selector_line_tracks_current_selection() {
+        let default = vec!["Python".to_string()];
+
+        assert_eq!(
+            selector_active_line(LANGUAGES, &default, 3, ""),
+            "    active: > ✓  4. Python"
+        );
+        assert_eq!(
+            selector_active_line(LANGUAGES, &default, 0, "go"),
+            "    active: >    5. Go"
+        );
+        assert_eq!(
+            selector_active_line(LANGUAGES, &default, 0, "not-a-language"),
+            "    active: >   not-a-language"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an 'active: >' line above the choice prompt that tracks the current selection as the user types or uses arrow keys.

### Changes
- : renders the active row with index, check marker, and selection
- Backspace now properly updates selection state via  rather than raw 
- Active row only shows index when typed input is empty or matches a valid option

### Testing
- 
running 9 tests
test init_prompt_tests::active_selector_line_tracks_current_selection ... ok
test init_prompt_tests::arrow_keys_move_selection_without_entering_input_text ... ok
test init_prompt_tests::comma_separated_language_selection_is_preserved ... ok
test init_prompt_tests::enter_accepts_inferred_default_language ... ok
test init_prompt_tests::inferred_language_wins_over_architecture_recommendation_for_default ... ok
test init_prompt_tests::line_prompt_escape_backstop_strips_raw_ansi_sequences ... ok
test init_prompt_tests::numeric_language_selection_targets_numbered_option ... ok
test init_prompt_tests::typed_language_selection_targets_matching_language ... ok
test init_prompt_tests::mixed_scripts_repo_infers_multiple_languages_without_compiled_bias ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s: 9/9 passed
- 
running 9 tests
test init_with_project_dir_creates_directory_and_initializes_inside_it ... ok
test init_with_architecture_seeds_ideal_language_when_unspecified ... ok
test init_with_accepts_noninteractive_spec_seed_env ... ok
test init_with_architecture_can_recommend_zig ... ok
test init_with_mixed_scripts_repo_uses_file_inference_noninteractively ... ok
test init_with_accepts_noninteractive_spec_seed_flags ... ok
test init_project_dir_creates_directory_and_initializes_inside_it ... ok
test init_uses_existing_config_for_noninteractive_defaults ... ok
test init_with_writes_config_toml_with_schema_and_diagram_style ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s: 9/9 passed
- Container validation: 197/197 passed

Closes code_01krykva6ydxcqx9