### PR TITLE
Fix: validation deadlock on stale task verification

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1781934204Z",
-  "repo_signal_fingerprint": "4c53d4a5fdc8bdde620b125783f148bd535b52fcd2f6a9551022afc2d2c13b1b",
+  "generated_at": "1781944153Z",
+  "repo_signal_fingerprint": "07a4ff705e9e6864bff0a8a8261a5ef920bdcddc3cbcf4e43ea0b51d838cea1a",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,10 @@ path = "tests/core/core.rs"
 name = "workspace_prune_regression"
 path = "tests/workspace_prune_regression.rs"
 
+[[test]]
+name = "verify_deadlock_regression"
+path = "tests/verify_deadlock_regression.rs"
+
 [[bench]]
 name = "perf_1_1"
 path = "project/benches/perf_1_1.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,9 @@ pub(crate) struct ValidateCli {
     /// Automatically refresh specs when staleness is detected
     #[clap(long)]
     pub refresh_specs: bool,
+    /// Skip checking if done tasks are verified (helps break verification deadlocks)
+    #[clap(long)]
+    pub skip_todo_verification: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -3796,11 +3796,17 @@ fn validate_plan_governed_execution_gate(
         }
     }
 
-    let unverified = plan_governance::collect_unverified_done_todos(&store.root)?;
+    let unverified = if std::env::var("DECAPOD_IGNORE_TODO_VERIFICATION").unwrap_or_default() == "1"
+    {
+        Vec::new()
+    } else {
+        plan_governance::collect_unverified_done_todos(&store.root)?
+    };
+
     if !unverified.is_empty() {
         fail(
             &format!(
-                "PROOF_HOOK_FAILED: {} done TODO(s) are CLAIMED but not VERIFIED: {}",
+                "PROOF_HOOK_FAILED: {} done TODO(s) are CLAIMED but not VERIFIED: {}. Run `decapod qa verify` or `decapod qa verify todo <id>` to replay verification proofs and unblock.",
                 unverified.len(),
                 output::preview_messages(&unverified, 4, 80)
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4425,6 +4425,12 @@ fn run_validate_command(
 ) -> Result<(), error::DecapodError> {
     use crate::core::workspace;
 
+    if validate_cli.skip_todo_verification {
+        unsafe {
+            std::env::set_var("DECAPOD_IGNORE_TODO_VERIFICATION", "1");
+        }
+    }
+
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         // Skip workspace check if gates are explicitly skipped
     } else {
@@ -4539,6 +4545,12 @@ fn run_validate_command(
         );
     } else {
         render_validation_text(&report, &heal_actions, validate_cli.verbose);
+    }
+
+    if validate_cli.skip_todo_verification {
+        unsafe {
+            std::env::remove_var("DECAPOD_IGNORE_TODO_VERIFICATION");
+        }
     }
 
     if report.fail_count > 0 {

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -234,6 +234,9 @@ fn run_validate_and_hash(
             std::env::set_var("DECAPOD_VERIFYING_TODO", id);
         }
     }
+    unsafe {
+        std::env::set_var("DECAPOD_IGNORE_TODO_VERIFICATION", "1");
+    }
     let exe = std::env::current_exe()?;
     let exe_str = exe.to_string_lossy().to_string();
     let output = external_action::execute(
@@ -252,6 +255,9 @@ fn run_validate_and_hash(
         unsafe {
             std::env::remove_var("DECAPOD_VERIFYING_TODO");
         }
+    }
+    unsafe {
+        std::env::remove_var("DECAPOD_IGNORE_TODO_VERIFICATION");
     }
     let output = output?;
 

--- a/tests/verify_deadlock_regression.rs
+++ b/tests/verify_deadlock_regression.rs
@@ -62,7 +62,10 @@ fn test_verify_deadlock_prevention() {
     // Disable container workspaces in config.toml for the test to avoid container_workspace_required blockers
     let config_path = main_repo.join(".decapod").join("config.toml");
     let mut config_content = std::fs::read_to_string(&config_path).unwrap();
-    config_content = config_content.replace("container_workspaces = true", "container_workspaces = false");
+    config_content = config_content.replace(
+        "container_workspaces = true",
+        "container_workspaces = false",
+    );
     std::fs::write(&config_path, config_content).unwrap();
 
     // Commit the initialized files (including .decapod, AGENTS.md, etc.) so that they exist in worktrees

--- a/tests/verify_deadlock_regression.rs
+++ b/tests/verify_deadlock_regression.rs
@@ -1,0 +1,228 @@
+use rusqlite::Connection;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn run_cmd(repo_root: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let exe = env!("CARGO_BIN_EXE_decapod");
+    let mut cmd = Command::new(exe);
+    cmd.current_dir(repo_root).args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output()
+        .unwrap_or_else(|e| panic!("failed to run decapod {args:?}: {e}"))
+}
+
+fn init_git_repo(path: &Path) {
+    Command::new("git")
+        .current_dir(path)
+        .args(["init"])
+        .output()
+        .expect("failed to init git repo");
+    Command::new("git")
+        .current_dir(path)
+        .args(["config", "user.email", "test@test.com"])
+        .output()
+        .expect("failed to config git email");
+    Command::new("git")
+        .current_dir(path)
+        .args(["config", "user.name", "test"])
+        .output()
+        .expect("failed to config git name");
+    std::fs::write(path.join(".gitkeep"), "").ok();
+    Command::new("git")
+        .current_dir(path)
+        .args(["add", "."])
+        .output()
+        .expect("failed to git add");
+    Command::new("git")
+        .current_dir(path)
+        .args(["commit", "-m", "initial"])
+        .output()
+        .expect("failed to git commit");
+}
+
+#[test]
+fn test_verify_deadlock_prevention() {
+    let tmp = tempdir().unwrap();
+    let main_repo = tmp.path().join("main_repo");
+    std::fs::create_dir_all(&main_repo).unwrap();
+
+    init_git_repo(&main_repo);
+
+    // Initialize decapod in main repo
+    let init = run_cmd(&main_repo, &["init", "--dir", "."], &[]);
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Disable container workspaces in config.toml for the test to avoid container_workspace_required blockers
+    let config_path = main_repo.join(".decapod").join("config.toml");
+    let mut config_content = std::fs::read_to_string(&config_path).unwrap();
+    config_content = config_content.replace("container_workspaces = true", "container_workspaces = false");
+    std::fs::write(&config_path, config_content).unwrap();
+
+    // Commit the initialized files (including .decapod, AGENTS.md, etc.) so that they exist in worktrees
+    Command::new("git")
+        .current_dir(&main_repo)
+        .args(["add", "-A"])
+        .output()
+        .expect("failed to git add all files");
+    Command::new("git")
+        .current_dir(&main_repo)
+        .args(["commit", "-m", "add decapod init and entrypoints metadata"])
+        .output()
+        .expect("failed to git commit");
+
+    // Create a worktree under .decapod/workspaces/test-wt
+    let wt_path = main_repo
+        .join(".decapod")
+        .join("workspaces")
+        .join("test-wt");
+    std::fs::create_dir_all(wt_path.parent().unwrap()).unwrap();
+
+    let wt_add = Command::new("git")
+        .current_dir(&main_repo)
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "agent/test-wt",
+            wt_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to create git worktree");
+    assert!(
+        wt_add.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&wt_add.stderr)
+    );
+
+    // Acquire session in worktree repo
+    let session = run_cmd(&wt_path, &["session", "acquire"], &[]);
+    assert!(
+        session.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&session.stderr)
+    );
+
+    // Add task 1
+    let add_1 = run_cmd(
+        &wt_path,
+        &["todo", "add", "Task 1", "--dir", ".", "--format", "json"],
+        &[],
+    );
+    assert!(
+        add_1.status.success(),
+        "add 1 failed: {}",
+        String::from_utf8_lossy(&add_1.stderr)
+    );
+    let stdout_1 = String::from_utf8_lossy(&add_1.stdout);
+    let start_1 = stdout_1.find('{').unwrap();
+    let add_1_json: serde_json::Value = serde_json::from_str(&stdout_1[start_1..]).unwrap();
+    let todo_id_1 = add_1_json["id"].as_str().unwrap().to_string();
+
+    // Add task 2
+    let add_2 = run_cmd(
+        &wt_path,
+        &["todo", "add", "Task 2", "--dir", ".", "--format", "json"],
+        &[],
+    );
+    assert!(
+        add_2.status.success(),
+        "add 2 failed: {}",
+        String::from_utf8_lossy(&add_2.stderr)
+    );
+    let stdout_2 = String::from_utf8_lossy(&add_2.stdout);
+    let start_2 = stdout_2.find('{').unwrap();
+    let add_2_json: serde_json::Value = serde_json::from_str(&stdout_2[start_2..]).unwrap();
+    let todo_id_2 = add_2_json["id"].as_str().unwrap().to_string();
+
+    // Mark both tasks as done so their status is 'done'
+    let done_1 = run_cmd(&wt_path, &["todo", "done", "--id", &todo_id_1], &[]);
+    assert!(
+        done_1.status.success(),
+        "done 1 failed: {}",
+        String::from_utf8_lossy(&done_1.stderr)
+    );
+    let done_2 = run_cmd(&wt_path, &["todo", "done", "--id", &todo_id_2], &[]);
+    assert!(
+        done_2.status.success(),
+        "done 2 failed: {}",
+        String::from_utf8_lossy(&done_2.stderr)
+    );
+
+    // Create a dummy plan.json so NEEDS_PLAN_APPROVAL check passes
+    let plan = serde_json::json!({
+        "schema_version": "1.0.0",
+        "title": "Test Plan",
+        "intent": "Test Intent",
+        "state": "APPROVED",
+        "todo_ids": [todo_id_1.clone(), todo_id_2.clone()],
+        "proof_hooks": [],
+        "unknowns": [],
+        "human_questions": [],
+        "stop_conditions": [],
+        "unresolved_contradictions": [],
+        "deferred_questions": [],
+        "constraints": {
+            "forbidden_paths": []
+        },
+        "updated_at": "2026-06-20T00:00:00Z"
+    });
+    let plan_str = serde_json::to_string_pretty(&plan).unwrap();
+
+    let plan_dir_wt = wt_path.join(".decapod").join("governance");
+    std::fs::create_dir_all(&plan_dir_wt).unwrap();
+    std::fs::write(plan_dir_wt.join("plan.json"), &plan_str).unwrap();
+
+    let plan_dir_main = main_repo.join(".decapod").join("governance");
+    std::fs::create_dir_all(&plan_dir_main).unwrap();
+    std::fs::write(plan_dir_main.join("plan.json"), &plan_str).unwrap();
+
+    // Manually force both tasks to have failed verification status in the SQLite DB
+    let db_path = main_repo.join(".decapod/data/todo.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute(
+        "INSERT INTO task_verification(todo_id, proof_plan, verification_artifacts, last_verified_at, last_verified_status, last_verified_notes, verification_policy_days, updated_at)
+         VALUES(?1, '[\"validate_passes\"]', '{}', '2026-06-20T00:00:00Z', 'fail', 'Stale failure', 90, '2026-06-20T00:00:00Z')
+         ON CONFLICT(todo_id) DO UPDATE SET last_verified_status = 'fail'",
+        [&todo_id_1]
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO task_verification(todo_id, proof_plan, verification_artifacts, last_verified_at, last_verified_status, last_verified_notes, verification_policy_days, updated_at)
+         VALUES(?1, '[\"validate_passes\"]', '{}', '2026-06-20T00:00:00Z', 'fail', 'Stale failure', 90, '2026-06-20T00:00:00Z')
+         ON CONFLICT(todo_id) DO UPDATE SET last_verified_status = 'fail'",
+        [&todo_id_2]
+    ).unwrap();
+
+    // 1. Standard validate should FAIL due to unverified done tasks
+    let val_normal = run_cmd(&wt_path, &["validate"], &[]);
+    let val_normal_combined = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&val_normal.stdout),
+        String::from_utf8_lossy(&val_normal.stderr)
+    );
+    assert!(
+        !val_normal.status.success(),
+        "validate should fail when there are failed task verifications: {}",
+        val_normal_combined
+    );
+    assert!(
+        val_normal_combined.contains("PROOF_HOOK_FAILED"),
+        "Expected PROOF_HOOK_FAILED error in: {}",
+        val_normal_combined
+    );
+
+    // 2. Validate with skip flag should PASS!
+    let val_skip = run_cmd(&wt_path, &["validate", "--skip-todo-verification"], &[]);
+    assert!(
+        val_skip.status.success(),
+        "validate --skip-todo-verification failed: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&val_skip.stdout),
+        String::from_utf8_lossy(&val_skip.stderr)
+    );
+}


### PR DESCRIPTION
Resolves GitHub Issue #721 by skipping checking if done tasks are verified during validate runs and active QA verify runs, and adding a --skip-todo-verification CLI option.