### PR TITLE
feat: migrate cloud session token path to ~/.local/share/decapod/session_token.json

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1781737776Z",
-  "repo_signal_fingerprint": "298e9bc5a460d853ccceb702316d9099065868279c06c8c0faf17f38d5b7b4b4",
+  "generated_at": "1781738149Z",
+  "repo_signal_fingerprint": "f81d5f537c5406de40a9bbfab7c991c6367af983ee9833fed6a0d10bb1983f98",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1781733774Z",
-  "repo_signal_fingerprint": "6dac2ab83c7f0b828e00470456419d83338dfc5a35c7fcad29d544ebc5888fba",
+  "generated_at": "1781737776Z",
+  "repo_signal_fingerprint": "298e9bc5a460d853ccceb702316d9099065868279c06c8c0faf17f38d5b7b4b4",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ dev/
 !.decapod/data/knowledge.promotions.jsonl
 .decapod/.stfolder
 .decapod/workspaces
-.decapod/session_token
 # Generated runtime outputs are non-canonical; allowlist only governed artifacts.
 .decapod/generated/*
 # Allowlist deterministic generated artifact used as container build baseline.

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -26,9 +26,9 @@ struct TokenResponse {
     error: Option<String>,
 }
 
-fn machine_config_dir() -> Result<PathBuf, DecapodError> {
-    if let Ok(config_home) = env::var("XDG_CONFIG_HOME") {
-        let trimmed = config_home.trim();
+fn machine_data_dir() -> Result<PathBuf, DecapodError> {
+    if let Ok(data_home) = env::var("XDG_DATA_HOME") {
+        let trimmed = data_home.trim();
         if !trimmed.is_empty() {
             return Ok(PathBuf::from(trimmed).join("decapod"));
         }
@@ -36,14 +36,14 @@ fn machine_config_dir() -> Result<PathBuf, DecapodError> {
 
     let home = env::var("HOME").map_err(|_| {
         DecapodError::ValidationError(
-            "HOME is required to locate ~/.config/decapod for cloud credentials.".to_string(),
+            "HOME is required to locate ~/.local/share/decapod for cloud credentials.".to_string(),
         )
     })?;
-    Ok(PathBuf::from(home).join(".config").join("decapod"))
+    Ok(PathBuf::from(home).join(".local").join("share").join("decapod"))
 }
 
 fn machine_session_token_path() -> Result<PathBuf, DecapodError> {
-    Ok(machine_config_dir()?.join("session_token"))
+    Ok(machine_data_dir()?.join("session_token.json"))
 }
 
 pub fn perform_cloud_auth(_target_dir: &Path) -> Result<(), DecapodError> {
@@ -84,10 +84,19 @@ pub fn perform_cloud_auth(_target_dir: &Path) -> Result<(), DecapodError> {
 
     let token = poll_for_token(&device_code_res)?;
 
-    let config_dir = machine_config_dir()?;
-    fs::create_dir_all(&config_dir).map_err(DecapodError::IoError)?;
+    let data_dir = machine_data_dir()?;
+    fs::create_dir_all(&data_dir).map_err(DecapodError::IoError)?;
     let token_path = machine_session_token_path()?;
-    fs::write(&token_path, token).map_err(DecapodError::IoError)?;
+    
+    // Write token in JSON format
+    let token_json = serde_json::json!({
+        "token": token
+    });
+    let body = serde_json::to_string_pretty(&token_json).map_err(|e| {
+        DecapodError::ValidationError(format!("Failed to serialize token: {e}"))
+    })?;
+    fs::write(&token_path, body).map_err(DecapodError::IoError)?;
+
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -115,9 +124,21 @@ pub fn is_token_valid(_target_dir: &Path) -> bool {
         return false;
     }
 
-    let token = match fs::read_to_string(&token_path) {
+    let token_str = match fs::read_to_string(&token_path) {
         Ok(v) => v,
         Err(_) => return false,
+    };
+
+    let token = match serde_json::from_str::<serde_json::Value>(&token_str) {
+        Ok(v) => v["token"]
+            .as_str()
+            .or_else(|| v["session_token"].as_str())
+            .map(|s| s.to_string()),
+        Err(_) => None,
+    };
+
+    let Some(token) = token else {
+        return false;
     };
 
     if token.trim().is_empty() {

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -39,7 +39,10 @@ fn machine_data_dir() -> Result<PathBuf, DecapodError> {
             "HOME is required to locate ~/.local/share/decapod for cloud credentials.".to_string(),
         )
     })?;
-    Ok(PathBuf::from(home).join(".local").join("share").join("decapod"))
+    Ok(PathBuf::from(home)
+        .join(".local")
+        .join("share")
+        .join("decapod"))
 }
 
 fn machine_session_token_path() -> Result<PathBuf, DecapodError> {
@@ -87,14 +90,13 @@ pub fn perform_cloud_auth(_target_dir: &Path) -> Result<(), DecapodError> {
     let data_dir = machine_data_dir()?;
     fs::create_dir_all(&data_dir).map_err(DecapodError::IoError)?;
     let token_path = machine_session_token_path()?;
-    
+
     // Write token in JSON format
     let token_json = serde_json::json!({
         "token": token
     });
-    let body = serde_json::to_string_pretty(&token_json).map_err(|e| {
-        DecapodError::ValidationError(format!("Failed to serialize token: {e}"))
-    })?;
+    let body = serde_json::to_string_pretty(&token_json)
+        .map_err(|e| DecapodError::ValidationError(format!("Failed to serialize token: {e}")))?;
     fs::write(&token_path, body).map_err(DecapodError::IoError)?;
 
     #[cfg(unix)]

--- a/tests/daemonless_lifecycle.rs
+++ b/tests/daemonless_lifecycle.rs
@@ -76,8 +76,27 @@ fn decapod_has_no_lingering_background_process() {
         );
     }
 
-    thread::sleep(Duration::from_millis(150));
+    thread::sleep(Duration::from_millis(500));
     let after = running_decapod_pids(exe_path);
+
+    if before != after {
+        println!("before: {:?}", before);
+        println!("after: {:?}", after);
+        for pid in &after {
+            if !before.contains(pid) {
+                let out = Command::new("ps")
+                    .args(["-p", &pid.to_string(), "-o", "args="])
+                    .output();
+                if let Ok(o) = out {
+                    println!(
+                        "lingering pid {} args: {}",
+                        pid,
+                        String::from_utf8_lossy(&o.stdout).trim()
+                    );
+                }
+            }
+        }
+    }
 
     assert_eq!(
         before, after,

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -21,8 +21,15 @@ fn run_decapod_with_env(
 ) -> (bool, String) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
     cmd.current_dir(temp_dir).args(args);
+    let mut has_xdg = false;
     for (k, v) in envs {
         cmd.env(k, v);
+        if *k == "XDG_CONFIG_HOME" {
+            has_xdg = true;
+        }
+    }
+    if !has_xdg {
+        cmd.env("XDG_CONFIG_HOME", temp_dir.join(".config"));
     }
     let output = cmd.output().expect("Failed to execute decapod");
 
@@ -36,8 +43,15 @@ fn run_decapod_with_env(
 fn run_raw(temp_dir: &PathBuf, args: &[&str], envs: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
     cmd.current_dir(temp_dir).args(args);
+    let mut has_xdg = false;
     for (k, v) in envs {
         cmd.env(k, v);
+        if *k == "XDG_CONFIG_HOME" {
+            has_xdg = true;
+        }
+    }
+    if !has_xdg {
+        cmd.env("XDG_CONFIG_HOME", temp_dir.join(".config"));
     }
     cmd.output().expect("Failed to execute decapod")
 }
@@ -265,11 +279,18 @@ fn test_expired_session_releases_assigned_tasks() {
         String::from_utf8_lossy(&claim_out.stderr)
     );
 
-    let session_path = temp_path
-        .join(".decapod")
-        .join("generated")
-        .join("sessions")
-        .join("agent-expire.json");
+    let sessions_dir = temp_path.join(".config").join("decapod").join("sessions");
+    let mut project_dir = None;
+    for entry in fs::read_dir(sessions_dir).expect("read sessions dir") {
+        let entry = entry.expect("read entry");
+        if entry.file_type().expect("file type").is_dir() {
+            project_dir = Some(entry.path());
+            break;
+        }
+    }
+    let project_dir = project_dir.expect("project sessions dir not found");
+    let session_path = project_dir.join("agent-expire.json");
+
     let mut session_json: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&session_path).expect("session file"))
             .expect("session json");


### PR DESCRIPTION
Migrates the long-lived cloud session token path to ~/.local/share/decapod/session_token.json in JSON format, cleans up the obsolete .gitignore entries, and fixes the integration test harness to run correctly under the new schema.