### PR TITLE
Add experimental Decapod Cloud init opt-in

### DIFF
--- a/docs/agent/config-schema.md
+++ b/docs/agent/config-schema.md
@@ -5,5 +5,7 @@ pub struct DecapodProjectConfig {
     pub schema_version: String,
     pub init: InitConfigSection,
     pub repo: RepoContext,
+    #[serde(default)]
+    pub cloud: CloudConfigSection,
 }
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,15 +164,12 @@ pub(crate) struct InitGroupCli {
     /// in this repository.
     #[clap(long = "no-container-workspaces", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub container_workspaces: bool,
-    /// Backend mode: 'local' (default) or 'cloud' (experimental).
+    /// Init storage boundary: 'local' (default) or 'cloud' (experimental, account required).
+    ///
+    /// Cloud mode records non-secret Decapod Cloud intent in `.decapod/config.toml`.
+    /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
-    /// Supabase URL for cloud mode.
-    #[clap(long)]
-    pub supabase_url: Option<String>,
-    /// Supabase API key (service role) for cloud mode.
-    #[clap(long)]
-    pub supabase_key: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -259,15 +256,12 @@ pub(crate) struct InitWithCli {
     /// in this repository.
     #[clap(long = "no-container-workspaces", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub container_workspaces: bool,
-    /// Backend mode: 'local' (default) or 'cloud' (experimental).
+    /// Init storage boundary: 'local' (default) or 'cloud' (experimental, account required).
+    ///
+    /// Cloud mode records non-secret Decapod Cloud intent in `.decapod/config.toml`.
+    /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
-    /// Supabase URL for cloud mode.
-    #[clap(long)]
-    pub supabase_url: Option<String>,
-    /// Supabase API key (service role) for cloud mode.
-    #[clap(long)]
-    pub supabase_key: Option<String>,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -282,6 +276,8 @@ pub struct DecapodProjectConfig {
     pub schema_version: String,
     pub init: InitConfigSection,
     pub repo: RepoContext,
+    #[serde(default)]
+    pub cloud: CloudConfigSection,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -304,6 +300,43 @@ pub enum BackendType {
     #[default]
     Local,
     Cloud,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CloudConfigSection {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub experimental: bool,
+    #[serde(default = "default_cloud_provider")]
+    pub provider: String,
+    #[serde(default = "default_cloud_api_url")]
+    pub api_url: String,
+    #[serde(default)]
+    pub project_id: String,
+    #[serde(default)]
+    pub repo_id: String,
+}
+
+fn default_cloud_provider() -> String {
+    "decapod".to_string()
+}
+
+fn default_cloud_api_url() -> String {
+    "https://api.decapodlabs.com".to_string()
+}
+
+impl Default for CloudConfigSection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            experimental: true,
+            provider: default_cloud_provider(),
+            api_url: default_cloud_api_url(),
+            project_id: String::new(),
+            repo_id: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -329,10 +362,6 @@ pub struct RepoContext {
     pub container_workspaces: bool,
     #[serde(default)]
     pub mode: BackendType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub supabase_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub supabase_key: Option<String>,
 }
 
 fn default_container_workspaces_true() -> bool {
@@ -371,6 +400,7 @@ impl Default for DecapodProjectConfig {
                 ],
             },
             repo: RepoContext::default(),
+            cloud: CloudConfigSection::default(),
         }
     }
 }

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,14 +1,15 @@
 use crate::core::ansi::AnsiExt;
 use crate::core::error::DecapodError;
 use serde::Deserialize;
+use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
 const AUTH0_DOMAIN: &str = "decapod.auth0.com";
 const AUTH0_CLIENT_ID: &str = "decapod-cli-client-id";
-const AUTH0_AUDIENCE: &str = "https://api.decapod.io";
+const AUTH0_AUDIENCE: &str = "https://api.decapodlabs.com";
 
 #[derive(Deserialize, Debug)]
 struct DeviceCodeResponse {
@@ -25,7 +26,27 @@ struct TokenResponse {
     error: Option<String>,
 }
 
-pub fn perform_cloud_auth(target_dir: &Path) -> Result<(), DecapodError> {
+fn machine_config_dir() -> Result<PathBuf, DecapodError> {
+    if let Ok(config_home) = env::var("XDG_CONFIG_HOME") {
+        let trimmed = config_home.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed).join("decapod"));
+        }
+    }
+
+    let home = env::var("HOME").map_err(|_| {
+        DecapodError::ValidationError(
+            "HOME is required to locate ~/.config/decapod for cloud credentials.".to_string(),
+        )
+    })?;
+    Ok(PathBuf::from(home).join(".config").join("decapod"))
+}
+
+fn machine_session_token_path() -> Result<PathBuf, DecapodError> {
+    Ok(machine_config_dir()?.join("session_token"))
+}
+
+pub fn perform_cloud_auth(_target_dir: &Path) -> Result<(), DecapodError> {
     // Check if curl is available
     if Command::new("curl").arg("--version").output().is_err() {
         return Err(DecapodError::ValidationError(
@@ -38,7 +59,8 @@ pub fn perform_cloud_auth(target_dir: &Path) -> Result<(), DecapodError> {
     println!("◢ {}", "Cloud Authentication".bright_cyan().bold());
     println!(
         "  {}",
-        "Authenticating with Auth0 to access Supabase backend...".bright_black()
+        "Authenticating with Decapod Cloud. Credentials are stored outside this repository."
+            .bright_black()
     );
 
     let device_code_res = initiate_device_flow()?;
@@ -62,8 +84,19 @@ pub fn perform_cloud_auth(target_dir: &Path) -> Result<(), DecapodError> {
 
     let token = poll_for_token(&device_code_res)?;
 
-    let token_path = target_dir.join(".decapod").join("session_token");
+    let config_dir = machine_config_dir()?;
+    fs::create_dir_all(&config_dir).map_err(DecapodError::IoError)?;
+    let token_path = machine_session_token_path()?;
     fs::write(&token_path, token).map_err(DecapodError::IoError)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&token_path)
+            .map_err(DecapodError::IoError)?
+            .permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(&token_path, perms).map_err(DecapodError::IoError)?;
+    }
 
     println!(
         "{} {}",
@@ -74,8 +107,10 @@ pub fn perform_cloud_auth(target_dir: &Path) -> Result<(), DecapodError> {
     Ok(())
 }
 
-pub fn is_token_valid(target_dir: &Path) -> bool {
-    let token_path = target_dir.join(".decapod").join("session_token");
+pub fn is_token_valid(_target_dir: &Path) -> bool {
+    let Ok(token_path) = machine_session_token_path() else {
+        return false;
+    };
     if !token_path.exists() {
         return false;
     }

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1080,7 +1080,6 @@ pub const DECAPOD_GITIGNORE_RULES: &[&str] = &[
     ".decapod/.stfolder",
     ".decapod/workspaces",
     ".decapod/generated/*",
-    ".decapod/session_token",
     "!.decapod/data/",
     "!.decapod/data/knowledge.promotions.jsonl",
     "!.decapod/generated/Dockerfile",

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -26,6 +26,7 @@ use crate::{db, primitives, todo};
 use fancy_regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -1273,6 +1274,75 @@ fn validate_project_config_toml(
             ctx,
         );
     }
+
+    let cloud_table = value.get("cloud").and_then(|v| v.as_table());
+    let forbidden_cloud_secret_keys = [
+        "access_token",
+        "refresh_token",
+        "device_code",
+        "auth_code",
+        "client_secret",
+        "session_cookie",
+        "account_password",
+        "private_key",
+        "supabase_key",
+        "supabase_url",
+    ];
+    let mut forbidden_present = Vec::new();
+    for key in forbidden_cloud_secret_keys {
+        if cloud_table.map(|t| t.contains_key(key)).unwrap_or(false)
+            || repo_table.map(|t| t.contains_key(key)).unwrap_or(false)
+        {
+            forbidden_present.push(key);
+        }
+    }
+    if forbidden_present.is_empty() {
+        pass(
+            "Project config does not store cloud credentials or tokens",
+            ctx,
+        );
+    } else {
+        fail(
+            &format!(
+                "Project config must not store cloud credentials or backend secrets in repo config: {forbidden_present:?}"
+            ),
+            ctx,
+        );
+    }
+
+    if let Some(cloud_table) = cloud_table {
+        let cloud_enabled = cloud_table
+            .get("enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if cloud_enabled {
+            let experimental = cloud_table
+                .get("experimental")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let provider_present = cloud_table
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false);
+            let api_url_present = cloud_table
+                .get("api_url")
+                .and_then(|v| v.as_str())
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false);
+            if experimental && provider_present && api_url_present {
+                pass(
+                    "Project config captures experimental Decapod Cloud opt-in boundary",
+                    ctx,
+                );
+            } else {
+                fail(
+                    "Enabled cloud config must be experimental and include non-secret provider/api_url wiring.",
+                    ctx,
+                );
+            }
+        }
+    }
     Ok(())
 }
 
@@ -2233,10 +2303,7 @@ fn validate_internalization_artifacts_if_present(
         }
     }
 
-    let sessions_dir = repo_root
-        .join(".decapod")
-        .join("generated")
-        .join("sessions");
+    let sessions_dir = validation_sessions_dir(repo_root);
     if sessions_dir.exists() {
         for session_entry in fs::read_dir(&sessions_dir).map_err(error::DecapodError::IoError)? {
             let session_entry = session_entry.map_err(error::DecapodError::IoError)?;
@@ -2522,6 +2589,36 @@ fn validate_policy_integrity(
     }
 
     Ok(())
+}
+
+fn validation_sessions_dir(repo_root: &Path) -> PathBuf {
+    machine_validation_sessions_dir(repo_root).unwrap_or_else(|| {
+        repo_root
+            .join(".decapod")
+            .join("generated")
+            .join("sessions")
+    })
+}
+
+fn machine_validation_sessions_dir(repo_root: &Path) -> Option<PathBuf> {
+    let config_root = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(|v| PathBuf::from(v.trim()).join("decapod"))
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|v| PathBuf::from(v).join(".config").join("decapod"))
+        })?;
+
+    let canonical = fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let mut scope = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        scope.push_str(&format!("{b:02x}"));
+    }
+    Some(config_root.join("sessions").join(scope))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,12 +418,6 @@ fn apply_repo_context_env_overrides(ctx: &mut RepoContext) {
             ctx.mode = crate::cli::BackendType::Local;
         }
     }
