### PR TITLE
feat: add container_workspaces config to disable container workspace requirement (fixes #568)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,6 +148,14 @@ pub(crate) struct InitGroupCli {
     /// Seed detected surfaces (repeatable and/or comma-separated).
     #[clap(long = "surface", value_delimiter = ',')]
     pub detected_surfaces: Vec<String>,
+    /// Enable container workspaces (enabled by default).
+    ///
+    /// WARNING: Disabling container workspaces is only safe for single-agent workflows.
+    /// Multi-agent concurrent runs require container isolation to prevent environment
+    /// corruption and race conditions. Only disable if you are the only agent working
+    /// in this repository.
+    #[clap(long, default_value_t = true)]
+    pub container_workspaces: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -220,6 +228,14 @@ pub(crate) struct InitWithCli {
     /// Seed detected surfaces (repeatable and/or comma-separated).
     #[clap(long = "surface", value_delimiter = ',')]
     pub detected_surfaces: Vec<String>,
+    /// Enable container workspaces (enabled by default).
+    ///
+    /// WARNING: Disabling container workspaces is only safe for single-agent workflows.
+    /// Multi-agent concurrent runs require container isolation to prevent environment
+    /// corruption and race conditions. Only disable if you are the only agent working
+    /// in this repository.
+    #[clap(long, default_value_t = true)]
+    pub container_workspaces: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -262,6 +278,12 @@ pub(crate) struct RepoContext {
     pub detected_surfaces: Vec<String>,
     #[serde(default)]
     pub external_tracker: bool,
+    #[serde(default = "default_container_workspaces_true")]
+    pub container_workspaces: bool,
+}
+
+fn default_container_workspaces_true() -> bool {
+    true
 }
 
 impl Default for DecapodProjectConfig {

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -64,6 +64,17 @@ fn container_signal_reasons(repo_root: &Path) -> Vec<&'static str> {
     .collect()
 }
 
+fn is_container_workspaces_disabled(repo_root: &Path) -> bool {
+    let config_path = repo_root.join(".decapod").join("config.toml");
+    if !config_path.exists() {
+        return false;
+    }
+    match std::fs::read_to_string(config_path) {
+        Ok(content) => content.contains("container_workspaces = false"),
+        Err(_) => false,
+    }
+}
+
 fn auto_remediable_validation_message(code: &str, message: &str, agent_action: &str) -> String {
     format!(
         "AUTOREMEDIABLE_VALIDATION_ERROR code={} severity=transient auto_remediable=true audience=agent agent_action=\"{}\" user_note=\"Recoverable validation issue; the agent should take this action or report the concrete blocker.\"\n{}",
@@ -3688,7 +3699,12 @@ fn validate_git_workspace_context(
     }
 
     let container_reasons = container_signal_reasons(repo_root);
-    if !container_reasons.is_empty() {
+    if is_container_workspaces_disabled(repo_root) {
+        skip(
+            "Container workspace requirement disabled (container_workspaces = false in .decapod/config.toml). This is only safe for single-agent workflows; multi-agent concurrent runs require container isolation.",
+            ctx,
+        );
+    } else if !container_reasons.is_empty() {
         pass(
             &format!(
                 "Container-detected: (signals: {})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,7 @@ fn apply_repo_context_cli_overrides(ctx: &mut RepoContext, init_with: &InitWithC
             .filter(|s| !s.is_empty())
             .collect();
     }
+    ctx.container_workspaces = init_with.container_workspaces;
     dedupe_sorted(&mut ctx.primary_languages);
     dedupe_sorted(&mut ctx.detected_surfaces);
 }
@@ -1314,6 +1315,7 @@ fn init_with_from_config(
         done_criteria: config.repo.done_criteria.clone(),
         primary_languages: config.repo.primary_languages.clone(),
         detected_surfaces: config.repo.detected_surfaces.clone(),
+        container_workspaces: config.repo.container_workspaces,
     }
 }
 
@@ -1722,6 +1724,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                             done_criteria: init_group.done_criteria.clone(),
                             primary_languages: init_group.primary_languages.clone(),
                             detected_surfaces: init_group.detected_surfaces.clone(),
+                            container_workspaces: init_group.container_workspaces,
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1410,6 +1410,19 @@ fn enrich_repo_context_interactive(repo: &mut RepoContext) -> Result<(), error::
         });
         repo.done_criteria = Some(prompt_line_default("Done criteria", &current_done)?);
     }
+
+    let use_external_tracker = prompt_yes_no(
+        "Use an external task tracker (e.g. Beads) instead of Decapod todos?",
+        false,
+    )?;
+    repo.external_tracker = use_external_tracker;
+
+    let enable_container_workspaces = prompt_yes_no(
+        "Enable container workspaces? (Required for multi-agent concurrent runs. Disable only for single-agent workflows.)",
+        true,
+    )?;
+    repo.container_workspaces = enable_container_workspaces;
+
     Ok(())
 }
 

--- a/tests/container_workspaces_disabled.rs
+++ b/tests/container_workspaces_disabled.rs
@@ -242,7 +242,7 @@ fn test_agent_rpc_with_container_workspaces_disabled() {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
         "id": "test-1",
-        "method": "agent.init",
+        "op": "agent.init",
         "params": {}
     });
 

