### PR TITLE
Feat: Restrict 'decapod docs' to 'docs/agent/' paths

### DIFF
--- a/build/compress_constitution.rs
+++ b/build/compress_constitution.rs
@@ -39,7 +39,7 @@ struct ConstitutionLinks {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=assets/constitution.json");
-    println!("cargo:rerun-if-changed=docs/");
+    println!("cargo:rerun-if-changed=docs/agent/");
     println!("cargo:rerun-if-changed=build/compress_constitution.rs");
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
@@ -56,10 +56,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let json_content = fs::read_to_string(&json_path)?;
     let mut graph: ConstitutionGraph = serde_json::from_str(&json_content)?;
 
-    // Also ingest files from docs/ directory
-    let docs_dir = Path::new(&manifest_dir).join("docs");
-    if docs_dir.exists() {
-        ingest_docs_recursive(&docs_dir, &docs_dir, &mut graph)?;
+    // Also ingest files from docs/agent/ directory
+    let docs_root = Path::new(&manifest_dir).join("docs");
+    let agent_docs_dir = docs_root.join("agent");
+    if agent_docs_dir.exists() {
+        ingest_docs_recursive(&docs_root, &agent_docs_dir, &mut graph)?;
     }
 
     generate_rust_module(&graph, Path::new(&out_dir))?;

--- a/docs/agent/command-contracts.md
+++ b/docs/agent/command-contracts.md
@@ -18,7 +18,8 @@ This document defines the normative operational contracts for the Decapod CLI.
 - **Intent:** Embedded Constitution Graph queries and lookups
 
 ## `decapod docs`
-- **Intent:** Access methodology documentation
+- **Intent:** Access agent-facing methodology documentation (restricted to docs/agent/)
+- **Restriction:** Only handles documents under `docs/agent/`.
 
 ## `decapod todo`
 - **Intent:** Track tasks and work items
@@ -116,6 +117,7 @@ This document defines the normative operational contracts for the Decapod CLI.
 ### Operation: `ConstitutionGet`
 ### Operation: `ConstitutionLinksQuery`
 ### Operation: `ConstitutionLinksNavigate`
+### Operation: `SpecsRefresh`
 ### Operation: `ConstitutionMigrate`
 ### Operation: `AgentRegistryQuery`
 ### Operation: `SchemaGet`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -798,7 +798,7 @@ pub(crate) enum Command {
     #[clap(name = "constitution", visible_alias = "c")]
     Constitution(constitution_cli::ConstitutionCli),
 
-    /// Access methodology documentation
+    /// Access agent-facing methodology documentation (restricted to docs/agent/)
     #[clap(name = "docs", visible_alias = "d")]
     Docs(docs_cli::DocsCli),
 

--- a/src/core/docs_cli.rs
+++ b/src/core/docs_cli.rs
@@ -124,112 +124,57 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
     match cli.command {
         DocsCommand::List => {
             let all_docs = assets::list_docs();
-            let (docs, constitution): (Vec<_>, Vec<_>) =
-                all_docs.into_iter().partition(|d| d.starts_with("docs/"));
+            let docs: Vec<_> = all_docs
+                .into_iter()
+                .filter(|d| d.starts_with("docs/agent/"))
+                .collect();
 
             if !docs.is_empty() {
-                println!("Decapod Documentation:");
+                println!("Decapod Agent Documentation:");
                 for doc in docs {
                     println!("- embedded/{}", doc);
                 }
-                println!();
-            }
-
-            println!("Embedded Decapod Constitution Sections:");
-            for doc in constitution {
-                println!("- embedded/constitution.json#{}", doc);
-            }
-
-            if let Ok(current_dir) = std::env::current_dir()
-                && let Ok(repo_root) = find_repo_root(&current_dir)
-            {
-                let override_sections = assets::list_override_sections(&repo_root);
-                if !override_sections.is_empty() {
-                    println!("\nProject Override Sections:");
-                    for section in override_sections {
-                        println!("- {}", section);
-                    }
-                }
+            } else {
+                println!("No agent documentation found.");
             }
             Ok(DocsRunResult::default())
         }
         DocsCommand::Show { path, source } => {
             let normalized_path = path.strip_prefix("embedded/").unwrap_or(&path).to_string();
 
-            if normalized_path.starts_with("docs/") {
-                // It's a direct document, not a constitution section
-                let content = assets::get_embedded_doc(&normalized_path);
-                match content {
-                    Some(content) => {
-                        println!("{}", content);
-                        Ok(DocsRunResult::default())
-                    }
-                    None => Err(error::DecapodError::NotFound(format!(
-                        "Document not found: {}",
-                        path
-                    ))),
-                }
-            } else {
-                let normalized_path = normalized_path
-                    .strip_prefix("constitution.json#")
-                    .unwrap_or(&normalized_path)
-                    .to_string();
+            if !normalized_path.starts_with("docs/agent/") {
+                return Err(error::DecapodError::ValidationError(format!(
+                    "Access denied: 'decapod docs' is restricted to 'docs/agent/' paths. Use 'decapod constitution' for other sections. Invalid path: {}",
+                    path
+                )));
+            }
 
-                // Split path and anchor
-                let (relative_path, anchor) = if let Some(pos) = normalized_path.find('#') {
-                    (&normalized_path[..pos], Some(&normalized_path[pos + 1..]))
-                } else {
-                    (normalized_path.as_str(), None)
-                };
-
-                let relative_path = if relative_path.is_empty() {
-                    "constitution.json"
-                } else {
-                    relative_path
-                };
-
-                if let Some(a) = anchor {
+            // It's a direct document, not a constitution section
+            let content = match source {
+                DocumentSource::Embedded => assets::get_embedded_doc(&normalized_path),
+                DocumentSource::Override => {
                     let current_dir =
                         std::env::current_dir().map_err(error::DecapodError::IoError)?;
                     let repo_root = find_repo_root(&current_dir)?;
-                    if let Some(fragment) = docs::get_fragment(&repo_root, relative_path, Some(a)) {
-                        println!("--- {} ---", fragment.title);
-                        println!("{}", fragment.excerpt);
-                        Ok(DocsRunResult::default())
-                    } else {
-                        Err(error::DecapodError::NotFound(format!(
-                            "Section not found: {} in {}",
-                            a, relative_path
-                        )))
-                    }
-                } else {
-                    let content = match source {
-                        DocumentSource::Embedded => assets::get_embedded_doc(relative_path),
-                        DocumentSource::Override => {
-                            let current_dir =
-                                std::env::current_dir().map_err(error::DecapodError::IoError)?;
-                            let repo_root = find_repo_root(&current_dir)?;
-                            assets::get_override_doc(&repo_root, relative_path)
-                        }
-                        DocumentSource::Merged => {
-                            let current_dir =
-                                std::env::current_dir().map_err(error::DecapodError::IoError)?;
-                            let repo_root = find_repo_root(&current_dir)?;
-                            assets::get_merged_doc(&repo_root, relative_path)
-                        }
-                    };
-
-                    match content {
-                        Some(content) => {
-                            println!("{}", content);
-                            Ok(DocsRunResult::default())
-                        }
-                        None => Err(error::DecapodError::NotFound(format!(
-                            "Document not found: {} (source: {:?})",
-                            path, source
-                        ))),
-                    }
+                    assets::get_override_doc(&repo_root, &normalized_path)
                 }
+                DocumentSource::Merged => {
+                    let current_dir =
+                        std::env::current_dir().map_err(error::DecapodError::IoError)?;
+                    let repo_root = find_repo_root(&current_dir)?;
+                    assets::get_merged_doc(&repo_root, &normalized_path)
+                }
+            };
+
+            match content {
+                Some(content) => {
+                    println!("{}", content);
+                    Ok(DocsRunResult::default())
+                }
+                None => Err(error::DecapodError::NotFound(format!(
+                    "Document not found: {}",
+                    path
+                ))),
             }
         }
         DocsCommand::Build { touched } => {
@@ -245,6 +190,10 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
             let mut ingested_core_constitution = false;
 
             for doc_path in docs {
+                if !doc_path.starts_with("docs/agent/") {
+                    continue;
+                }
+
                 // Convert embedded path to relative path for override merging
                 let relative_path = doc_path.strip_prefix("embedded/").unwrap_or(&doc_path);
                 if relative_path.starts_with("core/") {
@@ -271,14 +220,21 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
         } => {
             let current_dir = std::env::current_dir().map_err(error::DecapodError::IoError)?;
             let repo_root = find_repo_root(&current_dir)?;
-            let fragments = docs::resolve_scoped_fragments(
+            let all_fragments = docs::resolve_scoped_fragments(
                 &repo_root,
                 Some(&query),
                 op.as_deref(),
                 &path,
                 &tag,
-                limit,
+                limit * 2, // Get more to allow for filtering
             );
+
+            // Filter for only docs/agent/
+            let fragments: Vec<_> = all_fragments
+                .into_iter()
+                .filter(|f| f.r#ref.contains("docs/agent/"))
+                .take(limit)
+                .collect();
 
             if format.eq_ignore_ascii_case("json") {
                 println!(
@@ -293,7 +249,10 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
                     .map_err(|e| error::DecapodError::ValidationError(e.to_string()))?
                 );
             } else {
-                println!("Scoped constitution context:");
+                println!("Scoped agent documentation context:");
+                if fragments.is_empty() {
+                    println!("No matching agent documentation found.");
+                }
                 for (idx, fragment) in fragments.iter().enumerate() {
                     println!("\n{}. {} ({})", idx + 1, fragment.title, fragment.r#ref);
                     println!("{}", fragment.excerpt);
@@ -393,6 +352,12 @@ fn build_docs(touched: Vec<PathBuf>) -> Result<(), error::DecapodError> {
 
             // Extract more info if it's a known core command
             match name {
+                "docs" => {
+                    writeln!(
+                        file,
+                        "- **Restriction:** Only handles documents under `docs/agent/`."
+                    )?;
+                }
                 "todo" => {
                     writeln!(
                         file,

--- a/tests/cli_contract_enforcement.rs
+++ b/tests/cli_contract_enforcement.rs
@@ -171,10 +171,10 @@ fn test_todo_command_structure() {
 }
 
 #[test]
-fn test_constitution_docs_accessible() {
+fn test_agent_docs_accessible() {
     let (_tmp, dir) = setup_repo();
 
-    let docs = run_decapod(dir, &["docs", "show", "core/DECAPOD"]);
+    let docs = run_decapod(dir, &["docs", "show", "docs/agent/api-index.md"]);
     assert!(
         docs.status.success(),
         "docs show should succeed: {}",
@@ -183,8 +183,8 @@ fn test_constitution_docs_accessible() {
 
     let output = String::from_utf8_lossy(&docs.stdout);
     assert!(
-        output.contains("Decapod"),
-        "docs show should return Decapod content"
+        output.contains("Agent API"),
+        "docs show should return Agent API content"
     );
 }
 
@@ -252,43 +252,23 @@ fn test_interlock_drift_detection_capability() {
 }
 
 #[test]
-fn test_constitution_docs_are_accessible() {
+fn test_agent_docs_are_accessible() {
     let (_tmp, dir) = setup_repo();
 
     let list_output = run_decapod(dir, &["docs", "list"]);
     assert!(list_output.status.success(), "docs list should succeed");
 
     let docs_list = String::from_utf8_lossy(&list_output.stdout);
-    let all_doc_paths: Vec<String> = docs_list
-        .lines()
-        .filter_map(|l| {
-            let parts: Vec<&str> = l.split('-').collect();
-            let path = parts.last().copied().unwrap_or(l).trim();
-            if !path.is_empty() {
-                Some(path.to_string())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    assert!(
-        !all_doc_paths.is_empty(),
-        "docs list should return at least one doc"
-    );
-
+    
     let required_docs = [
-        "core/DECAPOD",
-        "interfaces/CLAIMS",
-        "specs/INTENT",
-        "methodology/ARCHITECTURE",
-        "architecture/SECURITY",
-        "plugins/TODO",
+        "docs/agent/api-index.md",
+        "docs/agent/command-contracts.md",
+        "docs/agent/payload-examples.md",
     ];
 
     for required in &required_docs {
         assert!(
-            all_doc_paths.iter().any(|p| p == required),
+            docs_list.contains(required),
             "docs list should include {}",
             required
         );
@@ -310,7 +290,48 @@ fn test_constitution_docs_are_accessible() {
 }
 
 #[test]
-fn test_constitution_docs_ingest_shows_links() {
+fn test_constitution_nodes_are_accessible() {
+    let (_tmp, dir) = setup_repo();
+
+    let list_output = run_decapod(dir, &["constitution", "list"]);
+    assert!(list_output.status.success(), "constitution list should succeed");
+
+    let nodes_list = String::from_utf8_lossy(&list_output.stdout);
+
+    let required_nodes = [
+        "core/DECAPOD",
+        "interfaces/CLAIMS",
+        "specs/INTENT",
+        "methodology/ARCHITECTURE",
+        "architecture/SECURITY",
+        "plugins/TODO",
+    ];
+
+    for required in &required_nodes {
+        assert!(
+            nodes_list.contains(required),
+            "constitution list should include {}",
+            required
+        );
+
+        let get_output = run_decapod(dir, &["constitution", "get", required]);
+        assert!(
+            get_output.status.success(),
+            "constitution get {} should succeed",
+            required
+        );
+
+        let content = String::from_utf8_lossy(&get_output.stdout);
+        assert!(
+            !content.is_empty() && content.len() > 50,
+            "constitution get {} should return content",
+            required
+        );
+    }
+}
+
+#[test]
+fn test_agent_docs_ingest_works() {
     let (_tmp, dir) = setup_repo();
 
     // Run docs ingest which dumps all docs
@@ -321,12 +342,11 @@ fn test_constitution_docs_ingest_shows_links() {
 
     // Verify each embedded doc appears in ingest output
     let required_docs = [
-        "core/DECAPOD",
-        "interfaces/CLAIMS",
-        "specs/INTENT",
-        "methodology/ARCHITECTURE",
-        "architecture/SECURITY",
-        "plugins/TODO",
+        "docs/agent/api-index.md",
+        "docs/agent/command-contracts.md",
+        "docs/agent/payload-examples.md",
+        "docs/agent/error-recovery.md",
+        "docs/agent/state-model.md",
     ];
 
     for doc_path in &required_docs {

--- a/tests/cli_contract_enforcement.rs
+++ b/tests/cli_contract_enforcement.rs
@@ -259,7 +259,7 @@ fn test_agent_docs_are_accessible() {
     assert!(list_output.status.success(), "docs list should succeed");
 
     let docs_list = String::from_utf8_lossy(&list_output.stdout);
-    
+
     let required_docs = [
         "docs/agent/api-index.md",
         "docs/agent/command-contracts.md",
@@ -294,7 +294,10 @@ fn test_constitution_nodes_are_accessible() {
     let (_tmp, dir) = setup_repo();
 
     let list_output = run_decapod(dir, &["constitution", "list"]);
-    assert!(list_output.status.success(), "constitution list should succeed");
+    assert!(
+        list_output.status.success(),
+        "constitution list should succeed"
+    );
 
     let nodes_list = String::from_utf8_lossy(&list_output.stdout);
 

--- a/tests/daemonless_lifecycle.rs
+++ b/tests/daemonless_lifecycle.rs
@@ -65,7 +65,7 @@ fn decapod_has_no_lingering_background_process() {
     for args in [
         vec!["version"],
         vec!["capabilities", "--format", "json"],
-        vec!["docs", "show", "core/DECAPOD"],
+        vec!["docs", "show", "docs/agent/api-index.md"],
     ] {
         let out = run_decapod(&dir, &args);
         assert!(


### PR DESCRIPTION
This PR restricts the 'decapod docs' command to only parse and display documents within the 'docs/agent/' directory. It also updates the build script to only embed documentation from this path into the binary, reducing bloat and focusing the agentic interface documentation.