-    if let Ok(v) = std::env::var("SUPABASE_URL") {
-        ctx.supabase_url = Some(v);
-    }
-    if let Ok(v) = std::env::var("SUPABASE_KEY") {
-        ctx.supabase_key = Some(v);
-    }
     dedupe_sorted(&mut ctx.primary_languages);
     dedupe_sorted(&mut ctx.detected_surfaces);
 }
@@ -477,12 +471,6 @@ fn apply_repo_context_cli_overrides(ctx: &mut RepoContext, init_with: &InitWithC
     }
     ctx.container_workspaces = init_with.container_workspaces;
     ctx.mode = init_with.mode.clone();
-    if let Some(v) = init_with.supabase_url.as_ref() {
-        ctx.supabase_url = Some(v.clone());
-    }
-    if let Some(v) = init_with.supabase_key.as_ref() {
-        ctx.supabase_key = Some(v.clone());
-    }
     dedupe_sorted(&mut ctx.primary_languages);
     dedupe_sorted(&mut ctx.detected_surfaces);
 }
@@ -1324,13 +1312,22 @@ fn init_with_from_config(
         primary_languages: config.repo.primary_languages.clone(),
         detected_surfaces: config.repo.detected_surfaces.clone(),
         container_workspaces: config.repo.container_workspaces,
-        mode: config.repo.mode.clone(),
-        supabase_url: config.repo.supabase_url.clone(),
-        supabase_key: config.repo.supabase_key.clone(),
+        mode: if config.cloud.enabled || config.repo.mode == crate::cli::BackendType::Cloud {
+            crate::cli::BackendType::Cloud
+        } else {
+            crate::cli::BackendType::Local
+        },
     }
 }
 
 fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjectConfig {
+    let cloud_enabled =
+        init.mode == crate::cli::BackendType::Cloud || repo.mode == crate::cli::BackendType::Cloud;
+    let mut repo = repo;
+    // #688 adds the cloud opt-in boundary only. Fresh init config must keep
+    // local storage canonical until a later sync feature explicitly changes it.
+    repo.mode = crate::cli::BackendType::Local;
+
     let mut entrypoints = Vec::new();
     let no_entrypoint_flags = !init.claude && !init.gemini && !init.cdx_ep && !init.agents;
     if init.all || init.agents || no_entrypoint_flags {
@@ -1354,6 +1351,10 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
             entrypoints,
         },
         repo,
+        cloud: crate::cli::CloudConfigSection {
+            enabled: cloud_enabled,
+            ..crate::cli::CloudConfigSection::default()
+        },
     }
 }
 
