### PR TITLE
Clarify scoped Decapod invocation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,14 +43,25 @@ decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 8. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
 9. **MUST** respect the Interface abstraction boundary.
 
-## Orientation & Precision (Doctrine)
+## Decapod Invocation Contract
 
-Before starting expensive exploration, broad refactors, or multi-path architecture work:
-- Call `decapod infer orientation`.
-- Treat the returned `orientation_packet` as the authoritative starting context.
-- If the packet contains `decision_gates`, present the options to the human and wait for a choice.
-- Do not bypass decision gates; they are placed where ambiguity would otherwise cause expensive waste.
-- Use the `allowed_scope` and `proof_required` fields to bound your work.
+Agents act. Decapod orients.
+
+Decapod is not your executor, model runtime, or workflow replacement. You remain responsible for implementation. Call Decapod as the repo-native pressure relief valve when the next responsible step requires explicit intent, boundaries, context, coordination, or proof.
+
+Call Decapod before proceeding when continuing would require guessing about:
+- **Intent pressure:** what you are actually trying to do.
+- **Boundary pressure:** what you are allowed to touch.
+- **Context pressure:** what matters right now.
+- **Coordination pressure:** whether this collides with other work.
+- **Proof pressure:** what evidence makes this complete.
+- **Completion pressure:** whether you can truthfully claim done.
+
+Concrete triggers: ambiguous requests, public behavior/security/data/migration/generated/release/architecture impact, unclear proof, todo create/update/split/complete, scope expansion, conflicting intent/specs/instructions/repo state, context loss, multi-agent collision risk, or readiness to claim completion.
+
+Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts: intent, context, constraints, todos, decisions, proof, and completion state.
+
+When using `decapod infer orientation`, treat the returned packet as starting context; stop on decision gates; use `allowed_scope` and `proof_required` to bound work.
 
 ## Invariants (Normative)
 
@@ -71,17 +82,6 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 - ✅ Session auth gate: `DECAPOD_SESSION_PASSWORD`
 - ✅ Workspace gate: Docker git workspaces
 - ✅ Privilege gate: request elevated permissions before Docker/container workspace commands
-
-## Universal Agent Operating Contract
-
-Decapod governs AI coding agents to ensure convergence on human intent and proof-backed completion.
-
-- **Doctrine:** Establish intent, shape context, bound mutation, and define proof BEFORE implementation.
-- **Rules:** Avoid opportunistic rewrites; preserve behavior; stop at subsystem boundaries; run strong verification.
-- **Workflow:** Claim task -> Orient -> Ensure Workspace -> Work in Worktree -> Validate -> Publish.
-- **Hierarchy:** Constitution and project intent outrank agent-local execution.
-
-Call Decapod before editing. Let Decapod validate after editing.
 
 ## Operating Notes
 

--- a/constitution/core/DECAPOD.md
+++ b/constitution/core/DECAPOD.md
@@ -2,12 +2,12 @@
 
 ## What Decapod Is
 
-Decapod is the daemonless, local-first, repo-native governance kernel behind AI coding agents. It makes an agent:
+Decapod is the daemonless, local-first, repo-native governance kernel behind AI coding agents. It helps agents:
 1. Build what the human intends
 2. Follow the rules the human intends  
 3. Produce the quality the human intends
 
-The human primarily interfaces with the agent as the UX. The agent calls Decapod.
+The human primarily interfaces with the agent as the UX. The agent acts; Decapod orients.
 
 Decapod is called on demand inside agent loops to turn intent into context, then context into explicit specifications before inference. Each invocation rehydrates repo state, emits artifacts or proof when needed, and exits.
 
@@ -16,7 +16,20 @@ Decapod is called on demand inside agent loops to turn intent into context, then
 - Not an agent framework.
 - Not a prompt-pack.
 - Not a user-facing workflow app.
+- Not the executor; agents remain responsible for implementation.
 - Not a daemonized control plane with hidden always-on state.
+
+## Router Charter
+
+`core/DECAPOD.md` is a router, not a competing instruction surface.
+
+- Agent operating rules: use `AGENTS.md`.
+- Current task state: use `decapod todo`, generated specs, and workspace/status surfaces.
+- Generated specs: use `.decapod/generated/specs/*` through Decapod CLI surfaces.
+- Proof and completion: use `decapod validate`, proof-plan/status surfaces, and TODO completion state.
+- Provider-specific shims (`CLAUDE.md`, `GEMINI.md`, `CODEX.md`): point back to `AGENTS.md`.
+
+Call Decapod at pressure points: intent, boundaries, context, coordination, proof, and completion. Do not turn this router into generic documentation noise or a wrapper around every file read, local edit, or mechanical command.
 
 ## Foundation Demands (Non-Negotiable)
 

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -350,14 +350,25 @@ decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 8. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
 9. **MUST** respect the Interface abstraction boundary.
 
-## Orientation & Precision (Doctrine)
+## Decapod Invocation Contract
 
