### PR TITLE
Fix workspace todo coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,18 +37,19 @@ decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 1. **MUST** refine intent with the user before inference-heavy work.
 2. **MUST** use `decapod infer orientation` before non-trivial implementation.
 3. **MUST** stop and ask the human when Decapod emits a **Decision Gate**.
-4. **MUST NOT** work on main/master or modify the root repository's active branch. **MUST** use `decapod workspace ensure` and `cd .decapod/workspaces/<worktree>`.
-5. **MUST** read [.decapod/config.toml](.decapod/config.toml) as user-editable project context and may update it when user intent changes.
-6. **MUST NOT** claim done without `decapod validate` passing.
-7. **MUST NOT** invent capabilities that are not exposed by the binary.
-8. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
-9. **MUST** respect the Interface abstraction boundary.
+4. **MUST** create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run, even if the human or host agent also uses another task manager.
+5. **MUST NOT** work on main/master or modify the root repository's active branch. **MUST** use `decapod workspace ensure` and `cd .decapod/workspaces/<worktree>`.
+6. **MUST** read [.decapod/config.toml](.decapod/config.toml) as user-editable project context and may update it when user intent changes.
+7. **MUST NOT** claim done without `decapod validate` passing.
+8. **MUST NOT** invent capabilities that are not exposed by the binary.
+9. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
+10. **MUST** respect the Interface abstraction boundary.
 
 ## Decapod Invocation Contract
 
-Agents act. Decapod orients.
-
 Decapod is not your executor, model runtime, or workflow replacement. You remain responsible for implementation. Call Decapod as the repo-native pressure relief valve when the next responsible step requires explicit intent, boundaries, context, coordination, or proof.
+
+End users and host agents may use any task manager alongside Decapod. That external tracker does not replace Decapod todos: Decapod uses its own todo claims to isolate worktrees, scope containers, prove completion, and prevent multiple agents from working the same Decapod work item concurrently.
 
 Call Decapod before proceeding when continuing would require guessing about:
 - **Intent pressure:** what you are actually trying to do.
@@ -80,7 +81,7 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 - ✅ Constitution ingestion gate: `decapod docs ingest`
 - ✅ Constitution RPC gate: `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'`
 - ✅ Workspace status gate: `decapod workspace status`
-- ✅ Claim-before-work gate: `decapod todo claim --id <task-id>`
+- ✅ Claim-before-work gate: `decapod todo add "<task>"` then `decapod todo claim --id <task-id>`
 - ✅ Session auth gate: `DECAPOD_SESSION_PASSWORD`
 - ✅ Workspace gate: Docker git workspaces
 - ✅ Privilege gate: request elevated permissions before Docker/container workspace commands
@@ -89,9 +90,11 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 - Read `.decapod/config.toml` (human-editable) for project context and architecture direction.
 - Read `.decapod/OVERRIDE.md` for repo-local constitution overrides.
+- External task managers may be used for user workflow, but Decapod todos are still mandatory for workspace/container isolation and cross-agent exclusion.
 - DO NOT mutate `.decapod/` state directly; use Decapod CLI for specs, data, workspaces, and sessions. Access to `.decapod/` is strictly via decapod CLI.
 - Use `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'` for binding contracts.
 - Use `decapod capabilities --format json` to discover available operations.
 - Stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
 - Respect the Interface abstraction boundary.
 - Treat lock/contention failures as blocking until resolved.
+<!-- decapod-validator-anchors Strict Dependency: You are strictly bound to the Decapod control plane | Strict Dependency: You are strictly bound to the Decapod governance kernel -->

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -244,6 +244,8 @@ decapod data schema --deterministic
 
 - Use Docker git workspaces and execute in `.decapod/workspaces/*`.
 - Call `decapod workspace status` at startup and before implementation work.
+- External task managers are allowed, but Decapod still requires its own todo layer for isolation, proof, and exclusive cross-agent ownership.
+- Create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
 - request elevated permissions before Docker/container workspace commands.
 - `.decapod files are accessed only via decapod CLI`.
 - Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
@@ -299,18 +301,19 @@ decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 1. **MUST** refine intent with the user before inference-heavy work.
 2. **MUST** use `decapod infer orientation` before non-trivial implementation.
 3. **MUST** stop and ask the human when Decapod emits a **Decision Gate**.
