### PR TITLE
fix(entrypoint): sync template assets with Interface abstraction boundary anchor

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1782287486Z",
-  "repo_signal_fingerprint": "c6f945bf5321c59a73a4c8918b2f23b37f4112c9e8a8210579fddb2175434acd",
+  "generated_at": "1782291878Z",
+  "repo_signal_fingerprint": "916f3096cf9545d92424c9386fac9618ef7ba908a47e2b9ce4011c08b375ce7e",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -408,6 +408,11 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 Strict Dependency: You are strictly bound to the Decapod control plane
 Strict Dependency: You are strictly bound to the Decapod governance kernel
 -->
+
+
+<!-- decapod-validator-anchors
+Interface abstraction boundary
+-->
 "#
         .to_string()
 }


### PR DESCRIPTION
This PR fixes the failing integration test `test_root_entrypoints_match_scaffold_generators` by updating the template generator in `assets.rs` to match the updated `AGENTS.md` format.