### PR TITLE
Docs: Agent-First Architecture and Skill Overrides

### DIFF
--- a/docs/agent/llms.txt
+++ b/docs/agent/llms.txt
@@ -14,6 +14,7 @@
 - [Introduction](docs/book/src/introduction.md)
 - [Quickstart](docs/book/src/quickstart.md)
 - [Mental Model](docs/book/src/mental-model.md)
+- [Agent-First Architecture](docs/book/src/concepts/agent-first.md)
 - [Configuration](docs/book/src/configuration.md)
 - [Single-Agent Workflow](docs/book/src/workflows/single-agent.md)
 - [Multi-Agent Workflow](docs/book/src/workflows/multi-agent.md)

--- a/docs/agent/payload-examples.md
+++ b/docs/agent/payload-examples.md
@@ -66,3 +66,20 @@ decapod data schema --subsystem "todo" --format "json" --deterministic
 ```bash
 decapod data knowledge search --query "crypto primitives"
 ```
+
+## Aptitude and Skills (`decapod data aptitude`)
+
+### Import a Skill
+```bash
+decapod data aptitude skill import --path metadata/skills/my-feature.SKILL.md --write-card
+```
+
+### Resolve Skills for Context
+```bash
+decapod data aptitude skill resolve --query "implementing a new rpc operation" --limit 3
+```
+
+### Add a Preference
+```bash
+decapod data aptitude add --category "code_style" --key "indentation" --value "4 spaces"
+```

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
   - [Workspace Isolation](workflows/workspace-isolation.md)
 
 - [Concepts]()
+  - [Agent-First Architecture](concepts/agent-first.md)
   - [Intent](concepts/intent.md)
   - [Workspaces](concepts/workspaces.md)
   - [Proof](concepts/proof.md)

--- a/docs/book/src/concepts/agent-first.md
+++ b/docs/book/src/concepts/agent-first.md
@@ -1,0 +1,35 @@
+# Agent-First Architecture
+
+Decapod is not just a CLI; it is an **Agent-First Governance Kernel**. This means every feature is designed with the AI model's cognitive lifecycle in mind, rather than just the human operator's convenience.
+
+## The Agentic Lifecycle
+
+Decapod structures agent work into a predictable, machine-readable lifecycle:
+
+1.  **Ingestion & Orientation:** The agent reads `docs/agent/` and queries the `constitution` to understand the repo's rules and available tools.
+2.  **Task Claiming:** The agent claims a `todo` to establish exclusive custody and prevent collisions.
+3.  **Context Resolution:** The agent uses `rpc --op context.resolve` or `infer orientation` to gather the precise context needed for the specific task.
+4.  **Implementation:** The agent works in an isolated `workspace` (worktree or container).
+5.  **Validation:** The agent runs `decapod validate` to verify its work against local gates *before* human review.
+6.  **Proof Generation:** Marking a task `done` generates cryptographic and evidence-based artifacts that prove the work was governed.
+
+## Key Agent-First Concepts
+
+### 1. Deterministic Context
+AI models are sensitive to context pollution. Decapod's **Context Capsules** ensure that every agent sees exactly what it needs, and nothing more. This reduces hallucinations and token waste.
+
+### 2. Living Specifications
+Agents should not just "write code"; they should maintain intent. Decapod promotes the use of "Living Specs" (`.decapod/generated/specs/*`) which are synchronized with both the code and the agent's internal state.
+
+### 3. Aptitude & Memory
+Shared memory allows agents to learn from each other. If one agent discovers a obscure bug in a library, it can record that observation in Aptitude, which subsequent agents will automatically retrieve during context resolution.
+
+### 4. Protocol-Native (MCP)
+By supporting the **Model Context Protocol (MCP)**, Decapod allows agents to treat the repository as a structured resource graph rather than a raw filesystem.
+
+## Design Patterns for Agents
+
+- **Pressure Points:** Call Decapod at decision boundaries (e.g., before choosing a library).
+- **Epistemic Custody:** Preserve the "Why" behind a change in the `INTENT.md` spec.
+- **Fail Fast:** Use `decapod validate` early and often to catch alignment drift.
+- **Skill Discovery:** Instead of hardcoding steps, use `skill resolve` to find the project's established best practices.

--- a/docs/book/src/concepts/skills.md
+++ b/docs/book/src/concepts/skills.md
@@ -36,6 +36,26 @@ decapod data aptitude skill import --path metadata/skills/rust-security-audit.SK
 
 The `--write-card` flag generates a deterministic JSON "Skill Card" in `.decapod/skills/`, which serves as a version-controlled proof of the skill's presence and state.
 
+## Deep Integration: The `OVERRIDE.md` Substrate
+
+Skills are not just static documents; they are part of the Decapod Constitution. This means they can be targeted for granular overrides in `.decapod/OVERRIDE.md`.
+
+### Targetting a Skill Node
+Every skill imported into Decapod is assigned a node ID: `metadata/skills/<skill-name>`. You can use this ID to add project-specific layers to a shared skill.
+
+```markdown
+### metadata/skills/rust-security-audit
+
+**Project-Specific Guidance:**
+- In addition to the standard audit, verify that no `panic!` macros are used in production paths.
+- Ensure all `Result` types are handled without `.unwrap()`.
+```
+
+### Why Override Skills?
+1. **Context Blending:** Use a global security skill but add project-specific exceptions.
+2. **Team Norms:** Adjust a shared "Release" skill to match your team's specific QA sign-off process.
+3. **Evolution:** Gradually migrate a global skill to a new version by overriding it locally first.
+
 ## Skill Resolution
 
 Agents don't need to know which skill to use. They can query Decapod for the most relevant skills for their current task.


### PR DESCRIPTION
This PR expands the agent-first documentation suite with:
- A new **Agent-First Architecture** concept guide.
- Detailed guidance on **Deep Integration** for Skills via `OVERRIDE.md`.
- New payload examples for **Aptitude and Skills** CLI operations.
- Updated navigation for both humans and agents.