-Before starting expensive exploration, broad refactors, or multi-path architecture work:
-- Call `decapod infer orientation`.
-- Treat the returned `orientation_packet` as the authoritative starting context.
-- If the packet contains `decision_gates`, present the options to the human and wait for a choice.
-- Do not bypass decision gates; they are placed where ambiguity would otherwise cause expensive waste.
-- Use the `allowed_scope` and `proof_required` fields to bound your work.
+Agents act. Decapod orients.
+
+Decapod is not your executor, model runtime, or workflow replacement. You remain responsible for implementation. Call Decapod as the repo-native pressure relief valve when the next responsible step requires explicit intent, boundaries, context, coordination, or proof.
+
+Call Decapod before proceeding when continuing would require guessing about:
+- **Intent pressure:** what you are actually trying to do.
+- **Boundary pressure:** what you are allowed to touch.
+- **Context pressure:** what matters right now.
+- **Coordination pressure:** whether this collides with other work.
+- **Proof pressure:** what evidence makes this complete.
+- **Completion pressure:** whether you can truthfully claim done.
+
+Concrete triggers: ambiguous requests, public behavior/security/data/migration/generated/release/architecture impact, unclear proof, todo create/update/split/complete, scope expansion, conflicting intent/specs/instructions/repo state, context loss, multi-agent collision risk, or readiness to claim completion.
+
+Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts: intent, context, constraints, todos, decisions, proof, and completion state.
+
+When using `decapod infer orientation`, treat the returned packet as starting context; stop on decision gates; use `allowed_scope` and `proof_required` to bound work.
 
 ## Invariants (Normative)
 
@@ -378,17 +389,6 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 - ✅ Session auth gate: `DECAPOD_SESSION_PASSWORD`
 - ✅ Workspace gate: Docker git workspaces
 - ✅ Privilege gate: request elevated permissions before Docker/container workspace commands
-
-## Universal Agent Operating Contract
-
-Decapod governs AI coding agents to ensure convergence on human intent and proof-backed completion.
-
-- **Doctrine:** Establish intent, shape context, bound mutation, and define proof BEFORE implementation.
-- **Rules:** Avoid opportunistic rewrites; preserve behavior; stop at subsystem boundaries; run strong verification.
-- **Workflow:** Claim task -> Orient -> Ensure Workspace -> Work in Worktree -> Validate -> Publish.
-- **Hierarchy:** Constitution and project intent outrank agent-local execution.
-
-Call Decapod before editing. Let Decapod validate after editing.
 
 ## Operating Notes
 

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -491,6 +491,32 @@ fn test_agent_specific_files_defer_to_agents() {
 }
 
 #[test]
+fn test_agents_entrypoint_scopes_decapod_invocation() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+
+    let agents_content =
+        fs::read_to_string(temp_path.join("AGENTS.md")).expect("Failed to read AGENTS.md");
+
+    for marker in [
+        "Agents act. Decapod orients.",
+        "Decapod is not your executor",
+        "Do not call Decapod for every trivial file read",
+        "Completion pressure",
+        "readiness to claim completion",
+    ] {
+        assert!(
+            agents_content.contains(marker),
+            "AGENTS.md should teach scoped Decapod invocation: {}",
+            marker
+        );
+    }
+}
+
+#[test]
 fn test_root_entrypoints_match_scaffold_generators() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     for file in ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CODEX.md"] {
@@ -629,4 +655,24 @@ fn test_intent_context_spec_contract_alignment() {
         lib_rs.contains(contract_phrase) || cli_rs.contains(contract_phrase),
         "src/lib.rs or src/cli.rs CLI about text must state the intent->context->specifications flow"
     );
+}
+
+#[test]
+fn test_core_decapod_routes_without_competing_with_agents() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let core_decapod = fs::read_to_string(repo_root.join("constitution/core/DECAPOD.md"))
+        .expect("read constitution/core/DECAPOD.md");
+
+    for marker in [
+        "`core/DECAPOD.md` is a router",
+        "Agent operating rules: use `AGENTS.md`",
+        "Provider-specific shims (`CLAUDE.md`, `GEMINI.md`, `CODEX.md`): point back to `AGENTS.md`",
+        "Do not turn this router into generic documentation noise",
+    ] {
+        assert!(
+            core_decapod.contains(marker),
+            "core/DECAPOD.md should route scoped purposes: {}",
+            marker
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Replace broad generated AGENTS.md guidance with a scoped Decapod Invocation Contract
- Clarify that agents execute while Decapod orients at intent, boundary, context, coordination, proof, and completion pressure points
- Add a DECAPOD.md Router Charter and regression tests for entrypoint/routing behavior

## Validation
- cargo test --test entrypoint_correctness
- decapod auto container run --agent unknown --branch agent/unknown/fend_01ks37r9jn7tpvqt-agents-routing --cmd "decapod validate" --task-id fend_01ks37r9jn7tpvqt