### PR TITLE
docs: add Jekyll landing page index.md and cross-link book files

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v2",
-  "generated_at": "1781738149Z",
-  "repo_signal_fingerprint": "f81d5f537c5406de40a9bbfab7c991c6367af983ee9833fed6a0d10bb1983f98",
+  "generated_at": "1781755120Z",
+  "repo_signal_fingerprint": "77c4494abce948df1d98934086636ab593b6e4bdd13c62507b7368571d18a365",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/docs/book/src/concepts/agent-first.md
+++ b/docs/book/src/concepts/agent-first.md
@@ -6,12 +6,12 @@ Decapod is not just a CLI; it is an **Agent-First Governance Kernel**. This mean
 
 Decapod structures agent work into a predictable, machine-readable lifecycle:
 
-1.  **Ingestion & Orientation:** The agent reads `docs/agent/` and queries the `constitution` to understand the repo's rules and available tools.
-2.  **Task Claiming:** The agent claims a `todo` to establish exclusive custody and prevent collisions.
+1.  **Ingestion & Orientation:** The agent reads `docs/agent/` and queries the `constitution` (see [Repository Constitution](constitution.md)) to understand the repo's rules and available tools.
+2.  **Task Claiming:** The agent claims a `todo` to establish exclusive custody and prevent collisions (see [Single-Agent Workflow](../workflows/single-agent.md)).
 3.  **Context Resolution:** The agent uses `rpc --op context.resolve` or `infer orientation` to gather the precise context needed for the specific task.
-4.  **Implementation:** The agent works in an isolated `workspace` (worktree or container).
-5.  **Validation:** The agent runs `decapod validate` to verify its work against local gates *before* human review.
-6.  **Proof Generation:** Marking a task `done` generates cryptographic and evidence-based artifacts that prove the work was governed.
+4.  **Implementation:** The agent works in an isolated `workspace` (see [Workspace Sandboxing](workspaces.md)).
+5.  **Validation:** The agent runs `decapod validate` to verify its work against local gates *before* human review (see [Proof & Validation](proof.md)).
+6.  **Proof Generation:** Marking a task `done` generates cryptographic and evidence-based artifacts that prove the work was governed (see [Artifacts Reference](../reference/artifacts.md)).
 
 ## Key Agent-First Concepts
 
@@ -19,13 +19,14 @@ Decapod structures agent work into a predictable, machine-readable lifecycle:
 AI models are sensitive to context pollution. Decapod's **Context Capsules** ensure that every agent sees exactly what it needs, and nothing more. This reduces hallucinations and token waste.
 
 ### 2. Living Specifications
-Agents should not just "write code"; they should maintain intent. Decapod promotes the use of "Living Specs" (`.decapod/generated/specs/*`) which are synchronized with both the code and the agent's internal state.
+Agents should not just "write code"; they should maintain intent. Decapod promotes the use of "Living Specs" (`.decapod/generated/specs/*`) which are synchronized with both the code and the agent's internal state (see [Explicit Intent](intent.md)).
 
 ### 3. Aptitude & Memory
-Shared memory allows agents to learn from each other. If one agent discovers a obscure bug in a library, it can record that observation in Aptitude, which subsequent agents will automatically retrieve during context resolution.
+Shared memory allows agents to learn from each other. If one agent discovers an obscure bug in a library, it can record that observation in Aptitude, which subsequent agents will automatically retrieve during context resolution.
 
 ### 4. Protocol-Native (MCP)
-By supporting the **Model Context Protocol (MCP)**, Decapod allows agents to treat the repository as a structured resource graph rather than a raw filesystem.
+By supporting the **Model Context Protocol (MCP)**, Decapod allows agents to treat the repository as a structured resource graph rather than a raw filesystem (see [Model Context Protocol (MCP)](mcp.md)).
+
 
 ## Design Patterns for Agents
 

--- a/docs/book/src/concepts/constitution.md
+++ b/docs/book/src/concepts/constitution.md
@@ -7,12 +7,12 @@ The **Constitution** is the foundational set of rules and engineering standards 
 Decapod's authority model is hierarchical:
 
 1.  **Global Constitution:** Over 100 normative documents embedded in the Decapod binary. These cover universal engineering standards (e.g., "Always write tests", "Minimize breaking changes").
