### PR TITLE
fix: workspace ergonomics and detection (#601, #602, #603, #604, #605)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,7 @@ pub(crate) struct WorkspaceCli {
 pub(crate) enum WorkspaceCommand {
     /// Ensure an isolated workspace exists (create if needed)
     Ensure {
-        /// Branch name (auto-generated if not provided)
+        /// Branch name. Mandatory: MUST contain the claimed Todo ID (e.g. agent/unknown/feat_01ks...) or hash.
         #[clap(long)]
         branch: Option<String>,
         /// Use a container for the workspace

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -199,12 +199,12 @@ fn collect_repo_files(
 
 fn validate_no_legacy_namespaces(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Namespace Purge Gate");
 
     let mut files = Vec::new();
-    collect_repo_files(decapod_dir, &mut files, ctx)?;
+    collect_repo_files(working_root, &mut files, ctx)?;
 
     let needles = [
         [".".to_string(), "globex".to_string()].concat(),
@@ -418,7 +418,7 @@ fn validate_user_store_blank_slate(ctx: &ValidationContext) -> Result<(), error:
 fn validate_repo_store_dogfood(
     store: &Store,
     ctx: &ValidationContext,
-    _decapod_dir: &Path,
+    _working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Store: repo (dogfood backlog semantics)");
 
@@ -490,7 +490,7 @@ fn validate_repo_store_dogfood(
 
 fn validate_repo_map(
     ctx: &ValidationContext,
-    _decapod_dir: &Path, // decapod_dir is no longer used for filesystem constitution checks
+    _working_root: &Path, // working_root is no longer used for filesystem constitution checks
 ) -> Result<(), error::DecapodError> {
     info("Repo Map");
 
@@ -522,14 +522,14 @@ fn validate_repo_map(
 
 fn validate_docs_templates_bucket(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Entrypoint Gate");
 
     // Entrypoints MUST be in the project root
     let required = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CODEX.md"];
     for a in required {
-        let p = decapod_dir.join(a);
+        let p = working_root.join(a);
         if p.is_file() {
             pass(&format!("Root entrypoint {} present", a), ctx);
         } else {
@@ -540,14 +540,14 @@ fn validate_docs_templates_bucket(
         }
     }
 
-    if decapod_dir.join(".decapod").join("README.md").is_file() {
+    if working_root.join(".decapod").join("README.md").is_file() {
         pass(".decapod/README.md present", ctx);
     } else {
         fail(".decapod/README.md missing", ctx);
     }
 
     // NEGATIVE GATE: Decapod docs MUST NOT be copied into the project
-    let forbidden_docs = decapod_dir.join(".decapod").join("docs");
+    let forbidden_docs = working_root.join(".decapod").join("docs");
     if forbidden_docs.exists() {
         fail(
             "Decapod internal docs were copied into .decapod/docs/ (Forbidden)",
@@ -561,7 +561,7 @@ fn validate_docs_templates_bucket(
     }
 
     // NEGATIVE GATE: projects/<id> MUST NOT exist
-    let forbidden_projects = decapod_dir.join(".decapod").join("projects");
+    let forbidden_projects = working_root.join(".decapod").join("projects");
     if forbidden_projects.exists() {
         fail("Legacy .decapod/projects/ directory found (Forbidden)", ctx);
     } else {
@@ -573,12 +573,12 @@ fn validate_docs_templates_bucket(
 
 fn validate_entrypoint_invariants(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Four Invariants Gate");
 
     // Check AGENTS.md for the four invariants
-    let agents_path = decapod_dir.join("AGENTS.md");
+    let agents_path = working_root.join("AGENTS.md");
     if !agents_path.is_file() {
         fail("AGENTS.md missing, cannot check invariants", ctx);
         return Ok(());
@@ -678,7 +678,7 @@ fn validate_entrypoint_invariants(
     // Check that agent-specific files defer to AGENTS.md and are thin
     const MAX_AGENT_SPECIFIC_LINES: usize = 70;
     for agent_file in ["CLAUDE.md", "GEMINI.md", "CODEX.md"] {
-        let agent_path = decapod_dir.join(agent_file);
+        let agent_path = working_root.join(agent_file);
         if !agent_path.is_file() {
             fail(&format!("{} missing from project root", agent_file), ctx);
             all_present = false;
@@ -1066,17 +1066,17 @@ fn extract_md_version(content: &str) -> Option<String> {
 
 fn validate_health_purity(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Health Purity Gate");
     let mut files = Vec::new();
-    collect_repo_files(decapod_dir, &mut files, ctx)?;
+    collect_repo_files(working_root, &mut files, ctx)?;
 
     let forbidden =
         Regex::new(r"(?i)\(health:\s*(VERIFIED|ASSERTED|STALE|CONTRADICTED)\)").unwrap();
     let mut offenders = Vec::new();
 
-    let generated_path = decapod_dir.join(".decapod").join("generated");
+    let generated_path = working_root.join(".decapod").join("generated");
 
     for path in files {
         if path.extension().is_some_and(|e| e == "md") {
@@ -1112,7 +1112,7 @@ fn validate_health_purity(
 fn validate_project_scoped_state(
     store: &Store,
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Project-Scoped State Gate");
     if store.kind != StoreKind::Repo {
@@ -1122,7 +1122,7 @@ fn validate_project_scoped_state(
 
     // Check if any .db or .jsonl files exist outside .decapod/ in the project root
     let mut offenders = Vec::new();
-    for entry in fs::read_dir(decapod_dir).map_err(error::DecapodError::IoError)? {
+    for entry in fs::read_dir(working_root).map_err(error::DecapodError::IoError)? {
         let entry = entry.map_err(error::DecapodError::IoError)?;
         let path = entry.path();
         if path.is_file() {
@@ -1150,7 +1150,7 @@ fn validate_project_scoped_state(
 fn validate_generated_artifact_whitelist(
     store: &Store,
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Generated Artifact Whitelist Gate");
 
@@ -1162,7 +1162,7 @@ fn validate_generated_artifact_whitelist(
         return Ok(());
     }
 
-    let gitignore_path = decapod_dir.join(".gitignore");
+    let gitignore_path = working_root.join(".gitignore");
     let gitignore = fs::read_to_string(&gitignore_path).map_err(error::DecapodError::IoError)?;
     for rule in DECAPOD_GITIGNORE_RULES {
         if gitignore.lines().any(|line| line.trim() == *rule) {
@@ -1180,7 +1180,7 @@ fn validate_generated_artifact_whitelist(
 
     let output = std::process::Command::new("git")
         .arg("-C")
-        .arg(decapod_dir)
+        .arg(working_root)
         .args(["ls-files", ".decapod/generated", ".decapod/data"])
         .output();
 
@@ -2517,7 +2517,7 @@ fn validate_internalization_artifacts_if_present(
 
 fn validate_schema_determinism(
     ctx: &ValidationContext,
-    _decapod_dir: &Path,
+    _working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Schema Determinism Gate");
     let run_schema = || -> Result<String, error::DecapodError> {
@@ -3276,12 +3276,12 @@ fn validate_lineage_hard_gate(
 
 fn validate_repomap_determinism(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Repo Map Determinism Gate");
     use crate::core::repomap;
-    let dir1 = decapod_dir.to_path_buf();
-    let dir2 = decapod_dir.to_path_buf();
+    let dir1 = working_root.to_path_buf();
+    let dir2 = working_root.to_path_buf();
     let h1 =
         std::thread::spawn(move || serde_json::to_string(&repomap::generate_map(&dir1)).unwrap());
     let h2 =
@@ -3508,12 +3508,12 @@ fn validate_canon_mutation(
 
 fn validate_heartbeat_invocation_gate(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Heartbeat Invocation Gate");
 
-    let lib_rs = decapod_dir.join("src").join("lib.rs");
-    let todo_rs = decapod_dir.join("src").join("plugins").join("todo.rs");
+    let lib_rs = working_root.join("src").join("lib.rs");
+    let todo_rs = working_root.join("src").join("plugins").join("todo.rs");
     if lib_rs.exists() && todo_rs.exists() {
         let lib_content = fs::read_to_string(&lib_rs).unwrap_or_default();
         let todo_content = fs::read_to_string(&todo_rs).unwrap_or_default();
@@ -3636,6 +3636,7 @@ fn validate_markdown_primitives_roundtrip_gate(
 /// This gate ensures formatting, linting, and type checking pass before promotion.
 fn validate_git_workspace_context(
     ctx: &ValidationContext,
+    main_root: &Path,
     repo_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Git Workspace Context Gate");
@@ -3682,13 +3683,10 @@ fn validate_git_workspace_context(
         return Ok(());
     }
 
-    let git_dir = repo_root.join(".git");
-    let is_worktree = git_dir.is_file() && {
-        let content = std::fs::read_to_string(&git_dir).unwrap_or_default();
-        content.contains("gitdir:")
-    };
+    let is_worktree = crate::core::workspace::is_worktree(repo_root).unwrap_or(false);
 
-    let is_isolated = is_worktree || repo_root.to_string_lossy().contains(".decapod/workspaces");
+    let workspaces_path = main_root.join(".decapod").join("workspaces");
+    let is_isolated = is_worktree && repo_root.starts_with(&workspaces_path);
 
     if is_isolated {
         pass("Running in isolated workspace (.decapod/workspaces/)", ctx);
@@ -3700,7 +3698,9 @@ fn validate_git_workspace_context(
     }
 
     let container_reasons = container_signal_reasons(repo_root);
-    if is_container_workspaces_disabled(repo_root) {
+    let is_non_code = is_non_code_change(repo_root);
+
+    if is_container_workspaces_disabled(main_root) {
         skip(
             "Container workspace requirement disabled (container_workspaces = false in .decapod/config.toml). This is only safe for single-agent workflows; multi-agent concurrent runs require container isolation.",
             ctx,
@@ -3711,6 +3711,11 @@ fn validate_git_workspace_context(
                 "Container-detected: (signals: {})",
                 container_reasons.join(", ")
             ),
+            ctx,
+        );
+    } else if is_non_code {
+        skip(
+            "Container workspace relaxation: only non-code files (docs, config, specs) are modified. Host-side execution is permitted for these tasks.",
             ctx,
         );
     } else {
@@ -3727,6 +3732,40 @@ fn validate_git_workspace_context(
     validate_commit_often_gate(ctx, repo_root)?;
 
     Ok(())
+}
+
+fn is_non_code_change(repo_root: &Path) -> bool {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(repo_root)
+        .output()
+        .ok();
+
+    let Some(output) = output else {
+        return false;
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+
+    if lines.is_empty() {
+        return true; // No changes is "non-code" for validation purposes
+    }
+
+    lines.iter().all(|line| {
+        if line.len() < 4 {
+            return false;
+        }
+        let path = line[3..].trim();
+
+        // Allowed paths for non-code relaxation
+        path.starts_with("docs/")
+            || path.ends_with(".md")
+            || path == ".decapod/config.toml"
+            || path == ".decapod/OVERRIDE.md"
+            || path.starts_with(".decapod/generated/specs/")
+            || path.starts_with(".decapod/generated/artifacts/")
+            || path.starts_with(".decapod/contracts/")
+    })
 }
 
 fn validate_commit_often_gate(
@@ -3784,7 +3823,7 @@ fn validate_commit_often_gate(
 fn validate_plan_governed_execution_gate(
     store: &Store,
     ctx: &ValidationContext,
-    repo_root: &Path,
+    main_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Plan-Governed Execution Gate");
 
@@ -3799,7 +3838,7 @@ fn validate_plan_governed_execution_gate(
         return Ok(());
     }
 
-    let plan = plan_governance::load_plan(repo_root)?;
+    let plan = plan_governance::load_plan(main_root)?;
     if let Some(plan) = plan {
         if plan.state != plan_governance::PlanState::Approved
             && plan.state != plan_governance::PlanState::Done
@@ -4551,14 +4590,14 @@ fn validate_lcm_rebuild_gate(
 
 fn validate_gatekeeper_gate(
     ctx: &ValidationContext,
-    decapod_dir: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Gatekeeper Safety Gate");
 
     // Get staged files from git (if in a git repo)
     let output = std::process::Command::new("git")
         .args(["diff", "--cached", "--name-only"])
-        .current_dir(decapod_dir)
+        .current_dir(working_root)
         .output();
 
     let staged_paths: Vec<PathBuf> = match output {
@@ -4582,7 +4621,7 @@ fn validate_gatekeeper_gate(
     }
 
     let config = crate::core::gatekeeper::GatekeeperConfig::default();
-    let result = crate::core::gatekeeper::run_gatekeeper(decapod_dir, &staged_paths, 0, &config)?;
+    let result = crate::core::gatekeeper::run_gatekeeper(working_root, &staged_paths, 0, &config)?;
 
     if result.passed {
         pass(
@@ -4722,7 +4761,7 @@ pub fn evaluate_mandates(
 /// no snapshot should produce a policy that is looser than a less-reliable one.
 fn validate_coplayer_policy_tightening(
     ctx: &ValidationContext,
-    _decapod_dir: &Path,
+    _working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Co-Player Policy Tightening Gate");
 
@@ -4789,8 +4828,8 @@ fn validate_coplayer_policy_tightening(
 
 pub fn run_validation(
     store: &Store,
-    decapod_dir: &Path,
-    _home_dir: &Path,
+    main_root: &Path,
+    working_root: &Path,
     _verbose: bool,
 ) -> Result<ValidationReport, error::DecapodError> {
     let total_start = Instant::now();
@@ -4814,7 +4853,7 @@ pub fn run_validation(
         }
         StoreKind::Repo => {
             let start = Instant::now();
-            validate_repo_store_dogfood(store, &ctx, decapod_dir)?;
+            validate_repo_store_dogfood(store, &ctx, main_root)?;
             let _ = start;
         }
     }
@@ -4832,147 +4871,147 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_repo_map",
-            validate_repo_map(ctx, decapod_dir)
+            validate_repo_map(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_no_legacy_namespaces",
-            validate_no_legacy_namespaces(ctx, decapod_dir)
+            validate_no_legacy_namespaces(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_embedded_self_contained",
-            validate_embedded_self_contained(ctx, decapod_dir)
+            validate_embedded_self_contained(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_docs_templates_bucket",
-            validate_docs_templates_bucket(ctx, decapod_dir)
+            validate_docs_templates_bucket(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_entrypoint_invariants",
-            validate_entrypoint_invariants(ctx, decapod_dir)
+            validate_entrypoint_invariants(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_interface_contract_bootstrap",
-            validate_interface_contract_bootstrap(ctx, decapod_dir)
+            validate_interface_contract_bootstrap(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_health_purity",
-            validate_health_purity(ctx, decapod_dir)
+            validate_health_purity(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_project_scoped_state",
-            validate_project_scoped_state(store, ctx, decapod_dir)
+            validate_project_scoped_state(store, ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_generated_artifact_whitelist",
-            validate_generated_artifact_whitelist(store, ctx, decapod_dir)
+            validate_generated_artifact_whitelist(store, ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_project_config_toml",
-            validate_project_config_toml(ctx, decapod_dir)
+            validate_project_config_toml(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_project_specs_docs",
-            validate_project_specs_docs(ctx, decapod_dir)
+            validate_project_specs_docs(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_spec_drift",
-            validate_spec_drift(ctx, decapod_dir)
+            validate_spec_drift(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_machine_contract",
-            validate_machine_contract(ctx, decapod_dir)
+            validate_machine_contract(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_workunit_manifests_if_present",
-            validate_workunit_manifests_if_present(ctx, decapod_dir)
+            validate_workunit_manifests_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_recursive_improvement_passes_if_present",
-            validate_recursive_improvement_passes_if_present(ctx, decapod_dir)
+            validate_recursive_improvement_passes_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_context_capsule_policy_contract",
-            validate_context_capsule_policy_contract(ctx, decapod_dir)
+            validate_context_capsule_policy_contract(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_context_capsules_if_present",
-            validate_context_capsules_if_present(ctx, decapod_dir)
+            validate_context_capsules_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_knowledge_promotions_if_present",
-            validate_knowledge_promotions_if_present(ctx, decapod_dir)
+            validate_knowledge_promotions_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_skill_cards_if_present",
-            validate_skill_cards_if_present(ctx, decapod_dir)
+            validate_skill_cards_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_skill_resolutions_if_present",
-            validate_skill_resolutions_if_present(ctx, decapod_dir)
+            validate_skill_resolutions_if_present(ctx, main_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_internalization_artifacts_if_present",
-            validate_internalization_artifacts_if_present(ctx, decapod_dir)
+            validate_internalization_artifacts_if_present(ctx, main_root)
         );
         gate!(
             s,
@@ -4986,7 +5025,7 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_schema_determinism",
-            validate_schema_determinism(ctx, decapod_dir)
+            validate_schema_determinism(ctx, working_root)
         );
         gate!(
             s,
@@ -5042,7 +5081,7 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_repomap_determinism",
-            validate_repomap_determinism(ctx, decapod_dir)
+            validate_repomap_determinism(ctx, working_root)
         );
         gate!(
             s,
@@ -5084,7 +5123,7 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_heartbeat_invocation_gate",
-            validate_heartbeat_invocation_gate(ctx, decapod_dir)
+            validate_heartbeat_invocation_gate(ctx, working_root)
         );
         gate!(
             s,
@@ -5105,28 +5144,28 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_git_workspace_context",
-            validate_git_workspace_context(ctx, decapod_dir)
+            validate_git_workspace_context(ctx, main_root, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_git_protected_branch",
-            validate_git_protected_branch(ctx, decapod_dir)
+            validate_git_protected_branch(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_tooling_gate",
-            validate_tooling_gate(ctx, decapod_dir)
+            validate_tooling_gate(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_state_commit_gate",
-            validate_state_commit_gate(ctx, decapod_dir)
+            validate_state_commit_gate(ctx, working_root)
         );
         gate!(
             s,
@@ -5141,14 +5180,14 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_gatekeeper_gate",
-            validate_gatekeeper_gate(ctx, decapod_dir)
+            validate_gatekeeper_gate(ctx, working_root)
         );
         gate!(
             s,
             timings,
             ctx,
             "validate_coplayer_policy_tightening",
-            validate_coplayer_policy_tightening(ctx, decapod_dir)
+            validate_coplayer_policy_tightening(ctx, working_root)
         );
         gate!(
             s,
@@ -5169,7 +5208,7 @@ pub fn run_validation(
             timings,
             ctx,
             "validate_plan_governed_execution_gate",
-            validate_plan_governed_execution_gate(store, ctx, decapod_dir)
+            validate_plan_governed_execution_gate(store, ctx, main_root)
         );
     }
 

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -768,7 +768,7 @@ fn build_workspace_image(workspace_path: &Path, image_tag: &str) -> Result<(), D
     Ok(())
 }
 
-fn get_main_repo_root(current_dir: &Path) -> Result<PathBuf, DecapodError> {
+pub fn get_main_repo_root(current_dir: &Path) -> Result<PathBuf, DecapodError> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -785,14 +785,22 @@ fn get_main_repo_root(current_dir: &Path) -> Result<PathBuf, DecapodError> {
     }
 
     let common_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let common_path = Path::new(&common_dir);
 
-    // If common_dir is ".git", then current_dir IS the main repo
-    if common_dir == ".git" {
-        return get_repo_root(current_dir);
+    // Canonicalize to handle relative paths from git
+    let common_path = if Path::new(&common_dir).is_absolute() {
+        PathBuf::from(common_dir)
+    } else {
+        current_dir.join(common_dir)
+    };
+
+    let common_path = std::fs::canonicalize(&common_path).unwrap_or(common_path);
+
+    // If common_path ends in .git, the root is its parent
+    if common_path.file_name().and_then(|n| n.to_str()) == Some(".git") {
+        return Ok(common_path.parent().unwrap_or(&common_path).to_path_buf());
     }
 
-    Ok(common_path.parent().unwrap_or(common_path).to_path_buf())
+    Ok(common_path)
 }
 
 /// Discover the Decapod repository root by searching upwards from a directory.
@@ -886,7 +894,7 @@ fn get_current_branch(repo_root: &Path) -> Result<String, DecapodError> {
     Ok(branch)
 }
 
-fn is_worktree(repo_root: &Path) -> Result<bool, DecapodError> {
+pub fn is_worktree(repo_root: &Path) -> Result<bool, DecapodError> {
     let output = Command::new("git")
         .args([
             "-C",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,12 @@ fn find_decapod_project_root(start_dir: &Path) -> Result<PathBuf, error::Decapod
     }
 }
 
+fn find_governance_root(workspace_root: &Path) -> PathBuf {
+    // If we are in a worktree, the governance root is the main repo.
+    // Otherwise, it's just the workspace root.
+    workspace::get_main_repo_root(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf())
+}
+
 // Process-local session password - eliminates unsafe env::set_var
 static SESSION_P_VAL: OnceLock<String> = OnceLock::new();
 
@@ -1762,17 +1768,20 @@ pub fn run() -> Result<(), error::DecapodError> {
             }
         },
         _ => {
-            let project_root = decapod_root_option?;
+            let workspace_root = decapod_root_option?;
+            let governance_root = find_governance_root(&workspace_root);
+
             let is_validate_cmd = matches!(&cli.command, Command::Validate(_));
             if requires_session_token(&cli.command) {
                 ensure_session_valid()?;
             }
-            enforce_worktree_requirement(&cli.command, &project_root)?;
+            enforce_worktree_requirement(&cli.command, &workspace_root)?;
 
-            // For other commands, ensure .decapod exists
-            let decapod_root_path = project_root.join(".decapod");
+            // For other commands, ensure .decapod exists in the GOVERNANCE root
+            let decapod_root_path = governance_root.join(".decapod");
             store_root = decapod_root_path.join("data");
             std::fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
+
             if should_route_via_group_broker(&cli.command, &argv) {
                 match core::group_broker::maybe_route_mutation(&store_root, &argv) {
                     Err(e) => {
@@ -1810,7 +1819,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                     let normalized = normalize_validate_error(e);
                     return Err(attach_validate_diagnostic_if_enabled(
                         normalized,
-                        &project_root,
+                        &workspace_root,
                         0,
                         validate_timeout_secs(),
                     ));
@@ -1820,7 +1829,7 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             // Best-effort hygiene: routinely scrub stale git worktree metadata/config.
             // This must not block primary command execution.
-            if let Err(e) = workspace::prune_stale_worktree_config(&project_root)
+            if let Err(e) = workspace::prune_stale_worktree_config(&workspace_root)
                 && !is_not_git_repository_error(&e)
             {
                 eprintln!("warn: worktree maintenance skipped: {e}");
@@ -1849,13 +1858,18 @@ pub fn run() -> Result<(), error::DecapodError> {
                     println!("decapod.activate: ok");
                 }
                 Command::Validate(validate_cli) => {
-                    run_validate_command(validate_cli, &project_root, &project_store)?;
+                    run_validate_command(
+                        validate_cli,
+                        &governance_root,
+                        &workspace_root,
+                        &project_store,
+                    )?;
                 }
                 Command::Version => show_version_info()?,
                 Command::Docs(docs_cli) => {
                     let result = docs_cli::run_docs_cli(docs_cli)?;
                     if result.ingested_core_constitution {
-                        mark_core_constitution_ingested(&project_root, "docs.ingest")?;
+                        mark_core_constitution_ingested(&governance_root, "docs.ingest")?;
                     }
                 }
                 Command::Todo(todo_cli) => todo::run_todo_cli(&project_store, todo_cli)?,
@@ -1863,25 +1877,31 @@ pub fn run() -> Result<(), error::DecapodError> {
                     obligation::run_obligation_cli(&project_store, obligation_cli)?
                 }
                 Command::Govern(govern_cli) => {
-                    run_govern_command(govern_cli, &project_store, &store_root)?;
+                    run_govern_command(govern_cli, &project_store, &store_root, &workspace_root)?;
                 }
                 Command::Data(data_cli) => {
-                    run_data_command(data_cli, &project_store, &project_root, &store_root)?;
+                    run_data_command(
+                        data_cli,
+                        &project_store,
+                        &governance_root,
+                        &workspace_root,
+                        &store_root,
+                    )?;
                 }
                 Command::Auto(auto_cli) => run_auto_command(auto_cli, &project_store)?,
-                Command::Qa(qa_cli) => run_qa_command(qa_cli, &project_store, &project_root)?,
+                Command::Qa(qa_cli) => run_qa_command(qa_cli, &project_store, &workspace_root)?,
                 Command::Decide(decide_cli) => decide::run_decide_cli(&project_store, decide_cli)?,
                 Command::Workspace(workspace_cli) => {
-                    run_workspace_command(workspace_cli, &project_root)?;
+                    run_workspace_command(workspace_cli, &workspace_root)?;
                 }
                 Command::Rpc(rpc_cli) => {
-                    run_rpc_command(rpc_cli, &project_root)?;
+                    run_rpc_command(rpc_cli, &workspace_root)?;
                 }
                 Command::Handshake(handshake_cli) => {
-                    run_handshake_command(handshake_cli, &project_root)?;
+                    run_handshake_command(handshake_cli, &workspace_root)?;
                 }
                 Command::Release(release_cli) => {
-                    run_release_command(release_cli, &project_root)?;
+                    run_release_command(release_cli, &workspace_root)?;
                 }
                 Command::Capabilities(cap_cli) => {
                     run_capabilities_command(cap_cli)?;
@@ -1890,16 +1910,16 @@ pub fn run() -> Result<(), error::DecapodError> {
                     internalize::run_internalize_cli(&project_store, &store_root, internalize_cli)?;
                 }
                 Command::Preflight(preflight_cli) => {
-                    run_preflight_command(preflight_cli, &project_root)?;
+                    run_preflight_command(preflight_cli, &workspace_root)?;
                 }
                 Command::Impact(impact_cli) => {
-                    run_impact_command(impact_cli, &project_root)?;
+                    run_impact_command(impact_cli, &workspace_root)?;
                 }
                 Command::Infer(infer_cli) => {
-                    run_infer_command(infer_cli, &project_root)?;
+                    run_infer_command(infer_cli, &workspace_root)?;
                 }
                 Command::Trace(trace_cli) => {
-                    run_trace_command(trace_cli, &project_root)?;
+                    run_trace_command(trace_cli, &workspace_root)?;
                 }
                 Command::Eval(eval_cli) => {
                     eval::run_eval_cli(&project_store, eval_cli)?;
@@ -1908,10 +1928,10 @@ pub fn run() -> Result<(), error::DecapodError> {
                     flight_recorder::run_flight_recorder_cli(&project_store, fr_cli)?;
                 }
                 Command::StateCommit(sc_cli) => {
-                    run_state_commit_command(sc_cli, &project_root)?;
+                    run_state_commit_command(sc_cli, &workspace_root)?;
                 }
                 Command::Doctor(doctor_cli) => {
-                    doctor::run_doctor_cli(&project_store, &project_root, doctor_cli)?;
+                    doctor::run_doctor_cli(&project_store, &workspace_root, doctor_cli)?;
                 }
                 Command::Lcm(lcm_cli) => {
                     lcm::run_lcm_cli(&project_store, lcm_cli)?;
@@ -1920,7 +1940,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                     map_ops::run_map_cli(&project_store, map_cli)?;
                 }
                 Command::Demo(demo_cli) => {
-                    run_demo_command(demo_cli, &project_root)?;
+                    run_demo_command(demo_cli, &workspace_root)?;
                 }
                 _ => unreachable!(),
             }
@@ -2116,7 +2136,7 @@ fn branch_contains_todo_ticket_id(branch: &str) -> bool {
 
 fn enforce_worktree_requirement(
     command: &Command,
-    project_root: &Path,
+    _project_root: &Path,
 ) -> Result<(), error::DecapodError> {
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         return Ok(());
@@ -2125,13 +2145,14 @@ fn enforce_worktree_requirement(
         return Ok(());
     }
 
-    let status = crate::core::workspace::get_workspace_status(project_root)?;
+    let current_dir = std::env::current_dir()?;
+    let status = crate::core::workspace::get_workspace_status(&current_dir)?;
     if status.git.in_worktree {
         let worktree_path = status
             .git
             .worktree_path
             .clone()
-            .unwrap_or_else(|| project_root.to_path_buf());
+            .unwrap_or_else(|| current_dir.to_path_buf());
         if command_requires_canonical_worktree_path(command)
             && !is_canonical_decapod_worktree_path(&worktree_path)
         {
@@ -2181,7 +2202,7 @@ fn rpc_op_requires_worktree(op: &str) -> bool {
 
 fn enforce_worktree_requirement_for_rpc(
     op: &str,
-    project_root: &Path,
+    _project_root: &Path,
 ) -> Result<(), error::DecapodError> {
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         return Ok(());
@@ -2190,13 +2211,14 @@ fn enforce_worktree_requirement_for_rpc(
         return Ok(());
     }
 
-    let status = crate::core::workspace::get_workspace_status(project_root)?;
+    let current_dir = std::env::current_dir()?;
+    let status = crate::core::workspace::get_workspace_status(&current_dir)?;
     if status.git.in_worktree {
         let worktree_path = status
             .git
             .worktree_path
             .clone()
-            .unwrap_or_else(|| project_root.to_path_buf());
+            .unwrap_or_else(|| current_dir.to_path_buf());
         if !matches!(
             op,
             "validate.run"
@@ -4247,7 +4269,8 @@ fn render_validation_text(
 
 fn run_validate_command(
     validate_cli: ValidateCli,
-    project_root: &Path,
+    governance_root: &Path,
+    workspace_root: &Path,
     project_store: &Store,
 ) -> Result<(), error::DecapodError> {
     use crate::core::workspace;
@@ -4256,7 +4279,8 @@ fn run_validate_command(
         // Skip workspace check if gates are explicitly skipped
     } else {
         // FIRST: Check workspace enforcement (non-negotiable)
-        let workspace_status = workspace::get_workspace_status(project_root)?;
+        // Check protection in the current workspace/worktree
+        let workspace_status = workspace::get_workspace_status(workspace_root)?;
 
         if !workspace_status.can_work {
             let blocker = workspace_status
@@ -4287,7 +4311,6 @@ fn run_validate_command(
         }
     }
 
-    let decapod_root = project_root.to_path_buf();
     let store = match validate_cli.store.as_str() {
         "user" => {
             // User store uses a temp directory for blank-slate validation
@@ -4305,30 +4328,40 @@ fn run_validate_command(
     };
 
     let mut heal_actions = Vec::new();
-    if let Some(action) = heal_override_checksum(project_root)? {
+    if let Some(action) = heal_override_checksum(workspace_root)? {
         heal_actions.push(action);
     }
-    if let Some(action) = heal_validation_scaffold(project_root)? {
+    if let Some(action) = heal_validation_scaffold(workspace_root)? {
         heal_actions.push(action);
     }
-    if let Some(action) = heal_agents_contract(project_root)? {
+    if let Some(action) = heal_agents_contract(workspace_root)? {
         heal_actions.push(action);
     }
-    if let Some(action) = heal_container_runtime_override(project_root)? {
+    if let Some(action) = heal_container_runtime_override(workspace_root)? {
         heal_actions.push(action);
     }
 
-    let mut report = run_validation_bounded(&store, &decapod_root, validate_cli.verbose)?;
+    let mut report = run_validation_bounded(
+        &store,
+        governance_root,
+        workspace_root,
+        validate_cli.verbose,
+    )?;
     for _ in 0..2 {
         if report.fail_count == 0 {
             break;
         }
-        let mut round_actions = attempt_validation_failure_heal(&report, project_root, &store)?;
+        let mut round_actions = attempt_validation_failure_heal(&report, workspace_root, &store)?;
         if round_actions.is_empty() {
             break;
         }
         heal_actions.append(&mut round_actions);
-        report = run_validation_bounded(&store, &decapod_root, validate_cli.verbose)?;
+        report = run_validation_bounded(
+            &store,
+            governance_root,
+            workspace_root,
+            validate_cli.verbose,
+        )?;
     }
 
     if validate_cli.format == "json" {
@@ -4350,7 +4383,7 @@ fn run_validate_command(
     if report.fail_count > 0 {
         std::process::exit(1);
     }
-    mark_validation_completed(project_root)?;
+    mark_validation_completed(workspace_root)?;
     Ok(())
 }
 
@@ -4571,17 +4604,19 @@ fn is_transient_sqlite_contention_error(err: &error::DecapodError) -> bool {
 
 fn run_validation_bounded(
     store: &Store,
-    project_root: &Path,
+    governance_root: &Path,
+    workspace_root: &Path,
     verbose: bool,
 ) -> Result<validate::ValidationReport, error::DecapodError> {
     let timeout_secs = validate_timeout_secs();
     let started = std::time::Instant::now();
     let (tx, rx) = mpsc::channel();
     let store_cloned = store.clone();
-    let root = project_root.to_path_buf();
+    let g_root = governance_root.to_path_buf();
+    let w_root = workspace_root.to_path_buf();
 
     std::thread::spawn(move || {
-        let mut result = validate::run_validation(&store_cloned, &root, &root, verbose);
+        let mut result = validate::run_validation(&store_cloned, &g_root, &w_root, verbose);
         for attempt in 1..=2 {
             let should_retry = match &result {
                 Err(error::DecapodError::RusqliteError(err)) => {
@@ -4600,7 +4635,7 @@ fn run_validation_bounded(
             }
             let backoff_ms = 200_u64 * attempt as u64;
             std::thread::sleep(std::time::Duration::from_millis(backoff_ms));
-            result = validate::run_validation(&store_cloned, &root, &root, verbose);
+            result = validate::run_validation(&store_cloned, &g_root, &w_root, verbose);
         }
         let _ = tx.send(result);
     });
@@ -4618,7 +4653,7 @@ fn run_validation_bounded(
     result.map_err(|err| {
         attach_validate_diagnostic_if_enabled(
             err,
-            project_root,
+            workspace_root,
             started.elapsed().as_millis() as u64,
             timeout_secs,
         )
@@ -4701,6 +4736,7 @@ fn run_govern_command(
     govern_cli: GovernCli,
     project_store: &Store,
     store_root: &Path,
+    workspace_root: &Path,
 ) -> Result<(), error::DecapodError> {
     match govern_cli.command {
         GovernCommand::Policy(policy_cli) => policy::run_policy_cli(project_store, policy_cli)?,
@@ -4739,11 +4775,7 @@ fn run_govern_command(
             } => {
                 use crate::core::gatekeeper;
 
-                let repo_root = project_store
-                    .root
-                    .parent()
-                    .and_then(|p| p.parent())
-                    .unwrap_or(&project_store.root);
+                let repo_root = workspace_root;
 
                 // Collect paths: explicit or git staged files
                 let check_paths: Vec<std::path::PathBuf> = if let Some(explicit) = paths {
@@ -4801,9 +4833,13 @@ fn run_govern_command(
                 }
             }
         },
-        GovernCommand::Plan(plan_cli) => run_plan_command(plan_cli, project_store)?,
-        GovernCommand::Workunit(workunit_cli) => run_workunit_command(workunit_cli, project_store)?,
-        GovernCommand::Capsule(capsule_cli) => run_capsule_command(capsule_cli, project_store)?,
+        GovernCommand::Plan(plan_cli) => run_plan_command(plan_cli, project_store, workspace_root)?,
+        GovernCommand::Workunit(workunit_cli) => {
+            run_workunit_command(workunit_cli, project_store, workspace_root)?
+        }
+        GovernCommand::Capsule(capsule_cli) => {
+            run_capsule_command(capsule_cli, project_store, workspace_root)?
+        }
     }
 
     Ok(())
@@ -4811,17 +4847,10 @@ fn run_govern_command(
 
 fn run_capsule_command(
     capsule_cli: CapsuleCli,
-    project_store: &Store,
+    _project_store: &Store,
+    workspace_root: &Path,
 ) -> Result<(), error::DecapodError> {
-    let project_root = project_store
-        .root
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| {
-            error::DecapodError::ValidationError(
-                "unable to resolve project root from store root".to_string(),
-            )
-        })?;
+    let project_root = workspace_root;
 
     match capsule_cli.command {
         CapsuleCommand::Query {
@@ -4877,17 +4906,10 @@ fn run_capsule_command(
 
 fn run_workunit_command(
     workunit_cli: WorkunitCli,
-    project_store: &Store,
+    _project_store: &Store,
+    workspace_root: &Path,
 ) -> Result<(), error::DecapodError> {
-    let project_root = project_store
-        .root
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| {
-            error::DecapodError::ValidationError(
-                "unable to resolve project root from store root".to_string(),
-            )
-        })?;
+    let project_root = workspace_root;
 
     match workunit_cli.command {
         WorkunitCommand::Init {
@@ -4968,16 +4990,12 @@ fn run_workunit_command(
     Ok(())
 }
 
-fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), error::DecapodError> {
-    let project_root = project_store
-        .root
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| {
-            error::DecapodError::ValidationError(
-                "unable to resolve project root from store root".to_string(),
-            )
-        })?;
+fn run_plan_command(
+    plan_cli: PlanCli,
+    project_store: &Store,
+    workspace_root: &Path,
+) -> Result<(), error::DecapodError> {
+    let project_root = workspace_root;
 
     match plan_cli.command {
         PlanCommand::Init {
@@ -5151,7 +5169,8 @@ fn run_plan_command(plan_cli: PlanCli, project_store: &Store) -> Result<(), erro
 fn run_data_command(
     data_cli: DataCli,
     project_store: &Store,
-    project_root: &Path,
+    _governance_root: &Path,
+    workspace_root: &Path,
     store_root: &Path,
 ) -> Result<(), error::DecapodError> {
     match data_cli.command {
@@ -5319,11 +5338,11 @@ fn run_data_command(
         }
         DataCommand::Repo(repo_cli) => match repo_cli.command {
             RepoCommand::Map => {
-                let map = repomap::generate_map(project_root);
+                let map = repomap::generate_map(workspace_root);
                 println!("{}", serde_json::to_string_pretty(&map).unwrap());
             }
             RepoCommand::Graph => {
-                let graph = repomap::generate_doc_graph(project_root);
+                let graph = repomap::generate_doc_graph(workspace_root);
                 println!("{}", graph.mermaid);
             }
         },
@@ -5586,11 +5605,11 @@ fn run_auto_command(auto_cli: AutoCli, project_store: &Store) -> Result<(), erro
 fn run_qa_command(
     qa_cli: QaCli,
     project_store: &Store,
-    project_root: &Path,
+    workspace_root: &Path,
 ) -> Result<(), error::DecapodError> {
     match qa_cli.command {
         QaCommand::Verify(verify_cli) => {
-            verify::run_verify_cli(project_store, project_root, verify_cli)?
+            verify::run_verify_cli(project_store, workspace_root, verify_cli)?
         }
         QaCommand::Check {
             crate_description,
@@ -5847,41 +5866,57 @@ fn run_workspace_command(
             );
         }
         WorkspaceCommand::Status => {
-            let status = workspace::get_workspace_status(project_root)?;
+            let workspace_root = project_root;
+            let status = workspace::get_workspace_status(workspace_root)?;
+            let governance_root = find_governance_root(workspace_root);
+
+            let mut report_summary = None;
+            let store_root = governance_root.join(".decapod").join("data");
+            if store_root.exists() {
+                let project_store = Store {
+                    kind: StoreKind::Repo,
+                    root: store_root,
+                };
+                let report = run_validation_bounded(
+                    &project_store,
+                    &governance_root,
+                    workspace_root,
+                    false,
+                )?;
+                report_summary = Some(report);
+            }
 
             println!(
                 "{}",
-                serde_json::json!({
-                    "can_work": status.can_work,
-                    "git_branch": status.git.current_branch,
-                    "git_is_protected": status.git.is_protected,
-                    "git_has_local_mods": status.git.has_local_mods,
-                    "in_container": status.container.in_container,
-                    "container_image": status.container.image,
-                    "docker_available": status.container.docker_available,
-                    "blockers": status.blockers.len(),
-                    "required_actions": status.required_actions,
-                })
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "status": "ok",
+                    "workspace": status,
+                    "validation": report_summary,
+                }))
+                .unwrap()
             );
         }
         WorkspaceCommand::Publish { title, description } => {
+            let governance_root = find_governance_root(project_root);
+            let workspace_root = project_root;
             let project_store = Store {
                 kind: StoreKind::Repo,
-                root: project_root.join(".decapod").join("data"),
+                root: governance_root.join(".decapod").join("data"),
             };
             plan_governance::ensure_execute_ready(plan_governance::ExecuteCheckInput {
-                project_root,
+                project_root: &governance_root,
                 store_root: &project_store.root,
                 todo_id: None,
             })?;
-            let report = run_validation_bounded(&project_store, project_root, false)?;
+            let report =
+                run_validation_bounded(&project_store, &governance_root, workspace_root, false)?;
             if report.fail_count > 0 {
                 return Err(error::DecapodError::ValidationError(format!(
                     "{} test(s) failed before workspace publish.",
                     report.fail_count
                 )));
             }
-            let result = workspace::publish_workspace(project_root, title, description)?;
+            let result = workspace::publish_workspace(workspace_root, title, description)?;
             println!(
                 "{}",
                 serde_json::json!({
@@ -6890,11 +6925,15 @@ mod rpc_handlers {
         let _params: ValidateRunParams = serde_json::from_value(ctx.request.params.clone())
             .map_err(|e| error::DecapodError::ValidationError(format!("Invalid params: {}", e)))?;
 
+        let workspace_root = &ctx.project_root;
+        let governance_root = super::find_governance_root(workspace_root);
         let project_store = Store {
             kind: StoreKind::Repo,
-            root: ctx.project_root.join(".decapod").join("data"),
+            root: governance_root.join(".decapod").join("data"),
         };
-        let res = run_validation_bounded(&project_store, ctx.project_root, false);
+        let res =
+            super::run_validation_bounded(&project_store, &governance_root, workspace_root, false);
+
         match res {
             Ok(report) if report.fail_count == 0 => {
                 let result = ValidateRunResult {

--- a/tests/workspace_resolution.rs
+++ b/tests/workspace_resolution.rs
@@ -1,0 +1,82 @@
+use decapod::core::workspace;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_get_main_repo_root_from_worktree() {
+    let tmp = tempdir().expect("tempdir");
+    let main_root = tmp.path().join("main_repo");
+    fs::create_dir_all(&main_root).expect("create main_repo");
+
+    // Initialize main repo
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&main_root)
+        .output()
+        .expect("git init main");
+    std::process::Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&main_root)
+        .output()
+        .expect("git commit main");
+
+    // Add a worktree
+    let wt_path = tmp.path().join("wt_repo");
+    std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "test-branch",
+            wt_path.to_str().unwrap(),
+        ])
+        .current_dir(&main_root)
+        .output()
+        .expect("git worktree add");
+
+    // Test resolving from main repo
+    let resolved_main = workspace::get_main_repo_root(&main_root).expect("resolve main");
+    // Canonicalize both for stable comparison
+    let canonical_resolved_main = fs::canonicalize(&resolved_main).unwrap_or(resolved_main);
+    let canonical_main_root = fs::canonicalize(&main_root).unwrap_or(main_root.clone());
+    assert_eq!(canonical_resolved_main, canonical_main_root);
+
+    // Test resolving from worktree
+    let resolved_wt = workspace::get_main_repo_root(&wt_path).expect("resolve wt");
+    let canonical_resolved_wt = fs::canonicalize(&resolved_wt).unwrap_or(resolved_wt);
+    assert_eq!(canonical_resolved_wt, canonical_main_root);
+}
+
+#[test]
+fn test_is_worktree_detection() {
+    let tmp = tempdir().expect("tempdir");
+    let main_root = tmp.path().join("main_repo");
+    fs::create_dir_all(&main_root).expect("create main_repo");
+
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&main_root)
+        .output()
+        .expect("git init main");
+    std::process::Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(&main_root)
+        .output()
+        .expect("git commit main");
+
+    let wt_path = tmp.path().join("wt_repo");
+    std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "test-branch-2",
+            wt_path.to_str().unwrap(),
+        ])
+        .current_dir(&main_root)
+        .output()
+        .expect("git worktree add");
+
+    assert!(!workspace::is_worktree(&main_root).unwrap_or(false));
+    assert!(workspace::is_worktree(&wt_path).unwrap_or(false));
+}


### PR DESCRIPTION
This PR introduces a robust distinction between the workspace_root (the local worktree checkout) and the governance_root (the main repository where .decapod/data resides). It also relaxes container requirements for non-code updates and clarifies branch naming requirements in CLI help.