@@ -1407,18 +1408,29 @@ fn enrich_repo_context_interactive(
     )?;
     repo.container_workspaces = enable_container_workspaces;
 
+    println!();
+    println!("Enable Decapod Cloud? [experimental, account required]");
+    println!("  No  - local-first repo governance only");
+    println!("  Yes - sign in to Decapod Labs to sync governed work state");
     let backend_choice = prompt_yes_no(
-        "Use cloud backend? (EXPERIMENTAL: Requires Auth0 authentication and grants access to Supabase.)",
-        matches!(repo.mode, crate::cli::BackendType::Cloud),
+        "Enable Decapod Cloud? [experimental, account required]",
+        matches!(init.mode, crate::cli::BackendType::Cloud),
     )?;
-    repo.mode = if backend_choice {
-        if repo.supabase_url.is_none() {
-            repo.supabase_url = Some("https://api.decapod.io".to_string());
+    init.mode = if backend_choice {
+        println!();
+        println!("Decapod Cloud is experimental.");
+        println!("It syncs governed operational state for this repo.");
+        println!("Local state remains canonical unless cloud sync is enabled.");
+        println!();
+        if prompt_yes_no("Continue?", false)? {
+            crate::cli::BackendType::Cloud
+        } else {
+            crate::cli::BackendType::Local
         }
-        crate::cli::BackendType::Cloud
     } else {
         crate::cli::BackendType::Local
     };
+    repo.mode = crate::cli::BackendType::Local;
 
     let enable_ci = prompt_yes_no("Scaffold GitHub Action for decapod validate?", init.ci)?;
     init.ci = enable_ci;
@@ -1756,8 +1768,6 @@ pub fn run() -> Result<(), error::DecapodError> {
                             detected_surfaces: init_group.detected_surfaces.clone(),
                             container_workspaces: init_group.container_workspaces,
                             mode: init_group.mode.clone(),
-                            supabase_url: init_group.supabase_url.clone(),
-                            supabase_key: init_group.supabase_key.clone(),
                         }
                     }
                 }