-2.  **Project Overrides (`.decapod/OVERRIDE.md`):** Repo-local rules that extend or supersede the global constitution. This is where you define team-specific conventions.
+2.  **Project Overrides (`.decapod/OVERRIDE.md`):** Repo-local rules that extend or supersede the global constitution. This is where you define team-specific conventions (see [Overrides](overrides.md) and [Configuration](../configuration.md)).
 3.  **Task Policy:** Temporary rules or constraints defined for a specific work unit.
 
 ## Selective Context
 
-Agents do not ingest the entire constitution. Instead, Decapod provides a **Context Capsule** interface. Agents perform targeted queries to retrieve only the directives relevant to their current task.
+Agents do not ingest the entire constitution. Instead, Decapod provides a **Context Capsule** interface (see [Agent-First Architecture](agent-first.md)). Agents perform targeted queries (see [CLI Reference](../reference/cli.md)) to retrieve only the directives relevant to their current task.
 
 ```bash
 decapod rpc --op constitution.get --params '{"section":"core/DECAPOD"}'
@@ -22,4 +22,5 @@ This high-signal, low-noise approach ensures that agents remain oriented without
 
 ## Enforcement
 
-The constitution is not merely "guidance"—it is enforced. `decapod validate` checks the repository state against the normative claims made in the constitution. If a change violates a constitutional rule, it cannot be promoted to `main`.
+The constitution is not merely "guidance"—it is enforced. `decapod validate` checks the repository state against the normative claims made in the constitution. If a change violates a constitutional rule, it cannot be promoted to `main` (see [Proof & Validation](proof.md)).
+

--- a/docs/book/src/concepts/intent.md
+++ b/docs/book/src/concepts/intent.md
@@ -6,9 +6,10 @@ In Decapod, **Intent** is the primary driver of the development lifecycle. It is
 
 Agents often dive into implementation before fully understanding the human operator's goal. Decapod prevents this by mandating a spec-first approach:
 
-1.  **Capture:** Vague requests are converted into explicit tasks via `decapod todo add`.
-2.  **Formalize:** Agents are required to update or verify the `specs/INTENT.md` document scaffolded in the repository.
-3.  **Validate:** The final implementation is checked against this intent. If the outcome deviates from the recorded intent, validation fails.
+1.  **Capture:** Vague requests are converted into explicit tasks via `decapod todo add` (see [CLI Reference](../reference/cli.md#task-tracking)).
+2.  **Formalize:** Agents are required to update or verify the `specs/INTENT.md` document scaffolded in the repository (see [Artifacts Reference](../reference/artifacts.md)).
+3.  **Validate:** The final implementation is checked against this intent. If the outcome deviates from the recorded intent, validation fails (see [Proof & Validation](proof.md)).
+
 
 ## Intent Pressure
 

--- a/docs/book/src/concepts/mcp.md
+++ b/docs/book/src/concepts/mcp.md
@@ -8,18 +8,19 @@ Decapod integrates with MCP-compatible environments (like Claude Desktop or spec
 
 ### Exposed MCP Resources
 
-- **Constitution:** Browsable nodes of the technology and methodology graph.
-- **Tasks:** The current todo list and ownership state.
-- **Specs:** The living specifications (`INTENT.md`, `ARCHITECTURE.md`, etc.) for the project.
-- **Context Capsules:** Deterministic snapshots of repo state used for inference.
+- **Constitution:** Browsable nodes of the technology and methodology graph (see [Repository Constitution](constitution.md)).
+- **Tasks:** The current todo list and ownership state (see [Single-Agent Workflow](../workflows/single-agent.md)).
+- **Specs:** The living specifications (`INTENT.md`, `ARCHITECTURE.md`, etc.) for the project (see [Explicit Intent](intent.md) and [Artifact Reference](../reference/artifacts.md)).
+- **Context Capsules:** Deterministic snapshots of repo state used for inference (see [Agent-First Architecture](agent-first.md)).
 
 ### Exposed MCP Tools
 
-Decapod exposes its core CLI capabilities as MCP Tools, allowing agents to:
+Decapod exposes its core CLI capabilities as MCP Tools, allowing agents to perform operations detailed in the [CLI Reference](../reference/cli.md):
 - `todo_add` / `todo_claim`
 - `workspace_ensure`
 - `constitution_search`
 - `validate`
+
 
 ## Benefits of MCP Integration
 

--- a/docs/book/src/concepts/overrides.md
+++ b/docs/book/src/concepts/overrides.md
@@ -1,10 +1,11 @@
 # Overrides
 
-Overrides are the primary mechanism for customizing Decapod's behavior for a specific project. They allow you to apply your team's unique engineering culture to the Decapod governance kernel.
+Overrides are the primary mechanism for customizing Decapod's behavior for a specific project. They allow you to apply your team's unique engineering culture to the Decapod governance kernel (see [Configuration](../configuration.md)).
 
 ## The `OVERRIDE.md` Substrate
 
-The `.decapod/OVERRIDE.md` file is a structured Markdown document where you can redefine specific constitution directives.
+The `.decapod/OVERRIDE.md` file is a structured Markdown document where you can redefine specific constitution directives (see [Repository Constitution](constitution.md)).
+
 
 ### Example Override
 

--- a/docs/book/src/concepts/proof.md
+++ b/docs/book/src/concepts/proof.md
@@ -5,14 +5,15 @@ Decapod replaces the unreliable "agent says it's done" claim with deterministic,
 ## Verification Gates
 
 A "Gate" is a discrete check that must pass for a task to be considered valid. Common gates include:
-- **Compliance Gates:** Checked by `decapod validate`.
+- **Compliance Gates:** Checked by `decapod validate` (see [CLI Reference](../reference/cli.md#core-operations)).
 - **Quality Gates:** Unit tests, linting, and type-checking.
 - **Security Gates:** Secret scanning and dependency audits.
 - **Human Gates:** Explicit approval for high-risk changes.
 
 ## The Evidence Ledger
 
-When an agent calls `decapod todo done --validated`, Decapod captures a snapshot of the repository state and the results of all required gates. This evidence is recorded in the `.decapod/generated/artifacts/` ledger.
+When an agent calls `decapod todo done --validated`, Decapod captures a snapshot of the repository state and the results of all required gates. This evidence is recorded in the `.decapod/generated/artifacts/` ledger (see [Artifacts Reference](../reference/artifacts.md)).
+
 
 This creates **Epistemic Custody**: a verifiable chain of proof that shows *how* the agent verified the work and *what* the state of the world was at the moment of completion.
 

--- a/docs/book/src/configuration.md
+++ b/docs/book/src/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Decapod is configured via `.decapod/config.toml`. This file is human-editable and should be committed to your repository.
+Decapod is configured via `.decapod/config.toml` (see the [Config Specification Reference](reference/config-toml.md)). This file is human-editable and should be committed to your repository.
 
 ## The `[init]` Section
 
@@ -12,7 +12,7 @@ Controls how `decapod init` behaves.
 
 ## The `[repo]` Section
 
-Defines project-specific metadata and policy.
+Defines project-specific policy and metadata.
 
 - `product_name`: The name of your project.
 - `product_summary`: A short description of what the project does.
@@ -24,4 +24,5 @@ Defines project-specific metadata and policy.
 
 ## Project Overrides
 
-For deep behavioral changes, use `.decapod/OVERRIDE.md`. This allows you to override specific directives in the embedded Decapod constitution without modifying the Decapod binary itself.
+For deep behavioral changes, use `.decapod/OVERRIDE.md` (see [Config Overrides](concepts/overrides.md)). This allows you to override specific directives in the embedded Decapod constitution (see [Repository Constitution](concepts/constitution.md)) without modifying the Decapod binary itself.
+

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -10,15 +10,15 @@ While modern LLMs are exceptionally capable at generating code, they often strug
 
 Decapod is built on four foundational pillars:
 
-1.  **Repo-Native State:** All governance data, from task tracking to architectural specifications, lives directly in your repository under the `.decapod/` directory. No external databases, no proprietary clouds—just your repo, your rules.
-2.  **Isolated Execution:** Decapod automates the creation of isolated git worktrees and (optionally) Docker containers for every task. This prevents environment corruption and race conditions, especially in concurrent multi-agent workflows.
-3.  **Explicit Intent:** We move beyond vague prompts. Decapod forces the formalization of human intent into versioned specifications (`specs/INTENT.md`) before implementation begins.
-4.  **Proof-Backed Completion:** "Done" is not a claim an agent makes; it is a state Decapod verifies. Mandatory validation gates and proof artifacts ensure that every change satisfies project-wide policy.
+1.  **Repo-Native State:** All governance data, from task tracking to architectural specifications, lives directly in your repository under the `.decapod/` directory. No external databases, no proprietary clouds—just your repo, your rules (see [Configuration](configuration.md)).
+2.  **[Isolated Execution](workflows/workspace-isolation.md):** Decapod automates the creation of isolated git worktrees and (optionally) Docker containers for every task. This prevents environment corruption and race conditions, especially in concurrent multi-agent workflows.
+3.  **[Explicit Intent](concepts/intent.md):** We move beyond vague prompts. Decapod forces the formalization of human intent into versioned specifications (`specs/INTENT.md`) before implementation begins.
+4.  **[Proof-Backed Completion](concepts/proof.md):** "Done" is not a claim an agent makes; it is a state Decapod verifies. Mandatory validation gates and proof artifacts ensure that every change satisfies project-wide policy.
 
 ## Who is it for?
 
 ### For Humans: The Safety Net
-Decapod gives you total oversight. You define the project's **Constitution** and local **Overrides**. Decapod ensures that every agent—regardless of provider or model—adheres to these rules. You receive auditable proof for every PR, ensuring your main branch remains stable and high-quality.
+Decapod gives you total oversight. You define the project's **[Constitution](concepts/constitution.md)** and local **[Overrides](concepts/overrides.md)**. Decapod ensures that every agent—regardless of provider or model—adheres to these rules. You receive auditable proof for every PR, ensuring your main branch remains stable and high-quality.
 
 ### For Agents: The Orientation System
 Decapod removes the guesswork from agentic work. Instead of hallucinating directory structures or inventing CLI arguments, agents use Decapod to orient themselves within the repository. By calling Decapod at key **Pressure Points**, agents gain the context and boundaries they need to deliver correct, first-pass implementations.

--- a/docs/book/src/mental-model.md
+++ b/docs/book/src/mental-model.md
@@ -12,12 +12,12 @@ In an operating system, the kernel manages hardware resources and provides a sta
 
 ## Pressure Points: The Agentic Loop
 
-Decapod is not intended to be called for every mechanical step. Instead, agents are taught to call Decapod at specific **Pressure Points** where governance is required:
+Decapod is not intended to be called for every mechanical step (see the [Single-Agent Workflow](workflows/single-agent.md)). Instead, agents are taught to call Decapod at specific **Pressure Points** where governance is required:
 
-1.  **Intent Pressure:** "I know what to do, but I need to formalize the spec." (`decapod todo add`, `decapod infer orientation`)
-2.  **Boundary Pressure:** "I'm about to touch a sensitive file or move to a new area." (`decapod workspace ensure`, `decapod govern gatekeeper`)
-3.  **Coordination Pressure:** "I need to ensure no one else is working on this." (`decapod todo claim`, `decapod workspace status`)
-4.  **Proof Pressure:** "I have finished the implementation and need to generate verification artifacts." (`decapod validate`, `decapod todo done`)
+1.  **Intent Pressure:** "I know what to do, but I need to formalize the spec." (see [Explicit Intent](concepts/intent.md), `decapod todo add`, `decapod infer orientation`)
+2.  **Boundary Pressure:** "I'm about to touch a sensitive file or move to a new area." (see [Workspace Sandboxing](concepts/workspaces.md), `decapod workspace ensure`, `decapod govern gatekeeper`)
+3.  **Coordination Pressure:** "I need to ensure no one else is working on this." (see [Multi-Agent Workflows](workflows/multi-agent.md), `decapod todo claim`, `decapod workspace status`)
+4.  **Proof Pressure:** "I have finished the implementation and need to generate verification artifacts." (see [Proof & Validation](concepts/proof.md), `decapod validate`, `decapod todo done`)
 
 ## The Thin Waist
 
@@ -25,4 +25,5 @@ Decapod serves as the "thin waist" of agentic software engineering. On the "top"
 
 ## Epistemic Custody
 
-A central concept in Decapod is **Epistemic Custody**. This is the preserved, auditable chain between the initial human intent, the context provided to the model, the assumptions made during implementation, and the final proof of completion. Decapod ensures this chain is never broken, making agent work fully falsifiable and transparent.
+A central concept in Decapod is **Epistemic Custody**. This is the preserved, auditable chain between the initial human intent, the context provided to the model, the assumptions made during implementation, and the final proof of completion. Decapod ensures this chain is never broken, making agent work fully falsifiable and transparent (see [Artifact Reference](reference/artifacts.md)).
+

--- a/docs/book/src/quickstart.md
+++ b/docs/book/src/quickstart.md
@@ -12,7 +12,7 @@ cargo install decapod
 
 ## 2. Initialization
 
-Initialize your repository. This creates the `.decapod/` directory and scaffolds the initial agent entrypoints (`AGENTS.md`, etc.). Agents will routinely run this during validation stages with the `--proof` flag for non-interactive agent-driven autonomous upgrades.
+Initialize your repository. This creates the `.decapod/` directory and scaffolds the initial agent entrypoints (`AGENTS.md`, etc.). Agents will routinely run this during validation stages with the `--proof` flag for non-interactive agent-driven autonomous upgrades (see [Configuration](configuration.md) and [Constitution](concepts/constitution.md)).
 
 ```bash
 decapod init
