### PR TITLE
fix(issue-721): remove global skip backdoor, implement secure multi-task verification, and verify prune/regen

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1781944153Z",
-  "repo_signal_fingerprint": "07a4ff705e9e6864bff0a8a8261a5ef920bdcddc3cbcf4e43ea0b51d838cea1a",
+  "generated_at": "1781981667Z",
+  "repo_signal_fingerprint": "30875900656559a6fb58edce7ad7dd1a2239ca45a456fdb6a1c46c0b41181af8",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1781981667Z",
+  "generated_at": "1781989365Z",
   "repo_signal_fingerprint": "30875900656559a6fb58edce7ad7dd1a2239ca45a456fdb6a1c46c0b41181af8",
   "files": [
     {

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -4,7 +4,8 @@
   "intent": "Make decapod validation converge toward green via safe self-heal actions, structured reporting, and environment-aware gating in the claimed workspace.",
   "state": "APPROVED",
   "todo_ids": [
-    "bugs_01kk3wktkzarkbqb"
+    "bugs_01kk3wktkzarkbqb",
+    "bugs_01kvk66syc16hehs"
   ],
   "proof_hooks": [
     "decapod validate",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,9 +40,6 @@ pub(crate) struct ValidateCli {
     /// Automatically refresh specs when staleness is detected
     #[clap(long)]
     pub refresh_specs: bool,
-    /// Skip checking if done tasks are verified (helps break verification deadlocks)
-    #[clap(long)]
-    pub skip_todo_verification: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/core/plan_governance.rs
+++ b/src/core/plan_governance.rs
@@ -296,10 +296,11 @@ pub fn collect_unverified_done_todos(
         .query_map([], |row| row.get::<_, String>(0))
         .map_err(error::DecapodError::RusqliteError)?;
     let verifying_todo = std::env::var("DECAPOD_VERIFYING_TODO").unwrap_or_default();
+    let verifying_ids: Vec<&str> = verifying_todo.split(',').map(|s| s.trim()).collect();
     let mut out = Vec::new();
     for row in rows {
         let id = row.map_err(error::DecapodError::RusqliteError)?;
-        if id != verifying_todo {
+        if !verifying_ids.contains(&id.as_str()) {
             out.push(id);
         }
     }

--- a/src/core/todo.rs
+++ b/src/core/todo.rs
@@ -4231,6 +4231,18 @@ pub fn rebuild_db_from_events(events: &Path, out_db: &Path) -> Result<u64, error
                         ],
                     )?;
                 }
+                "task.verify.prune" => {
+                    let id = ev.task_id.clone().ok_or_else(|| {
+                        error::DecapodError::ValidationError(
+                            "task.verify.prune missing task_id".to_string(),
+                        )
+                    })?;
+                    conn.execute("DELETE FROM task_verification WHERE todo_id = ?1", [&id])?;
+                    conn.execute(
+                        "UPDATE tasks SET status = 'open', completed_at = NULL, updated_at = ?1 WHERE id = ?2",
+                        rusqlite::params![ev.ts, id],
+                    )?;
+                }
                 "task.proof.claimed" => {
                     let id = ev.task_id.clone().ok_or_else(|| {
                         error::DecapodError::ValidationError(

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -3796,12 +3796,7 @@ fn validate_plan_governed_execution_gate(
         }
     }
 
-    let unverified = if std::env::var("DECAPOD_IGNORE_TODO_VERIFICATION").unwrap_or_default() == "1"
-    {
-        Vec::new()
-    } else {
-        plan_governance::collect_unverified_done_todos(&store.root)?
-    };
+    let unverified = plan_governance::collect_unverified_done_todos(&store.root)?;
 
     if !unverified.is_empty() {
         fail(

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -902,7 +902,8 @@ pub fn is_worktree(repo_root: &Path) -> Result<bool, DecapodError> {
     let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
     // In a worktree, git-dir is usually <main-repo>/.git/worktrees/<name>
     // A local-clone workspace under .decapod/workspaces is also treated as a worktree context
-    Ok(git_dir.contains("/worktrees/") || repo_root.to_string_lossy().contains(".decapod/workspaces"))
+    Ok(git_dir.contains("/worktrees/")
+        || repo_root.to_string_lossy().contains(".decapod/workspaces"))
 }
 
 fn has_local_modifications(repo_root: &Path) -> Result<bool, DecapodError> {

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -901,7 +901,8 @@ pub fn is_worktree(repo_root: &Path) -> Result<bool, DecapodError> {
 
     let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
     // In a worktree, git-dir is usually <main-repo>/.git/worktrees/<name>
-    Ok(git_dir.contains("/worktrees/"))
+    // A local-clone workspace under .decapod/workspaces is also treated as a worktree context
+    Ok(git_dir.contains("/worktrees/") || repo_root.to_string_lossy().contains(".decapod/workspaces"))
 }
 
 fn has_local_modifications(repo_root: &Path) -> Result<bool, DecapodError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4425,8 +4425,6 @@ fn run_validate_command(
 ) -> Result<(), error::DecapodError> {
     use crate::core::workspace;
 
-
-
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         // Skip workspace check if gates are explicitly skipped
     } else {
@@ -4542,8 +4540,6 @@ fn run_validate_command(
     } else {
         render_validation_text(&report, &heal_actions, validate_cli.verbose);
     }
-
-
 
     if report.fail_count > 0 {
         std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4425,11 +4425,7 @@ fn run_validate_command(
 ) -> Result<(), error::DecapodError> {
     use crate::core::workspace;
 
-    if validate_cli.skip_todo_verification {
-        unsafe {
-            std::env::set_var("DECAPOD_IGNORE_TODO_VERIFICATION", "1");
-        }
-    }
+
 
     if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
         // Skip workspace check if gates are explicitly skipped
@@ -4547,11 +4543,7 @@ fn run_validate_command(
         render_validation_text(&report, &heal_actions, validate_cli.verbose);
     }
 
-    if validate_cli.skip_todo_verification {
-        unsafe {
-            std::env::remove_var("DECAPOD_IGNORE_TODO_VERIFICATION");
-        }
-    }
+
 
     if report.fail_count > 0 {
         std::process::exit(1);

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -907,7 +907,10 @@ pub fn prune_verification_for_todo(
     let broker = DbBroker::new(&store.root);
 
     broker.with_conn(&db_path, "decapod", None, "verify.prune", |conn| {
-        conn.execute("DELETE FROM task_verification WHERE todo_id = ?1", [todo_id])?;
+        conn.execute(
+            "DELETE FROM task_verification WHERE todo_id = ?1",
+            [todo_id],
+        )?;
         conn.execute(
             "UPDATE tasks SET status = 'open', completed_at = NULL, updated_at = ?1 WHERE id = ?2",
             rusqlite::params![ts, todo_id],
@@ -943,7 +946,9 @@ pub fn run_verify_cli(
             VerifyCommand::Prune { id } => {
                 prune_verification_for_todo(store, id)?;
                 if !cli.json {
-                    println!("Successfully pruned verification record and reverted task {id} to status 'open'.");
+                    println!(
+                        "Successfully pruned verification record and reverted task {id} to status 'open'."
+                    );
                 } else {
                     println!("{}", serde_json::json!({ "status": "ok", "todo_id": id }));
                 }
@@ -953,13 +958,10 @@ pub fn run_verify_cli(
         }
     }
 
-    let single_id = cli
-        .command
-        .as_ref()
-        .map(|cmd| match cmd {
-            VerifyCommand::Todo { id } => id.as_str(),
-            _ => unreachable!(),
-        });
+    let single_id = cli.command.as_ref().map(|cmd| match cmd {
+        VerifyCommand::Todo { id } => id.as_str(),
+        _ => unreachable!(),
+    });
 
     let targets = load_targets(store, single_id)?;
     if single_id.is_some() && targets.is_empty() {

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -34,6 +34,19 @@ pub enum VerifyCommand {
         #[clap(value_name = "ID")]
         id: String,
     },
+    /// Regenerate/re-capture the verification baseline for a completed TODO.
+    Regen {
+        #[clap(value_name = "ID")]
+        id: String,
+        /// File path(s) to hash for drift detection. Defaults to AGENTS.md.
+        #[clap(long = "artifact")]
+        artifact: Vec<String>,
+    },
+    /// Prune/reset verification record for a TODO, returning its status to 'open'.
+    Prune {
+        #[clap(value_name = "ID")]
+        id: String,
+    },
 }
 
 #[derive(Debug)]
@@ -224,18 +237,20 @@ fn run_validate_and_hash(
     repo_root: &Path,
     todo_id: Option<&str>,
 ) -> Result<(bool, String), error::DecapodError> {
+    let mut old_verifying_todo = None;
     if let Some(id) = todo_id {
-        // SAFETY: Setting env var is safe here because:
-        // 1. This is a CLI tool that runs single-threaded by default
-        // 2. We immediately scope the env var to the validate call below
-        // 3. We remove the var right after the call, ensuring no leakage
-        // 4. No concurrent threads are spawned that might race on this env var
+        let existing = std::env::var("DECAPOD_VERIFYING_TODO").unwrap_or_default();
+        old_verifying_todo = Some(existing.clone());
+        let new_val = if existing.is_empty() {
+            id.to_string()
+        } else if existing.split(',').any(|x| x.trim() == id) {
+            existing
+        } else {
+            format!("{},{}", existing, id)
+        };
         unsafe {
-            std::env::set_var("DECAPOD_VERIFYING_TODO", id);
+            std::env::set_var("DECAPOD_VERIFYING_TODO", new_val);
         }
-    }
-    unsafe {
-        std::env::set_var("DECAPOD_IGNORE_TODO_VERIFICATION", "1");
     }
     let exe = std::env::current_exe()?;
     let exe_str = exe.to_string_lossy().to_string();
@@ -247,17 +262,14 @@ fn run_validate_and_hash(
         &["validate", "--format", "json"],
         repo_root,
     );
-    if todo_id.is_some() {
-        // SAFETY: Removing env var is safe here because:
-        // 1. We only remove the var we set above
-        // 2. No other part of the code depends on this var during validation
-        // 3. This restores the environment to its original state
+    if let Some(old_val) = old_verifying_todo {
         unsafe {
-            std::env::remove_var("DECAPOD_VERIFYING_TODO");
+            if old_val.is_empty() {
+                std::env::remove_var("DECAPOD_VERIFYING_TODO");
+            } else {
+                std::env::set_var("DECAPOD_VERIFYING_TODO", old_val);
+            }
         }
-    }
-    unsafe {
-        std::env::remove_var("DECAPOD_IGNORE_TODO_VERIFICATION");
     }
     let output = output?;
 
@@ -886,15 +898,68 @@ pub fn capture_baseline_for_todo(
     Ok(())
 }
 
+pub fn prune_verification_for_todo(
+    store: &Store,
+    todo_id: &str,
+) -> Result<(), error::DecapodError> {
+    let ts = now_iso();
+    let db_path = todo::todo_db_path(&store.root);
+    let broker = DbBroker::new(&store.root);
+
+    broker.with_conn(&db_path, "decapod", None, "verify.prune", |conn| {
+        conn.execute("DELETE FROM task_verification WHERE todo_id = ?1", [todo_id])?;
+        conn.execute(
+            "UPDATE tasks SET status = 'open', completed_at = NULL, updated_at = ?1 WHERE id = ?2",
+            rusqlite::params![ts, todo_id],
+        )?;
+        Ok(())
+    })?;
+
+    todo::record_task_event(
+        &store.root,
+        "task.verify.prune",
+        Some(todo_id),
+        serde_json::json!({}),
+    )?;
+    Ok(())
+}
+
 pub fn run_verify_cli(
     store: &Store,
     repo_root: &Path,
     cli: VerifyCli,
 ) -> Result<(), error::DecapodError> {
+    if let Some(cmd) = &cli.command {
+        match cmd {
+            VerifyCommand::Regen { id, artifact } => {
+                capture_baseline_for_todo(store, repo_root, id, artifact.clone())?;
+                if !cli.json {
+                    println!("Successfully regenerated verification baseline for task {id}.");
+                } else {
+                    println!("{}", serde_json::json!({ "status": "ok", "todo_id": id }));
+                }
+                return Ok(());
+            }
+            VerifyCommand::Prune { id } => {
+                prune_verification_for_todo(store, id)?;
+                if !cli.json {
+                    println!("Successfully pruned verification record and reverted task {id} to status 'open'.");
+                } else {
+                    println!("{}", serde_json::json!({ "status": "ok", "todo_id": id }));
+                }
+                return Ok(());
+            }
+            VerifyCommand::Todo { .. } => {}
+        }
+    }
+
     let single_id = cli
         .command
         .as_ref()
-        .map(|VerifyCommand::Todo { id }| id.as_str());
+        .map(|cmd| match cmd {
+            VerifyCommand::Todo { id } => id.as_str(),
+            _ => unreachable!(),
+        });
 
     let targets = load_targets(store, single_id)?;
     if single_id.is_some() && targets.is_empty() {
@@ -942,6 +1007,13 @@ pub fn run_verify_cli(
 
     let run_id = crate::core::ulid::new_ulid();
     let mut results = Vec::new();
+
+    let old_verifying = std::env::var("DECAPOD_VERIFYING_TODO").ok();
+    let target_ids: Vec<String> = targets.iter().map(|t| t.todo_id.clone()).collect();
+    let target_ids_str = target_ids.join(",");
+    unsafe {
+        std::env::set_var("DECAPOD_VERIFYING_TODO", &target_ids_str);
+    }
 
     for target in &targets {
         let result = verify_target(target, &store.root, repo_root)?;
@@ -1037,6 +1109,14 @@ pub fn run_verify_cli(
             report.summary.unknown,
             report.summary.stale
         );
+    }
+
+    unsafe {
+        if let Some(val) = old_verifying {
+            std::env::set_var("DECAPOD_VERIFYING_TODO", val);
+        } else {
+            std::env::remove_var("DECAPOD_VERIFYING_TODO");
+        }
     }
 
     if report.summary.failed > 0 {

--- a/tests/verify_deadlock_regression.rs
+++ b/tests/verify_deadlock_regression.rs
@@ -220,12 +220,54 @@ fn test_verify_deadlock_prevention() {
         val_normal_combined
     );
 
-    // 2. Validate with skip flag should PASS!
-    let val_skip = run_cmd(&wt_path, &["validate", "--skip-todo-verification"], &[]);
+    // 2. Prune verification of task 1 (reverts status to 'open' and deletes verification record)
+    let prune_1 = run_cmd(&wt_path, &["qa", "verify", "prune", &todo_id_1], &[]);
     assert!(
-        val_skip.status.success(),
-        "validate --skip-todo-verification failed: stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&val_skip.stdout),
-        String::from_utf8_lossy(&val_skip.stderr)
+        prune_1.status.success(),
+        "prune 1 failed: {}",
+        String::from_utf8_lossy(&prune_1.stderr)
+    );
+
+    // 3. Prune verification of task 2
+    let prune_2 = run_cmd(&wt_path, &["qa", "verify", "prune", &todo_id_2], &[]);
+    assert!(
+        prune_2.status.success(),
+        "prune 2 failed: {}",
+        String::from_utf8_lossy(&prune_2.stderr)
+    );
+
+    // 4. Standard validate should now PASS since both tasks are 'open' again!
+    let val_post_prune = run_cmd(&wt_path, &["validate"], &[]);
+    assert!(
+        val_post_prune.status.success(),
+        "validate failed post-prune: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&val_post_prune.stdout),
+        String::from_utf8_lossy(&val_post_prune.stderr)
+    );
+
+    // 5. Mark task 1 done again
+    let done_again_1 = run_cmd(&wt_path, &["todo", "done", "--id", &todo_id_1], &[]);
+    assert!(
+        done_again_1.status.success(),
+        "done again 1 failed: {}",
+        String::from_utf8_lossy(&done_again_1.stderr)
+    );
+
+    // 6. Regenerate verification baseline for task 1
+    let regen_1 = run_cmd(&wt_path, &["qa", "verify", "regen", &todo_id_1], &[]);
+    assert!(
+        regen_1.status.success(),
+        "regen 1 failed: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&regen_1.stdout),
+        String::from_utf8_lossy(&regen_1.stderr)
+    );
+
+    // 7. Verify task 1 is indeed in 'pass' verification state now
+    let verify_status_1 = run_cmd(&wt_path, &["qa", "verify", "todo", &todo_id_1], &[]);
+    assert!(
+        verify_status_1.status.success(),
+        "verify status 1 check failed: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verify_status_1.stdout),
+        String::from_utf8_lossy(&verify_status_1.stderr)
     );
 }


### PR DESCRIPTION
Replaces the global --skip-todo-verification flag and DECAPOD_IGNORE_TODO_VERIFICATION backdoor with a secure, comma-separated list of target IDs in DECAPOD_VERIFYING_TODO. Adds 'decapod qa verify prune' and 'decapod qa verify regen' to streamline proof regeneration and pruning when verification is stale or failing.