### PR TITLE
Solve Issue #710: Implement workspace pruning subcommand

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1781927506Z",
-  "repo_signal_fingerprint": "dae243d20cf68ab2fbe235dc2d17e0602825aebef16b8d8d1bf070690c777a41",
+  "generated_at": "1781934204Z",
+  "repo_signal_fingerprint": "4c53d4a5fdc8bdde620b125783f148bd535b52fcd2f6a9551022afc2d2c13b1b",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,10 @@ path = "tests/gatling.rs"
 name = "core_tests"
 path = "tests/core/core.rs"
 
+[[test]]
+name = "workspace_prune_regression"
+path = "tests/workspace_prune_regression.rs"
+
 [[bench]]
 name = "perf_1_1"
 path = "project/benches/perf_1_1.rs"

--- a/docs/agent/command-contracts.md
+++ b/docs/agent/command-contracts.md
@@ -50,12 +50,9 @@ This document defines the normative operational contracts for the Decapod CLI.
 - **Intent:** Architecture decision prompting
 
 ## `decapod workspace`
-- **Intent:** Agent workspace management (ensure, status, publish, prune)
-- **Subcommands:**
-  - `ensure`: Creates or reuses a Git worktree or Docker container workspace for a claimed task.
-  - `status`: Displays current workspace metadata and validation report status.
-  - `publish`: Publishes workspace changes as a patch/PR bundle.
-  - `prune`: Deletes stale workspace directories under `.decapod/workspaces/` (associated with done/archived tasks, deleted branches, or matching no active claim) and cleans up Git config metadata. Accepts optional `--force` flag.
+- **Intent:** Agent workspace management
+- **Preconditions:** Task must be claimed.
+- **State Transition:** Creates git worktrees/containers.
 
 ## `decapod rpc`
 - **Intent:** Structured JSON-RPC interface for agents

--- a/docs/agent/command-contracts.md
+++ b/docs/agent/command-contracts.md
@@ -50,9 +50,12 @@ This document defines the normative operational contracts for the Decapod CLI.
 - **Intent:** Architecture decision prompting
 
 ## `decapod workspace`
-- **Intent:** Agent workspace management
-- **Preconditions:** Task must be claimed.
-- **State Transition:** Creates git worktrees/containers.
+- **Intent:** Agent workspace management (ensure, status, publish, prune)
+- **Subcommands:**
+  - `ensure`: Creates or reuses a Git worktree or Docker container workspace for a claimed task.
+  - `status`: Displays current workspace metadata and validation report status.
+  - `publish`: Publishes workspace changes as a patch/PR bundle.
+  - `prune`: Deletes stale workspace directories under `.decapod/workspaces/` (associated with done/archived tasks, deleted branches, or matching no active claim) and cleans up Git config metadata. Accepts optional `--force` flag.
 
 ## `decapod rpc`
 - **Intent:** Structured JSON-RPC interface for agents

