### PR TITLE
feat: implement epistemic custody preservation

### DIFF
--- a/.decapod/config.toml
+++ b/.decapod/config.toml
@@ -13,9 +13,9 @@ entrypoints = [
 [repo]
 product_name = "decapod"
 product_summary = "Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work."
-architecture_direction = "webapp"
-product_type = "service_or_library"
+architecture_direction = "cli"
+product_type = "cli"
 done_criteria = "Decapod validate passes, required tests pass, and promotion-relevant artifacts are present."
 primary_languages = ["Rust"]
 detected_surfaces = ["cargo"]
-external_tracker = true
+external_tracker = false

--- a/.decapod/generated/artifacts/custody/README.md
+++ b/.decapod/generated/artifacts/custody/README.md
@@ -1,0 +1,12 @@
+# Epistemic Custody Artifacts
+
+This directory tracks the preserved chain of intent, context, assumptions, and proof for this repository.
+
+## Directory Structure
+- `assumptions.md`: Log of active and verified assumptions.
+- `contradictions.md`: Log of evidence that conflicts with current plans or assumptions.
+- `deferred_questions.md`: Questions identified during work that were postponed.
+- `evidence/`: Detailed proof artifacts (logs, screenshots, data captures) tied to specific claims.
+
+## Agent Guidance
+Agents operating in this repo MUST maintain these artifacts to ensure long-horizon integrity. Do not compress away uncertainty; surface it here so it remains inspectable by humans and future agent passes.

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,28 +1,28 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1779571668Z",
-  "repo_signal_fingerprint": "81fd4ba8e55e5d376dd32a44f1a4ab7df662aea52c337180334cc0c981e9faea",
+  "generated_at": "1779678743Z",
+  "repo_signal_fingerprint": "c199830b21bba0c2265dbe139b358db4575f9a673a9c4248f44b288d572f9c6c",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
-      "template_hash": "14c0255251cbf0b9423a1262517978cda5ee77be9c0893b2f1501781d5ab27b1",
-      "content_hash": "14c0255251cbf0b9423a1262517978cda5ee77be9c0893b2f1501781d5ab27b1"
+      "template_hash": "ca0c70016626403b25952658cd1a689ea820839a2901bd617437a11663f14458",
+      "content_hash": "ca0c70016626403b25952658cd1a689ea820839a2901bd617437a11663f14458"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
-      "template_hash": "585a5bb16e65702cf5bd3dbbb450e9962676a0450810e0d705f63aaf238cd6a3",
-      "content_hash": "585a5bb16e65702cf5bd3dbbb450e9962676a0450810e0d705f63aaf238cd6a3"
+      "template_hash": "6a345714f2df2b8e345e65ab1054627c904019e3e720cf3213a413f38a70f233",
+      "content_hash": "6a345714f2df2b8e345e65ab1054627c904019e3e720cf3213a413f38a70f233"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
-      "template_hash": "54c2f887f04cfa3da6d6afdf3439aa86b10c2bc6fc2b07a19193c6d7f7229ce1",
-      "content_hash": "54c2f887f04cfa3da6d6afdf3439aa86b10c2bc6fc2b07a19193c6d7f7229ce1"
+      "template_hash": "c59235a1c326fcc6c543b1a112d04a2ce49c543481b2ad658956280db0f5954b",
+      "content_hash": "c59235a1c326fcc6c543b1a112d04a2ce49c543481b2ad658956280db0f5954b"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
-      "template_hash": "60163ea031c507eb45e47eb3bed84d3c877c38661b10d994143d21be75afcf90",
-      "content_hash": "60163ea031c507eb45e47eb3bed84d3c877c38661b10d994143d21be75afcf90"
+      "template_hash": "59173d7fecfc89c6d9ab8f7f43c150f171650f44e02bc6b61763af5888e60cff",
+      "content_hash": "59173d7fecfc89c6d9ab8f7f43c150f171650f44e02bc6b61763af5888e60cff"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -1,21 +1,21 @@
 # Architecture
 
 ## Direction
-webapp
+cli
 
 ## Current Facts
 - Runtime/languages: Rust
 - Detected surfaces/framework hints: cargo
-- Product type: service_or_library
+- Product type: cli
 
 ## Topology
 ```mermaid
 flowchart LR
-  H[Host Application] --> L[Library API]
-  L --> D[Domain Core]
-  D --> AD[Adapter Layer]
-  AD --> DB[(Store)]
-  AD --> N[Network]
+  U[User] --> C[CLI Entrypoint]
+  C --> R[Command Router]
+  R --> E[Core Engine]
+  E --> S[(Local Store)]
+  E --> X[External APIs / Filesystem]
 ```
 
 ## Store Boundaries
@@ -31,16 +31,16 @@ flowchart LR
 ## Happy Path Sequence
 ```mermaid
 sequenceDiagram
-  participant C as Client
-  participant G as API
-  participant D as Domain
-  participant DB as Datastore
-  C->>G: Request
-  G->>D: Validate + execute
-  D->>DB: Commit transaction
-  DB-->>D: Commit ok
-  D-->>G: Domain result
-  G-->>C: Response + trace_id
+  participant U as User
+  participant C as CLI
+  participant E as Core Engine
+  participant S as Store
+  U->>C: Run command
+  C->>E: Parse + validate
+  E->>S: Persist mutation
+  S-->>E: Ack
+  E-->>C: Result
+  C-->>U: Structured output
 ```
 
 ## Error Path

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -14,7 +14,7 @@ flowchart LR
 
 ## Inferred Baseline
 - Repository: decapod
-- Product type: service_or_library
+- Product type: cli
 - Primary languages: Rust
 - Detected surfaces: cargo
 

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -45,6 +45,33 @@ flowchart LR
 - [ ] `cargo clippy -- -D warnings` passes with no denied lints
 - [ ] `cargo fmt --check` passes on the repo
 
+## Epistemic Custody Fields
+
+### Active Assumptions
+- [ ] List any assumptions made to proceed.
+- [ ] Flag assumptions that require future verification.
+
+### Confidence & Risk Level
+- **Confidence**: Low/Medium/High (Rationale: )
+- **Risk**: Low/Medium/High (Impact of wrong assumptions: )
+
+### Measured vs Inferred Facts
+| Fact | Source (Provenance) | Type (Measured/Inferred) |
+|---|---|---|
+| | | |
+
+### Unresolved Contradictions
+- [ ] List any evidence that conflicts with current assumptions or intent.
+
+### Deferred Questions
+- [ ] Questions to be answered later.
+
+### Stop Conditions
+- [ ] Explicit conditions under which the agent should stop and ask for help.
+
+### Proof Required Before Completion
+- [ ] Specific evidence needed to prove the outcome is met.
+
 ## Tradeoffs Register
 | Decision | Benefit | Cost | Review Trigger |
 |---|---|---|---|

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -31,7 +31,7 @@
 - Cross-boundary read models:
 - Consistency expectations:
 
-## Error Taxonomy Example (service_or_library)
+## Error Taxonomy Example (cli)
 ```rust
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -20,10 +20,11 @@ These files are the project-local contract for humans and agents.
 
 ## Canonical `.decapod/` Layout
 - `.decapod/data/`: canonical control-plane state (SQLite + ledgers).
-- `.decapod/generated/specs/`: living project specs for humans and agents.
+- `.decapod/generated/specs/`: **Living project specs** for humans and agents.
 - `.decapod/generated/context/`: deterministic context capsules.
 - `.decapod/generated/policy/context_capsule_policy.json`: repo-native JIT context policy contract.
 - `.decapod/generated/artifacts/provenance/`: promotion manifests and convergence checklist.
+- `.decapod/generated/artifacts/custody/`: epistemic custody artifacts (assumptions, contradictions, deferred questions).
 - `.decapod/generated/artifacts/inventory/`: deterministic release inventory.
 - `.decapod/generated/artifacts/diagnostics/`: opt-in diagnostics artifacts.
 - `.decapod/workspaces/`: isolated todo-scoped git worktrees.
@@ -41,4 +42,6 @@ These files are the project-local contract for humans and agents.
 - [ ] Run all validation/test commands and attach evidence artifacts.
 
 ## Agent Directive
-- Treat these files as executable governance surfaces. Before implementation: resolve ambiguity and update specs. After implementation: refresh drifted sections, rerun proof gates, and attach evidence.
+- **Living Specs**: Treat these files as executable governance surfaces.
+- **Continuous Alignment**: Before implementation: resolve ambiguity and update specs. During/After implementation: align specs with reality.
+- **Intent-Driven**: Spec changes should generally only occur when user intent has evolved. Clarify code changes in the context of these updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,6 @@ Call Decapod before proceeding when continuing would require guessing about:
 Concrete triggers: ambiguous requests, public impact, unclear proof, todo lifecycle, scope expansion, conflicting intent/specs, context loss, multi-agent collision risk, or readiness to claim completion.
 
 Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts.
-
 ## Epistemic Custody
 
 **Epistemic custody** is the preserved chain between intent, context, assumptions, action, evidence, contradiction, and proof, so agent work remains inspectable, bounded, and falsifiable across time, agents, and recursive passes.
@@ -84,7 +83,7 @@ Do not call Decapod for every trivial file read, local edit, or mechanical comma
 
 ### Custody Rules
 1. **Preserve Uncertainty**: Summaries must preserve uncertainty, risk, and unresolved contradictions instead of compressing them away into polished prose.
-2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes or different agents until explicitly resolved or falsified.
+2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes until resolved.
 3. **Evidence-Based Claims**: Any claim of success or completion must be tied to measured evidence (artifacts, tests, or explicit user instruction).
 4. **Falsifiability**: Work must be structured so a human can quickly identify where an assumption was wrong or where proof failed.
 5. **Clarification Trigger**: If a critical assumption cannot be proven or a contradiction cannot be resolved, you MUST stop and request human clarification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,20 @@ decapod rpc --op context.scope --params '{"query":"<problem>","limit":8}'
 8. **MUST NOT** invent capabilities that are not exposed by the binary.
 9. **MUST** stop if requirements conflict or intent is ambiguous.
 10. **MUST** respect the interface abstraction boundary.
+11. **MUST** maintain **Living Specs**: treat `.decapod/generated/specs/*` as dynamic documents; align them with reality before and after every implementation.
 
 ## Decapod Invocation Contract
 
 Agents act. Decapod orients.
 
 Decapod is not your executor, model runtime, or workflow replacement. You remain responsible for implementation. Call Decapod as the repo-native pressure relief valve when the next responsible step requires explicit intent, boundaries, context, coordination, or proof.
+
+## Living Specs & Governance
+
+The files under `.decapod/generated/specs/` are not static documentation; they are living contracts.
+- **Before Changes**: Review the specs. If the task changes intent, update [INTENT.md](.decapod/generated/specs/INTENT.md) first.
+- **During Implementation**: If architectural or interface decisions shift, update [ARCHITECTURE.md](.decapod/generated/specs/ARCHITECTURE.md) and [INTERFACES.md](.decapod/generated/specs/INTERFACES.md).
+- **After Changes**: Ensure all specs align with the new reality. Clarify code changes in the context of these spec updates. Spec changes should generally only occur when user intent has evolved.
 
 End users and host agents may use any task manager alongside Decapod. That external tracker does not replace Decapod todos: Decapod uses its own todo claims to isolate worktrees, scope containers, prove completion, and prevent multiple agents from working the same Decapod work item concurrently.
 
@@ -60,6 +68,31 @@ Call Decapod before proceeding when continuing would require guessing about:
 Concrete triggers: ambiguous requests, public impact, unclear proof, todo lifecycle, scope expansion, conflicting intent/specs, context loss, multi-agent collision risk, or readiness to claim completion.
 
 Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts.
+
+## Epistemic Custody
+
+**Epistemic custody** is the preserved chain between intent, context, assumptions, action, evidence, contradiction, and proof, so agent work remains inspectable, bounded, and falsifiable across time, agents, and recursive passes.
+
+| Term | Meaning |
+|---|---|
+| Intent | Original human goal; the "Why" that must not be lost during compression. |
+| Assumption | A belief or prior used to proceed when evidence is incomplete. |
+| Contradiction | Evidence or observation that conflicts with a prior assumption or intent. |
+| Measured | Direct observation (e.g., test output, file content, shell exit code). |
+| Inferred | Derived conclusion or guess (e.g., "this looks like a bug in the parser"). |
+| Provenance | The source of a fact or change (e.g., "User said X", "File Y contains Z"). |
+
+### Custody Rules
+1. **Preserve Uncertainty**: Summaries must preserve uncertainty, risk, and unresolved contradictions instead of compressing them away into polished prose.
+2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes or different agents until explicitly resolved or falsified.
+3. **Evidence-Based Claims**: Any claim of success or completion must be tied to measured evidence (artifacts, tests, or explicit user instruction).
+4. **Falsifiability**: Work must be structured so a human can quickly identify where an assumption was wrong or where proof failed.
+5. **Clarification Trigger**: If a critical assumption cannot be proven or a contradiction cannot be resolved, you MUST stop and request human clarification.
+
+## Custody artifacts
+Decapod maintains custody via:
+- `.decapod/generated/specs/INTENT.md`: Tracks active assumptions and stop conditions.
+- `.decapod/generated/artifacts/custody/`: Directory for detailed evidence, contradiction logs, and deferred questions.
 
 ## Invariants (Normative)
 - **INV-DAEMONLESS**: Decapod MUST NOT leave background processes running.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,7 @@ decapod data schema --deterministic
 - Capability authority: `decapod capabilities --format json`.
 -- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
 
-## Living Specs Governance
-
-Treat `.decapod/generated/specs/*` as living documents.
-- **Continuous Alignment**: Adjust specs as intent and code change over time.
-- **Intent-Driven**: Generally, specs only change when user intent evolves.
-- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
-
+Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,15 @@ decapod data schema --deterministic
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).
 - Operator reference: `decapod rpc --op constitution.get --params '{"section":"docs/PLAYBOOK"}'`.
 - Capability authority: `decapod capabilities --format json`.
-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+
+## Living Specs Governance
+
+Treat `.decapod/generated/specs/*` as living documents.
+- **Continuous Alignment**: Adjust specs as intent and code change over time.
+- **Intent-Driven**: Generally, specs only change when user intent evolves.
+- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
+
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/CODEX.md
+++ b/CODEX.md
@@ -50,13 +50,7 @@ decapod data schema --deterministic
 - Capability authority: `decapod capabilities --format json`.
 -- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
 
-## Living Specs Governance
-
-Treat `.decapod/generated/specs/*` as living documents.
-- **Continuous Alignment**: Adjust specs as intent and code change over time.
-- **Intent-Driven**: Generally, specs only change when user intent evolves.
-- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
-
+Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/CODEX.md
+++ b/CODEX.md
@@ -48,7 +48,15 @@ decapod data schema --deterministic
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).
 - Operator reference: `decapod rpc --op constitution.get --params '{"section":"docs/PLAYBOOK"}'`.
 - Capability authority: `decapod capabilities --format json`.
-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+
+## Living Specs Governance
+
+Treat `.decapod/generated/specs/*` as living documents.
+- **Continuous Alignment**: Adjust specs as intent and code change over time.
+- **Intent-Driven**: Generally, specs only change when user intent evolves.
+- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
+
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -50,13 +50,7 @@ decapod data schema --deterministic
 - Capability authority: `decapod capabilities --format json`.
 -- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
 
-## Living Specs Governance
-
-Treat `.decapod/generated/specs/*` as living documents.
-- **Continuous Alignment**: Adjust specs as intent and code change over time.
-- **Intent-Driven**: Generally, specs only change when user intent evolves.
-- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
-
+Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -48,7 +48,15 @@ decapod data schema --deterministic
 - Use shared aptitude memory for human-taught preferences across sessions/providers: `decapod data memory add|get` (aliases: `decapod data aptitude`).
 - Operator reference: `decapod rpc --op constitution.get --params '{"section":"docs/PLAYBOOK"}'`.
 - Capability authority: `decapod capabilities --format json`.
-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+-- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
+
+## Living Specs Governance
+
+Treat `.decapod/generated/specs/*` as living documents.
+- **Continuous Alignment**: Adjust specs as intent and code change over time.
+- **Intent-Driven**: Generally, specs only change when user intent evolves.
+- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
+
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -412,6 +412,12 @@ pub(crate) enum PlanCommand {
         unknowns: Vec<String>,
         #[clap(long = "question")]
         human_questions: Vec<String>,
+        #[clap(long = "stop-condition")]
+        stop_conditions: Vec<String>,
+        #[clap(long = "contradiction")]
+        unresolved_contradictions: Vec<String>,
+        #[clap(long = "deferred-question")]
+        deferred_questions: Vec<String>,
         #[clap(long = "forbidden-path")]
         forbidden_paths: Vec<String>,
         #[clap(long)]
@@ -431,10 +437,22 @@ pub(crate) enum PlanCommand {
         unknowns: Vec<String>,
         #[clap(long = "question")]
         human_questions: Vec<String>,
+        #[clap(long = "stop-condition")]
+        stop_conditions: Vec<String>,
+        #[clap(long = "contradiction")]
+        unresolved_contradictions: Vec<String>,
+        #[clap(long = "deferred-question")]
+        deferred_questions: Vec<String>,
         #[clap(long, default_value_t = false)]
         clear_unknowns: bool,
         #[clap(long, default_value_t = false)]
         clear_questions: bool,
+        #[clap(long, default_value_t = false)]
+        clear_stop_conditions: bool,
+        #[clap(long, default_value_t = false)]
+        clear_contradictions: bool,
+        #[clap(long, default_value_t = false)]
+        clear_deferred_questions: bool,
         #[clap(long = "forbidden-path")]
         forbidden_paths: Vec<String>,
         #[clap(long)]

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -275,13 +275,7 @@ decapod data schema --deterministic
 - Capability authority: `decapod capabilities --format json`.
 -- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod rpc --op context.scope`.
 
-## Living Specs Governance
-
-Treat `.decapod/generated/specs/*` as living documents.
-- **Continuous Alignment**: Adjust specs as intent and code change over time.
-- **Intent-Driven**: Generally, specs only change when user intent evolves.
-- **Clarification**: When specs change, clarify the code change in terms of the updated intent.
-
+Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 
 Stop if requirements are ambiguous or conflicting.
 <!-- decapod-validator-anchors
@@ -362,7 +356,6 @@ Call Decapod before proceeding when continuing would require guessing about:
 Concrete triggers: ambiguous requests, public impact, unclear proof, todo lifecycle, scope expansion, conflicting intent/specs, context loss, multi-agent collision risk, or readiness to claim completion.
 
 Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts.
-
 ## Epistemic Custody
 
 **Epistemic custody** is the preserved chain between intent, context, assumptions, action, evidence, contradiction, and proof, so agent work remains inspectable, bounded, and falsifiable across time, agents, and recursive passes.
@@ -378,7 +371,7 @@ Do not call Decapod for every trivial file read, local edit, or mechanical comma
 
 ### Custody Rules
 1. **Preserve Uncertainty**: Summaries must preserve uncertainty, risk, and unresolved contradictions instead of compressing them away into polished prose.
-2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes or different agents until explicitly resolved or falsified.
+2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes until resolved.
 3. **Evidence-Based Claims**: Any claim of success or completion must be tied to measured evidence (artifacts, tests, or explicit user instruction).
 4. **Falsifiability**: Work must be structured so a human can quickly identify where an assumption was wrong or where proof failed.
 5. **Clarification Trigger**: If a critical assumption cannot be proven or a contradiction cannot be resolved, you MUST stop and request human clarification.

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -363,6 +363,31 @@ Concrete triggers: ambiguous requests, public impact, unclear proof, todo lifecy
 
 Do not call Decapod for every trivial file read, local edit, or mechanical command. Call it at decision boundaries that need governance, memory, boundaries, coordination, or proof. Decapod calls should produce or update explicit artifacts.
 
+## Epistemic Custody
+
+**Epistemic custody** is the preserved chain between intent, context, assumptions, action, evidence, contradiction, and proof, so agent work remains inspectable, bounded, and falsifiable across time, agents, and recursive passes.
+
+| Term | Meaning |
+|---|---|
+| Intent | Original human goal; the "Why" that must not be lost during compression. |
+| Assumption | A belief or prior used to proceed when evidence is incomplete. |
+| Contradiction | Evidence or observation that conflicts with a prior assumption or intent. |
+| Measured | Direct observation (e.g., test output, file content, shell exit code). |
+| Inferred | Derived conclusion or guess (e.g., "this looks like a bug in the parser"). |
+| Provenance | The source of a fact or change (e.g., "User said X", "File Y contains Z"). |
+
+### Custody Rules
+1. **Preserve Uncertainty**: Summaries must preserve uncertainty, risk, and unresolved contradictions instead of compressing them away into polished prose.
+2. **Recursive Continuity**: Prior assumptions and unresolved contradictions MUST carry forward across recursive agent passes or different agents until explicitly resolved or falsified.
+3. **Evidence-Based Claims**: Any claim of success or completion must be tied to measured evidence (artifacts, tests, or explicit user instruction).
+4. **Falsifiability**: Work must be structured so a human can quickly identify where an assumption was wrong or where proof failed.
+5. **Clarification Trigger**: If a critical assumption cannot be proven or a contradiction cannot be resolved, you MUST stop and request human clarification.
+
+## Custody artifacts
+Decapod maintains custody via:
+- `.decapod/generated/specs/INTENT.md`: Tracks active assumptions and stop conditions.
+- `.decapod/generated/artifacts/custody/`: Directory for detailed evidence, contradiction logs, and deferred questions.
+
 ## Invariants (Normative)
 - **INV-DAEMONLESS**: Decapod MUST NOT leave background processes running.
 - **INV-BOUNDED-VALIDATE**: `decapod validate` MUST terminate within bounded time.

--- a/src/core/plan_governance.rs
+++ b/src/core/plan_governance.rs
@@ -405,6 +405,9 @@ mod tests {
                 proof_hooks: vec!["validate_passes".to_string()],
                 unknowns: vec![],
                 human_questions: vec![],
+                stop_conditions: vec![],
+                unresolved_contradictions: vec![],
+                deferred_questions: vec![],
                 constraints: ScopeConstraints::default(),
             },
         )

--- a/src/core/plan_governance.rs
+++ b/src/core/plan_governance.rs
@@ -41,6 +41,12 @@ pub struct GovernedPlan {
     #[serde(default)]
     pub human_questions: Vec<String>,
     #[serde(default)]
+    pub stop_conditions: Vec<String>,
+    #[serde(default)]
+    pub unresolved_contradictions: Vec<String>,
+    #[serde(default)]
+    pub deferred_questions: Vec<String>,
+    #[serde(default)]
     pub constraints: ScopeConstraints,
     pub updated_at: String,
 }
@@ -54,6 +60,9 @@ pub struct PlanPatch {
     pub proof_hooks: Option<Vec<String>>,
     pub unknowns: Option<Vec<String>>,
     pub human_questions: Option<Vec<String>>,
+    pub stop_conditions: Option<Vec<String>>,
+    pub unresolved_contradictions: Option<Vec<String>>,
+    pub deferred_questions: Option<Vec<String>>,
     pub constraints: Option<ScopeConstraints>,
 }
 
@@ -64,6 +73,9 @@ pub struct InitPlanInput {
     pub proof_hooks: Vec<String>,
     pub unknowns: Vec<String>,
     pub human_questions: Vec<String>,
+    pub stop_conditions: Vec<String>,
+    pub unresolved_contradictions: Vec<String>,
+    pub deferred_questions: Vec<String>,
     pub constraints: ScopeConstraints,
 }
 
@@ -114,6 +126,9 @@ pub fn init_plan(
         proof_hooks: input.proof_hooks,
         unknowns: input.unknowns,
         human_questions: input.human_questions,
+        stop_conditions: input.stop_conditions,
+        unresolved_contradictions: input.unresolved_contradictions,
+        deferred_questions: input.deferred_questions,
         constraints: input.constraints,
         updated_at: crate::core::time::now_epoch_z(),
     };
@@ -153,6 +168,15 @@ pub fn patch_plan(
     }
     if let Some(human_questions) = patch.human_questions {
         plan.human_questions = human_questions;
+    }
+    if let Some(stop_conditions) = patch.stop_conditions {
+        plan.stop_conditions = stop_conditions;
+    }
+    if let Some(unresolved_contradictions) = patch.unresolved_contradictions {
+        plan.unresolved_contradictions = unresolved_contradictions;
+    }
+    if let Some(deferred_questions) = patch.deferred_questions {
+        plan.deferred_questions = deferred_questions;
     }
     if let Some(constraints) = patch.constraints {
         plan.constraints = constraints;

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -47,6 +47,10 @@ pub struct ProofEvent {
     pub store: String,
     pub root: String,
     pub actor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_conditions: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_requirements: Option<Vec<String>>,
 }
 
 /// Summary of a proof run
@@ -60,6 +64,10 @@ pub struct ProofRunSummary {
     pub skipped: usize,
     pub all_passed: bool,
     pub results: Vec<ProofResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_conditions: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_requirements: Option<Vec<String>>,
 }
 
 /// Result of running a single proof
@@ -169,6 +177,8 @@ pub fn run_proofs(
             store: format!("{:?}", store.kind),
             root: store.root.to_string_lossy().to_string(),
             actor: actor.to_string(),
+            stop_conditions: None,
+            proof_requirements: None,
         };
 
         append_proof_event(store, &event)?;
@@ -201,6 +211,8 @@ pub fn run_proofs(
         skipped: 0,
         all_passed: failed == 0,
         results,
+        stop_conditions: None,
+        proof_requirements: None,
     })
 }
 

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -527,6 +527,33 @@ flowchart LR
 - [ ] Validation gates pass and artifacts are attached.
 {language_criteria}
 
+## Epistemic Custody Fields
+
+### Active Assumptions
+- [ ] List any assumptions made to proceed.
+- [ ] Flag assumptions that require future verification.
+
+### Confidence & Risk Level
+- **Confidence**: Low/Medium/High (Rationale: )
+- **Risk**: Low/Medium/High (Impact of wrong assumptions: )
+
+### Measured vs Inferred Facts
+| Fact | Source (Provenance) | Type (Measured/Inferred) |
+|---|---|---|
+| | | |
+
+### Unresolved Contradictions
+- [ ] List any evidence that conflicts with current assumptions or intent.
+
+### Deferred Questions
+- [ ] Questions to be answered later.
+
+### Stop Conditions
+- [ ] Explicit conditions under which the agent should stop and ask for help.
+
+### Proof Required Before Completion
+- [ ] Specific evidence needed to prove the outcome is met.
+
 ## Tradeoffs Register
 | Decision | Benefit | Cost | Review Trigger |
 |---|---|---|---|
@@ -1250,6 +1277,29 @@ pub fn scaffold_project_entrypoints(
     fs::create_dir_all(generated_dir.join("policy")).map_err(error::DecapodError::IoError)?;
     fs::create_dir_all(generated_dir.join("artifacts").join("provenance"))
         .map_err(error::DecapodError::IoError)?;
+    fs::create_dir_all(generated_dir.join("artifacts").join("custody"))
+        .map_err(error::DecapodError::IoError)?;
+    let custody_readme_path = generated_dir
+        .join("artifacts")
+        .join("custody")
+        .join("README.md");
+    if !custody_readme_path.exists() {
+        let custody_readme_content = r#"# Epistemic Custody Artifacts
+
+This directory tracks the preserved chain of intent, context, assumptions, and proof for this repository.
+
+## Directory Structure
+- `assumptions.md`: Log of active and verified assumptions.
+- `contradictions.md`: Log of evidence that conflicts with current plans or assumptions.
+- `deferred_questions.md`: Questions identified during work that were postponed.
+- `evidence/`: Detailed proof artifacts (logs, screenshots, data captures) tied to specific claims.
+
+## Agent Guidance
+Agents operating in this repo MUST maintain these artifacts to ensure long-horizon integrity. Do not compress away uncertainty; surface it here so it remains inspectable by humans and future agent passes.
+"#;
+        fs::write(&custody_readme_path, custody_readme_content)
+            .map_err(error::DecapodError::IoError)?;
+    }
     fs::create_dir_all(generated_dir.join("artifacts").join("inventory"))
         .map_err(error::DecapodError::IoError)?;
     fs::create_dir_all(
@@ -1323,7 +1373,42 @@ pub fn scaffold_project_entrypoints(
             specs_files.push((spec.path, content));
         }
 
-        for (rel_path, content) in specs_files {
+        for (rel_path, mut content) in specs_files {
+            // Epistemic Custody Preservation:
+            // If we are regenerating INTENT.md and it already exists, try to preserve the Epistemic Custody Fields section.
+            if rel_path == LOCAL_PROJECT_SPECS_INTENT {
+                let dest = opts.target_dir.join(rel_path);
+                if dest.exists() {
+                    if let Ok(existing_content) = fs::read_to_string(&dest) {
+                        if let Some(start_idx) =
+                            existing_content.find("## Epistemic Custody Fields")
+                        {
+                            let end_marker = "## Tradeoffs Register";
+                            let custody_section = if let Some(end_idx) =
+                                existing_content[start_idx..].find(end_marker)
+                            {
+                                &existing_content[start_idx..start_idx + end_idx]
+                            } else {
+                                &existing_content[start_idx..]
+                            };
+
+                            // Now replace it in the new content
+                            if let Some(new_start_idx) = content.find("## Epistemic Custody Fields")
+                            {
+                                if let Some(new_end_idx) = content[new_start_idx..].find(end_marker)
+                                {
+                                    let mut new_merged = content[..new_start_idx].to_string();
+                                    new_merged.push_str(custody_section.trim_end());
+                                    new_merged.push_str("\n\n");
+                                    new_merged.push_str(&content[new_start_idx + new_end_idx..]);
+                                    content = new_merged;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             let template_hash = hash_text(&content);
             match write_file(opts, rel_path, &content)? {
                 FileAction::Created => created += 1,

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1378,33 +1378,26 @@ Agents operating in this repo MUST maintain these artifacts to ensure long-horiz
             // If we are regenerating INTENT.md and it already exists, try to preserve the Epistemic Custody Fields section.
             if rel_path == LOCAL_PROJECT_SPECS_INTENT {
                 let dest = opts.target_dir.join(rel_path);
-                if dest.exists() {
-                    if let Ok(existing_content) = fs::read_to_string(&dest) {
-                        if let Some(start_idx) =
-                            existing_content.find("## Epistemic Custody Fields")
-                        {
-                            let end_marker = "## Tradeoffs Register";
-                            let custody_section = if let Some(end_idx) =
-                                existing_content[start_idx..].find(end_marker)
-                            {
-                                &existing_content[start_idx..start_idx + end_idx]
-                            } else {
-                                &existing_content[start_idx..]
-                            };
+                if let Ok(existing_content) = fs::read_to_string(&dest)
+                    && let Some(start_idx) = existing_content.find("## Epistemic Custody Fields")
+                {
+                    let end_marker = "## Tradeoffs Register";
+                    let custody_section =
+                        if let Some(end_idx) = existing_content[start_idx..].find(end_marker) {
+                            &existing_content[start_idx..start_idx + end_idx]
+                        } else {
+                            &existing_content[start_idx..]
+                        };
 
-                            // Now replace it in the new content
-                            if let Some(new_start_idx) = content.find("## Epistemic Custody Fields")
-                            {
-                                if let Some(new_end_idx) = content[new_start_idx..].find(end_marker)
-                                {
-                                    let mut new_merged = content[..new_start_idx].to_string();
-                                    new_merged.push_str(custody_section.trim_end());
-                                    new_merged.push_str("\n\n");
-                                    new_merged.push_str(&content[new_start_idx + new_end_idx..]);
-                                    content = new_merged;
-                                }
-                            }
-                        }
+                    // Now replace it in the new content
+                    if let Some(new_start_idx) = content.find("## Epistemic Custody Fields")
+                        && let Some(new_end_idx) = content[new_start_idx..].find(end_marker)
+                    {
+                        let mut new_merged = content[..new_start_idx].to_string();
+                        new_merged.push_str(custody_section.trim_end());
+                        new_merged.push_str("\n\n");
+                        new_merged.push_str(&content[new_start_idx + new_end_idx..]);
+                        content = new_merged;
                     }
                 }
             }

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1208,10 +1208,14 @@ fn validate_generated_artifact_whitelist(
         let is_allowed_specs_md = path.starts_with(".decapod/generated/specs/")
             && path.ends_with(".md")
             && !path.contains("/../");
+        let is_allowed_custody_md = path.starts_with(".decapod/generated/artifacts/custody/")
+            && path.ends_with(".md")
+            && !path.contains("/../");
         if !is_allowed_exact
             && !is_allowed_context_json
             && !is_allowed_provenance_json
             && !is_allowed_specs_md
+            && !is_allowed_custody_md
         {
             offenders.push(path.to_string());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4988,6 +4988,9 @@ fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), erro
             proof_hooks,
             unknowns,
             human_questions,
+            stop_conditions,
+            unresolved_contradictions,
+            deferred_questions,
             forbidden_paths,
             file_touch_budget,
         } => {
@@ -5000,6 +5003,9 @@ fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), erro
                     proof_hooks,
                     unknowns,
                     human_questions,
+                    stop_conditions,
+                    unresolved_contradictions,
+                    deferred_questions,
                     constraints: plan_governance::ScopeConstraints {
                         forbidden_paths,
                         file_touch_budget,
@@ -5015,8 +5021,14 @@ fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), erro
             proof_hooks,
             unknowns,
             human_questions,
+            stop_conditions,
+            unresolved_contradictions,
+            deferred_questions,
             clear_unknowns,
             clear_questions,
+            clear_stop_conditions,
+            clear_contradictions,
+            clear_deferred_questions,
             forbidden_paths,
             file_touch_budget,
         } => {
@@ -5049,6 +5061,27 @@ fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), erro
                         None
                     } else {
                         Some(human_questions)
+                    },
+                    stop_conditions: if clear_stop_conditions {
+                        Some(vec![])
+                    } else if stop_conditions.is_empty() {
+                        None
+                    } else {
+                        Some(stop_conditions)
+                    },
+                    unresolved_contradictions: if clear_contradictions {
+                        Some(vec![])
+                    } else if unresolved_contradictions.is_empty() {
+                        None
+                    } else {
+                        Some(unresolved_contradictions)
+                    },
+                    deferred_questions: if clear_deferred_questions {
+                        Some(vec![])
+                    } else if deferred_questions.is_empty() {
+                        None
+                    } else {
+                        Some(deferred_questions)
                     },
                     constraints: if forbidden_paths.is_empty() && file_touch_budget.is_none() {
                         None

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -511,3 +511,30 @@ fn agents_md_contains_epistemic_custody_section() {
         "AGENTS.md should describe custody artifacts directory"
     );
 }
+
+#[test]
+fn init_preserves_manually_added_custody_fields_in_intent_md() {
+    let tmp = tempdir().expect("tempdir");
+    // 1. Initial init
+    run_decapod(tmp.path(), &["init", "with", "--force"]);
+
+    let intent_path = tmp.path().join(".decapod/generated/specs/INTENT.md");
+    let mut intent_content = fs::read_to_string(&intent_path).expect("read intent");
+
+    // 2. Manually add an assumption
+    intent_content = intent_content.replace(
+        "### Active Assumptions\n- [ ] List any assumptions made to proceed.",
+        "### Active Assumptions\n- [ ] List any assumptions made to proceed.\n- [ ] MANUALLY_ADDED_ASSUMPTION"
+    );
+    fs::write(&intent_path, intent_content).expect("write modified intent");
+
+    // 3. Re-init
+    run_decapod(tmp.path(), &["init", "--force"]);
+
+    // 4. Verify assumption is still there
+    let re_init_intent = fs::read_to_string(&intent_path).expect("read re-init intent");
+    assert!(
+        re_init_intent.contains("MANUALLY_ADDED_ASSUMPTION"),
+        "re-init should preserve manually added assumptions in INTENT.md"
+    );
+}


### PR DESCRIPTION
Implement epistemic custody preservation, artifacts, and guidance. This includes updating AGENTS.md and INTENT.md templates, adding custody fields to governed plans and proof artifacts, and ensuring preservation of custody context during project re-initialization.