### PR TITLE
fix(init): enable arrow key selector even when no default exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,8 +638,8 @@ fn enter_raw_terminal_mode() -> Option<TerminalModeGuard> {
     Some(TerminalModeGuard { saved_mode })
 }
 
-fn terminal_selector_available(default: &[String]) -> bool {
-    io::stdin().is_terminal() && !default.is_empty()
+fn terminal_selector_available(_default: &[String]) -> bool {
+    io::stdin().is_terminal()
 }
 
 fn find_selector_match(options: &[&str], typed: &str) -> Option<usize> {


### PR DESCRIPTION
## Summary

Previously `terminal_selector_available` required the default selection to be non-empty, which caused the interactive arrow-key selector to be skipped when no architecture matched `ARCH_DIRECTIONS`.

### Fix

Changed `terminal_selector_available` to only check if stdin is a terminal — arrow key navigation now works in init prompts regardless of whether there's a pre-existing default.

### Testing
- `cargo test init_prompt_tests --lib`: 8/8 passed
- `cargo test --test init_config_behavior`: 9/9 passed

Closes bugs_01krypq0j289xabc