### PR TITLE
feat: refine agent entrypoint adoption with structured consolidation

### DIFF
--- a/.decapod/README.md
+++ b/.decapod/README.md
@@ -27,7 +27,7 @@ It keeps Decapod-owned state, generated artifacts, and isolated workspaces separ
 
 If you have existing files like `SKILLS.md`, `SOUL.md`, or `MEMORY.md` that were used for agent instructions, you can easily migrate them into the Decapod governance layer. 
 
-After running `decapod init`, simply ask your agent to **"blend my [FILE.md] content into .decapod/OVERRIDE.md"**. This preserves your custom intent while allowing Decapod to manage the primary entrypoints.
+After running `decapod init`, simply ask your agent to **"consolidate my [FILE.md] content into the .decapod/OVERRIDE.md substrate"**. This ensures your project-specific intent is merged into the correct constitutional sections while allowing Decapod to manage the primary entrypoints.
 
 ## Skills - Your Personal Optimization Layer
 

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1779567973Z",
-  "repo_signal_fingerprint": "d810bd766a35b84ab16ddbd2b66fc4e23b1cb4ed3c2fa51f192d1df424880b65",
+  "generated_at": "1779571668Z",
+  "repo_signal_fingerprint": "81fd4ba8e55e5d376dd32a44f1a4ab7df662aea52c337180334cc0c981e9faea",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -414,7 +414,7 @@ It keeps Decapod-owned state, generated artifacts, and isolated workspaces separ
 
 If you have existing files like `SKILLS.md`, `SOUL.md`, or `MEMORY.md` that were used for agent instructions, you can easily migrate them into the Decapod governance layer. 
 
-After running `decapod init`, simply ask your agent to **"blend my [FILE.md] content into .decapod/OVERRIDE.md"**. This preserves your custom intent while allowing Decapod to manage the primary entrypoints.
+After running `decapod init`, simply ask your agent to **"consolidate my [FILE.md] content into the .decapod/OVERRIDE.md substrate"**. This ensures your project-specific intent is merged into the correct constitutional sections while allowing Decapod to manage the primary entrypoints.
 
 ## Skills - Your Personal Optimization Layer
 

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1177,13 +1177,16 @@ pub fn scaffold_project_entrypoints(
         if !override_md.ends_with('\n') {
             override_md.push('\n');
         }
+        override_md.push_str("\n## PENDING CONSOLIDATION (ADOPTED INTENT)\n\n");
+        override_md.push_str("> **AGENT INSTRUCTION:** Analyze the content below and consolidate relevant rules into the appropriate `### section/ID` headers within this file. The `### adoption/*` headers below represent your previous project-specific intent which MUST be preserved in the substrate above.\n");
         for (file, content) in &opts.preserved_agent_content {
             override_md.push_str(&format!(
-                "\n## Adopted from {}\n\n{}\n",
+                "\n### adoption/{}\n\n{}\n",
                 file,
                 content.trim()
             ));
         }
+        override_md.push_str("\n---\n");
     }
 
     // AGENT ENTRYPOINTS - Neural Interfaces (only generate specified files)
@@ -1218,17 +1221,21 @@ pub fn scaffold_project_entrypoints(
             if !existing_override.ends_with('\n') {
                 existing_override.push('\n');
             }
+            existing_override.push_str("\n## PENDING CONSOLIDATION (ADOPTED INTENT)\n\n");
+            existing_override.push_str("> **AGENT INSTRUCTION:** Analyze the content below and consolidate relevant rules into the appropriate `### section/ID` headers within this file. The `### adoption/*` headers below represent your previous project-specific intent which MUST be preserved in the substrate above.\n");
             for (file, content) in &opts.preserved_agent_content {
                 existing_override.push_str(&format!(
-                    "\n## Adopted from {}\n\n{}\n",
+                    "\n### adoption/{}\n\n{}\n",
                     file,
                     content.trim()
                 ));
             }
+            existing_override.push_str("\n---\n");
             fs::write(&override_path, existing_override).map_err(error::DecapodError::IoError)?;
         }
         cfg_preserved += 1;
