### PR TITLE
feat: implement strict spec maintenance with specs.refresh RPC (closes #620)

### DIFF
--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -275,6 +275,55 @@ pub fn read_specs_manifest(
     Ok(Some(manifest))
 }
 
+pub fn refresh_specs_manifest(
+    project_root: &Path,
+) -> Result<ProjectSpecsManifest, error::DecapodError> {
+    let existing = read_specs_manifest(project_root)?.ok_or_else(|| {
+        error::DecapodError::NotFound(
+            "Project specs manifest not found. Run `decapod init` first.".to_string(),
+        )
+    })?;
+
+    let mut manifest_entries = Vec::new();
+    for spec in LOCAL_PROJECT_SPECS {
+        let path = project_root.join(spec.path);
+        if !path.exists() {
+            continue;
+        }
+        let body = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+        let content_hash = hash_text(&body);
+
+        let template_hash = existing
+            .files
+            .iter()
+            .find(|f| f.path == spec.path)
+            .map(|f| f.template_hash.clone())
+            .unwrap_or_else(|| content_hash.clone());
+
+        manifest_entries.push(ProjectSpecManifestEntry {
+            path: spec.path.to_string(),
+            template_hash,
+            content_hash,
+        });
+    }
+
+    let manifest = ProjectSpecsManifest {
+        schema_version: LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA.to_string(),
+        template_version: existing.template_version,
+        generated_at: crate::core::time::now_epoch_z(),
+        repo_signal_fingerprint: repo_signal_fingerprint(project_root)?,
+        files: manifest_entries,
+    };
+
+    let manifest_path = project_root.join(LOCAL_PROJECT_SPECS_MANIFEST);
+    let manifest_body = serde_json::to_string_pretty(&manifest).map_err(|e| {
+        error::DecapodError::ValidationError(format!("Failed to serialize specs manifest: {}", e))
+    })?;
+    fs::write(manifest_path, manifest_body).map_err(error::DecapodError::IoError)?;
+
+    Ok(manifest)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/rpc.rs
+++ b/src/core/rpc.rs
@@ -205,6 +205,17 @@ pub struct ConstitutionLinksNavigateResult {
     pub recommended_sections: Vec<String>,
 }
 
+// Specs Subsystem
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SpecsRefreshParams {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SpecsRefreshResult {
+    pub manifest_path: String,
+    pub repo_signal_fingerprint: String,
+    pub refreshed_at: String,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ConstitutionMigrateParams {
     pub target_version: String,
@@ -692,6 +703,14 @@ pub fn generate_capabilities() -> CapabilitiesReport {
                 description: "Retrieve canonical entities deterministically".to_string(),
                 stability: "stable".to_string(),
                 cost: "medium".to_string(),
+            },
+            Capability {
+                name: "specs.refresh".to_string(),
+                description:
+                    "Update the project specs manifest to acknowledge current codebase state"
+                        .to_string(),
+                stability: "stable".to_string(),
+                cost: "low".to_string(),
             },
             Capability {
                 name: "validate.run".to_string(),

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1402,6 +1402,7 @@ fn validate_project_specs_docs(
         }
 
         let mut untouched_templates = Vec::new();
+        let mut out_of_sync_specs = Vec::new();
         for entry in &manifest.files {
             let path = repo_root.join(&entry.path);
             if !path.exists() {
@@ -1412,7 +1413,23 @@ fn validate_project_specs_docs(
             if current_hash == entry.template_hash {
                 untouched_templates.push(entry.path.clone());
             }
+            if current_hash != entry.content_hash {
+                out_of_sync_specs.push(entry.path.clone());
+            }
         }
+
+        if out_of_sync_specs.is_empty() {
+            pass("Project specs content hashes match manifest", ctx);
+        } else {
+            fail(
+                &format!(
+                    "OUT_OF_SYNC_SPECS: Spec content changed on disk but manifest is not updated for {:?}. Review changes and call `decapod rpc --op specs.refresh` to acknowledge.",
+                    out_of_sync_specs
+                ),
+                ctx,
+            );
+        }
+
         if untouched_templates.is_empty() {
             pass(
                 "Project specs are not raw scaffold templates (content evolved)",
@@ -1435,8 +1452,8 @@ fn validate_project_specs_docs(
                 ctx,
             );
         } else {
-            warn(
-                "TASK: Significant repo surfaces changed since specs scaffold/hydration. Review and update INTENT/ARCHITECTURE/INTERFACES/VALIDATION accordingly.",
+            fail(
+                "STALE_SPECS_FINGERPRINT: Significant repo surfaces changed since last specs refresh. Review and update INTENT/ARCHITECTURE/INTERFACES/VALIDATION accordingly, then call `decapod rpc --op specs.refresh`.",
                 ctx,
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7417,6 +7417,32 @@ mod rpc_handlers {
             ctx.mandates.clone(),
         ))
     }
+
+    pub(crate) fn handle_specs_refresh(ctx: &RpcCtx) -> Result<RpcResponse, error::DecapodError> {
+        let _params: SpecsRefreshParams = serde_json::from_value(ctx.request.params.clone())
+            .map_err(|e| error::DecapodError::ValidationError(format!("Invalid params: {}", e)))?;
+
+        let manifest = crate::core::project_specs::refresh_specs_manifest(ctx.project_root)?;
+
+        Ok(success_response(
+            ctx.request.id.clone(),
+            ctx.request.op.clone(),
+            ctx.request.params.clone(),
+            Some(
+                serde_json::to_value(SpecsRefreshResult {
+                    manifest_path: crate::core::project_specs::LOCAL_PROJECT_SPECS_MANIFEST
+                        .to_string(),
+                    repo_signal_fingerprint: manifest.repo_signal_fingerprint,
+                    refreshed_at: manifest.generated_at,
+                })
+                .unwrap(),
+            ),
+            vec![],
+            None,
+            vec![],
+            ctx.mandates.clone(),
+        ))
+    }
 }
 
 /// Run RPC command
@@ -7514,6 +7540,7 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
         }
         "constitution.migrate" => rpc_handlers::handle_constitution_migrate(&rpc_ctx)?,
         "agent.registry.query" => rpc_handlers::handle_agent_registry_query(&rpc_ctx)?,
+        "specs.refresh" => rpc_handlers::handle_specs_refresh(&rpc_ctx)?,
         "schema.get" => rpc_handlers::handle_schema_get(&rpc_ctx)?,
         "store.upsert" => rpc_handlers::handle_store_upsert(&rpc_ctx)?,
         "store.query" => rpc_handlers::handle_store_query(&rpc_ctx)?,


### PR DESCRIPTION
## Summary

Implements Issue #620 - Researching Spec Management

### Changes

1. **src/core/project_specs.rs** - Added  function that:
   - Recalculates content hashes for all spec files
   - Updates 
   - Updates  timestamp
   - Writes the refreshed manifest back to disk

2. **src/core/rpc.rs** - Added:
   -  and  types
   -  capability registration

3. **src/core/validate.rs** - Modified :
   - **NEW**: Fails with  if spec content hash doesn't match manifest
   - **CHANGED**: Changed stale fingerprint from  to  with 

4. **src/lib.rs** - Added:
   -  RPC handler
   -  operation dispatch

### Verification

The issue mentions these tests:
- Fingerprint Failure: Modify a codebase file and verify decapod validate fails
- Content Hash Failure: Modify a spec file and verify decapod validate fails  
- Refresh Success: Run  and verify decapod validate passes again

See [Issue #620](https://github.com/DecapodLabs/decapod/issues/620) for full details.