### PR TITLE
Fix QA verify replay for completed todos

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1782287486Z",
-  "repo_signal_fingerprint": "c6f945bf5321c59a73a4c8918b2f23b37f4112c9e8a8210579fddb2175434acd",
+  "generated_at": "1782496079Z",
+  "repo_signal_fingerprint": "916f3096cf9545d92424c9386fac9618ef7ba908a47e2b9ce4011c08b375ce7e",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/src/core/plan_governance.rs
+++ b/src/core/plan_governance.rs
@@ -295,12 +295,11 @@ pub fn collect_unverified_done_todos(
     let rows = stmt
         .query_map([], |row| row.get::<_, String>(0))
         .map_err(error::DecapodError::RusqliteError)?;
-    let verifying_todo = std::env::var("DECAPOD_VERIFYING_TODO").unwrap_or_default();
-    let verifying_ids: Vec<&str> = verifying_todo.split(',').map(|s| s.trim()).collect();
+    let verifying_ids = verifying_todo_ids();
     let mut out = Vec::new();
     for row in rows {
         let id = row.map_err(error::DecapodError::RusqliteError)?;
-        if !verifying_ids.contains(&id.as_str()) {
+        if !verifying_ids.iter().any(|verifying_id| verifying_id == &id) {
             out.push(id);
         }
     }
@@ -313,6 +312,24 @@ pub fn count_done_todos(store_root: &Path) -> Result<usize, error::DecapodError>
         return Ok(0);
     }
     let conn = Connection::open(db_path).map_err(error::DecapodError::RusqliteError)?;
+    let verifying_ids = verifying_todo_ids();
+    if !verifying_ids.is_empty() {
+        let mut stmt = conn
+            .prepare("SELECT id FROM tasks WHERE status = 'done'")
+            .map_err(error::DecapodError::RusqliteError)?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(error::DecapodError::RusqliteError)?;
+        let mut count = 0usize;
+        for row in rows {
+            let id = row.map_err(error::DecapodError::RusqliteError)?;
+            if !verifying_ids.iter().any(|verifying_id| verifying_id == &id) {
+                count += 1;
+            }
+        }
+        return Ok(count);
+    }
+
     let count: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM tasks WHERE status = 'done'",
@@ -321,6 +338,16 @@ pub fn count_done_todos(store_root: &Path) -> Result<usize, error::DecapodError>
         )
         .map_err(error::DecapodError::RusqliteError)?;
     Ok(count.max(0) as usize)
