### PR TITLE
Fix: idempotent Git initialization for decapod init

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1781763924Z",
-  "repo_signal_fingerprint": "239e88839bd66123c10793c2511fccbf49587e65ded7937400d95aee20024d31",
+  "generated_at": "1781927506Z",
+  "repo_signal_fingerprint": "dae243d20cf68ab2fbe235dc2d17e0602825aebef16b8d8d1bf070690c777a41",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,6 +173,12 @@ pub(crate) struct InitGroupCli {
     /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
+    /// Explicitly opt into local Git repository initialization.
+    #[clap(long = "git", action = clap::ArgAction::SetTrue)]
+    pub git: bool,
+    /// Explicitly decline local Git repository initialization.
+    #[clap(long = "no-git", action = clap::ArgAction::SetTrue)]
+    pub no_git: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -265,6 +271,12 @@ pub(crate) struct InitWithCli {
     /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
+    /// Explicitly opt into local Git repository initialization.
+    #[clap(long = "git", action = clap::ArgAction::SetTrue)]
+    pub git: bool,
+    /// Explicitly decline local Git repository initialization.
+    #[clap(long = "no-git", action = clap::ArgAction::SetTrue)]
+    pub no_git: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1317,6 +1317,8 @@ fn init_with_from_config(
         } else {
             crate::cli::BackendType::Local
         },
+        git: false,
+        no_git: false,
     }
 }
 
@@ -1356,6 +1358,54 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
             ..crate::cli::CloudConfigSection::default()
         },
     }
+}
+
+fn is_git_repository(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output();
+    match output {
+        Ok(out) => out.status.success(),
+        Err(_) => false,
+    }
+}
+
+fn run_git_init(target_dir: &Path) -> Result<(), error::DecapodError> {
+    let output = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(target_dir)
+        .output()
+        .map_err(|e| error::DecapodError::ValidationError(format!("Failed to run git init: {e}")))?;
+
+    if !output.status.success() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "git init failed: {}\nRemediation: Ensure Git is installed and you have write permissions to '{}'.",
+            String::from_utf8_lossy(&output.stderr).trim(),
+            target_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+fn verify_git_status(target_dir: &Path) -> Result<(), error::DecapodError> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--short", "--branch"])
+        .current_dir(target_dir)
+        .output()
+        .map_err(|e| error::DecapodError::ValidationError(format!("Failed to verify Git repository status: {e}")))?;
+
+    if !output.status.success() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "Git repository verification failed: git status --short --branch did not succeed after git init.\nstderr: {}\nRemediation: Git repository may be corrupt or misconfigured in '{}'.",
+            String::from_utf8_lossy(&output.stderr).trim(),
+            target_dir.display()
+        )));
+    }
+    Ok(())
 }
 
 fn enrich_repo_context_interactive(
@@ -1717,6 +1767,12 @@ pub fn run() -> Result<(), error::DecapodError> {
                         if !init_group.ci {
                             with.ci = false;
                         }
+                        if init_group.git {
+                            with.git = true;
+                        }
+                        if init_group.no_git {
+                            with.no_git = true;
+                        }
                         if init_group.product_name.is_some() {
                             with.product_name = init_group.product_name.clone();
                         }
@@ -1768,6 +1824,8 @@ pub fn run() -> Result<(), error::DecapodError> {
                             detected_surfaces: init_group.detected_surfaces.clone(),
                             container_workspaces: init_group.container_workspaces,
                             mode: init_group.mode.clone(),
+                            git: init_group.git,
+                            no_git: init_group.no_git,
                         }
                     }
                 }