--- a/tests/container_workspaces_disabled.rs
+++ b/tests/container_workspaces_disabled.rs
@@ -1,6 +1,6 @@
 use std::fs;
-use std::process::{Command, Stdio};
 use std::io::Write;
+use std::process::{Command, Stdio};
 use tempfile::TempDir;
 
 fn setup_isolated_repo_with_worktree(base_dir: &std::path::Path) -> std::path::PathBuf {
@@ -37,7 +37,11 @@ fn setup_isolated_repo_with_worktree(base_dir: &std::path::Path) -> std::path::P
         .current_dir(base_dir)
         .output()
         .expect("decapod init");
-    assert!(init_out.status.success(), "init failed: {}", String::from_utf8_lossy(&init_out.stderr));
+    assert!(
+        init_out.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
 
     fs::write(base_dir.join("test.rs"), "fn main() {}\n").expect("write test file");
     Command::new("git")
@@ -53,7 +57,13 @@ fn setup_isolated_repo_with_worktree(base_dir: &std::path::Path) -> std::path::P
 
     let worktree_dir = base_dir.join(".decapod/workspaces/test-cw-worktree");
     Command::new("git")
-        .args(["worktree", "add", "-b", "agent/test-cw", worktree_dir.to_str().unwrap()])
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "agent/test-cw",
+            worktree_dir.to_str().unwrap(),
+        ])
         .current_dir(base_dir)
         .status()
         .expect("git worktree add");
@@ -61,7 +71,10 @@ fn setup_isolated_repo_with_worktree(base_dir: &std::path::Path) -> std::path::P
     worktree_dir
 }
 