@@ -1781,6 +1791,11 @@ pub fn run() -> Result<(), error::DecapodError> {
             let mut repo_ctx = infer_repo_context(&init_target);
             apply_repo_context_env_overrides(&mut repo_ctx);
             apply_repo_context_cli_overrides(&mut repo_ctx, &init_with);
+            if repo_ctx.mode == crate::cli::BackendType::Cloud
+                && init_with.mode == crate::cli::BackendType::Local
+            {
+                init_with.mode = crate::cli::BackendType::Cloud;
+            }
             apply_substrate_adoption(&mut repo_ctx, &init_target);
             apply_architecture_language_recommendation(&mut repo_ctx);
 
@@ -1791,9 +1806,6 @@ pub fn run() -> Result<(), error::DecapodError> {
                 enrich_repo_context_interactive(&mut repo_ctx, &mut init_with)?;
             }
             let target_dir = run_init_apply(&init_with, &current_dir, &repo_ctx)?;
-            if repo_ctx.mode == crate::cli::BackendType::Cloud && !init_with.dry_run {
-                crate::core::auth::perform_cloud_auth(&target_dir)?;
-            }
             let config = config_from_init_with(&init_with, repo_ctx);
             write_project_config(&target_dir, &config, init_with.dry_run)?;
             seed_init_generated_state(&target_dir, init_with.dry_run)?;
@@ -2363,11 +2375,50 @@ fn sanitize_agent_component(s: &str) -> String {
     out.trim_matches('-').to_string()
 }
 
-fn sessions_dir(project_root: &Path) -> PathBuf {
+fn machine_config_dir() -> Result<PathBuf, error::DecapodError> {
+    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        let trimmed = config_home.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed).join("decapod"));
+        }
+    }
+
+    let home = std::env::var("HOME").map_err(|_| {
+        error::DecapodError::ValidationError(
+            "HOME is required to locate ~/.config/decapod for session state.".to_string(),
+        )
+    })?;
+    Ok(PathBuf::from(home).join(".config").join("decapod"))
+}
+
+fn project_session_scope(project_root: &Path) -> String {
+    let canonical = fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+fn machine_project_sessions_dir(project_root: &Path) -> Result<PathBuf, error::DecapodError> {
+    Ok(machine_config_dir()?
+        .join("sessions")
+        .join(project_session_scope(project_root)))
+}
+
+fn legacy_project_sessions_dir(project_root: &Path) -> PathBuf {
     project_root
         .join(".decapod")
         .join("generated")
         .join("sessions")
+}
+
+fn sessions_dir(project_root: &Path) -> PathBuf {
+    machine_project_sessions_dir(project_root)
+        .unwrap_or_else(|_| legacy_project_sessions_dir(project_root))
 }
 
 fn session_file_for_agent(project_root: &Path, agent_id: &str) -> PathBuf {

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -2,21 +2,10 @@ use std::process::Command;
 use tempfile::TempDir;
 
 #[test]
-fn test_cloud_backend_can_add_and_list_tasks() {
-    // Only run if credentials are provided in the environment
-    if std::env::var("SUPABASE_URL").is_err() || std::env::var("SUPABASE_KEY").is_err() {
-        println!(
-            "Skipping test_cloud_backend_can_add_and_list_tasks: missing SUPABASE_URL or SUPABASE_KEY"
-        );
-        return;
-    }
-
+fn test_cloud_opt_in_keeps_local_state_usable() {
     let tmp = TempDir::new().expect("tempdir");
     let dir = tmp.path().to_path_buf();
 
-    // 1. Initialize Decapod with cloud backend
-    // Since SUPABASE_URL and SUPABASE_KEY are in the environment,
-    // clap will pick them up automatically for the `init` command.
     let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["init", "--mode", "cloud", "--force", "--proof"])
         .current_dir(&dir)
@@ -29,16 +18,14 @@ fn test_cloud_backend_can_add_and_list_tasks() {
         String::from_utf8_lossy(&init_out.stderr)
     );
 
-    // Create a unique title to ensure we are retrieving the task we just added
     let title = format!(
-        "Test cloud task {}",
+        "Test local task with cloud opt-in {}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_millis()
     );
 
-    // 2. Add a task to the cloud backend
     let add_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["todo", "add", &title, "--format", "json"])
         .current_dir(&dir)
@@ -55,7 +42,6 @@ fn test_cloud_backend_can_add_and_list_tasks() {
         serde_json::from_slice(&add_out.stdout).expect("parse todo add json");
     let task_id = add_json["id"].as_str().expect("task id").to_string();
 
-    // 3. List tasks and verify the newly added task exists
     let list_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["todo", "list", "--format", "json"])
         .current_dir(&dir)
@@ -71,7 +57,7 @@ fn test_cloud_backend_can_add_and_list_tasks() {
     let list_stdout = String::from_utf8_lossy(&list_out.stdout);
     assert!(
         list_stdout.contains(&title),
-        "Cloud task '{}' not found in list output: {}",
+        "Task '{}' not found in list output after cloud opt-in: {}",
         title,
         list_stdout
     );
@@ -81,7 +67,6 @@ fn test_cloud_backend_can_add_and_list_tasks() {
         task_id
     );
 
-    // 4. Test retrieving the specific task
     let get_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["todo", "get", "--id", &task_id, "--format", "json"])
         .current_dir(&dir)
@@ -99,77 +84,13 @@ fn test_cloud_backend_can_add_and_list_tasks() {
         get_stdout.contains(&title),
         "Task get did not return expected title"
     );
-
-    // 5. Add a decision to the cloud backend
-    let decide_start_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["decide", "start", "architecture", "--format", "json"])
-        .current_dir(&dir)
-        .output()
-        .expect("decide start");
-
-    assert!(
-        decide_start_out.status.success(),
-        "decide start failed: {}",
-        String::from_utf8_lossy(&decide_start_out.stderr)
-    );
-
-    let start_json: serde_json::Value =
-        serde_json::from_slice(&decide_start_out.stdout).expect("parse decide start json");
-    let session_id = start_json["id"].as_str().expect("session id").to_string();
-
-    let decide_record_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args([
-            "decide",
-            "record",
-            "--session",
-            &session_id,
-            "--question",
-            "Is this cloud?",
-            "--answer",
-            "Yes, it is Supabase",
-            "--rationale",
-            "Testing cloud backend",
-            "--format",
-            "json",
-        ])
-        .current_dir(&dir)
-        .output()
-        .expect("decide record");
-
-    assert!(
-        decide_record_out.status.success(),
-        "decide record failed: {}",
-        String::from_utf8_lossy(&decide_record_out.stderr)
-    );
-
-    // 6. List decisions and verify
-    let decide_list_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["decide", "list", "--format", "json"])
-        .current_dir(&dir)
-        .output()
-        .expect("decide list");
-
-    assert!(
-        decide_list_out.status.success(),
-        "decide list failed: {}",
-        String::from_utf8_lossy(&decide_list_out.stderr)
-    );
-
-    let list_decisions_stdout = String::from_utf8_lossy(&decide_list_out.stdout);
-    assert!(
-        list_decisions_stdout.contains("Yes, it is Supabase"),
-        "Cloud decision not found in list output: {}",
-        list_decisions_stdout
-    );
 }
 
 #[test]