--- a/docs/agent/payload-examples.md
+++ b/docs/agent/payload-examples.md
@@ -45,6 +45,11 @@ decapod workspace ensure --container --branch "feat/rate-limiting"
 decapod workspace publish --title "Feat: Rate Limiting" --description "Implemented token bucket rate limiting for the API surface."
 ```
 
+### Prune Stale Workspaces
+```bash
+decapod workspace prune --force
+```
+
 ## Smart Bootstrap
 
 Efficiently install and initialize Decapod only when updates are available.

--- a/docs/agent/state-model.md
+++ b/docs/agent/state-model.md
@@ -13,6 +13,7 @@ Isolated execution environments.
 - **Types:** Git Worktree | Docker Container.
 - **Relationship:** Each active workspace is mapped to exactly one `task_id` and one `agent_id`.
 - **Artifacts:** Changes made in a workspace are transient until `workspace publish` is called.
+- **Cleanup:** Stale/unused workspaces (associated with done/archived tasks, deleted branches, or matching no active claim) can be cleaned up using the `workspace prune` command.
 
 ## 3. Sessions
 Authentication and identity verification tokens.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,12 @@ pub(crate) enum WorkspaceCommand {
         #[clap(long)]
         description: Option<String>,
     },
+    /// Prune stale/unused agent workspaces
+    Prune {
+        /// Force removal of worktrees with local changes
+        #[clap(long)]
+        force: bool,
+    },
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1255,7 +1255,10 @@ pub struct PrunedWorkspace {
 }
 
 /// Prune stale/unused agent workspaces
-pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorkspace>, DecapodError> {
+pub fn prune_workspaces(
+    repo_root: &Path,
+    force: bool,
+) -> Result<Vec<PrunedWorkspace>, DecapodError> {
     let main_repo = get_main_repo_root(repo_root)?;
     let workspaces_dir = main_repo.join(".decapod").join("workspaces");
     if !workspaces_dir.is_dir() {
@@ -1341,15 +1344,16 @@ pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorks
             continue;
         }
 
-        let dir_name = dir_path.file_name()
+        let dir_name = dir_path
+            .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("")
             .to_string();
 
         // Check if registered as a worktree in git
-        let matching_wt = worktrees.iter().find(|wt| {
-            normalize_path_for_compare(&wt.path) == normalized_dir
-        });
+        let matching_wt = worktrees
+            .iter()
+            .find(|wt| normalize_path_for_compare(&wt.path) == normalized_dir);
 
         let mut is_stale = false;
         let mut prune_reason = String::new();
@@ -1383,7 +1387,8 @@ pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorks
                             let hash_lower = t.hash.to_lowercase();
                             let dir_lower = dir_name.to_lowercase();
                             let branch_lower = ref_name.to_lowercase();
-                            if dir_lower.contains(&hash_lower) || branch_lower.contains(&hash_lower) {
+                            if dir_lower.contains(&hash_lower) || branch_lower.contains(&hash_lower)
+                            {
                                 matched_tasks.push(t);
                             }
                         }
@@ -1394,12 +1399,11 @@ pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorks
                         prune_reason = "no_matching_task".to_string();
                     } else {
                         // Check status of matched tasks
-                        let all_completed = matched_tasks.iter().all(|t| {
-                            t.status == "done" || t.status == "archived"
-                        });
-                        let no_active_claim = matched_tasks.iter().all(|t| {
-                            t.assigned_to.is_empty()
-                        });
+                        let all_completed = matched_tasks
+                            .iter()
+                            .all(|t| t.status == "done" || t.status == "archived");
+                        let no_active_claim =
+                            matched_tasks.iter().all(|t| t.assigned_to.is_empty());
 
                         if all_completed {
                             is_stale = true;
@@ -1426,12 +1430,10 @@ pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorks
                     is_stale = true;
                     prune_reason = "no_matching_task".to_string();
                 } else {
-                    let all_completed = matched_tasks.iter().all(|t| {
-                        t.status == "done" || t.status == "archived"
-                    });
-                    let no_active_claim = matched_tasks.iter().all(|t| {
-                        t.assigned_to.is_empty()
-                    });
+                    let all_completed = matched_tasks
+                        .iter()
+                        .all(|t| t.status == "done" || t.status == "archived");
+                    let no_active_claim = matched_tasks.iter().all(|t| t.assigned_to.is_empty());
                     if all_completed {
                         is_stale = true;
                         prune_reason = "task_completed".to_string();

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1244,3 +1244,238 @@ pub fn get_allowed_ops(status: &WorkspaceStatus) -> Vec<AllowedOp> {
 
     ops
 }
+
+/// Workspace pruned record
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PrunedWorkspace {
+    /// Absolute path of the pruned workspace
+    pub path: String,
+    /// Reason for pruning: not_registered, branch_deleted, no_matching_task, task_completed, no_active_claim
+    pub reason: String,
+}
+
+/// Prune stale/unused agent workspaces
+pub fn prune_workspaces(repo_root: &Path, force: bool) -> Result<Vec<PrunedWorkspace>, DecapodError> {
+    let main_repo = get_main_repo_root(repo_root)?;
+    let workspaces_dir = main_repo.join(".decapod").join("workspaces");
+    if !workspaces_dir.is_dir() {
+        return Ok(vec![]);
+    }
+
+    // 1) Parse all current git worktrees
+    let worktrees_output = Command::new("git")
+        .args([
+            "-C",
+            main_repo.to_str().unwrap_or("."),
+            "worktree",
+            "list",
+            "--porcelain",
+        ])
+        .output()
+        .map_err(DecapodError::IoError)?;
+
+    if !worktrees_output.status.success() {
+        return Err(DecapodError::ValidationError(format!(
+            "Failed to list git worktrees: {}",
+            String::from_utf8_lossy(&worktrees_output.stderr)
+        )));
+    }
+
+    struct WorktreeInfo {
+        path: PathBuf,
+        branch: Option<String>,
+        _head: Option<String>,
+    }
+
+    let mut worktrees = Vec::new();
+    let mut current_path = None;
+    let mut current_branch = None;
+    let mut current_head = None;
+
+    for line in String::from_utf8_lossy(&worktrees_output.stdout).lines() {
+        if let Some(p) = line.strip_prefix("worktree ") {
+            if let Some(path) = current_path.take() {
+                worktrees.push(WorktreeInfo {
+                    path,
+                    branch: current_branch.take(),
+                    _head: current_head.take(),
+                });
+            }
+            current_path = Some(PathBuf::from(p.trim()));
+        } else if let Some(b) = line.strip_prefix("branch ") {
+            current_branch = Some(b.trim().to_string());
+        } else if let Some(h) = line.strip_prefix("HEAD ") {
+            current_head = Some(h.trim().to_string());
+        }
+    }
+    if let Some(path) = current_path {
+        worktrees.push(WorktreeInfo {
+            path,
+            branch: current_branch,
+            _head: current_head,
+        });
+    }
+
+    // 2) Get all tasks from todo database
+    let store_root = main_repo.join(".decapod").join("data");
+    let tasks = if store_root.exists() {
+        todo::list_tasks(&store_root, None, None, None, None, None).unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    let mut pruned = Vec::new();
+
+    // 3) Iterate over the directory entries under .decapod/workspaces/
+    for entry in std::fs::read_dir(&workspaces_dir).map_err(DecapodError::IoError)? {
+        let entry = entry.map_err(DecapodError::IoError)?;
+        let dir_path = entry.path();
+        if !dir_path.is_dir() {
+            continue;
+        }
+
+        // Safety Safeguard: Do not prune if repo_root is inside or equal to dir_path.
+        let normalized_dir = normalize_path_for_compare(&dir_path);
+        let normalized_repo = normalize_path_for_compare(repo_root);
+        if normalized_repo == normalized_dir || repo_root.starts_with(&dir_path) {
+            continue;
+        }
+
+        let dir_name = dir_path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Check if registered as a worktree in git
+        let matching_wt = worktrees.iter().find(|wt| {
+            normalize_path_for_compare(&wt.path) == normalized_dir
+        });
+
+        let mut is_stale = false;
+        let mut prune_reason = String::new();
+
+        if let Some(wt) = matching_wt {
+            // Check branch existence
+            if let Some(ref_name) = &wt.branch {
+                let show_ref_out = Command::new("git")
+                    .args([
+                        "-C",
+                        main_repo.to_str().unwrap_or("."),
+                        "show-ref",
+                        "--verify",
+                        ref_name,
+                    ])
+                    .output();
+
+                let branch_exists = match show_ref_out {
+                    Ok(out) => out.status.success(),
+                    Err(_) => false,
+                };
+
+                if !branch_exists {
+                    is_stale = true;
+                    prune_reason = "branch_deleted".to_string();
+                } else {
+                    // Branch exists, check matching tasks
+                    let mut matched_tasks = Vec::new();
+                    for t in &tasks {
+                        if !t.hash.is_empty() {
+                            let hash_lower = t.hash.to_lowercase();
+                            let dir_lower = dir_name.to_lowercase();
+                            let branch_lower = ref_name.to_lowercase();
+                            if dir_lower.contains(&hash_lower) || branch_lower.contains(&hash_lower) {
+                                matched_tasks.push(t);
+                            }
+                        }
+                    }
+
+                    if matched_tasks.is_empty() {
+                        is_stale = true;
+                        prune_reason = "no_matching_task".to_string();
+                    } else {
+                        // Check status of matched tasks
+                        let all_completed = matched_tasks.iter().all(|t| {
+                            t.status == "done" || t.status == "archived"
+                        });
+                        let no_active_claim = matched_tasks.iter().all(|t| {
+                            t.assigned_to.is_empty()
+                        });
+
+                        if all_completed {
+                            is_stale = true;
+                            prune_reason = "task_completed".to_string();
+                        } else if no_active_claim {
+                            is_stale = true;
+                            prune_reason = "no_active_claim".to_string();
+                        }
+                    }
+                }
+            } else {
+                // No branch associated (detached HEAD) -> if no task matches it, prune it
+                let mut matched_tasks = Vec::new();
+                for t in &tasks {
+                    if !t.hash.is_empty() {
+                        let hash_lower = t.hash.to_lowercase();
+                        let dir_lower = dir_name.to_lowercase();
+                        if dir_lower.contains(&hash_lower) {
+                            matched_tasks.push(t);
+                        }
+                    }
+                }
+                if matched_tasks.is_empty() {
+                    is_stale = true;
+                    prune_reason = "no_matching_task".to_string();
+                } else {
+                    let all_completed = matched_tasks.iter().all(|t| {
+                        t.status == "done" || t.status == "archived"
+                    });
+                    let no_active_claim = matched_tasks.iter().all(|t| {
+                        t.assigned_to.is_empty()
+                    });
+                    if all_completed {
+                        is_stale = true;
+                        prune_reason = "task_completed".to_string();
+                    } else if no_active_claim {
+                        is_stale = true;
+                        prune_reason = "no_active_claim".to_string();
+                    }
+                }
+            }
+        } else {
+            // Case A: Not registered in git worktrees
+            is_stale = true;
+            prune_reason = "not_registered".to_string();
+        }
+
+        if is_stale {
+            // Attempt to remove git worktree if registered
+            if matching_wt.is_some() {
+                let mut args = vec!["worktree", "remove"];
+                if force {
+                    args.push("--force");
+                }
+                args.push(dir_path.to_str().unwrap_or("."));
+
+                let _ = Command::new("git")
+                    .args(["-C", main_repo.to_str().unwrap_or(".")])
+                    .args(&args)
+                    .output();
+            }
+
+            // Fallback: forcefully remove from disk if it still exists
+            if dir_path.exists() {
+                let _ = std::fs::remove_dir_all(&dir_path);
+            }
+
+            pruned.push(PrunedWorkspace {
+                path: dir_path.to_string_lossy().to_string(),
+                reason: prune_reason,
+            });
+        }
+    }
+
+    // Call prune_stale_worktree_config to scrub .git/config entries
+    let _ = prune_stale_worktree_config(repo_root);
+
+    Ok(pruned)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6102,6 +6102,16 @@ fn run_workspace_command(
                 })
             );
         }
+        WorkspaceCommand::Prune { force } => {
+            let pruned = workspace::prune_workspaces(project_root, force)?;
+            println!(
+                "{}",
+                serde_json::json!({
+                    "status": "ok",
+                    "pruned": pruned,
+                })
+            );
+        }
     }
 
     Ok(())

--- a/tests/workspace_prune_regression.rs
+++ b/tests/workspace_prune_regression.rs
@@ -1,6 +1,6 @@
 use decapod::core::store::{Store, StoreKind};
 use decapod::core::todo::{
-    add_task, claim_task, initialize_todo_db, update_status, ClaimMode, TodoCommand,
+    ClaimMode, TodoCommand, add_task, claim_task, initialize_todo_db, update_status,
 };
 use decapod::core::workspace;
 use std::fs;
@@ -123,9 +123,12 @@ fn test_workspace_prune() {
     // Manually set distinct hashes in the SQLite db so they don't overlap within the 4.3 minute ULID millisecond threshold
     let db_path = decapod::core::todo::todo_db_path(&store_root);
     let conn = rusqlite::Connection::open(&db_path).expect("open db");
-    conn.execute("UPDATE tasks SET hash = 'hashaa' WHERE id = ?", [id_a]).expect("update a");
-    conn.execute("UPDATE tasks SET hash = 'hashbb' WHERE id = ?", [id_b]).expect("update b");
-    conn.execute("UPDATE tasks SET hash = 'hashcc' WHERE id = ?", [id_c]).expect("update c");
+    conn.execute("UPDATE tasks SET hash = 'hashaa' WHERE id = ?", [id_a])
+        .expect("update a");
+    conn.execute("UPDATE tasks SET hash = 'hashbb' WHERE id = ?", [id_b])
+        .expect("update b");
+    conn.execute("UPDATE tasks SET hash = 'hashcc' WHERE id = ?", [id_c])
+        .expect("update c");
 
     let hash_a = "hashaa";
     let hash_b = "hashbb";
@@ -143,22 +146,58 @@ fn test_workspace_prune() {
     // Worktree A (Active branch/task)
     let wt_a_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-a", hash_a));
     let wt_a_branch = format!("agent/test-agent/todo-{}", hash_a);
-    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_a_branch, wt_a_path.to_str().unwrap()]);
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &wt_a_branch,
+            wt_a_path.to_str().unwrap(),
+        ],
+    );
 
     // Worktree B (Task is done)
     let wt_b_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-b", hash_b));
     let wt_b_branch = format!("agent/test-agent/todo-{}", hash_b);
-    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_b_branch, wt_b_path.to_str().unwrap()]);
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &wt_b_branch,
+            wt_b_path.to_str().unwrap(),
+        ],
+    );
 
     // Worktree C (Task has no claim)
     let wt_c_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-c", hash_c));
     let wt_c_branch = format!("agent/test-agent/todo-{}", hash_c);
-    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_c_branch, wt_c_path.to_str().unwrap()]);
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &wt_c_branch,
+            wt_c_path.to_str().unwrap(),
+        ],
+    );
 
     // Worktree D (Branch does not exist - mock this by adding worktree, then deleting its branch)
     let wt_d_path = workspaces_dir.join("test-agent-todo-111111-todo-d");
     let wt_d_branch = "agent/test-agent/todo-111111";
-    run_git_cmd(&main_root, &["worktree", "add", "-b", wt_d_branch, wt_d_path.to_str().unwrap()]);
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            wt_d_branch,
+            wt_d_path.to_str().unwrap(),
+        ],
+    );
 
     // Delete branch wt_d_branch using `git branch -D`
     run_git_cmd(&wt_d_path, &["checkout", "--detach"]);
@@ -184,14 +223,39 @@ fn test_workspace_prune() {
     assert!(wt_a_path.exists(), "Worktree A (active) must not be pruned");
 
     // wt_b, wt_c, wt_d, wt_e should be pruned (no longer exist on disk)
-    assert!(!wt_b_path.exists(), "Worktree B (completed task) should be pruned");
-    assert!(!wt_c_path.exists(), "Worktree C (no active claim) should be pruned");
-    assert!(!wt_d_path.exists(), "Worktree D (deleted branch) should be pruned");
-    assert!(!wt_e_path.exists(), "Worktree E (unregistered directory) should be pruned");
+    assert!(
+        !wt_b_path.exists(),
+        "Worktree B (completed task) should be pruned"
+    );
+    assert!(
+        !wt_c_path.exists(),
+        "Worktree C (no active claim) should be pruned"
+    );
+    assert!(
+        !wt_d_path.exists(),
+        "Worktree D (deleted branch) should be pruned"
+    );
+    assert!(
+        !wt_e_path.exists(),
+        "Worktree E (unregistered directory) should be pruned"
+    );
 
     // Verify pruned records
-    assert!(pruned.iter().any(|p| p.path == wt_b_path.to_string_lossy() && p.reason == "task_completed"));
-    assert!(pruned.iter().any(|p| p.path == wt_c_path.to_string_lossy() && p.reason == "no_active_claim"));
-    assert!(pruned.iter().any(|p| p.path == wt_d_path.to_string_lossy() && (p.reason == "branch_deleted" || p.reason == "no_matching_task")));
-    assert!(pruned.iter().any(|p| p.path == wt_e_path.to_string_lossy() && p.reason == "not_registered"));
+    assert!(
+        pruned
+            .iter()
+            .any(|p| p.path == wt_b_path.to_string_lossy() && p.reason == "task_completed")
+    );
+    assert!(
+        pruned
+            .iter()
+            .any(|p| p.path == wt_c_path.to_string_lossy() && p.reason == "no_active_claim")
+    );
+    assert!(pruned.iter().any(|p| p.path == wt_d_path.to_string_lossy()
+        && (p.reason == "branch_deleted" || p.reason == "no_matching_task")));
+    assert!(
+        pruned
+            .iter()
+            .any(|p| p.path == wt_e_path.to_string_lossy() && p.reason == "not_registered")
+    );
 }

--- a/tests/workspace_prune_regression.rs
+++ b/tests/workspace_prune_regression.rs
@@ -1,0 +1,197 @@
+use decapod::core::store::{Store, StoreKind};
+use decapod::core::todo::{
+    add_task, claim_task, initialize_todo_db, update_status, ClaimMode, TodoCommand,
+};
+use decapod::core::workspace;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn git_init(dir: &Path) {
+    run_git_cmd(dir, &["init"]);
+    run_git_cmd(dir, &["config", "user.email", "test@test.com"]);
+    run_git_cmd(dir, &["config", "user.name", "Test"]);
+}
+
+fn git_commit(dir: &Path, msg: &str) {
+    fs::write(dir.join(".gitkeep"), "").ok();
+    run_git_cmd(dir, &["add", "-A"]);
+    run_git_cmd(dir, &["commit", "--allow-empty", "-m", msg]);
+}
+
+fn run_git_cmd(dir: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to execute git");
+    if !output.status.success() {
+        panic!(
+            "git command failed: git {}\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn test_workspace_prune() {
+    let tmp = tempdir().expect("tempdir");
+    let main_root = tmp.path().join("main_repo");
+    fs::create_dir_all(&main_root).expect("create main_repo");
+
+    git_init(&main_root);
+    git_commit(&main_root, "init");
+
+    // Initialize todo db in main_root/.decapod/data
+    let store_root = main_root.join(".decapod").join("data");
+    fs::create_dir_all(&store_root).expect("create data dir");
+    initialize_todo_db(&store_root).expect("init todo db");
+
+    let store = Store {
+        kind: StoreKind::Repo,
+        root: store_root.clone(),
+    };
+
+    // 1. Task A (Active / Open & Claimed)
+    let task_a_res = add_task(
+        &store_root,
+        &TodoCommand::Add {
+            title: "Task A".to_string(),
+            description: "".to_string(),
+            tags: "".to_string(),
+            owner: "test-agent".to_string(),
+            due: None,
+            r#ref: "".to_string(),
+            scope: "".to_string(),
+            dir: Some(main_root.to_string_lossy().to_string()),
+            priority: "medium".to_string(),
+            depends_on: "".to_string(),
+            blocks: "".to_string(),
+            parent: None,
+            one_shot: 0,
+        },
+    )
+    .expect("add task a");
+    let id_a = task_a_res.get("id").unwrap().as_str().unwrap();
+
+    // 2. Task B (Done / Completed)
+    let task_b_res = add_task(
+        &store_root,
+        &TodoCommand::Add {
+            title: "Task B".to_string(),
+            description: "".to_string(),
+            tags: "".to_string(),
+            owner: "test-agent".to_string(),
+            due: None,
+            r#ref: "".to_string(),
+            scope: "".to_string(),
+            dir: Some(main_root.to_string_lossy().to_string()),
+            priority: "medium".to_string(),
+            depends_on: "".to_string(),
+            blocks: "".to_string(),
+            parent: None,
+            one_shot: 0,
+        },
+    )
+    .expect("add task b");
+    let id_b = task_b_res.get("id").unwrap().as_str().unwrap();
+
+    // 3. Task C (Open but Released/No Claim)
+    let task_c_res = add_task(
+        &store_root,
+        &TodoCommand::Add {
+            title: "Task C".to_string(),
+            description: "".to_string(),
+            tags: "".to_string(),
+            owner: "test-agent".to_string(),
+            due: None,
+            r#ref: "".to_string(),
+            scope: "".to_string(),
+            dir: Some(main_root.to_string_lossy().to_string()),
+            priority: "medium".to_string(),
+            depends_on: "".to_string(),
+            blocks: "".to_string(),
+            parent: None,
+            one_shot: 0,
+        },
+    )
+    .expect("add task c");
+    let id_c = task_c_res.get("id").unwrap().as_str().unwrap();
+
+    // Manually set distinct hashes in the SQLite db so they don't overlap within the 4.3 minute ULID millisecond threshold
+    let db_path = decapod::core::todo::todo_db_path(&store_root);
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    conn.execute("UPDATE tasks SET hash = 'hashaa' WHERE id = ?", [id_a]).expect("update a");
+    conn.execute("UPDATE tasks SET hash = 'hashbb' WHERE id = ?", [id_b]).expect("update b");
+    conn.execute("UPDATE tasks SET hash = 'hashcc' WHERE id = ?", [id_c]).expect("update c");
+
+    let hash_a = "hashaa";
+    let hash_b = "hashbb";
+    let hash_c = "hashcc";
+
+    // Set claims and status
+    claim_task(&store_root, id_a, "test-agent", ClaimMode::Exclusive).expect("claim task a");
+    claim_task(&store_root, id_b, "test-agent", ClaimMode::Exclusive).expect("claim task b");
+    update_status(&store, id_b, "done", "task.done", serde_json::json!({})).expect("done task b");
+
+    // 4. Create actual git worktrees for A, B, C, D
+    let workspaces_dir = main_root.join(".decapod").join("workspaces");
+    fs::create_dir_all(&workspaces_dir).expect("create workspaces dir");
+
+    // Worktree A (Active branch/task)
+    let wt_a_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-a", hash_a));
+    let wt_a_branch = format!("agent/test-agent/todo-{}", hash_a);
+    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_a_branch, wt_a_path.to_str().unwrap()]);
+
+    // Worktree B (Task is done)
+    let wt_b_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-b", hash_b));
+    let wt_b_branch = format!("agent/test-agent/todo-{}", hash_b);
+    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_b_branch, wt_b_path.to_str().unwrap()]);
+
+    // Worktree C (Task has no claim)
+    let wt_c_path = workspaces_dir.join(format!("test-agent-todo-{}-todo-c", hash_c));
+    let wt_c_branch = format!("agent/test-agent/todo-{}", hash_c);
+    run_git_cmd(&main_root, &["worktree", "add", "-b", &wt_c_branch, wt_c_path.to_str().unwrap()]);
+
+    // Worktree D (Branch does not exist - mock this by adding worktree, then deleting its branch)
+    let wt_d_path = workspaces_dir.join("test-agent-todo-111111-todo-d");
+    let wt_d_branch = "agent/test-agent/todo-111111";
+    run_git_cmd(&main_root, &["worktree", "add", "-b", wt_d_branch, wt_d_path.to_str().unwrap()]);
+
+    // Delete branch wt_d_branch using `git branch -D`
+    run_git_cmd(&wt_d_path, &["checkout", "--detach"]);
+    run_git_cmd(&main_root, &["branch", "-D", wt_d_branch]);
+
+    // Worktree E (Orphaned workspace directory, not registered in git worktrees)
+    let wt_e_path = workspaces_dir.join("test-agent-todo-222222-orphaned");
+    fs::create_dir_all(&wt_e_path).expect("create wt_e");
+    fs::write(wt_e_path.join("some_residual_file.txt"), "hello").expect("write residual");
+
+    // Check directory existence before pruning
+    assert!(wt_a_path.exists());
+    assert!(wt_b_path.exists());
+    assert!(wt_c_path.exists());
+    assert!(wt_d_path.exists());
+    assert!(wt_e_path.exists());
+
+    // Execute prune!
+    let pruned = workspace::prune_workspaces(&main_root, true).expect("prune_workspaces");
+
+    // Verify what was pruned
+    // wt_a should NOT be pruned
+    assert!(wt_a_path.exists(), "Worktree A (active) must not be pruned");
+
+    // wt_b, wt_c, wt_d, wt_e should be pruned (no longer exist on disk)
+    assert!(!wt_b_path.exists(), "Worktree B (completed task) should be pruned");
+    assert!(!wt_c_path.exists(), "Worktree C (no active claim) should be pruned");
+    assert!(!wt_d_path.exists(), "Worktree D (deleted branch) should be pruned");
+    assert!(!wt_e_path.exists(), "Worktree E (unregistered directory) should be pruned");
+
+    // Verify pruned records
+    assert!(pruned.iter().any(|p| p.path == wt_b_path.to_string_lossy() && p.reason == "task_completed"));
+    assert!(pruned.iter().any(|p| p.path == wt_c_path.to_string_lossy() && p.reason == "no_active_claim"));
+    assert!(pruned.iter().any(|p| p.path == wt_d_path.to_string_lossy() && (p.reason == "branch_deleted" || p.reason == "no_matching_task")));
+    assert!(pruned.iter().any(|p| p.path == wt_e_path.to_string_lossy() && p.reason == "not_registered"));
+}


### PR DESCRIPTION
This PR adds the 'decapod workspace prune' subcommand to easily identify and clean up stale/unused agent workspaces on disk and in git configuration. Closes #710.