+}
+
+fn verifying_todo_ids() -> Vec<String> {
+    std::env::var("DECAPOD_VERIFYING_TODO")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 pub fn marker_error(

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -172,7 +172,9 @@ fn normalize_json_value(value: &serde_json::Value) -> serde_json::Value {
                         key.clone(),
                         serde_json::Value::Number(serde_json::Number::from(0)),
                     );
-                } else if key == "failures" || key == "warnings" || key == "self_heal" {
+                } else if key == "self_heal" {
+                    normalized.insert(key.clone(), serde_json::Value::Array(Vec::new()));
+                } else if key == "failures" || key == "warnings" {
                     if let Some(arr) = map[key].as_array() {
                         let mut sorted_arr = arr.clone();
                         sorted_arr.sort_by_key(|a| a.to_string());

--- a/tests/verify_deadlock_regression.rs
+++ b/tests/verify_deadlock_regression.rs
@@ -271,3 +271,130 @@ fn test_verify_deadlock_prevention() {
         String::from_utf8_lossy(&verify_status_1.stderr)
     );
 }
+
+#[test]
+fn test_verify_replay_excludes_target_from_missing_plan_gate() {
+    let tmp = tempdir().unwrap();
+    let main_repo = tmp.path().join("main_repo");
+    std::fs::create_dir_all(&main_repo).unwrap();
+
+    init_git_repo(&main_repo);
+
+    let init = run_cmd(&main_repo, &["init", "--dir", "."], &[]);
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let config_path = main_repo.join(".decapod").join("config.toml");
+    let mut config_content = std::fs::read_to_string(&config_path).unwrap();
+    config_content = config_content.replace(
+        "container_workspaces = true",
+        "container_workspaces = false",
+    );
+    std::fs::write(&config_path, config_content).unwrap();
+
+    Command::new("git")
+        .current_dir(&main_repo)
+        .args(["add", "-A"])
+        .output()
+        .expect("failed to git add all files");
+    Command::new("git")
+        .current_dir(&main_repo)
+        .args(["commit", "-m", "add decapod init and entrypoints metadata"])
+        .output()
+        .expect("failed to git commit");
+
+    let wt_path = main_repo
+        .join(".decapod")
+        .join("workspaces")
+        .join("test-wt-missing-plan");
+    std::fs::create_dir_all(wt_path.parent().unwrap()).unwrap();
+
+    let wt_add = Command::new("git")
+        .current_dir(&main_repo)
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            "agent/test-wt-missing-plan",
+            wt_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to create git worktree");
+    assert!(
+        wt_add.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&wt_add.stderr)
+    );
+
+    let session = run_cmd(&wt_path, &["session", "acquire"], &[]);
+    assert!(
+        session.status.success(),
+        "session acquire failed: {}",
+        String::from_utf8_lossy(&session.stderr)
+    );
+
+    let add = run_cmd(
+        &wt_path,
+        &[
+            "todo",
+            "add",
+            "Task without governed plan",
+            "--dir",
+            ".",
+            "--format",
+            "json",
+        ],
+        &[],
+    );
+    assert!(
+        add.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&add.stdout);
+    let start = stdout.find('{').unwrap();
+    let add_json: serde_json::Value = serde_json::from_str(&stdout[start..]).unwrap();
+    let todo_id = add_json["id"].as_str().unwrap().to_string();
+
+    let done = run_cmd(&wt_path, &["todo", "done", "--id", &todo_id], &[]);
+    assert!(
+        done.status.success(),
+        "done failed: {}",
+        String::from_utf8_lossy(&done.stderr)
+    );
+
+    let regen = run_cmd(&wt_path, &["qa", "verify", "regen", &todo_id], &[]);
+    assert!(
+        regen.status.success(),
+        "regen failed: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&regen.stdout),
+        String::from_utf8_lossy(&regen.stderr)
+    );
+
+    let verify = run_cmd(&wt_path, &["qa", "verify", "todo", &todo_id], &[]);
+    assert!(
+        verify.status.success(),
+        "verify should not fail the target TODO on the missing-plan gate: stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verify.stdout),
+        String::from_utf8_lossy(&verify.stderr)
+    );
+
+    let validate = run_cmd(&wt_path, &["validate"], &[]);
+    let validate_combined = format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+    assert!(
+        !validate.status.success(),
+        "regular validation should still require a governed plan after completion"
+    );
+    assert!(
+        validate_combined.contains("NEEDS_PLAN_APPROVAL"),
+        "expected regular validation to keep the missing-plan gate: {}",
+        validate_combined
+    );
+}


### PR DESCRIPTION
## Summary
- exclude the TODO currently being replay-verified from the missing governed-plan done TODO count
- normalize volatile validate JSON self-heal entries out of QA verify output hashes
- add a regression test for Issue #751 covering a completed TODO with no plan during verify replay while preserving normal validate enforcement

Closes #751.

## Tests
- cargo fmt
- cargo test --test verify_deadlock_regression
- decapod rpc --op specs.refresh

## Validation
- decapod validate --format json: blocked on existing host-worktree gate: "Not running in isolated git worktree - must use .decapod/workspaces/" even though decapod workspace status reports in_worktree=true for the claimed workspace.
- decapod auto container run --agent unknown --branch agent/unknown/bugs-01kw2f2bn85rhzrd --task-id bugs_01kw2f2bn85rhzrd --cmd "decapod validate --format json" --keep-worktree: blocked before validation because the container wrapper invokes cargo run without selecting a binary; cargo reports available binaries: decapod, selective-test.