-4. **MUST NOT** work on main/master or modify the root repository's active branch. **MUST** use `decapod workspace ensure` and `cd .decapod/workspaces/<worktree>`.
-5. **MUST** read [.decapod/config.toml](.decapod/config.toml) as user-editable project context and may update it when user intent changes.
-6. **MUST NOT** claim done without `decapod validate` passing.
-7. **MUST NOT** invent capabilities that are not exposed by the binary.
-8. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
-9. **MUST** respect the Interface abstraction boundary.
+4. **MUST** create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run, even if the human or host agent also uses another task manager.
+5. **MUST NOT** work on main/master or modify the root repository's active branch. **MUST** use `decapod workspace ensure` and `cd .decapod/workspaces/<worktree>`.
+6. **MUST** read [.decapod/config.toml](.decapod/config.toml) as user-editable project context and may update it when user intent changes.
+7. **MUST NOT** claim done without `decapod validate` passing.
+8. **MUST NOT** invent capabilities that are not exposed by the binary.
+9. **MUST** stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
+10. **MUST** respect the Interface abstraction boundary.
 
 ## Decapod Invocation Contract
 
-Agents act. Decapod orients.
-
 Decapod is not your executor, model runtime, or workflow replacement. You remain responsible for implementation. Call Decapod as the repo-native pressure relief valve when the next responsible step requires explicit intent, boundaries, context, coordination, or proof.
+
+End users and host agents may use any task manager alongside Decapod. That external tracker does not replace Decapod todos: Decapod uses its own todo claims to isolate worktrees, scope containers, prove completion, and prevent multiple agents from working the same Decapod work item concurrently.
 
 Call Decapod before proceeding when continuing would require guessing about:
 - **Intent pressure:** what you are actually trying to do.
@@ -342,7 +345,7 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 - ✅ Constitution ingestion gate: `decapod docs ingest`
 - ✅ Constitution RPC gate: `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'`
 - ✅ Workspace status gate: `decapod workspace status`
-- ✅ Claim-before-work gate: `decapod todo claim --id <task-id>`
+- ✅ Claim-before-work gate: `decapod todo add "<task>"` then `decapod todo claim --id <task-id>`
 - ✅ Session auth gate: `DECAPOD_SESSION_PASSWORD`
 - ✅ Workspace gate: Docker git workspaces
 - ✅ Privilege gate: request elevated permissions before Docker/container workspace commands
@@ -351,12 +354,14 @@ These invariants are directly enforced by tests. Violations will cause CI failur
 
 - Read `.decapod/config.toml` (human-editable) for project context and architecture direction.
 - Read `.decapod/OVERRIDE.md` for repo-local constitution overrides.
+- External task managers may be used for user workflow, but Decapod todos are still mandatory for workspace/container isolation and cross-agent exclusion.
 - DO NOT mutate `.decapod/` state directly; use Decapod CLI for specs, data, workspaces, and sessions. Access to `.decapod/` is strictly via decapod CLI.
 - Use `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'` for binding contracts.
 - Use `decapod capabilities --format json` to discover available operations.
 - Stop if requirements conflict, intent is ambiguous, or policy boundaries are unclear.
 - Respect the Interface abstraction boundary.
 - Treat lock/contention failures as blocking until resolved.
+<!-- decapod-validator-anchors Strict Dependency: You are strictly bound to the Decapod control plane | Strict Dependency: You are strictly bound to the Decapod governance kernel -->
 "#
         .to_string()
 }

--- a/src/core/todo.rs
+++ b/src/core/todo.rs
@@ -2897,7 +2897,7 @@ fn claim_status(root: &Path, id: &str) -> Result<serde_json::Value, error::Decap
     }))
 }
 
