### PR TITLE
chore(workspace): remove legacy OVERRIDE.md tracker marker logic

### DIFF
--- a/.decapod/config.toml
+++ b/.decapod/config.toml
@@ -18,3 +18,4 @@ product_type = "service_or_library"
 done_criteria = "Decapod validate passes, required tests pass, and promotion-relevant artifacts are present."
 primary_languages = ["Rust"]
 detected_surfaces = ["cargo"]
+external_tracker = true

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -429,6 +429,7 @@ These files are the project-local contract for humans and agents.
 - `.decapod/generated/context/`: deterministic context capsules.
 - `.decapod/generated/policy/context_capsule_policy.json`: repo-native JIT context policy contract.
 - `.decapod/generated/artifacts/provenance/`: promotion manifests and convergence checklist.
+- `.decapod/generated/artifacts/custody/`: epistemic custody artifacts (assumptions, contradictions, deferred questions).
 - `.decapod/generated/artifacts/inventory/`: deterministic release inventory.
 - `.decapod/generated/artifacts/diagnostics/`: opt-in diagnostics artifacts.
 - `.decapod/workspaces/`: isolated todo-scoped git worktrees.
@@ -1058,6 +1059,8 @@ pub const DECAPOD_GITIGNORE_RULES: &[&str] = &[
     "!.decapod/generated/artifacts/provenance/",
     "!.decapod/generated/artifacts/provenance/*.json",
     "!.decapod/generated/artifacts/provenance/kcr_trend.jsonl",
+    "!.decapod/generated/artifacts/custody/",
+    "!.decapod/generated/artifacts/custody/*.md",
     "!.decapod/generated/specs/",
     "!.decapod/generated/specs/*.md",
     "!.decapod/generated/specs/.manifest.json",

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -90,8 +90,6 @@ const PROTECTED_PATTERNS: &[&str] = &[
     "hotfix/*",
 ];
 
-pub(crate) const EXTERNAL_TRACKER_OVERRIDE_MARKER: &str = "DECAPOD_EXTERNAL_TRACKER=true";
-
 /// Prune stale git worktree metadata and remove stale worktree sections from .git/config.
 ///
 /// This is a best-effort maintenance operation to keep worktree state healthy after
@@ -485,10 +483,8 @@ pub fn ensure_workspace(
 
     // If we're already in a valid worktree, on todo-scoped branch, and no upgrade needed, we're good.
     // Relaxation for Issue #586: Allow non-scoped branches in worktrees if using external tracker
-    // or if the project has explicitly opted into external tracker compatibility in OVERRIDE.md or config.toml.
-    let allow_unscoped = !external_task_ref().is_empty()
-        || is_external_tracker_override(repo_root)
-        || is_external_tracker_config(repo_root);
+    // or if the project has explicitly opted into external tracker compatibility in config.toml.
+    let allow_unscoped = !external_task_ref().is_empty() || is_external_tracker_config(repo_root);
 
     if status.git.in_worktree
         && !assigned_todos.is_empty()
@@ -833,21 +829,6 @@ fn is_branch_protected(branch: &str) -> bool {
         }
     }
     false
-}
-
-fn is_external_tracker_override(repo_root: &Path) -> bool {
-    let main_repo = get_main_repo_root(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
-    let override_path = main_repo.join(".decapod").join("OVERRIDE.md");
-    if !override_path.exists() {
-        return false;
-    }
-    match std::fs::read_to_string(override_path) {
-        Ok(content) => {
-            content.contains(EXTERNAL_TRACKER_OVERRIDE_MARKER)
-                || content.contains("DECAPOD_EXTERNAL_TRACKER=true")
-        }
-        Err(_) => false,
-    }
 }
 
 fn is_external_tracker_config(repo_root: &Path) -> bool {

--- a/tests/external_tracker_compatibility.rs
+++ b/tests/external_tracker_compatibility.rs
@@ -126,56 +126,6 @@ fn test_external_tracker_env_var_relaxation() {
 }
 
 #[test]
-fn test_external_tracker_override_md_relaxation() {
-    let tmp = TempDir::new().expect("tempdir");
-    let dir = tmp.path();
-    setup_repo(dir);
-
-    let branch = "feature/external-task";
-    let worktree_dir = dir.join(".decapod/workspaces/override-test");
-
-    Command::new("git")
-        .args([
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            worktree_dir.to_str().unwrap(),
-        ])
-        .current_dir(dir)
-        .status()
-        .expect("git worktree add");
-
-    // 1. Add marker to OVERRIDE.md
-    let override_path = dir.join(".decapod/OVERRIDE.md");
-    let mut content = fs::read_to_string(&override_path).expect("read override");
-    content.push_str("\nDECAPOD_EXTERNAL_TRACKER=true\n");
-    fs::write(&override_path, content).expect("write override");
-
-    // 2. Run - should succeed even without env var and STAY
-    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["workspace", "ensure"])
-        .current_dir(&worktree_dir)
-        .output()
-        .expect("workspace ensure with override.md");
-
-    assert!(
-        out.status.success(),
-        "should succeed with OVERRIDE.md marker. Stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
-    assert_eq!(
-        json["branch"], branch,
-        "should have stayed on branch with OVERRIDE.md marker. JSON: {}",
-        stdout
-    );
-    assert_eq!(json["status"], "ok");
-}
-
-#[test]
 fn test_external_tracker_config_toml_relaxation() {
     let tmp = TempDir::new().expect("tempdir");
     let dir = tmp.path();

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -437,3 +437,33 @@ fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
     assert!(override_content.contains("### adoption/CLAUDE.md"));
     assert!(override_content.contains("# Original Claude Intent"));
 }
+
+
+#[test]
+fn init_creates_custody_directory_and_intent_has_epistemic_custody_fields() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(tmp.path(), &["init", "with", "--force"]);
+    assert!(out.status.success(), "decapod init with failed: {}", String::from_utf8_lossy(&out.stderr));
+    let custody_dir = tmp.path().join(".decapod/generated/artifacts/custody");
+    assert!(custody_dir.exists(), "expected .decapod/generated/artifacts/custody/ directory to exist");
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/INTENT.md")).expect("read INTENT.md");
+    assert!(intent.contains("## Epistemic Custody Fields"), "INTENT.md should contain Epistemic Custody Fields section");
+    assert!(intent.contains("### Active Assumptions"), "INTENT.md should contain Active Assumptions subsection");
+    assert!(intent.contains("### Measured vs Inferred Facts"), "INTENT.md should contain Measured vs Inferred Facts subsection");
+    assert!(intent.contains("### Unresolved Contradictions"), "INTENT.md should contain Unresolved Contradictions subsection");
+    assert!(intent.contains("### Deferred Questions"), "INTENT.md should contain Deferred Questions subsection");
+    assert!(intent.contains("### Stop Conditions"), "INTENT.md should contain Stop Conditions subsection");
+    assert!(intent.contains("### Proof Required Before Completion"), "INTENT.md should contain Proof Required Before Completion subsection");
+}
+
+#[test]
+fn agents_md_contains_epistemic_custody_section() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(tmp.path(), &["init", "with", "--force", "--all"]);
+    assert!(out.status.success(), "decapod init with failed: {}", String::from_utf8_lossy(&out.stderr));
+    let agents_md = fs::read_to_string(tmp.path().join("AGENTS.md")).expect("read AGENTS.md");
+    assert!(agents_md.contains("## Epistemic Custody"), "AGENTS.md should contain Epistemic Custody section");
+    assert!(agents_md.contains("**Epistemic custody** is the preserved chain"), "AGENTS.md should define epistemic custody");
+    assert!(agents_md.contains("| Term | Meaning |"), "AGENTS.md should contain epistemic custody vocabulary table");
+    assert!(agents_md.contains("## Custody artifacts"), "AGENTS.md should describe custody artifacts directory");
+}

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -438,32 +438,76 @@ fn init_with_claude_only_adopts_it_and_generates_all_four_entrypoints() {
     assert!(override_content.contains("# Original Claude Intent"));
 }
 
