### PR TITLE
fix(workspace): finalize shadow custody - move external tracker opt-in to config.toml

### DIFF
--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -90,8 +90,6 @@ const PROTECTED_PATTERNS: &[&str] = &[
     "hotfix/*",
 ];
 
-pub(crate) const EXTERNAL_TRACKER_OVERRIDE_MARKER: &str = "DECAPOD_EXTERNAL_TRACKER=true";
-
 /// Prune stale git worktree metadata and remove stale worktree sections from .git/config.
 ///
 /// This is a best-effort maintenance operation to keep worktree state healthy after
@@ -485,10 +483,8 @@ pub fn ensure_workspace(
 
     // If we're already in a valid worktree, on todo-scoped branch, and no upgrade needed, we're good.
     // Relaxation for Issue #586: Allow non-scoped branches in worktrees if using external tracker
-    // or if the project has explicitly opted into external tracker compatibility in OVERRIDE.md or config.toml.
-    let allow_unscoped = !external_task_ref().is_empty()
-        || is_external_tracker_override(repo_root)
-        || is_external_tracker_config(repo_root);
+    // or if the project has explicitly opted into external tracker compatibility in config.toml.
+    let allow_unscoped = !external_task_ref().is_empty() || is_external_tracker_config(repo_root);
 
     if status.git.in_worktree
         && !assigned_todos.is_empty()
@@ -833,21 +829,6 @@ fn is_branch_protected(branch: &str) -> bool {
         }
     }
     false
-}
-
-fn is_external_tracker_override(repo_root: &Path) -> bool {
-    let main_repo = get_main_repo_root(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
-    let override_path = main_repo.join(".decapod").join("OVERRIDE.md");
-    if !override_path.exists() {
-        return false;
-    }
-    match std::fs::read_to_string(override_path) {
-        Ok(content) => {
-            content.contains(EXTERNAL_TRACKER_OVERRIDE_MARKER)
-                || content.contains("DECAPOD_EXTERNAL_TRACKER=true")
-        }
-        Err(_) => false,
-    }
 }
 
 fn is_external_tracker_config(repo_root: &Path) -> bool {

--- a/tests/external_tracker_compatibility.rs
+++ b/tests/external_tracker_compatibility.rs
@@ -126,56 +126,6 @@ fn test_external_tracker_env_var_relaxation() {
 }
 
 #[test]
-fn test_external_tracker_override_md_relaxation() {
-    let tmp = TempDir::new().expect("tempdir");
-    let dir = tmp.path();
-    setup_repo(dir);
-
-    let branch = "feature/external-task";
-    let worktree_dir = dir.join(".decapod/workspaces/override-test");
-
-    Command::new("git")
-        .args([
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            worktree_dir.to_str().unwrap(),
-        ])
-        .current_dir(dir)
-        .status()
-        .expect("git worktree add");
-
-    // 1. Add marker to OVERRIDE.md
-    let override_path = dir.join(".decapod/OVERRIDE.md");
-    let mut content = fs::read_to_string(&override_path).expect("read override");
-    content.push_str("\nDECAPOD_EXTERNAL_TRACKER=true\n");
-    fs::write(&override_path, content).expect("write override");
-
-    // 2. Run - should succeed even without env var and STAY
-    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["workspace", "ensure"])
-        .current_dir(&worktree_dir)
-        .output()
-        .expect("workspace ensure with override.md");
-
-    assert!(
-        out.status.success(),
-        "should succeed with OVERRIDE.md marker. Stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
-    assert_eq!(
-        json["branch"], branch,
-        "should have stayed on branch with OVERRIDE.md marker. JSON: {}",
-        stdout
-    );
-    assert_eq!(json["status"], "ok");
-}
-
-#[test]
 fn test_external_tracker_config_toml_relaxation() {
     let tmp = TempDir::new().expect("tempdir");
     let dir = tmp.path();


### PR DESCRIPTION
# fix(workspace): finalize shadow custody - move external tracker opt-in to config.toml

## Why (what problem / what user outcome)
Following the transition to first-class `config.toml` management for external trackers in v0.51.3, this PR removes the legacy `DECAPOD_EXTERNAL_TRACKER=true` marker logic from `OVERRIDE.md`. 

This ensures that the "Shadow Custody" model—which allows Decapod to yield branch-naming authority to external task-management systems while maintaining internal execution safety—is perfectly aligned with the project's new configuration standards.

## Scope
- [x] Core
- [ ] Plugin
- [ ] Docs
- [x] CI / tooling

## How to test (required)
Commands run:
- `cargo test --test external_tracker_compatibility`
- `cargo test --test workspace_interlock`

Expected result:
- Tests verify that `external_tracker = true` in `config.toml` successfully allows working on project-native branches (e.g., `feature/BEADS-123`) without forcing a rename.
- Core safety gates (protected branch checks, isolation requirements) still function as expected.

## Risk / blast radius (required)
- Affected components: `src/core/workspace.rs` (removal of legacy marker logic).
- Backward compat: Fully compatible with v0.51.3 configuration. Deprecates the temporary `OVERRIDE.md` marker.
- Failure modes: None anticipated.

## Technical Details

### 1. Unified Configuration
Removed `EXTERNAL_TRACKER_OVERRIDE_MARKER` and `is_external_tracker_override`. Compatibility is now managed exclusively via:
1. Environment variables (`BEADS_TASK_ID`, `BD_TASK_ID`, `DECAPOD_TASK_ID`, `DECAPOD_EXTERNAL_TASK_ID`).
2. Project-wide opt-in via `external_tracker = true` in `.decapod/config.toml` (under the `[repo]` section).

### 2. Runtime Integrity
Decapod continues to create and claim an internal coordination todo silently. This ensures that runtime safety (lock prevention, proof tracking) is maintained even when branch-naming authority is yielded to an external tracker.

### 3. Cleanup
Removed legacy test cases from `tests/external_tracker_compatibility.rs` that relied on the `OVERRIDE.md` marker.

# Core checklist (required if core touched)
- [x] Public interfaces documented (or explicitly unchanged).
- [x] Added/updated tests covering the change.
- [x] Failure behavior is deterministic (no silent partial success).
- [x] Logging added/updated at the right level (info/warn/error) with actionable context.