@@ -1799,8 +1857,41 @@ pub fn run() -> Result<(), error::DecapodError> {
             apply_substrate_adoption(&mut repo_ctx, &init_target);
             apply_architecture_language_recommendation(&mut repo_ctx);
 
-            // Only do full TUI experience if not refreshing an existing project
+            let is_git = is_git_repository(&init_target);
             let is_refresh = init_target.join(".decapod").exists();
+            let is_interactive = base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof;
+ 
+            if !is_git {
+                let opt_in = if init_with.no_git {
+                    false
+                } else if init_with.git {
+                    true
+                } else if is_interactive {
+                    print_init_block(
+                        "Git Repository",
+                        "Decapod worktree workflows require a Git repository to isolate agent changes.",
+                    );
+                    prompt_yes_no("Initialize Git repository for this project?", true)?
+                } else {
+                    // Non-interactive: do not automatically initialize git unless explicitly requested via --git
+                    false
+                };
+
+                if opt_in {
+                    if !init_with.dry_run {
+                        run_git_init(&init_target)?;
+                        verify_git_status(&init_target)?;
+                    }
+                } else {
+                    use crate::core::ansi::AnsiExt;
+                    println!(
+                        "{} Git repository was not initialized. Decapod workspace/worktree workflows will not function until a Git repository is created.",
+                        "warning:".bright_yellow()
+                    );
+                }
+            }
+
+            // Only do full TUI experience if not refreshing an existing project
             if base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof
             {
                 enrich_repo_context_interactive(&mut repo_ctx, &mut init_with)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1379,7 +1379,9 @@ fn run_git_init(target_dir: &Path) -> Result<(), error::DecapodError> {
         .arg("init")
         .current_dir(target_dir)
         .output()
-        .map_err(|e| error::DecapodError::ValidationError(format!("Failed to run git init: {e}")))?;
+        .map_err(|e| {
+            error::DecapodError::ValidationError(format!("Failed to run git init: {e}"))
+        })?;
 
     if !output.status.success() {
         return Err(error::DecapodError::ValidationError(format!(
@@ -1396,7 +1398,11 @@ fn verify_git_status(target_dir: &Path) -> Result<(), error::DecapodError> {
         .args(["status", "--short", "--branch"])
         .current_dir(target_dir)
         .output()
-        .map_err(|e| error::DecapodError::ValidationError(format!("Failed to verify Git repository status: {e}")))?;
+        .map_err(|e| {
+            error::DecapodError::ValidationError(format!(
+                "Failed to verify Git repository status: {e}"
+            ))
+        })?;
 
     if !output.status.success() {
         return Err(error::DecapodError::ValidationError(format!(
@@ -1859,8 +1865,11 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             let is_git = is_git_repository(&init_target);
             let is_refresh = init_target.join(".decapod").exists();
-            let is_interactive = base_init_invocation && io::stdin().is_terminal() && !is_refresh && !init_with.proof;
- 
+            let is_interactive = base_init_invocation
+                && io::stdin().is_terminal()
+                && !is_refresh
+                && !init_with.proof;
+
             if !is_git {
                 let opt_in = if init_with.no_git {
                     false

--- a/tests/git_init_regression.rs
+++ b/tests/git_init_regression.rs
@@ -83,19 +83,33 @@ fn test_init_in_existing_git_repository_preserves_state() {
     assert!(git_init.status.success());
 
     // Configure dummy user for git
-    let _ = Command::new("git").args(["config", "user.name", "Test User"]).current_dir(dir).output();
-    let _ = Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(dir).output();
+    let _ = Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(dir)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .output();
 
     fs::write(dir.join("dummy.txt"), "hello").expect("write dummy");
-    let _ = Command::new("git").args(["add", "."]).current_dir(dir).output();
-    let _ = Command::new("git").args(["commit", "-m", "first commit"]).current_dir(dir).output();
+    let _ = Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output();
+    let _ = Command::new("git")
+        .args(["commit", "-m", "first commit"])
+        .current_dir(dir)
+        .output();
 
     let git_head_before = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(dir)
         .output()
         .expect("git rev-parse");
-    let head_before = String::from_utf8_lossy(&git_head_before.stdout).trim().to_string();
+    let head_before = String::from_utf8_lossy(&git_head_before.stdout)
+        .trim()
+        .to_string();
 
     // Run decapod init (it should skip git init and preserve the repo state)
     let out = run_decapod(
@@ -114,7 +128,10 @@ fn test_init_in_existing_git_repository_preserves_state() {
         ],
         &[],
     );
-    assert!(out.status.success(), "decapod init on existing git repo failed");
+    assert!(
+        out.status.success(),
+        "decapod init on existing git repo failed"
+    );
 
     // Check HEAD is still the same (state preserved)
     let git_head_after = Command::new("git")
@@ -122,7 +139,9 @@ fn test_init_in_existing_git_repository_preserves_state() {
         .current_dir(dir)
         .output()
         .expect("git rev-parse");
-    let head_after = String::from_utf8_lossy(&git_head_after.stdout).trim().to_string();
+    let head_after = String::from_utf8_lossy(&git_head_after.stdout)
+        .trim()
+        .to_string();
 
     assert_eq!(head_before, head_after, "Git HEAD changed after init");
 }
@@ -157,12 +176,16 @@ fn test_init_with_no_git_declined() {
     );
 
     // Verify .git does NOT exist
-    assert!(!dir.join(".git").exists(), "Expected .git to not be created when declined");
+    assert!(
+        !dir.join(".git").exists(),
+        "Expected .git to not be created when declined"
+    );
 
     // Verify stdout/stderr contains warning
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("Git repository was not initialized") || String::from_utf8_lossy(&out.stderr).contains("Git repository was not initialized"),
+        stdout.contains("Git repository was not initialized")
+            || String::from_utf8_lossy(&out.stderr).contains("Git repository was not initialized"),
         "Warning message should be printed"
     );
 }
@@ -192,12 +215,24 @@ fn test_workspace_creation_immediately_after_init() {
     assert!(out.status.success());
 
     // Configure dummy user for git
-    let _ = Command::new("git").args(["config", "user.name", "Test User"]).current_dir(dir).output();
-    let _ = Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(dir).output();
+    let _ = Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(dir)
+        .output();
+    let _ = Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .output();
 
     // Make an initial commit
-    let _ = Command::new("git").args(["add", "."]).current_dir(dir).output();
-    let _ = Command::new("git").args(["commit", "-m", "first commit"]).current_dir(dir).output();
+    let _ = Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output();
+    let _ = Command::new("git")
+        .args(["commit", "-m", "first commit"])
+        .current_dir(dir)
+        .output();
 
     // Acquire session
     let acquire = run_decapod(
@@ -223,7 +258,11 @@ fn test_workspace_creation_immediately_after_init() {
         &password,
         &[],
     );
-    assert!(todo_add.status.success(), "todo add failed: {}", String::from_utf8_lossy(&todo_add.stderr));
+    assert!(
+        todo_add.status.success(),
+        "todo add failed: {}",
+        String::from_utf8_lossy(&todo_add.stderr)
+    );
 
     // Get todo ID from stdout
     let todo_stdout = String::from_utf8_lossy(&todo_add.stdout);
@@ -242,20 +281,15 @@ fn test_workspace_creation_immediately_after_init() {
         .expect("todo ID in output");
 
     // Claim todo
-    let todo_claim = run_decapod_with_password(
-        dir,
-        &["todo", "claim", "--id", &todo_id],
-        &password,
-        &[],
-    );
+    let todo_claim =
+        run_decapod_with_password(dir, &["todo", "claim", "--id", &todo_id], &password, &[]);
     assert!(todo_claim.status.success(), "todo claim failed");
 
     // Ensure workspace
-    let workspace_ensure = run_decapod_with_password(
-        dir,
-        &["workspace", "ensure"],
-        &password,
-        &[],
+    let workspace_ensure = run_decapod_with_password(dir, &["workspace", "ensure"], &password, &[]);
+    assert!(
+        workspace_ensure.status.success(),
+        "workspace ensure failed: {}",
+        String::from_utf8_lossy(&workspace_ensure.stderr)
     );
-    assert!(workspace_ensure.status.success(), "workspace ensure failed: {}", String::from_utf8_lossy(&workspace_ensure.stderr));
 }

--- a/tests/git_init_regression.rs
+++ b/tests/git_init_regression.rs
@@ -1,0 +1,261 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    cmd.current_dir(dir).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run decapod")
+}
+
+fn run_decapod_with_password(
+    dir: &Path,
+    args: &[&str],
+    password: &str,
+    extra_envs: &[(&str, &str)],
+) -> std::process::Output {
+    let mut envs = vec![
+        ("DECAPOD_AGENT_ID", "git-init-test-agent"),
+        ("DECAPOD_SESSION_PASSWORD", password),
+    ];
+    for (k, v) in extra_envs {
+        envs.push((*k, *v));
+    }
+    run_decapod(dir, args, &envs)
+}
+
+#[test]
+fn test_init_in_non_git_directory_with_git_opt_in() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    // Run decapod init with --git (explicit opt-in)
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--git",
+            "--product-name",
+            "Test Git Project",
+            "--product-summary",
+            "Summary",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+
+    assert!(
+        out.status.success(),
+        "decapod init with --git failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Verify .git exists
+    assert!(dir.join(".git").exists(), "Expected .git to be created");
+
+    // Verify git status succeeds
+    let git_status = Command::new("git")
+        .args(["status", "--short", "--branch"])
+        .current_dir(dir)
+        .output()
+        .expect("git status");
+    assert!(git_status.status.success(), "git status failed after init");
+}
+
+#[test]
+fn test_init_in_existing_git_repository_preserves_state() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    // Manually run git init and create an initial commit
+    let git_init = Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .expect("git init");
+    assert!(git_init.status.success());
+
+    // Configure dummy user for git
+    let _ = Command::new("git").args(["config", "user.name", "Test User"]).current_dir(dir).output();
+    let _ = Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(dir).output();
+
+    fs::write(dir.join("dummy.txt"), "hello").expect("write dummy");
+    let _ = Command::new("git").args(["add", "."]).current_dir(dir).output();
+    let _ = Command::new("git").args(["commit", "-m", "first commit"]).current_dir(dir).output();
+
+    let git_head_before = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .expect("git rev-parse");
+    let head_before = String::from_utf8_lossy(&git_head_before.stdout).trim().to_string();
+
+    // Run decapod init (it should skip git init and preserve the repo state)
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--git",
+            "--product-name",
+            "Existing Project",
+            "--product-summary",
+            "Summary",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+    assert!(out.status.success(), "decapod init on existing git repo failed");
+
+    // Check HEAD is still the same (state preserved)
+    let git_head_after = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .expect("git rev-parse");
+    let head_after = String::from_utf8_lossy(&git_head_after.stdout).trim().to_string();
+
+    assert_eq!(head_before, head_after, "Git HEAD changed after init");
+}
+
+#[test]
+fn test_init_with_no_git_declined() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    // Run decapod init with --no-git (explicitly decline)
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--no-git",
+            "--product-name",
+            "No Git Project",
+            "--product-summary",
+            "Summary",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+
+    assert!(
+        out.status.success(),
+        "decapod init with --no-git failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Verify .git does NOT exist
+    assert!(!dir.join(".git").exists(), "Expected .git to not be created when declined");
+
+    // Verify stdout/stderr contains warning
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Git repository was not initialized") || String::from_utf8_lossy(&out.stderr).contains("Git repository was not initialized"),
+        "Warning message should be printed"
+    );
+}
+
+#[test]
+fn test_workspace_creation_immediately_after_init() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    // Run init with git enabled
+    let out = run_decapod(
+        dir,
+        &[
+            "init",
+            "with",
+            "--force",
+            "--git",
+            "--product-name",
+            "Clean Project",
+            "--product-summary",
+            "Summary",
+            "--primary-language",
+            "Rust",
+        ],
+        &[],
+    );
+    assert!(out.status.success());
+
+    // Configure dummy user for git
+    let _ = Command::new("git").args(["config", "user.name", "Test User"]).current_dir(dir).output();
+    let _ = Command::new("git").args(["config", "user.email", "test@example.com"]).current_dir(dir).output();
+
+    // Make an initial commit
+    let _ = Command::new("git").args(["add", "."]).current_dir(dir).output();
+    let _ = Command::new("git").args(["commit", "-m", "first commit"]).current_dir(dir).output();
+
+    // Acquire session
+    let acquire = run_decapod(
+        dir,
+        &["session", "acquire"],
+        &[("DECAPOD_AGENT_ID", "git-init-test-agent")],
+    );
+    assert!(acquire.status.success());
+
+    let stdout = String::from_utf8_lossy(&acquire.stdout);
+    let password = stdout
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Password: ")
+                .map(|s| s.trim().to_string())
+        })
+        .expect("password in session acquire output");
+
+    // Add a todo
+    let todo_add = run_decapod_with_password(
+        dir,
+        &["todo", "add", "workspace test task", "--priority", "high"],
+        &password,
+        &[],
+    );
+    assert!(todo_add.status.success(), "todo add failed: {}", String::from_utf8_lossy(&todo_add.stderr));
+
+    // Get todo ID from stdout
+    let todo_stdout = String::from_utf8_lossy(&todo_add.stdout);
+    let todo_id = todo_stdout
+        .lines()
+        .find_map(|line| {
+            if line.contains("\"id\":\"") {
+                let parts: Vec<&str> = line.split("\"id\":\"").collect();
+                if parts.len() > 1 {
+                    let end_parts: Vec<&str> = parts[1].split('"').collect();
+                    return Some(end_parts[0].to_string());
+                }
+            }
+            None
+        })
+        .expect("todo ID in output");
+
+    // Claim todo
+    let todo_claim = run_decapod_with_password(
+        dir,
+        &["todo", "claim", "--id", &todo_id],
+        &password,
+        &[],
+    );
+    assert!(todo_claim.status.success(), "todo claim failed");
+
+    // Ensure workspace
+    let workspace_ensure = run_decapod_with_password(
+        dir,
+        &["workspace", "ensure"],
+        &password,
+        &[],
+    );
+    assert!(workspace_ensure.status.success(), "workspace ensure failed: {}", String::from_utf8_lossy(&workspace_ensure.stderr));
+}


### PR DESCRIPTION
Closes #716.

This PR implements idempotent Git repository checking and initialization during `decapod init`:
- Detects if already inside a Git repository using `git rev-parse --is-inside-work-tree`.
- Adds `--git` and `--no-git` flags to allow explicit, non-interactive control over Git repository setup.
- In interactive mode, prompts the user to initialize a Git repository if one isn't detected.
- Verifies successful Git initialization via `git status --short --branch` and fails loudly with remediation advice if it fails.
- Adds comprehensive integration tests covering all scenarios (non-git directory, existing git repo, declined git setup, and workspace creation immediately after init).