### PR TITLE
Docs: Expand Agent-First Documentation (Skills, MCP, Overrides)

### DIFF
--- a/docs/agent/api-index.md
+++ b/docs/agent/api-index.md
@@ -34,5 +34,7 @@ Call Decapod at **Inference Pressure Points**:
 | [Error Recovery](error-recovery.md) | How to respond to Decapod exit codes and messages. |
 | [State Model](state-model.md) | Understanding the lifecycle of Tasks and Workspaces. |
 | [Config Schema](config-schema.md) | Policy keys that govern your behavior. |
+| [Agent Skills](skills.md) | Procedural instructions for specific tasks. |
+| [MCP Integration](mcp.md) | Using Decapod via Model Context Protocol. |
 
 Do not attempt to bypass Decapod boundaries. If you encounter a block, resolve it through the governed policy path or ask the human operator.

--- a/docs/agent/llms.txt
+++ b/docs/agent/llms.txt
@@ -6,6 +6,8 @@
 - [Error Recovery](docs/agent/error-recovery.md)
 - [State Model](docs/agent/state-model.md)
 - [Config Schema](docs/agent/config-schema.md)
+- [Agent Skills](docs/agent/skills.md)
+- [MCP Integration](docs/agent/mcp.md)
 
 # Decapod Human Book
 
@@ -22,6 +24,8 @@
 - [Proof](docs/book/src/concepts/proof.md)
 - [Constitution](docs/book/src/concepts/constitution.md)
 - [Overrides](docs/book/src/concepts/overrides.md)
+- [Skills](docs/book/src/concepts/skills.md)
+- [MCP](docs/book/src/concepts/mcp.md)
 - [Config Reference](docs/book/src/reference/config-toml.md)
 - [CLI Reference](docs/book/src/reference/cli.md)
 - [Error Codes](docs/book/src/reference/errors.md)

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -1,0 +1,23 @@
+# Model Context Protocol (MCP)
+
+Decapod supports integration with MCP-compatible agent environments to provide structured resources and tools.
+
+## Resources
+
+When connected via MCP, Decapod exposes:
+- `decapod://constitution/*`: Direct access to constitution nodes.
+- `decapod://todo/list`: The current actionable backlog.
+- `decapod://specs/intent`: The project's intent specification.
+
+## Tools
+
+Standard Decapod operations are available as MCP tools. If your environment supports MCP, you SHOULD use these tools instead of raw CLI calls to benefit from structured parsing and better error handling.
+
+Key tools include:
+- `orientation_get`: Retrieve the orientation packet for a task.
+- `validate_repo`: Run the full project validation gate.
+- `aptitude_query`: Search the shared memory for project-specific knowledge.
+
+## Handshake
+
+In MCP sessions, ensure you have called `decapod handshake` at least once to establish your agent identity within the repository's governance log. This identity persists across tool calls and resource retrievals.

--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -1,0 +1,32 @@
+# Agent Skills
+
+Skills are procedural, domain-specific instruction sets stored in Decapod's Aptitude memory. Use them to follow project-specific best practices for complex engineering tasks.
+
+## Discovery and Usage
+
+Before performing specialized implementation work, you SHOULD query Decapod for relevant skills.
+
+```bash
+decapod data aptitude skill resolve --query "how to write integration tests for sqlite"
+```
+
+The output will provide a ranked list of procedural steps, tool recommendations, and verification gates.
+
+## Skill Cards
+
+Importing a skill with `--write-card` creates a JSON artifact in `.decapod/skills/`. This card is a **Mandatory Orientation Asset**:
+- If you see `.decapod/skills/*.json`, you MUST read the corresponding skill before proceeding with related work.
+- Use `decapod data aptitude skill get --name <name>` to retrieve the full procedural content.
+
+## Overriding Skills
+
+Skills can be overridden or extended in `.decapod/OVERRIDE.md` using the `metadata/skills/<name>` directive ID. Always check `decapod constitution get metadata/skills/<name>` to see the merged final instructions.
+
+## Key Commands
+
+| Command | Purpose |
+|---|---|
+| `skill resolve` | Discover relevant procedures for a task. |
+| `skill import` | Onboard a new SKILL.md into the repo. |
+| `skill get` | Retrieve full workflow and context for a skill. |
+| `skill list` | See all active skills in the repository. |

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -17,6 +17,8 @@
   - [Proof](concepts/proof.md)
   - [Constitution](concepts/constitution.md)
   - [Overrides](concepts/overrides.md)
+  - [Skills](concepts/skills.md)
+  - [Model Context Protocol (MCP)](concepts/mcp.md)
 
 - [Reference]()
   - [Config (config.toml)](reference/config-toml.md)