@@ -20,7 +20,7 @@ decapod init
 
 ## 3. Orientation
 
-Verify that your repository meets basic governance requirements. Decapod will check for the presence of mandatory files and invariants. Agemts will automatically call `decapod validate` as needed.
+Verify that your repository meets basic governance requirements. Decapod will check for the presence of mandatory files and invariants. Agents will automatically call `decapod validate` as needed (see [Proof & Validation](concepts/proof.md)).
 
 ```bash
 decapod validate
@@ -28,7 +28,7 @@ decapod validate
 
 ## 4. The Agent Handshake
 
-Before performing governed work, an agent must acquire a session. This establishes the agent's identity and permissions for the current work period. Human users should never call this.
+Before performing governed work, an agent must acquire a session. This establishes the agent's identity and permissions for the current work period (see [CLI Reference](reference/cli.md#decapod-session)). Human users should never call this.
 
 ```bash
 decapod session acquire
@@ -36,7 +36,7 @@ decapod session acquire
 
 ## 5. Claiming a Task
 
-Identify a task from the backlog and claim it. This prevents other agents from attempting the same work simultaneously. Human users should never call this.
+Identify a task from the backlog and claim it. This prevents other agents from attempting the same work simultaneously (see [Single-Agent Workflows](workflows/single-agent.md) and [Multi-Agent Workflows](workflows/multi-agent.md)). Human users should never call this.
 
 ```bash
 # Add a task if one doesn't exist
@@ -49,17 +49,17 @@ decapod todo claim --id <task-id>
 
 ## 6. Entering the Workspace
 
-Create an isolated git worktree for the task. Decapod ensures you are working in a clean environment, safely away from the main branch. Human users should never call this.
+Create an isolated git worktree for the task. Decapod ensures you are working in a clean environment, safely away from the main branch (see [Workspace Sandboxing](concepts/workspaces.md)). Human users should never call this.
 
 ```bash
 decapod workspace ensure
 ```
 
-**Note:** If `container_workspaces = true` is set in your config, add the `--container` flag to wrap the workspace in Docker.
+**Note:** If `container_workspaces = true` is set in your config (see [Config Specification](reference/config-toml.md)), add the `--container` flag to wrap the workspace in Docker (see [Workspace Isolation Workflow](workflows/workspace-isolation.md)).
 
 ## 7. Delivery and Proof
 
-Once implementation is complete within the isolated workspace, run validation and mark the task as done. This generates the final proof artifacts. Human users should never call this.
+Once implementation is complete within the isolated workspace, run validation and mark the task as done. This generates the final proof artifacts (see [Artifact Reference](reference/artifacts.md)). Human users should never call this.
 
 ```bash
 decapod validate