-fn test_cloud_backend_rejects_initialization_without_auth() {
+fn test_cloud_init_records_opt_in_without_auth_or_repo_credentials() {
     let tmp = TempDir::new().expect("tempdir");
     let dir = tmp.path().to_path_buf();
 
-    // Init decapod with cloud backend but without credentials
-    // We intentionally unset SUPABASE_URL and SUPABASE_KEY for this process
     let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["init", "--mode", "cloud", "--force", "--proof"])
         .env_remove("SUPABASE_URL")
@@ -178,25 +99,20 @@ fn test_cloud_backend_rejects_initialization_without_auth() {
         .output()
         .expect("decapod init");
 
-    // It should fail or fallback/require Auth0 (which in CI without terminal defaults to fail or prompt error)
-    // Wait, the cli validation might not fail strictly if auth0 can be triggered interactively.
-    // In a non-tty environment, if it requires auth and can't, it should fail.
-    // For now, let's just assert it runs and maybe fails, or if it has a specific behavior.
-    // Actually, Decapod init might succeed but then `todo add` would fail, or init itself fails
-    // if cloud mode requires credentials upfront.
+    assert!(
+        init_out.status.success(),
+        "cloud opt-in init should not require auth/backend calls: {}",
+        String::from_utf8_lossy(&init_out.stderr)
+    );
 
-    // In `src/lib.rs`, `init` might require token or Supabase URL. If not provided,
-    // does it fail?
-    // Let's just check the status or error message.
-    let _stderr = String::from_utf8_lossy(&init_out.stderr);
-
-    // We don't strictly assert failure here unless we are sure.
-    // But since the user wants to test the cloud backend, we'll verify it doesn't just
-    // silently fall back to local if we requested cloud.
     let config_path = dir.join(".decapod/config.toml");
-    if config_path.exists() {
-        let config = std::fs::read_to_string(config_path).unwrap();
-        // It might set it to cloud but have no credentials, which is fine if Auth0 flow is expected later.
-        assert!(config.contains("mode = \"cloud\""));
-    }
+    let config = std::fs::read_to_string(config_path).unwrap();
+    assert!(config.contains("[cloud]"));
+    assert!(config.contains("enabled = true"));
+    assert!(config.contains("experimental = true"));
+    assert!(config.contains("mode = \"local\""));
+    assert!(!config.contains("SUPABASE"));
+    assert!(!config.contains("supabase"));
+    assert!(!config.contains("token"));
+    assert!(!dir.join(".decapod/session_token").exists());
 }

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -13,17 +13,48 @@ fn run_decapod(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
 #[test]
 fn init_with_backend_cloud_saves_to_config() {
     let tmp = tempdir().expect("tempdir");
-    // We use a dummy curl that returns failure to avoid hanging on real Auth0 flow
-    // or we just check that the config was written before auth (it's not, auth is before config write)
-
-    // Actually, let's just test that the CLI accepts the flag.
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["init", "with", "--mode", "cloud", "--force", "--dry-run"])
+        .args(["init", "with", "--mode", "cloud", "--force"])
         .current_dir(tmp.path())
         .output()
         .expect("run decapod");
 
-    assert!(out.status.success());
+    assert!(
+        out.status.success(),
+        "decapod init with --mode cloud failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config_path = tmp.path().join(".decapod/config.toml");
+    let config = fs::read_to_string(config_path).expect("read config.toml");
+    assert!(
+        config.contains("[cloud]"),
+        "missing [cloud] section: {config}"
+    );
+    assert!(
+        config.contains("enabled = true"),
+        "cloud opt-in should be recorded: {config}"
+    );
+    assert!(
+        config.contains("experimental = true"),
+        "cloud should be marked experimental: {config}"
+    );
+    assert!(
+        config.contains("provider = \"decapod\""),
+        "cloud provider should be non-secret Decapod wiring: {config}"
+    );
+    assert!(
+        config.contains("api_url = \"https://api.decapodlabs.com\""),
+        "cloud API URL should use Decapod Labs default: {config}"
+    );
+    assert!(
+        config.contains("mode = \"local\""),
+        "cloud opt-in must not switch storage away from local by default: {config}"
+    );
+    assert!(
+        !config.contains("supabase") && !config.contains("token") && !config.contains("secret"),
+        "repo config must not contain credentials or legacy backend secrets: {config}"
+    );
 }
 
 #[test]
@@ -34,6 +65,87 @@ fn init_with_backend_local_is_default() {
     let config_path = tmp.path().join(".decapod/config.toml");
     let config = fs::read_to_string(config_path).expect("read config.toml");
     assert!(config.contains("mode = \"local\""));
+    assert!(config.contains("[cloud]"));
+    assert!(config.contains("enabled = false"));
+}
+
+#[test]
+fn init_cloud_opt_in_does_not_store_secret_environment_values() {
+    let tmp = tempdir().expect("tempdir");
+    let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "with", "--mode", "cloud", "--force"])
+        .current_dir(tmp.path())
+        .env("SUPABASE_URL", "https://private.supabase.local")
+        .env("SUPABASE_KEY", "super-secret-service-role")
+        .env("DECAPOD_ACCESS_TOKEN", "repo-config-must-not-store-this")
+        .output()
+        .expect("run decapod");
+
+    assert!(
+        out.status.success(),
+        "decapod init with secret-like env failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config_path = tmp.path().join(".decapod/config.toml");
+    let config = fs::read_to_string(config_path).expect("read config.toml");
+    assert!(config.contains("enabled = true"));
+    assert!(!config.contains("private.supabase.local"));
+    assert!(!config.contains("super-secret-service-role"));
+    assert!(!config.contains("repo-config-must-not-store-this"));
+    assert!(!config.contains("supabase_key"));
+    assert!(!config.contains("access_token"));
+}
+
+#[test]
+fn session_acquire_uses_machine_local_config_not_repo_session_file() {
+    let tmp = tempdir().expect("tempdir");
+    let config_home = tempdir().expect("config home");
+    let out = run_decapod(tmp.path(), &["init", "with", "--force"]);
+    assert!(
+        out.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let acquire = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["session", "acquire"])
+        .current_dir(tmp.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("DECAPOD_AGENT_ID", "machine-local-agent")
+        .output()
+        .expect("session acquire");
+    assert!(
+        acquire.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&acquire.stderr)
+    );
+
+    assert!(
+        !tmp.path().join(".decapod/session_token").exists(),
+        "repo-local session_token should not be created"
+    );
+    assert!(
+        !tmp.path().join(".decapod/generated/sessions").exists(),
+        "session credentials should not be written under repo generated state"
+    );
+
+    let machine_sessions = config_home.path().join("decapod/sessions");
+    assert!(
+        machine_sessions.exists(),
+        "machine-local session directory missing"
+    );
+    let mut found_session = false;
+    for project_entry in fs::read_dir(machine_sessions).expect("read machine sessions") {
+        let project_entry = project_entry.expect("project session dir");
+        for agent_entry in fs::read_dir(project_entry.path()).expect("read project session dir") {
+            let agent_entry = agent_entry.expect("agent session file");
+            if agent_entry.file_name() == "machine-local-agent.json" {
+                found_session = true;
+            }
+        }
+    }
+    assert!(found_session, "machine-local agent session file missing");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an explicit experimental Decapod Cloud opt-in boundary to `decapod init` / `init with`
- record only non-secret `[cloud]` config while keeping local state canonical by default
- stop writing session credentials under repo-local `.decapod` paths; use machine-local config storage instead
- add validation/tests to prevent cloud tokens, Supabase credentials, or other secrets from being stored in repo config

Closes #688.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test --test init_config_behavior`
- `cargo test --test cloud_backend_storage`
- `decapod validate --format json` still fails on existing ambient repo gates: `STALE_SPECS_FINGERPRINT` and `PROOF_HOOK_FAILED` for 154 done TODOs claimed but not verified.

Note: full `cargo test` was started and passed library/unit tests before the user interrupted the long integration run; focused suites covering this change pass.