--- a/docs/book/src/concepts/mcp.md
+++ b/docs/book/src/concepts/mcp.md
@@ -1,0 +1,37 @@
+# Model Context Protocol (MCP)
+
+Decapod is designed to be a "Protocol First" governance layer. While it provides a rich CLI, its core value is in standardizing the context and control signals exchanged between repositories and AI models. This aligns perfectly with the **Model Context Protocol (MCP)**.
+
+## Decapod as an MCP Provider
+
+Decapod integrates with MCP-compatible environments (like Claude Desktop or specialized IDE extensions) by acting as an MCP Server. This allows agents to access Decapod's governance kernel directly through standard protocol messages.
+
+### Exposed MCP Resources
+
+- **Constitution:** Browsable nodes of the technology and methodology graph.
+- **Tasks:** The current todo list and ownership state.
+- **Specs:** The living specifications (`INTENT.md`, `ARCHITECTURE.md`, etc.) for the project.
+- **Context Capsules:** Deterministic snapshots of repo state used for inference.
+
+### Exposed MCP Tools
+
+Decapod exposes its core CLI capabilities as MCP Tools, allowing agents to:
+- `todo_add` / `todo_claim`
+- `workspace_ensure`
+- `constitution_search`
+- `aptitude_resolve_skills`
+- `validate`
+
+## Benefits of MCP Integration
+
+1.  **Lower Friction:** Agents don't need to "learn" CLI flags if they can call structured tools via MCP.
+2.  **Rich Context:** MCP allows for richer metadata (like URIs and structured resources) to be passed alongside documentation.
+3.  **Discovery:** MCP-native agents can automatically discover Decapod's capabilities as soon as they connect to the repository.
+
+## Handshaking and Identity
+
+Decapod uses its `handshake` command to generate a deterministic identity artifact. In an MCP context, this ensures that the agent provider and the local governance kernel have a shared, cryptographically verifiable understanding of which agent is operating on which task.
+
+## Future Direction
+
+We are actively expanding Decapod's MCP surface to support native resource templates and more granular tool definitions, making Decapod the standard "Governance MCP" for any repository it manages.

--- a/docs/book/src/concepts/overrides.md
+++ b/docs/book/src/concepts/overrides.md
@@ -22,6 +22,17 @@ For this repository, we target a minimum of 80% line coverage. Critical paths in
 - **Tighter Security:** Block agents from touching specific directories or files.
 - **Workflow Adjustments:** Add mandatory manual review steps for specific subsystems.
 - **Platform Specifics:** Define how Decapod should interact with your specific CI/CD pipeline.
+- **Skill Customization:** Tailor the workflows and steps of specific agent [Skills](skills.md) to your project's needs.
+
+## Skill Overrides
+
+Skills are identified by their `metadata/skills/` path. You can override a global or default skill by adding a section for it in `OVERRIDE.md`:
+
+```markdown
+### metadata/skills/rust-security-audit
+
+For this project, additionally check for usage of `std::sync::Mutex` and recommend `tokio::sync::Mutex` where appropriate.
+```
 
 ## Policy as Code
 

--- a/docs/book/src/concepts/skills.md
+++ b/docs/book/src/concepts/skills.md
@@ -1,0 +1,63 @@
+# Skills
+
+Skills are specialized, agent-first instruction sets that define how an AI agent should approach specific tasks, subsystems, or workflows within your repository. Unlike the general Decapod Constitution, which defines "What" the rules are, Skills define the "How"—the concrete procedures, tool usage, and verification steps for a domain-specific concern.
+
+## Anatomy of a Skill
+
+A Skill is defined as a Markdown file with a YAML frontmatter.
+
+```markdown
+---
+name: rust-security-audit
+description: Procedure for auditing Rust code for common vulnerabilities and unsafe usage.
+tags: [rust, security, audit]
+---
+
+# Rust Security Audit Skill
+
+## Workflow
+1. Run `cargo audit` to check for known vulnerabilities in dependencies.
+2. Search for `unsafe` blocks and verify they have safety comments.
+3. Check for potential integer overflows in arithmetic operations.
+4. Verify that sensitive data is cleared from memory.
+
+## Tools
+- `cargo-audit`
+- `grep` / `ripgrep`
+```
+
+## Importing Skills
+
+Skills are imported into the Decapod Aptitude memory, making them discoverable by agents.
+
+```bash
+decapod data aptitude skill import --path metadata/skills/rust-security-audit.SKILL.md --write-card
+```
+
+The `--write-card` flag generates a deterministic JSON "Skill Card" in `.decapod/skills/`, which serves as a version-controlled proof of the skill's presence and state.
+
+## Skill Resolution
+
+Agents don't need to know which skill to use. They can query Decapod for the most relevant skills for their current task.
+
+```bash
+decapod data aptitude skill resolve --query "auditing security in our rust service"
+```
+
+Decapod ranks skills based on lexical match, tags, and usage history, returning a scoped set of instructions.
+
+## Overriding Skills
+
+Just like any other Decapod directive, skills can be customized per-project via `.decapod/OVERRIDE.md`.
+
+```markdown
+### metadata/skills/rust-security-audit
+
+In this project, additionally ensure that all `unwrap()` calls are replaced with proper error handling or `expect()` with a descriptive message.
+```
+
+## Why use Skills?
+
+- **Standardization:** Ensure all agents follow the same best practices for complex tasks.
+- **Knowledge Persistence:** Skills survive session boundaries and different agent providers.
+- **Provenance:** Skill cards provide a deterministic audit trail of which instructions were active during a task.


### PR DESCRIPTION
This PR adds comprehensive documentation for agent-first concepts in Decapod:
- Dedicated guides for **Skills** (definitions, imports, resolution).
- Integration guide for **Model Context Protocol (MCP)**.
- Updated guidance on **Agent-First Overrides** in `.decapod/OVERRIDE.md`.
- Synchronized navigation indices for both humans and agents.