-    } else {
+    }
+ else {
         match write_file(opts, ".decapod/OVERRIDE.md", &override_md)? {
             FileAction::Created => cfg_created += 1,
             FileAction::Unchanged => cfg_unchanged += 1,

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1180,11 +1180,7 @@ pub fn scaffold_project_entrypoints(
         override_md.push_str("\n## PENDING CONSOLIDATION (ADOPTED INTENT)\n\n");
         override_md.push_str("> **AGENT INSTRUCTION:** Analyze the content below and consolidate relevant rules into the appropriate `### section/ID` headers within this file. The `### adoption/*` headers below represent your previous project-specific intent which MUST be preserved in the substrate above.\n");
         for (file, content) in &opts.preserved_agent_content {
-            override_md.push_str(&format!(
-                "\n### adoption/{}\n\n{}\n",
-                file,
-                content.trim()
-            ));
+            override_md.push_str(&format!("\n### adoption/{}\n\n{}\n", file, content.trim()));
         }
         override_md.push_str("\n---\n");
     }
@@ -1234,8 +1230,7 @@ pub fn scaffold_project_entrypoints(
             fs::write(&override_path, existing_override).map_err(error::DecapodError::IoError)?;
         }
         cfg_preserved += 1;
-    }
- else {
+    } else {
         match write_file(opts, ".decapod/OVERRIDE.md", &override_md)? {
             FileAction::Created => cfg_created += 1,
             FileAction::Unchanged => cfg_unchanged += 1,

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -374,13 +374,17 @@ fn init_blends_existing_agent_entrypoints_into_override_md() {
         "OVERRIDE.md should contain custom AGENTS.md content"
     );
     assert!(
-        override_content.contains("## Adopted from AGENTS.md"),
-        "OVERRIDE.md should have a header for adopted content"
+        override_content.contains("## PENDING CONSOLIDATION (ADOPTED INTENT)"),
+        "OVERRIDE.md should have a header for pending consolidation"
     );
-}
+    assert!(
+        override_content.contains("### adoption/AGENTS.md"),
+        "OVERRIDE.md should have a sub-header for adopted content"
+    );
+    }
 
-#[test]
-fn init_blends_all_agent_entrypoints_when_forced() {
+    #[test]
+    fn init_blends_all_agent_entrypoints_when_forced() {
     let tmp = tempdir().expect("tempdir");
     let repo_dir = tmp.path();
 
@@ -394,16 +398,17 @@ fn init_blends_all_agent_entrypoints_when_forced() {
     let override_content =
         fs::read_to_string(repo_dir.join(".decapod/OVERRIDE.md")).expect("read OVERRIDE.md");
 
-    assert!(override_content.contains("## Adopted from CLAUDE.md"));
+    assert!(override_content.contains("## PENDING CONSOLIDATION (ADOPTED INTENT)"));
+    assert!(override_content.contains("### adoption/CLAUDE.md"));
     assert!(override_content.contains("# Custom Claude"));
-    assert!(override_content.contains("## Adopted from GEMINI.md"));
+    assert!(override_content.contains("### adoption/GEMINI.md"));
     assert!(override_content.contains("# Custom Gemini"));
-    assert!(override_content.contains("## Adopted from CODEX.md"));
+    assert!(override_content.contains("### adoption/CODEX.md"));
     assert!(override_content.contains("# Custom Codex"));
-}
+    }
 
-#[test]
-fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
+    #[test]
+    fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
     let tmp = tempdir().expect("tempdir");
     let repo_dir = tmp.path();
 
@@ -428,6 +433,8 @@ fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
     // 5. Verify adoption in OVERRIDE.md
     let override_content =
         fs::read_to_string(repo_dir.join(".decapod/OVERRIDE.md")).expect("read OVERRIDE.md");
-    assert!(override_content.contains("## Adopted from CLAUDE.md"));
+    assert!(override_content.contains("## PENDING CONSOLIDATION (ADOPTED INTENT)"));
+    assert!(override_content.contains("### adoption/CLAUDE.md"));
     assert!(override_content.contains("# Original Claude Intent"));
-}
+    }
+

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -381,10 +381,10 @@ fn init_blends_existing_agent_entrypoints_into_override_md() {
         override_content.contains("### adoption/AGENTS.md"),
         "OVERRIDE.md should have a sub-header for adopted content"
     );
-    }
+}
 
-    #[test]
-    fn init_blends_all_agent_entrypoints_when_forced() {
+#[test]
+fn init_blends_all_agent_entrypoints_when_forced() {
     let tmp = tempdir().expect("tempdir");
     let repo_dir = tmp.path();
 
@@ -405,10 +405,10 @@ fn init_blends_existing_agent_entrypoints_into_override_md() {
     assert!(override_content.contains("# Custom Gemini"));
     assert!(override_content.contains("### adoption/CODEX.md"));
     assert!(override_content.contains("# Custom Codex"));
-    }
+}
 
-    #[test]
-    fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
+#[test]
+fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
     let tmp = tempdir().expect("tempdir");
     let repo_dir = tmp.path();
 
@@ -436,5 +436,4 @@ fn init_blends_existing_agent_entrypoints_into_override_md() {
     assert!(override_content.contains("## PENDING CONSOLIDATION (ADOPTED INTENT)"));
     assert!(override_content.contains("### adoption/CLAUDE.md"));
     assert!(override_content.contains("# Original Claude Intent"));
-    }
-
+}


### PR DESCRIPTION
This PR refines how Decapod handles existing agent entrypoint files during `decapod init`.

Instead of a generic header, Decapod now:
1. Places adopted content into structured `### adoption/*` sub-headers within `.decapod/OVERRIDE.md`.
2. Includes a strong prompt for the agent to consolidate this intent into the existing constitutional substrate (H3 sections).
3. Provides updated guidance in `.decapod/README.md` for migrating other custom files like `SKILLS.md`.

This ensures that pre-existing project intent is not just 'moved', but actively integrated into the Decapod governance layer.