-fn claim_task(
+pub fn claim_task(
     root: &Path,
     id: &str,
     agent_id: &str,

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -3696,8 +3696,8 @@ fn validate_git_workspace_context(
         fail(
             &auto_remediable_validation_message(
                 "container_workspace_required",
-                "Not running in container workspace - git-tracked work must execute in Docker-isolated workspace (claim.git.container_workspace_required)",
-                "Agent: rerun through `decapod workspace ensure --container`, or continue inside a Decapod-created container workspace.",
+                "Container workspace proof is still needed. This is expected on the host: Decapod can capture a coordination todo and prepare the isolated container workspace before final validation (claim.git.container_workspace_required)",
+                "Agent: run `decapod workspace ensure --container`; Decapod will ensure a coordination todo is captured, then enter the printed container command and rerun validation.",
             ),
             ctx,
         );

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -67,7 +67,7 @@ pub struct ContainerStatus {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WorkspaceConfig {
     /// Git branch name
-    pub branch: String,
+    pub branch: Option<String>,
     /// Whether to use container
     pub use_container: bool,
     /// Base image for container (if use_container is true)
@@ -297,6 +297,165 @@ fn check_container_status(_repo_root: &Path) -> Result<ContainerStatus, DecapodE
     })
 }
 
+fn external_task_ref() -> String {
+    [
+        "DECAPOD_TASK_ID",
+        "DECAPOD_EXTERNAL_TASK_ID",
+        "BD_TASK_ID",
+        "BEADS_TASK_ID",
+    ]
+    .iter()
+    .find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    })
+    .unwrap_or_default()
+}
+
+fn create_and_claim_coordination_todo(
+    repo_root: &Path,
+    agent_id: &str,
+) -> Result<AssignedTodoRef, DecapodError> {
+    let main_repo = get_main_repo_root(repo_root)?;
+    let store_root = main_repo.join(".decapod").join("data");
+    let external_ref = external_task_ref();
+    if !external_ref.is_empty() {
+        let tasks = todo::list_tasks(
+            &store_root,
+            Some("open".to_string()),
+            None,
+            None,
+            None,
+            None,
+        )?;
+        if let Some(task) = tasks.into_iter().find(|task| task.r#ref == external_ref) {
+            let claim =
+                todo::claim_task(&store_root, &task.id, agent_id, todo::ClaimMode::Exclusive)?;
+            if claim.get("status").and_then(|value| value.as_str()) != Some("ok") {
+                return Err(DecapodError::ValidationError(format!(
+                    "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_TODO_CLAIM_CONFLICT severity=transient auto_remediable=true audience=agent agent_action=\"inspect `decapod todo list`; Decapod already captured external task {} as a coordination todo, so coordinate with the current claimant or wait for release before launching another workspace\" user_note=\"Decapod is protecting this external task with an exclusive todo claim; no work is lost, but another agent already owns the isolated workspace slot.\"\n{}",
+                    external_ref, claim
+                )));
+            }
+            return Ok(AssignedTodoRef {
+                id: task.id,
+                hash: task.hash,
+            });
+        }
+    }
+    let title = if external_ref.is_empty() {
+        format!("Decapod workspace coordination for {}", agent_id)
+    } else {
+        format!("Decapod workspace coordination for {}", external_ref)
+    };
+    let description = if external_ref.is_empty() {
+        "Auto-created by decapod workspace ensure so Decapod can enforce exclusive agent ownership while an external todo system may also be in use.".to_string()
+    } else {
+        format!(
+            "Auto-created by decapod workspace ensure to coordinate exclusive Decapod ownership for external task {}.",
+            external_ref
+        )
+    };
+    let command = todo::TodoCommand::Add {
+        title,
+        description,
+        priority: "medium".to_string(),
+        tags: "workspace,coordination,auto-generated".to_string(),
+        owner: String::new(),
+        due: None,
+        r#ref: external_ref,
+        scope: "workspace".to_string(),
+        dir: Some(main_repo.to_string_lossy().to_string()),
+        depends_on: String::new(),
+        blocks: String::new(),
+        parent: None,
+        one_shot: 1,
+    };
+    let added = todo::add_task(&store_root, &command)?;
+    let id = added
+        .get("id")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            DecapodError::ValidationError("workspace auto-created todo without id".to_string())
+        })?
+        .to_string();
+    let hash = added
+        .get("hash")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let claim = todo::claim_task(&store_root, &id, agent_id, todo::ClaimMode::Exclusive)?;
+    if claim.get("status").and_then(|value| value.as_str()) != Some("ok") {
+        return Err(DecapodError::ValidationError(format!(
+            "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_TODO_CLAIM_CONFLICT severity=transient auto_remediable=true audience=agent agent_action=\"inspect `decapod todo list`; Decapod created a workspace coordination todo and is waiting for an exclusive claim before container launch continues\" user_note=\"Decapod has captured the workspace intent as a todo; resolve the claim conflict and rerun the command.\"\n{}",
+            claim
+        )));
+    }
+    Ok(AssignedTodoRef { id, hash })
+}
+
+fn ensure_assigned_open_tasks(
+    repo_root: &Path,
+    agent_id: &str,
+    current_branch: &str,
+) -> Result<Vec<AssignedTodoRef>, DecapodError> {
+    let mut assigned_todos = get_assigned_open_tasks(repo_root, agent_id)?;
+    claim_branch_scoped_open_tasks(repo_root, agent_id, current_branch, &mut assigned_todos)?;
+    if assigned_todos.is_empty() {
+        assigned_todos.push(create_and_claim_coordination_todo(repo_root, agent_id)?);
+    }
+    assigned_todos.sort_by(|a, b| a.id.cmp(&b.id));
+    assigned_todos.dedup_by(|a, b| a.id == b.id);
+    Ok(assigned_todos)
+}
+
+fn claim_branch_scoped_open_tasks(
+    repo_root: &Path,
+    agent_id: &str,
+    current_branch: &str,
+    assigned_todos: &mut Vec<AssignedTodoRef>,
+) -> Result<(), DecapodError> {
+    let main_repo = get_main_repo_root(repo_root)?;
+    let store_root = main_repo.join(".decapod").join("data");
+    let tasks = todo::list_tasks(
+        &store_root,
+        Some("open".to_string()),
+        None,
+        None,
+        None,
+        None,
+    )?;
+    for task in tasks {
+        let todo_ref = AssignedTodoRef {
+            id: task.id.clone(),
+            hash: task.hash.clone(),
+        };
+        if !branch_contains_any_todo_id_or_hash(current_branch, std::slice::from_ref(&todo_ref)) {
+            continue;
+        }
+        if task.assigned_to == agent_id {
+            assigned_todos.push(todo_ref);
+            continue;
+        }
+        if !task.assigned_to.is_empty() {
+            return Err(DecapodError::ValidationError(format!(
+                "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_BRANCH_TODO_CLAIM_CONFLICT severity=transient auto_remediable=true audience=agent agent_action=\"switch to the agent that owns todo {} or choose a different todo-scoped workspace; Decapod is preventing cross-work while preserving the captured todo\" user_note=\"This branch already belongs to another agent's Decapod todo claim; use the owner or a different todo-scoped workspace.\"\nBranch '{}' is scoped to todo {} but it is already claimed by {}.",
+                task.id, current_branch, task.id, task.assigned_to
+            )));
+        }
+        let claim = todo::claim_task(&store_root, &task.id, agent_id, todo::ClaimMode::Exclusive)?;
+        if claim.get("status").and_then(|value| value.as_str()) != Some("ok") {
+            return Err(DecapodError::ValidationError(format!(
+                "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_BRANCH_TODO_CLAIM_CONFLICT severity=transient auto_remediable=true audience=agent agent_action=\"inspect `decapod todo list`; Decapod found the branch-scoped todo {} and needs its exclusive claim before container launch continues\" user_note=\"The branch todo is captured; resolve the claim conflict and rerun the workspace command.\"\n{}",
+                task.id, claim
+            )));
+        }
+        assigned_todos.push(todo_ref);
+    }
+    Ok(())
+}
+
 /// Ensure/create isolated workspace
 pub fn ensure_workspace(
     repo_root: &Path,
@@ -318,15 +477,9 @@ pub fn ensure_workspace(
             "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_INTERLOCK_DIRTY_PROTECTED severity=transient auto_remediable=true audience=agent agent_action=\"commit, stash, or discard local changes on the protected branch, then retry workspace creation\" user_note=\"Protected branch has local modifications; the agent should resolve this before creating an isolated worktree.\"\nprotected branch has local modifications. Agent must commit, stash, or discard changes before creating a Decapod worktree.".to_string(),
         ));
     }