-
 #[test]
 fn init_creates_custody_directory_and_intent_has_epistemic_custody_fields() {
     let tmp = tempdir().expect("tempdir");
     let out = run_decapod(tmp.path(), &["init", "with", "--force"]);
-    assert!(out.status.success(), "decapod init with failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "decapod init with failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let custody_dir = tmp.path().join(".decapod/generated/artifacts/custody");
-    assert!(custody_dir.exists(), "expected .decapod/generated/artifacts/custody/ directory to exist");
-    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/INTENT.md")).expect("read INTENT.md");
-    assert!(intent.contains("## Epistemic Custody Fields"), "INTENT.md should contain Epistemic Custody Fields section");
-    assert!(intent.contains("### Active Assumptions"), "INTENT.md should contain Active Assumptions subsection");
-    assert!(intent.contains("### Measured vs Inferred Facts"), "INTENT.md should contain Measured vs Inferred Facts subsection");
-    assert!(intent.contains("### Unresolved Contradictions"), "INTENT.md should contain Unresolved Contradictions subsection");
-    assert!(intent.contains("### Deferred Questions"), "INTENT.md should contain Deferred Questions subsection");
-    assert!(intent.contains("### Stop Conditions"), "INTENT.md should contain Stop Conditions subsection");
-    assert!(intent.contains("### Proof Required Before Completion"), "INTENT.md should contain Proof Required Before Completion subsection");
+    assert!(
+        custody_dir.exists(),
+        "expected .decapod/generated/artifacts/custody/ directory to exist"
+    );
+    let intent = fs::read_to_string(tmp.path().join(".decapod/generated/specs/INTENT.md"))
+        .expect("read INTENT.md");
+    assert!(
+        intent.contains("## Epistemic Custody Fields"),
+        "INTENT.md should contain Epistemic Custody Fields section"
+    );
+    assert!(
+        intent.contains("### Active Assumptions"),
+        "INTENT.md should contain Active Assumptions subsection"
+    );
+    assert!(
+        intent.contains("### Measured vs Inferred Facts"),
+        "INTENT.md should contain Measured vs Inferred Facts subsection"
+    );
+    assert!(
+        intent.contains("### Unresolved Contradictions"),
+        "INTENT.md should contain Unresolved Contradictions subsection"
+    );
+    assert!(
+        intent.contains("### Deferred Questions"),
+        "INTENT.md should contain Deferred Questions subsection"
+    );
+    assert!(
+        intent.contains("### Stop Conditions"),
+        "INTENT.md should contain Stop Conditions subsection"
+    );
+    assert!(
+        intent.contains("### Proof Required Before Completion"),
+        "INTENT.md should contain Proof Required Before Completion subsection"
+    );
 }
 
 #[test]
 fn agents_md_contains_epistemic_custody_section() {
     let tmp = tempdir().expect("tempdir");
     let out = run_decapod(tmp.path(), &["init", "with", "--force", "--all"]);
-    assert!(out.status.success(), "decapod init with failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "decapod init with failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let agents_md = fs::read_to_string(tmp.path().join("AGENTS.md")).expect("read AGENTS.md");
-    assert!(agents_md.contains("## Epistemic Custody"), "AGENTS.md should contain Epistemic Custody section");
-    assert!(agents_md.contains("**Epistemic custody** is the preserved chain"), "AGENTS.md should define epistemic custody");
-    assert!(agents_md.contains("| Term | Meaning |"), "AGENTS.md should contain epistemic custody vocabulary table");
-    assert!(agents_md.contains("## Custody artifacts"), "AGENTS.md should describe custody artifacts directory");
+    assert!(
+        agents_md.contains("## Epistemic Custody"),
+        "AGENTS.md should contain Epistemic Custody section"
+    );
+    assert!(
+        agents_md.contains("**Epistemic custody** is the preserved chain"),
+        "AGENTS.md should define epistemic custody"
+    );
+    assert!(
+        agents_md.contains("| Term | Meaning |"),
+        "AGENTS.md should contain epistemic custody vocabulary table"
+    );
+    assert!(
+        agents_md.contains("## Custody artifacts"),
+        "AGENTS.md should describe custody artifacts directory"
+    );
 }


### PR DESCRIPTION
Following the transition to first-class `config.toml` management for external trackers in v0.51.3, this PR removes the legacy `DECAPOD_EXTERNAL_TRACKER=true` marker logic from `OVERRIDE.md`.

All external tracker compatibility is now managed exclusively via:
1. Environment variables (`BEADS_TASK_ID`, etc.)
2. Project-wide opt-in via `external_tracker = true` in `.decapod/config.toml`.

This simplifies the governance model and reduces project-level boilerplate.