--- a/docs/book/src/workflows/external-trackers.md
+++ b/docs/book/src/workflows/external-trackers.md
@@ -5,13 +5,14 @@ Decapod is built to be a "good citizen" in your existing developer ecosystem. It
 ## The Integration Pattern
 
 1.  **Management Layer (External):** A human creates an issue in Linear (e.g., `DEV-456`).
-2.  **Operational Layer (Decapod):** An agent adds a Decapod todo that references the external issue.
+2.  **Operational Layer (Decapod):** An agent adds a Decapod todo that references the external issue (see [CLI Reference](../reference/cli.md#task-tracking)).
     ```bash
     decapod todo add "Fix regression in auth" --ref "DEV-456"
     ```
-3.  **Execution (Isolated):** The agent claims the todo and enters its isolated workspace.
-4.  **Proof (Verification):** The agent marks the task as done, satisfying the Decapod proof gates.
+3.  **Execution (Isolated):** The agent claims the todo and enters its isolated workspace (see [Workspace Isolation](workspace-isolation.md)).
+4.  **Proof (Verification):** The agent marks the task as done, satisfying the Decapod proof gates (see [Proof & Validation](../concepts/proof.md)).
 5.  **Sync (Closure):** The passing Decapod state provides the "green light" to close the external Linear issue.
+
 
 ## Why This Bridge Matters
 

--- a/docs/book/src/workflows/multi-agent.md
+++ b/docs/book/src/workflows/multi-agent.md
@@ -6,16 +6,17 @@ Decapod is designed from the ground up to support concurrent multi-agent operati
 
 Decapod uses a **Lock-then-Isolate** model for multi-agent work:
 
-1.  **Global Lock:** Agents use `decapod todo claim` to acquire an exclusive lock on a task. This prevents two agents from working on the same logical unit of work.
-2.  **Filesystem Isolation:** Each agent is assigned a unique git worktree. Even if multiple agents are working on the same repository, they never see each other's uncommitted files.
-3.  **Container Isolation:** For maximum safety, `container_workspaces = true` ensures that each agent has its own process space and system dependencies.
+1.  **Global Lock:** Agents use `decapod todo claim` (see [CLI Reference](../reference/cli.md#todo-claim)) to acquire an exclusive lock on a task. This prevents two agents from working on the same logical unit of work.
+2.  **Filesystem Isolation:** Each agent is assigned a unique git worktree. Even if multiple agents are working on the same repository, they never see each other's uncommitted files (see [Workspace Isolation](workspace-isolation.md)).
+3.  **Container Isolation:** For maximum safety, `container_workspaces = true` (see [Config Specification](../reference/config-toml.md)) ensures that each agent has its own process space and system dependencies.
 
 ## Shared Context
 
-While execution is isolated, context is shared. Agents use `decapod data memory` (Aptitude) to share learned preferences and project-specific knowledge across sessions. This allows Agent B to benefit from a code convention learned by Agent A five minutes earlier.
+While execution is isolated, context is shared. Agents use `decapod data memory` (Aptitude) to share learned preferences and project-specific knowledge across sessions. This allows Agent B to benefit from a code convention learned by Agent A five minutes earlier (see [Agent-First Architecture](../concepts/agent-first.md)).
 
 ## Best Practices
 
-- **Frequent Heartbeats:** Agents should run `decapod todo heartbeat` to signal they are still active.
+- **Frequent Heartbeats:** Agents should run `decapod todo heartbeat` (see [CLI Reference](../reference/cli.md)) to signal they are still active.
 - **Explicit Handoffs:** Use `decapod todo handoff` to transfer a task (and its current uncommitted state) between agents.
-- **Centralized Validation:** Always run `decapod validate` before publishing to ensure your changes haven't introduced regressions against the latest state of the root repository.
+- **Centralized Validation:** Always run `decapod validate` before publishing to ensure your changes haven't introduced regressions against the latest state of the root repository (see [Proof & Validation](../concepts/proof.md)).
+

--- a/docs/book/src/workflows/single-agent.md
+++ b/docs/book/src/workflows/single-agent.md
@@ -1,21 +1,22 @@
 # Single-Agent Workflow
 
-Even in single-agent environments, Decapod provides a rigorous structure that prevents common agentic errors and ensures high-quality delivery.
+Even in single-agent environments, Decapod provides a rigorous structure that prevents common agentic errors and ensures high-quality delivery (see [Agent-First Architecture](../concepts/agent-first.md)).
 
 ## The Standard Loop
 
-1.  **Orientation:** The agent reads `AGENTS.md` and initializes its session.
+1.  **Orientation:** The agent reads `AGENTS.md` and initializes its session (see [CLI Reference](../reference/cli.md#core-operations)).
     - `decapod session acquire`
-2.  **Intent Capture:** The agent identifies its task and formalizes the intent.
+2.  **Intent Capture:** The agent identifies its task and formalizes the intent (see [Explicit Intent](../concepts/intent.md)).
     - `decapod todo claim --id <id>`
-    - `update specs/INTENT.md`
-3.  **Workspace Entry:** The agent moves into an isolated environment.
+    - `update specs/INTENT.md` (see [Artifacts Reference](../reference/artifacts.md))
+3.  **Workspace Entry:** The agent moves into an isolated environment (see [Workspace Sandboxing](../concepts/workspaces.md)).
     - `decapod workspace ensure`
 4.  **Implementation:** The agent performs the work within the workspace.
 5.  **Validation:** The agent verifies the change against project policy.
     - `decapod validate`
-6.  **Completion:** The agent generates proof and marks the task as done.
+6.  **Completion:** The agent generates proof and marks the task as done (see [Proof & Validation](../concepts/proof.md)).
     - `decapod todo done --id <id> --validated`
+
 
 ## Key Benefits
 

--- a/docs/book/src/workflows/workspace-isolation.md
+++ b/docs/book/src/workflows/workspace-isolation.md
@@ -1,17 +1,17 @@
 # Workspace Isolation
 
-Workspace isolation is Decapod's primary defense against the "dirty tree" problem and multi-agent environment corruption.
+Workspace isolation is Decapod's primary defense against the "dirty tree" problem and multi-agent environment corruption (see [Workspace Sandboxing](../concepts/workspaces.md)).
 
 ## Git Worktrees: The First Line of Defense
 
-By default, `decapod workspace ensure` creates a **Git Worktree**. Unlike a standard clone, a worktree allows you to have multiple branches checked out simultaneously in different directories while sharing a single `.git` database.
+By default, `decapod workspace ensure` (see [CLI Reference](../reference/cli.md#workspace-ensure)) creates a **Git Worktree**. Unlike a standard clone, a worktree allows you to have multiple branches checked out simultaneously in different directories while sharing a single `.git` database.
 
 - **Speed:** Creating a worktree is nearly instantaneous.
 - **Integrity:** Each workspace is a clean slate. There are no residual build artifacts from other branches.
 
 ## Container Isolation: The Gold Standard
 
-When working with multiple agents or complex dependency chains, filesystem isolation is often not enough. Decapod can wrap each worktree in a Docker container.
+When working with multiple agents or complex dependency chains, filesystem isolation is often not enough. Decapod can wrap each worktree in a Docker container (see [Multi-Agent Workflow](multi-agent.md)).
 
 ### Benefits of Containerization:
 - **Dependency Sandboxing:** One agent can run `npm install` for Node 18 while another uses Node 20 in a separate workspace.
@@ -21,3 +21,4 @@ When working with multiple agents or complex dependency chains, filesystem isola
 ## Managing the Workspace Pool
 
 Use `decapod workspace status` to view the health and ownership of all active workspaces. Decapod handles the complex plumbing of mapping these directories to specific agents and tasks, so you don't have to.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Decapod Book
+nav_order: 1
+---
+
+# Decapod Documentation
+
+Welcome to the official documentation for **Decapod**—the daemonless, local-first, repo-native governance kernel for AI coding agents.
+
+This documentation serves as the comprehensive guide (the **Decapod Book**) for both humans designing repository boundaries and agents navigating them.
+
+---
+
+## 🚀 Getting Started
+
+*   **[Introduction](book/src/introduction.md)**: What is Decapod? Learn about the governance gap and the core pillars of repo-native agent control.
+*   **[Quickstart](book/src/quickstart.md)**: Install, initialize, and run your first agent handshake and validation in under five minutes.
+*   **[Mental Model](book/src/mental-model.md)**: Understand how agents, tasks, sessions, and workspaces interact.
+*   **[Configuration](book/src/configuration.md)**: Structure your repository config, enable cloud backends, and configure containerization.
+
+---
+
+## 🔄 Governed Workflows
+
+Learn how agents move through the lifecycle of planning, execution, validation, and completion.
+
+*   **[Single-Agent Workflows](book/src/workflows/single-agent.md)**: The lifecycle of an agent claim, ensure, validate, and finish loop.
+*   **[Multi-Agent Workflows](book/src/workflows/multi-agent.md)**: Handling concurrent agents, task claiming, and locking database state.
+*   **[Workspace Isolation](book/src/workflows/workspace-isolation.md)**: Setting up isolated Git worktrees and Docker containers to run tasks securely.
+*   **[External Trackers](book/src/workflows/external-trackers.md)**: Integrating Decapod with Jira, Linear, or GitHub Issues.
+
+---
+
+## 💡 Core Concepts
+
+Deep dive into the architecture and mechanisms that make Decapod unique.
+
+*   **[Agent-First Architecture](book/src/concepts/agent-first.md)**: Why Decapod is designed to be called directly at agent "inference pressure points".
+*   **[Explicit Intent](book/src/concepts/intent.md)**: Converting ambiguous prompts into concrete, versioned specifications.
+*   **[Workspace Sandboxing](book/src/concepts/workspaces.md)**: How isolated execution layers keep your primary branches clean and safe.
+*   **[Proof & Validation](book/src/concepts/proof.md)**: Verifying correctness programmatically through policy evaluation instead of agent self-reporting.
+*   **[Repository Constitution](book/src/concepts/constitution.md)**: Setting the global guidelines that steer agent behavior.
+*   **[Config Overrides](book/src/concepts/overrides.md)**: Project-specific adjustments to constitutional guidelines.
+*   **[Model Context Protocol (MCP)](book/src/concepts/mcp.md)**: Navigating Decapod tools through structured agent protocols.
+
+---
+
+## 📖 Reference Manual
+
+Hard specifications, command lists, configuration schemas, and error codes.
+
+*   **[Config Specification (config.toml)](book/src/reference/config-toml.md)**: Key-value reference for repo-level policy control.
+*   **[CLI Reference](book/src/reference/cli.md)**: Detailed breakdown of commands and options (init, validate, session, todo, decide).
+*   **[Error Reference](book/src/reference/errors.md)**: Decapod exit codes, validator failures, and self-healing instructions.
+*   **[Artifact Reference](book/src/reference/artifacts.md)**: Layout and schema of generated intent, handshake, and validation specs.
+
+---
+
+## 🛠️ Developer Resources
+
+To contribute or integrate Decapod into your platform:
+*   Visit the main GitHub Repository: [DecapodLabs/decapod](https://github.com/DecapodLabs/decapod)


### PR DESCRIPTION
Creates docs/index.md with Jekyll frontmatter mapping the chapters of the Decapod Book, and adds cross-references between the introduction and quickstart guides.