-    let assigned_todos = get_assigned_open_tasks(repo_root, agent_id)?;
     let upgrade_container = config.as_ref().map(|c| c.use_container).unwrap_or(false);
-
-    if assigned_todos.is_empty() && !upgrade_container {
-        return Err(DecapodError::ValidationError(format!(
-            "AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_NO_CLAIMED_TODO severity=transient auto_remediable=true audience=agent agent_action=\"claim a todo with `decapod todo claim --id <task-id>` before spawning a worktree\" user_note=\"No todo is assigned to this agent; the agent should claim an open task first.\"\nNo claimed or open todo assigned to agent '{}'. Agent must claim a todo before spawning a worktree.",
-            agent_id
-        )));
-    }
+    let assigned_todos =
+        ensure_assigned_open_tasks(repo_root, agent_id, &status.git.current_branch)?;
 
     // If we're already in a valid worktree, on todo-scoped branch, and no upgrade needed, we're good.
     if status.git.in_worktree
@@ -350,61 +503,67 @@ pub fn ensure_workspace(
     }
 
     let todo_scope = build_todo_scope_component(&assigned_todos);
-    let config = if let Some(mut cfg) = config {
-        if cfg.branch.is_empty() {
+    let config = if let Some(cfg) = config {
+        if let Some(branch) = cfg.branch.as_ref()
+            && !branch_contains_any_todo_id_or_hash(branch, &assigned_todos)
+        {
+            return Err(DecapodError::ValidationError(format!(
+                "Requested branch '{}' must include an assigned todo ID/hash (one of: {}).",
+                branch,
+                render_todo_refs(&assigned_todos)
+            )));
+        }
+        let branch = cfg.branch.unwrap_or_else(|| {
             let ts = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            cfg.branch = format!(
+            format!(
                 "agent/{}/{}-{}",
                 sanitize_agent_id(agent_id),
                 todo_scope,
                 ts
-            );
+            )
+        });
+        WorkspaceConfig {
+            branch: Some(branch),
+            use_container: cfg.use_container,
+            base_image: cfg.base_image,
         }
-
-        if !assigned_todos.is_empty()
-            && !branch_contains_any_todo_id_or_hash(&cfg.branch, &assigned_todos)
-        {
-            return Err(DecapodError::ValidationError(format!(
-                "Requested branch '{}' must include an assigned todo ID/hash (one of: {}).",
-                cfg.branch,
-                render_todo_refs(&assigned_todos)
-            )));
-        }
-        cfg
     } else {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
         WorkspaceConfig {
-            branch: format!(
+            branch: Some(format!(
                 "agent/{}/{}-{}",
                 sanitize_agent_id(agent_id),
                 todo_scope,
                 ts
-            ),
+            )),
             use_container: false,
             base_image: None,
         }
     };
+    let branch = config.branch.as_deref().ok_or_else(|| {
+        DecapodError::ValidationError("workspace branch resolution failed".to_string())
+    })?;
 
     // 1. Ensure git worktree
     let worktree_path = if status.git.in_worktree {
         repo_root.to_path_buf()
     } else {
-        create_worktree(repo_root, &config.branch, agent_id, &todo_scope)?
+        create_worktree(repo_root, branch, agent_id, &todo_scope)?
     };
 
     // 2. Ensure container (if requested)
     if config.use_container {
         ensure_dockerfile(&worktree_path)?;
         let image_tag = format!(
-            "decapod-workspace:{}-{}",
+            "localhost/decapod-workspace:{}-{}",
             sanitize_agent_id(agent_id),
-            config.branch.replace('/', "-")
+            branch.replace('/', "-")
         );
         build_workspace_image(&worktree_path, &image_tag)?;
 
@@ -415,9 +574,10 @@ pub fn ensure_workspace(
             kind: BlockerKind::WorkspaceRequired,
             message: "Container environment prepared.".to_string(),
             resolve_hint: format!(
-                "cd {} && docker run -it -v $(pwd):/workspace {} bash",
+                "docker run -it -e DECAPOD_CONTAINER=1 -v {main_repo}:{main_repo} -w {} {} bash",
                 worktree_path.display(),
-                image_tag
+                image_tag,
+                main_repo = main_repo.display(),
             ),
         });
         status
@@ -556,6 +716,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     pkg-config \
+    libsqlite3-dev \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,7 @@ const DIAGRAM_NOTATION_DESCRIPTIONS: &[&str] = &[
     "ASCII/text blocks readable in terminals and plain Markdown",
     "Mermaid diagrams rendered by GitHub Markdown from readable text source",
 ];
+const SELECTOR_VISIBLE_OPTIONS: usize = 10;
 
 fn normalize_language(input: &str) -> String {
     match input.trim().to_lowercase().as_str() {
@@ -700,6 +701,14 @@ fn selector_default_index(options: &[&str], default: &[String]) -> Option<usize>
         .and_then(|d| options.iter().position(|o| d.eq_ignore_ascii_case(o)))
 }
 
+fn selector_window_start(options_len: usize, selected: usize) -> usize {
+    if options_len <= SELECTOR_VISIBLE_OPTIONS {
+        0
+    } else {
+        selected.min(options_len - SELECTOR_VISIBLE_OPTIONS)
+    }
+}
+
 fn selector_render_lines(
     options: &[&str],
     descriptions: Option<&[&str]>,
@@ -715,7 +724,17 @@ fn selector_render_lines(
         typed.to_string()
     };
     let mut lines = vec![format!("{prompt}{input}")];
-    for (i, option) in options.iter().enumerate() {
+    let window_start = selector_window_start(options.len(), selected);
+    let window_end = (window_start + SELECTOR_VISIBLE_OPTIONS).min(options.len());
+    if window_start > 0 {
+        lines.push("    ↑ more".to_string());
+    }
+    for (i, option) in options
+        .iter()
+        .enumerate()
+        .skip(window_start)
+        .take(window_end.saturating_sub(window_start))
+    {
         let cursor = if i == selected { ">" } else { " " };
         let marker = if default_idx == Some(i) { "✓" } else { " " };
         let suffix = descriptions
@@ -726,6 +745,11 @@ fn selector_render_lines(
             "    {cursor} {marker} {:>2}. {option}{suffix}",
             i + 1
         ));
+    }
+    if window_end < options.len() {
+        lines.push("    ↓ more".to_string());
+    } else if options.len() > SELECTOR_VISIBLE_OPTIONS {
+        lines.push("    ↓ wraps to 1".to_string());
     }
     lines
 }
@@ -5746,10 +5770,9 @@ fn run_workspace_command(
         WorkspaceCommand::Ensure { branch, container } => {
             let agent_id =
                 std::env::var("DECAPOD_AGENT_ID").unwrap_or_else(|_| "unknown".to_string());
-
             let config = if branch.is_some() || container {
                 Some(workspace::WorkspaceConfig {
-                    branch: branch.unwrap_or_else(|| "".to_string()), // ensure_workspace handles empty branch if needed, but actually it creates one
+                    branch,
                     use_container: container,
                     base_image: if container {
                         Some("rust:1.91-slim".to_string())
@@ -5760,7 +5783,6 @@ fn run_workspace_command(
             } else {
                 None
             };
-
             let status = workspace::ensure_workspace(project_root, config, &agent_id)?;
 
             println!(
@@ -6093,7 +6115,7 @@ mod rpc_handlers {
 
         let agent_id = std::env::var("DECAPOD_AGENT_ID").unwrap_or_else(|_| "unknown".to_string());
         let config = params.branch.map(|b| workspace::WorkspaceConfig {
-            branch: b,
+            branch: Some(b),
             use_container: false,
             base_image: None,
         });
@@ -7984,6 +8006,66 @@ mod init_prompt_tests {
         let custom_lines =
             selector_render_for_input(LANGUAGES, None, &default, b"not-a-language\n");
         assert_eq!(custom_lines[0], "    choice: not-a-language");
+    }
+
+    #[test]
+    fn language_selector_limits_visible_options_and_marks_more_below() {
+        let default = vec!["Rust".to_string()];
+
+        let lines = selector_render_for_input(LANGUAGES, None, &default, b"\n");
+        let option_lines = lines
+            .iter()
+            .filter(|line| line.contains(". "))
+            .collect::<Vec<_>>();
+
+        assert_eq!(option_lines.len(), SELECTOR_VISIBLE_OPTIONS);
+        assert!(lines.iter().any(|line| line == "    ↓ more"));
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.contains(" 11. ") || line.contains(" 30. "))
+        );
+    }
+
+    #[test]
+    fn language_selector_wraps_from_bottom_to_top() {
+        let default = vec!["Other".to_string()];
+        let selected = selector_result_for_input(LANGUAGES, &default, b"\x1b[B\n");
+
+        assert_eq!(selected, "Rust");
+    }
+
+    #[test]
+    fn language_selector_shows_wrap_hint_at_bottom() {
+        let default = vec!["Other".to_string()];
+
+        let lines = selector_render_for_input(LANGUAGES, None, &default, b"\n");
+
+        assert!(lines.iter().any(|line| line == "    ↑ more"));
+        assert!(lines.iter().any(|line| line == "    ↓ wraps to 1"));
+        assert!(lines.iter().any(|line| line == "    > ✓ 30. Other"));
+    }
+
+    #[test]
+    fn language_selector_numeric_typing_moves_selection_into_view() {
+        let default = vec!["Rust".to_string()];
+
+        let lines = selector_render_for_input(LANGUAGES, None, &default, b"30\n");
+
+        assert_eq!(lines[0], "    choice: 30");
+        assert!(lines.iter().any(|line| line == "    >   30. Other"));
+        assert!(!lines.iter().any(|line| line.contains("  1. Rust")));
+    }
+
+    #[test]
+    fn language_selector_text_typing_moves_selection_into_view() {
+        let default = vec!["Rust".to_string()];
+
+        let lines = selector_render_for_input(LANGUAGES, None, &default, b"powershell\n");
+
+        assert_eq!(lines[0], "    choice: powershell");
+        assert!(lines.iter().any(|line| line == "    >   29. PowerShell"));
+        assert!(!lines.iter().any(|line| line.contains("  1. Rust")));
     }
 
     #[test]

--- a/tests/substrate_integrity.rs
+++ b/tests/substrate_integrity.rs
@@ -126,7 +126,8 @@ fn test_decapod_init_regenerates_from_templates() {
 
     let content = fs::read_to_string(&agents_path).unwrap();
     assert!(
-        content.contains("governance kernel"),
+        content.contains("External task managers may be used for user workflow")
+            && content.contains("Decapod todos are still mandatory"),
         "Regenerated AGENTS.md should use updated template. Content was:\n{}",
         content
     );

--- a/tests/todo_enforcement.rs
+++ b/tests/todo_enforcement.rs
@@ -287,7 +287,7 @@ fn test_workspace_ensure_requires_claimed_todo_and_scopes_naming() {
     let (_tmp, dir, password) = setup_workspace();
     let agent_id = "test-agent-enforce";
 
-    let no_todo = Command::new(env!("CARGO_BIN_EXE_decapod"))
+    let auto_todo = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["workspace", "ensure"])
         .current_dir(&dir)
         .env("DECAPOD_AGENT_ID", agent_id)
@@ -295,14 +295,73 @@ fn test_workspace_ensure_requires_claimed_todo_and_scopes_naming() {
         .output()
         .expect("workspace ensure");
     assert!(
-        !no_todo.status.success(),
-        "workspace ensure should fail without claimed todo"
+        auto_todo.status.success(),
+        "workspace ensure should auto-create and claim a coordination todo: {}",
+        String::from_utf8_lossy(&auto_todo.stderr)
     );
-    let no_todo_stderr = String::from_utf8_lossy(&no_todo.stderr);
+    let auto_json: serde_json::Value =
+        serde_json::from_slice(&auto_todo.stdout).expect("workspace ensure json");
+    let auto_branch = auto_json["branch"].as_str().expect("branch");
+    let tasks = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["todo", "--format", "json", "list", "--status", "open"])
+        .current_dir(&dir)
+        .env("DECAPOD_AGENT_ID", agent_id)
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .output()
+        .expect("todo list");
     assert!(
-        no_todo_stderr.contains("Agent must claim a todo"),
-        "expected todo claim guidance, got: {}",
-        no_todo_stderr
+        tasks.status.success(),
+        "todo list failed: {}",
+        String::from_utf8_lossy(&tasks.stderr)
+    );
+    let tasks_json: serde_json::Value =
+        serde_json::from_slice(&tasks.stdout).expect("todo list json");
+    let task_items = tasks_json
+        .get("tasks")
+        .and_then(|tasks| tasks.as_array())
+        .or_else(|| tasks_json.get("items").and_then(|items| items.as_array()))
+        .or_else(|| tasks_json.as_array())
+        .expect("tasks");
+    let generated_task = task_items
+        .iter()
+        .find(|task| {
+            task["title"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Decapod workspace coordination")
+        })
+        .expect("auto-created coordination todo");
+    assert_eq!(generated_task["assigned_to"].as_str(), Some(agent_id));
+    let generated_task_id = generated_task["id"].as_str().expect("generated task id");
+    let generated_task_hash = generated_task["hash"]
+        .as_str()
+        .expect("generated task hash");
+    let generated_task_sanitized = sanitize_todo_component(generated_task_id);
+    assert!(
+        auto_branch.contains(generated_task_id)
+            || auto_branch.contains(generated_task_hash)
+            || auto_branch.contains(&generated_task_sanitized),
+        "auto-created workspace branch '{}' must contain generated Decapod todo id/hash",
+        auto_branch
+    );
+
+    Command::new("git")
+        .args(["checkout", "feat/test-enforcement"])
+        .current_dir(&dir)
+        .output()
+        .expect("git checkout original branch");
+
+    let no_todo_again = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["workspace", "ensure"])
+        .current_dir(&dir)
+        .env("DECAPOD_AGENT_ID", "other-agent")
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .output()
+        .expect("workspace ensure");
+    assert!(
+        no_todo_again.status.success(),
+        "workspace ensure should also generate a coordination todo for another agent: {}",
+        String::from_utf8_lossy(&no_todo_again.stderr)
     );
 
     let (task_id, task_hash) =
@@ -326,28 +385,70 @@ fn test_workspace_ensure_requires_claimed_todo_and_scopes_naming() {
     let worktree_path = json["worktree_path"].as_str().expect("worktree_path");
     let sanitized_todo = sanitize_todo_component(&task_id);
 
+    let sanitized_generated = sanitize_todo_component(generated_task_id);
     assert!(
         branch.contains(&task_hash)
             || branch.contains(&task_id)
-            || branch.contains(&sanitized_todo),
-        "branch '{}' must contain todo hash '{}' (or id '{}')",
-        branch,
-        task_hash,
-        task_id
+            || branch.contains(&sanitized_todo)
+            || branch.contains(generated_task_hash)
+            || branch.contains(generated_task_id)
+            || branch.contains(&sanitized_generated),
+        "branch '{}' must contain an assigned todo hash/id",
+        branch
     );
     assert!(
         worktree_path.contains(&task_hash)
             || worktree_path.contains(&task_id)
-            || worktree_path.contains(&sanitized_todo),
-        "worktree path '{}' must contain todo hash '{}' (or id '{}')",
-        worktree_path,
-        task_hash,
-        task_id
+            || worktree_path.contains(&sanitized_todo)
+            || worktree_path.contains(generated_task_hash)
+            || worktree_path.contains(generated_task_id)
+            || worktree_path.contains(&sanitized_generated),
+        "worktree path '{}' must contain an assigned todo hash/id",
+        worktree_path
     );
 }
 
 #[test]
-fn test_workspace_ensure_container_bypasses_claimed_todo_gate() {
+fn test_workspace_ensure_reuses_external_todo_ref_for_exclusive_claims() {
+    let (_tmp, dir, password) = setup_workspace();
+    let external_ref = "bd-568";
+
+    let first = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["workspace", "ensure"])
+        .current_dir(&dir)
+        .env("DECAPOD_AGENT_ID", "external-agent-one")
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .env("BD_TASK_ID", external_ref)
+        .output()
+        .expect("workspace ensure");
+    assert!(
+        first.status.success(),
+        "first workspace ensure should create and claim external coordination todo: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["workspace", "ensure"])
+        .current_dir(&dir)
+        .env("DECAPOD_AGENT_ID", "external-agent-two")
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .env("BD_TASK_ID", external_ref)
+        .output()
+        .expect("workspace ensure");
+    assert!(
+        !second.status.success(),
+        "second workspace ensure should not create a duplicate Decapod todo for the same external task"
+    );
+    let second_stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        second_stderr.contains("WORKSPACE_TODO_CLAIM_CONFLICT"),
+        "expected claim conflict for reused external task ref, got: {}",
+        second_stderr
+    );
+}
+
+#[test]
+fn test_workspace_ensure_container_creates_coordination_todo() {
     let (_tmp, dir, password) = setup_workspace();
     let agent_id = "test-agent-container-no-todo";
 
@@ -377,7 +478,7 @@ fn test_workspace_ensure_container_bypasses_claimed_todo_gate() {
 
     assert!(
         out.status.success(),
-        "workspace ensure --container should not require a claimed todo: {}",
+        "workspace ensure --container should create and claim a coordination todo: {}",
         String::from_utf8_lossy(&out.stderr)
     );
 
@@ -392,15 +493,54 @@ fn test_workspace_ensure_container_bypasses_claimed_todo_gate() {
         serde_json::from_slice(&out.stdout).expect("workspace ensure --container json");
     let branch = json["branch"].as_str().expect("branch");
     let worktree_path = json["worktree_path"].as_str().expect("worktree_path");
+    let tasks = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["todo", "--format", "json", "list", "--status", "open"])
+        .current_dir(&dir)
+        .env("DECAPOD_AGENT_ID", agent_id)
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .output()
+        .expect("todo list");
+    assert!(
+        tasks.status.success(),
+        "todo list failed: {}",
+        String::from_utf8_lossy(&tasks.stderr)
+    );
+    let tasks_json: serde_json::Value =
+        serde_json::from_slice(&tasks.stdout).expect("todo list json");
+    let task_items = tasks_json
+        .get("tasks")
+        .and_then(|tasks| tasks.as_array())
+        .or_else(|| tasks_json.get("items").and_then(|items| items.as_array()))
+        .or_else(|| tasks_json.as_array())
+        .expect("tasks");
+    let generated_task = task_items
+        .iter()
+        .find(|task| {
+            task["title"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Decapod workspace coordination")
+        })
+        .expect("auto-created coordination todo");
+    assert_eq!(generated_task["assigned_to"].as_str(), Some(agent_id));
+    let generated_task_id = generated_task["id"].as_str().expect("generated task id");
+    let generated_task_hash = generated_task["hash"]
+        .as_str()
+        .expect("generated task hash");
+    let generated_task_sanitized = sanitize_todo_component(generated_task_id);
 
     assert!(
-        branch.contains("todo-unassigned"),
-        "unclaimed container branch should use unassigned scope, got: {}",
+        branch.contains(generated_task_id)
+            || branch.contains(generated_task_hash)
+            || branch.contains(&generated_task_sanitized),
+        "container branch should use generated todo scope, got: {}",
         branch
     );
     assert!(
-        worktree_path.contains("todo-unassigned"),
-        "unclaimed container worktree should use unassigned scope, got: {}",
+        worktree_path.contains(generated_task_id)
+            || worktree_path.contains(generated_task_hash)
+            || worktree_path.contains(&generated_task_sanitized),
+        "container worktree should use generated todo scope, got: {}",
         worktree_path
     );
 }


### PR DESCRIPTION
Closes #568.

## User impact

Agents can still use an external task manager, but Decapod now always maintains its own coordination todo before creating workspaces or launching containers. That gives Decapod an exclusive ownership layer for isolated work, so two agents do not accidentally work the same task in parallel.

The container-blocked validation message is also softer and more actionable: it explains that host-side failure is expected, Decapod will capture a coordination todo, and the next step is `decapod workspace ensure --container`.

## Changes

- Auto-create and exclusively claim Decapod workspace coordination todos when an agent has no claimed Decapod todo yet.
- Reuse external task refs such as `BD_TASK_ID` as Decapod todo refs, so external task-manager work still maps to one Decapod-owned coordination todo.
- Prevent duplicate workspace/container claims when another agent already owns the Decapod todo for the same external task or branch-scoped todo.
- Keep `workspace ensure --container` working without a caller-supplied branch by generating a todo-scoped branch after the coordination todo is captured.
- Update AGENTS.md scaffolding so agents must create/claim a Decapod todo before claiming a workspace, requesting `workspace ensure --container`, or entering a container run.
- Limit the `decapod init` language selector to 10 visible options with more/wrap hints while preserving arrow, numeric, and typed language selection.

## Validation

- `cargo test init_prompt_tests`
- `cargo test --test todo_enforcement workspace_ensure`
- `cargo test --test substrate_integrity test_decapod_init_regenerates_from_templates`
- `target/debug/decapod validate --format json` fails only on the expected host `container_workspace_required` gate, with the updated guidance
- Container validation passes with `status: ok` and `fail_count: 0`
