### PR TITLE
feat: implement non-interactive initialization with --proof flag

### DIFF
--- a/.decapod/README.md
+++ b/.decapod/README.md
@@ -14,7 +14,7 @@ It keeps Decapod-owned state, generated artifacts, and isolated workspaces separ
 
 ## Quick Start
 
-1. `decapod init`
+1. `decapod init --proof`
 2. `decapod validate`
 3. `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'`
 4. `decapod session acquire`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This is a Decapod-managed repository. **Strict Dependency: You are strictly boun
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ See `AGENTS.md` for the universal contract.
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status

--- a/CODEX.md
+++ b/CODEX.md
@@ -22,7 +22,7 @@ See `AGENTS.md` for the universal contract.
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,7 +22,7 @@ See `AGENTS.md` for the universal contract.
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">🦀</p>
 
 <p align="center">
-  <code>cargo install decapod && decapod init</code>
+  <code>cargo install decapod && decapod init --proof</code>
 </p>
 
 <p align="center">
@@ -36,10 +36,10 @@ Decapod provides comprehensive documentation for both human operators and AI age
 
 ```bash
 cargo install decapod
-decapod init
+decapod init --proof
 ```
 
-`decapod init` creates `.decapod/`, a local folder your agent uses to remember intent, rules, context, specs, and proof.
+`decapod init --proof` creates `.decapod/`, a local folder your agent uses to remember intent, rules, context, specs, and proof.
 
 Your **conversational** workflow does not change. You keep working through your agent; Decapod gives the agent the missing control plane. Intent is captured, scope is bounded, context is shaped, protected areas are respected, work is isolated, and completion is proven against the project’s rules and the Decapod constitution.
 

--- a/docs/agent/payload-examples.md
+++ b/docs/agent/payload-examples.md
@@ -52,7 +52,7 @@ Efficiently install and initialize Decapod only when updates are available.
 ### Version-Aware Installation
 ```bash
 # Checks crates.io and installs/refreshes only if a newer version exists
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 ```
 
 ## Subsystem Queries

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -12,10 +12,10 @@ cargo install decapod
 
 ## 2. Initialization
 
-Initialize your repository. This creates the `.decapod/` directory and scaffolds the initial agent entrypoints (`AGENTS.md`, etc.).
+Initialize your repository. This creates the `.decapod/` directory and scaffolds the initial agent entrypoints (`AGENTS.md`, etc.). Use the `--proof` flag for non-interactive agent-driven setup.
 
 ```bash
-decapod init
+decapod init --proof
 ```
 
 ## 3. Orientation

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,6 +115,9 @@ pub(crate) struct InitGroupCli {
     /// Force creation of all 4 entrypoint files (AGENTS.md, CLAUDE.md, GEMINI.md, CODEX.md).
     #[clap(long)]
     pub all: bool,
+    /// Support non-interactive agent initialization for proof-gated flows.
+    #[clap(long)]
+    pub proof: bool,
     /// Create only CLAUDE.md entrypoint file.
     #[clap(long)]
     pub claude: bool,
@@ -188,6 +191,9 @@ pub(crate) struct InitWithCli {
     /// Force creation of all 4 entrypoint files (AGENTS.md, CLAUDE.md, GEMINI.md, CODEX.md).
     #[clap(long)]
     pub all: bool,
+    /// Support non-interactive agent initialization for proof-gated flows.
+    #[clap(long)]
+    pub proof: bool,
     /// Create only CLAUDE.md entrypoint file.
     #[clap(long)]
     pub claude: bool,

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -247,7 +247,7 @@ See `AGENTS.md` for the universal contract.
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status
@@ -311,7 +311,7 @@ This is a Decapod-managed repository. **Strict Dependency: You are strictly boun
 
 ```bash
 # Smart bootstrap: only install/init if a newer version is available
-(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init)
+(decapod capabilities --format json | grep -q '"is_latest":true') || (cargo install decapod && decapod init --proof)
 decapod docs ingest && decapod validate && decapod session acquire
 decapod rpc --op agent.init
 decapod workspace status
@@ -416,7 +416,7 @@ It keeps Decapod-owned state, generated artifacts, and isolated workspaces separ
 
 ## Quick Start
 
-1. `decapod init`
+1. `decapod init --proof`
 2. `decapod validate`
 3. `decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'`
 4. `decapod session acquire`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1736,7 +1736,8 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             // Only do full TUI experience if not refreshing an existing project
             let is_refresh = init_target.join(".decapod").exists();
-            if base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof {
+            if base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof
+            {
                 enrich_repo_context_interactive(&mut repo_ctx)?;
             }
             let target_dir = run_init_apply(&init_with, &current_dir, &repo_ctx)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1300,6 +1300,7 @@ fn init_with_from_config(
         dir: Some(target_dir),
         project_dir: None,
         force,
+        proof: false,
         dry_run,
         all: all_entrypoints,
         claude: has("CLAUDE.md"),
@@ -1622,6 +1623,8 @@ pub fn run() -> Result<(), error::DecapodError> {
                         )?
                     } else if let Some(dir) = init_group.dir.as_ref() {
                         resolve_existing_init_dir(dir)?
+                    } else if init_group.proof {
+                        resolve_existing_init_dir(&current_dir)?
                     } else if io::stdin().is_terminal() {
                         prompt_init_target_dir(&current_dir)?
                     } else {
@@ -1679,7 +1682,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                         }
                         with
                     } else {
-                        let diagram_style = if io::stdin().is_terminal() {
+                        let diagram_style = if io::stdin().is_terminal() && !init_group.proof {
                             prompt_diagram_style(init_group.diagram_style)?
                         } else {
                             init_group.diagram_style
@@ -1688,6 +1691,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                             dir: Some(target),
                             project_dir: None,
                             force: init_group.force,
+                            proof: init_group.proof,
                             dry_run: init_group.dry_run,
                             all: init_group.all,
                             claude: init_group.claude,
@@ -1732,7 +1736,7 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             // Only do full TUI experience if not refreshing an existing project
             let is_refresh = init_target.join(".decapod").exists();
-            if base_init_invocation && io::stdin().is_terminal() && !is_refresh {
+            if base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof {
                 enrich_repo_context_interactive(&mut repo_ctx)?;
             }
             let target_dir = run_init_apply(&init_with, &current_dir, &repo_ctx)?;

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -151,6 +151,27 @@ fn init_uses_existing_config_for_noninteractive_defaults() {
 }
 
 #[test]
+fn init_with_proof_bypasses_interaction_and_initializes_cwd() {
+    let tmp = tempdir().expect("tempdir");
+    // Ensure it's a git repo so init works correctly
+    let _ = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(tmp.path())
+        .output()
+        .expect("git init");
+
+    let out = run_decapod(tmp.path(), &["init", "--proof"]);
+    assert!(
+        out.status.success(),
+        "decapod init --proof failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(tmp.path().join(".decapod").is_dir());
+    assert!(tmp.path().join("AGENTS.md").is_file());
+}
+
+#[test]
 fn init_with_accepts_noninteractive_spec_seed_flags() {
     let tmp = tempdir().expect("tempdir");
     let out = run_decapod(


### PR DESCRIPTION
Implement --proof flag for non-interactive decapod init and update templates/docs to ensure a smooth, interaction-free bootstrap for agents.