### PR TITLE
fix(release): restore release environment and bump to 0.58.3 for Issue 693

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1779948780Z",
-  "repo_signal_fingerprint": "2cd2f589480acfc9d499745ef88f9b9aaa6088cfdf1e46ea547502ef757ac88c",
+  "generated_at": "1781733774Z",
+  "repo_signal_fingerprint": "6dac2ab83c7f0b828e00470456419d83338dfc5a35c7fcad29d544ebc5888fba",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   release-publish:
     name: Release (Publish)
     runs-on: ubuntu-latest
+    environment: release
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Generate GitHub App token

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dev/
 !.decapod/data/knowledge.promotions.jsonl
 .decapod/.stfolder
 .decapod/workspaces
+.decapod/session_token
 # Generated runtime outputs are non-canonical; allowlist only governed artifacts.
 .decapod/generated/*
 # Allowlist deterministic generated artifact used as container build baseline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "decapod"
-version = "0.58.2"
+version = "0.58.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decapod"
-version = "0.58.2"
+version = "0.58.3"
 edition = "2024"
 rust-version = "1.91.1"
 build = "build/compress_constitution.rs"


### PR DESCRIPTION
Fixes #693 by restoring the release environment configuration to the release workflow so that CARGO_REGISTRY_TOKEN is populated, adding .decapod/session_token to .gitignore to satisfy validation, and bumping version to 0.58.3.