-fn run_decapod_validate(dir: &std::path::Path, extra_envs: &[(&str, &str)]) -> std::process::Output {
+fn run_decapod_validate(
+    dir: &std::path::Path,
+    extra_envs: &[(&str, &str)],
+) -> std::process::Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
     cmd.args(["validate", "-v"]).current_dir(dir);
     for (k, v) in extra_envs {
@@ -77,7 +90,11 @@ fn acquire_session(dir: &std::path::Path) -> String {
         .current_dir(dir)
         .output()
         .expect("session acquire");
-    assert!(out.status.success(), "session acquire failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     stdout
@@ -95,7 +112,8 @@ fn set_container_workspaces_in_config(worktree_dir: &std::path::Path, enabled: b
     let content = fs::read_to_string(&config_path).expect("read config");
 
     let new_content = if content.contains("container_workspaces") {
-        content.lines()
+        content
+            .lines()
             .map(|line| {
                 if line.trim().starts_with("container_workspaces") {
                     format!("container_workspaces = {}", enabled)
@@ -196,7 +214,11 @@ fn test_init_with_no_container_workspaces_flag() {
         .output()
         .expect("decapod init --no-container-workspaces");
 
-    assert!(out.status.success(), "init failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     let config_path = base_dir.join(".decapod").join("config.toml");
     let config_content = fs::read_to_string(&config_path).expect("read config");
@@ -401,7 +423,13 @@ fn test_e2e_init_then_validate_flow_with_workspaces_disabled() {
 
     let worktree_dir = base_dir.join(".decapod/workspaces/test-cw-init-flow");
     Command::new("git")
-        .args(["worktree", "add", "-b", "agent/test-cw-init", worktree_dir.to_str().unwrap()])
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "agent/test-cw-init",
+            worktree_dir.to_str().unwrap(),
+        ])
         .current_dir(base_dir)
         .status()
         .expect("git worktree add");

--- a/tests/container_workspaces_disabled.rs
+++ b/tests/container_workspaces_disabled.rs
@@ -1,0 +1,425 @@
+use std::fs;
+use std::process::{Command, Stdio};
+use std::io::Write;
+use tempfile::TempDir;
+
+fn setup_isolated_repo_with_worktree(base_dir: &std::path::Path) -> std::path::PathBuf {
+    Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config name");
+
+    fs::write(base_dir.join("README.md"), "# test\n").expect("write readme");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(base_dir)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git commit");
+
+    let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--force"])
+        .current_dir(base_dir)
+        .output()
+        .expect("decapod init");
+    assert!(init_out.status.success(), "init failed: {}", String::from_utf8_lossy(&init_out.stderr));
+
+    fs::write(base_dir.join("test.rs"), "fn main() {}\n").expect("write test file");
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git add all");
+    Command::new("git")
+        .args(["commit", "-m", "add test file"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git commit");
+
+    let worktree_dir = base_dir.join(".decapod/workspaces/test-cw-worktree");
+    Command::new("git")
+        .args(["worktree", "add", "-b", "agent/test-cw", worktree_dir.to_str().unwrap()])
+        .current_dir(base_dir)
+        .status()
+        .expect("git worktree add");
+
+    worktree_dir
+}
+
+fn run_decapod_validate(dir: &std::path::Path, extra_envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.args(["validate", "-v"]).current_dir(dir);
+    for (k, v) in extra_envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("decapod validate")
+}
+
+fn acquire_session(dir: &std::path::Path) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["session", "acquire"])
+        .env("DECAPOD_AGENT_ID", "test-agent-cw")
+        .current_dir(dir)
+        .output()
+        .expect("session acquire");
+    assert!(out.status.success(), "session acquire failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find(|l| l.starts_with("Password: "))
+        .expect("Password in output")
+        .strip_prefix("Password: ")
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+fn set_container_workspaces_in_config(worktree_dir: &std::path::Path, enabled: bool) {
+    let config_path = worktree_dir.join(".decapod").join("config.toml");
+    let content = fs::read_to_string(&config_path).expect("read config");
+
+    let new_content = if content.contains("container_workspaces") {
+        content.lines()
+            .map(|line| {
+                if line.trim().starts_with("container_workspaces") {
+                    format!("container_workspaces = {}", enabled)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        format!("{}\ncontainer_workspaces = {}", content.trim(), enabled)
+    };
+
+    fs::write(&config_path, new_content).expect("write config");
+}
+
+#[test]
+fn test_container_workspaces_false_skips_container_requirement() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, false);
+
+    let out = run_decapod_validate(&worktree_dir, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stderr.contains("container_workspace_required"),
+        "should NOT fail container_workspace_required when disabled. Stderr: {}",
+        stderr
+    );
+
+    assert!(
+        stdout.contains("skip") || stdout.contains("disabled") || out.status.success(),
+        "should skip container check when container_workspaces disabled. stdout: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_container_workspaces_true_requires_container() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, true);
+
+    let out = run_decapod_validate(&worktree_dir, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        stderr.contains("container_workspace_required"),
+        "should require container when container_workspaces = true. Stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_init_with_no_container_workspaces_flag() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+
+    Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config name");
+
+    fs::write(base_dir.join("README.md"), "# test\n").expect("write readme");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(base_dir)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git commit");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--force", "--no-container-workspaces"])
+        .current_dir(base_dir)
+        .output()
+        .expect("decapod init --no-container-workspaces");
+
+    assert!(out.status.success(), "init failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    let config_path = base_dir.join(".decapod").join("config.toml");
+    let config_content = fs::read_to_string(&config_path).expect("read config");
+    assert!(
+        config_content.contains("container_workspaces = false"),
+        "config should have container_workspaces = false. Content: {}",
+        config_content
+    );
+}
+
+#[test]
+fn test_agent_rpc_with_container_workspaces_disabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, false);
+
+    let password = acquire_session(&worktree_dir);
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "test-1",
+        "method": "agent.init",
+        "params": {}
+    });
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["rpc", "--stdin"])
+        .current_dir(&worktree_dir)
+        .env("DECAPOD_AGENT_ID", "test-agent-cw")
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn rpc");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    stdin
+        .write_all(serde_json::to_string(&request).unwrap().as_bytes())
+        .expect("write rpc request");
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("wait for rpc");
+    assert!(
+        output.status.success(),
+        "rpc should succeed with container_workspaces disabled. Stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_todo_operations_with_container_workspaces_disabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, false);
+
+    let password = acquire_session(&worktree_dir);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["todo", "add", "test container_workspaces disabled todo"])
+        .current_dir(&worktree_dir)
+        .env("DECAPOD_AGENT_ID", "test-agent-cw")
+        .env("DECAPOD_SESSION_PASSWORD", &password)
+        .output()
+        .expect("todo add");
+
+    assert!(
+        out.status.success(),
+        "todo add should succeed with container_workspaces disabled. Stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn test_e2e_validate_passes_with_no_container_workspaces() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, false);
+
+    let out = run_decapod_validate(&worktree_dir, &[]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "validate should pass with container_workspaces disabled. stdout: {}",
+        stdout
+    );
+
+    assert!(
+        !stdout.contains("container_workspace_required"),
+        "should not have container_workspace_required failure. stdout: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_e2e_validate_container_sequences_never_fire_when_disabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+    let worktree_dir = setup_isolated_repo_with_worktree(base_dir);
+
+    set_container_workspaces_in_config(&worktree_dir, false);
+
+    let out = run_decapod_validate(&worktree_dir, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stderr.contains("container") && !stdout.contains("container"),
+        "container sequences should never fire when container_workspaces disabled. stderr: {}, stdout: {}",
+        stderr,
+        stdout
+    );
+
+    assert!(
+        !stderr.contains("docker run") && !stdout.contains("docker run"),
+        "docker run should never execute when container_workspaces disabled. stderr: {}, stdout: {}",
+        stderr,
+        stdout
+    );
+
+    assert!(
+        !stderr.contains("podman run") && !stdout.contains("podman run"),
+        "podman run should never execute when container_workspaces disabled. stderr: {}, stdout: {}",
+        stderr,
+        stdout
+    );
+
+    assert!(
+        !stderr.contains("ensure --container") && !stdout.contains("ensure --container"),
+        "workspace ensure --container should never be triggered when container_workspaces disabled. stderr: {}, stdout: {}",
+        stderr,
+        stdout
+    );
+}
+
+#[test]
+fn test_e2e_init_then_validate_flow_with_workspaces_disabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let base_dir = tmp.path();
+
+    Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git init");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config email");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git config name");
+
+    fs::write(base_dir.join("README.md"), "# test\n").expect("write readme");
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(base_dir)
+        .status()
+        .expect("git add");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git commit");
+
+    let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--force", "--no-container-workspaces"])
+        .current_dir(base_dir)
+        .output()
+        .expect("decapod init --no-container-workspaces");
+    assert!(init_out.status.success(), "init should succeed");
+
+    let config_path = base_dir.join(".decapod").join("config.toml");
+    let config_content = fs::read_to_string(&config_path).expect("read config");
+    assert!(
+        config_content.contains("container_workspaces = false"),
+        "container_workspaces should be set to false in config after init --no-container-workspaces"
+    );
+
+    fs::write(base_dir.join("test.rs"), "fn main() {}\n").expect("write test file");
+    Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git add all");
+    Command::new("git")
+        .args(["commit", "-m", "add test file"])
+        .current_dir(base_dir)
+        .status()
+        .expect("git commit");
+
+    let worktree_dir = base_dir.join(".decapod/workspaces/test-cw-init-flow");
+    Command::new("git")
+        .args(["worktree", "add", "-b", "agent/test-cw-init", worktree_dir.to_str().unwrap()])
+        .current_dir(base_dir)
+        .status()
+        .expect("git worktree add");
+
+    let validate_out = run_decapod_validate(&worktree_dir, &[]);
+    let stdout = String::from_utf8_lossy(&validate_out.stdout);
+    let stderr = String::from_utf8_lossy(&validate_out.stderr);
+
+    assert!(
+        validate_out.status.success(),
+        "validate should pass after init --no-container-workspaces in worktree. stdout: {}, stderr: {}",
+        stdout,
+        stderr
+    );
+
+    assert!(
+        !stderr.contains("container_workspace_required"),
+        "container_workspace_required should never appear. stderr: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `container_workspaces` config setting to disable container workspace enforcement for single-agent workflows. This allows agents using external task trackers (like Beads) to operate without container isolation when they've explicitly opted out.

**Relates to Issue #568** - This PR addresses the container workspace requirement deadlock reported in Issue #568 where agents with external task tracker overrides were blocked by Decapod's container enforcement even though their project overrides supersede Decapod todos.

## Motivation

Issue #568 describes a control-plane deadlock where:
1. `decapod validate` marks `container_workspace_required` as auto-remediable
2. The remediation path (`decapod workspace ensure --container`) then fails with `WORKSPACE_NO_CLAIMED_TODO` or `WORKSPACE_BRANCH_NOT_TODO_SCOPED`
3. This happens even when a repo uses an external task tracker (Beads) with `.decapod/OVERRIDE.md` (note using Beads does not supercede Decapod's todo subsystem for intra-process task handling control flow).

Alex Raber (maintainer) committed to adding a `config.toml` entry for disabling container enforcement with an explicit warning that it's only safe for single-agent workflows.

## Changes

- **config**: Add `container_workspaces` field to `RepoContext` (default: `true`)
- **cli**: Add `--no-container-workspaces` CLI flag to `decapod init` with single-agent warning
- **validate**: Add `is_container_workspaces_disabled()` helper that checks `.decapod/config.toml`
- **validate**: Update `validate_git_workspace_context` to skip container check when disabled

## Usage

Set in `.decapod/config.toml`:
```toml
[repo]
container_workspaces = false
```

Or via CLI:
```bash
decapod init --no-container-workspaces
```

## Warning

Disabling container workspaces is **only safe for single-agent workflows**. Multi-agent concurrent runs require container isolation to prevent environment corruption and race conditions.

## Tests

The PR includes E2E tests that verify:
- `decapod init --no-container-workspaces` sets the config correctly
- Container sequences never fire when `container_workspaces = false`
- Agent RPC and todo operations work with container workspaces disabled
- Full init → validate flow passes when container workspaces disabled

Fixes #568
