### PR TITLE
Wire Decapod cloud init to Propodus backend seam

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1782496527Z",
-  "repo_signal_fingerprint": "aa24000fc7d7370bceb61f526747b6cefadafeb9b5508d3ef78f2f37ccb9cc00",
+  "generated_at": "1782498128Z",
+  "repo_signal_fingerprint": "8bb600ed5ae81350494fbb6183d58fcc68a8e1e80782076be3b0a0eb66421191",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -340,11 +340,11 @@ pub struct CloudConfigSection {
 }
 
 fn default_cloud_provider() -> String {
-    "decapod".to_string()
+    "vercel".to_string()
 }
 
 fn default_cloud_api_url() -> String {
-    "https://api.decapodlabs.com".to_string()
+    "https://decapod-cloud.vercel.app".to_string()
 }
 
 impl Default for CloudConfigSection {

--- a/src/core/cloud_backend.rs
+++ b/src/core/cloud_backend.rs
@@ -1,7 +1,96 @@
 use crate::core::error::DecapodError;
+use crate::core::time;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-pub const PUBLIC_CLOUD_BACKEND_UNAVAILABLE: &str = "Cloud backend is not included in the public Decapod crate. Use local mode; future cloud integrations must attach through a public backend boundary without private git/path dependencies.";
+pub const PUBLIC_CLOUD_BACKEND_UNAVAILABLE: &str = "Cloud backend is not included in the public Decapod crate. Use local mode; future cloud integrations must attach through the Vercel backend boundary without private git/path dependencies.";
+
+pub const INIT_REGISTRATION_ROUTE: &str = "POST /api/decapod/init/register";
 
 pub fn unavailable_error() -> DecapodError {
     DecapodError::NotImplemented(PUBLIC_CLOUD_BACKEND_UNAVAILABLE.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CloudInitRegistration {
+    pub schema_version: String,
+    pub provider: String,
+    pub api_url: String,
+    pub route: String,
+    pub project_id: String,
+    pub repo_id: String,
+    pub repo_root_hint: String,
+    pub created_at: String,
+    pub writes: Vec<CloudWriteIntent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CloudWriteIntent {
+    pub table: String,
+    pub operation: String,
+    pub key: String,
+}
+
+impl CloudInitRegistration {
+    pub fn for_init(
+        provider: &str,
+        api_url: &str,
+        project_id: &str,
+        repo_id: &str,
+        repo_root: &Path,
+    ) -> Self {
+        Self {
+            schema_version: "1.0.0".to_string(),
+            provider: provider.to_string(),
+            api_url: api_url.trim_end_matches('/').to_string(),
+            route: INIT_REGISTRATION_ROUTE.to_string(),
+            project_id: project_id.to_string(),
+            repo_id: repo_id.to_string(),
+            repo_root_hint: repo_root.display().to_string(),
+            created_at: time::now_epoch_z(),
+            writes: vec![
+                CloudWriteIntent {
+                    table: "repositories".to_string(),
+                    operation: "upsert".to_string(),
+                    key: "repo_id".to_string(),
+                },
+                CloudWriteIntent {
+                    table: "init_events".to_string(),
+                    operation: "insert".to_string(),
+                    key: "event_id".to_string(),
+                },
+            ],
+        }
+    }
+}
+
+pub fn init_registration_outbox_path(repo_root: &Path) -> PathBuf {
+    repo_root
+        .join(".decapod")
+        .join("generated")
+        .join("cloud")
+        .join("init-registration.json")
+}
+
+pub fn write_mock_init_registration(
+    repo_root: &Path,
+    registration: &CloudInitRegistration,
+    dry_run: bool,
+) -> Result<Option<PathBuf>, DecapodError> {
+    if dry_run {
+        return Ok(None);
+    }
+
+    let path = init_registration_outbox_path(repo_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(DecapodError::IoError)?;
+    }
+    let bytes = serde_json::to_vec_pretty(registration).map_err(|e| {
+        DecapodError::ValidationError(format!(
+            "Failed to serialize cloud init registration payload: {e}"
+        ))
+    })?;
+    fs::write(&path, bytes).map_err(DecapodError::IoError)?;
+    Ok(Some(path))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub(crate) mod subsystems;
 use cli::*;
 
 use core::{
-    db, docs, docs_cli, error, flight_recorder, migration, obligation, plan_governance, proof,
-    repomap, scaffold, state_commit,
+    cloud_backend, db, docs, docs_cli, error, flight_recorder, migration, obligation,
+    plan_governance, proof, repomap, scaffold, state_commit,
     store::{Store, StoreKind, find_decapod_project_root, find_governance_root},
     todo, trace, validate, workspace,
 };
@@ -107,6 +107,33 @@ fn write_project_config(
         error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=CONFIG_SERIALIZE_FAILED severity=transient auto_remediable=true audience=agent agent_action=\"ensure the .decapod/config.toml data can be serialized (e.g., fix data types)\" user_note=\"Failed to serialize configuration; the agent should adjust the config content or report the issue.\"\nFailed to serialize config.toml: {e}"))
     })?;
     fs::write(config_path, serialized).map_err(error::DecapodError::IoError)?;
+    Ok(())
+}
+
+fn record_cloud_init_registration(
+    target_dir: &Path,
+    config: &DecapodProjectConfig,
+    dry_run: bool,
+) -> Result<(), error::DecapodError> {
+    if !config.cloud.enabled {
+        return Ok(());
+    }
+
+    let registration = cloud_backend::CloudInitRegistration::for_init(
+        &config.cloud.provider,
+        &config.cloud.api_url,
+        &config.cloud.project_id,
+        &config.cloud.repo_id,
+        target_dir,
+    );
+    if let Some(path) =
+        cloud_backend::write_mock_init_registration(target_dir, &registration, dry_run)?
+    {
+        println!(
+            "Cloud: recorded mock init registration payload at {}",
+            path.display()
+        );
+    }
     Ok(())
 }
 
@@ -1951,6 +1978,7 @@ pub fn run() -> Result<(), error::DecapodError> {
             let target_dir = run_init_apply(&init_with, &current_dir, &repo_ctx)?;
             let config = config_from_init_with(&init_with, repo_ctx);
             write_project_config(&target_dir, &config, init_with.dry_run)?;
+            record_cloud_init_registration(&target_dir, &config, init_with.dry_run)?;
             seed_init_generated_state(&target_dir, init_with.dry_run)?;
         }
         Command::Session(session_cli) => {

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -110,9 +110,28 @@ fn test_cloud_init_records_opt_in_without_auth_or_repo_credentials() {
     assert!(config.contains("[cloud]"));
     assert!(config.contains("enabled = true"));
     assert!(config.contains("experimental = true"));
+    assert!(config.contains("provider = \"vercel\""));
+    assert!(config.contains("api_url = \"https://decapod-cloud.vercel.app\""));
     assert!(config.contains("mode = \"local\""));
     assert!(!config.contains("SUPABASE"));
     assert!(!config.contains("supabase"));
     assert!(!config.contains("token"));
     assert!(!dir.join(".decapod/session_token").exists());
+
+    let registration_path = dir.join(".decapod/generated/cloud/init-registration.json");
+    let registration = std::fs::read_to_string(registration_path)
+        .expect("cloud opt-in should create a mock init registration payload");
+    let registration: serde_json::Value =
+        serde_json::from_str(&registration).expect("parse cloud init registration");
+    assert_eq!(registration["provider"], "vercel");
+    assert_eq!(registration["api_url"], "https://decapod-cloud.vercel.app");
+    assert_eq!(registration["route"], "POST /api/decapod/init/register");
+    assert!(
+        registration["writes"]
+            .as_array()
+            .expect("writes array")
+            .iter()
+            .any(|write| write["table"] == "init_events" && write["operation"] == "insert"),
+        "registration should model backend-owned init event insert"
+    );
 }

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -40,12 +40,12 @@ fn init_with_backend_cloud_saves_to_config() {
         "cloud should be marked experimental: {config}"
     );
     assert!(
-        config.contains("provider = \"decapod\""),
-        "cloud provider should be non-secret Decapod wiring: {config}"
+        config.contains("provider = \"vercel\""),
+        "cloud provider should be non-secret Vercel wiring: {config}"
     );
     assert!(
-        config.contains("api_url = \"https://api.decapodlabs.com\""),
-        "cloud API URL should use Decapod Labs default: {config}"
+        config.contains("api_url = \"https://decapod-cloud.vercel.app\""),
+        "cloud API URL should use the Vercel backend default: {config}"
     );
     assert!(
         config.contains("mode = \"local\""),
@@ -54,6 +54,27 @@ fn init_with_backend_cloud_saves_to_config() {
     assert!(
         !config.contains("supabase") && !config.contains("token") && !config.contains("secret"),
         "repo config must not contain credentials or legacy backend secrets: {config}"
+    );
+
+    let registration_path = tmp
+        .path()
+        .join(".decapod/generated/cloud/init-registration.json");
+    let registration =
+        fs::read_to_string(registration_path).expect("read cloud init registration payload");
+    let registration: serde_json::Value =
+        serde_json::from_str(&registration).expect("parse cloud init registration");
+    assert_eq!(registration["provider"], "vercel");
+    assert_eq!(
+        registration["route"], "POST /api/decapod/init/register",
+        "registration should target the modeled Vercel init route"
+    );
+    assert!(
+        registration["writes"]
+            .as_array()
+            .expect("writes array")
+            .iter()
+            .any(|write| write["table"] == "repositories" && write["operation"] == "upsert"),
+        "registration should model repository upsert"
     );
 }
 
@@ -95,6 +116,15 @@ fn init_cloud_opt_in_does_not_store_secret_environment_values() {
     assert!(!config.contains("repo-config-must-not-store-this"));
     assert!(!config.contains("supabase_key"));
     assert!(!config.contains("access_token"));
+
+    let registration = fs::read_to_string(
+        tmp.path()
+            .join(".decapod/generated/cloud/init-registration.json"),
+    )
+    .expect("read cloud init registration");
+    assert!(!registration.contains("private.supabase.local"));
+    assert!(!registration.contains("super-secret-service-role"));
+    assert!(!registration.contains("repo-config-must-not-store-this"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- switch experimental cloud init defaults to the Vercel/Propodus backend boundary
- add a local generated cloud init registration payload for the future backend-owned database writes
- keep Decapod local-first: cloud opt-in records intent and mock registration metadata, but does not perform network calls or store secrets
- update cloud init tests to assert the generated registration payload and Vercel defaults

## Notes
- The backend mock files were moved out of this Decapod branch into /home/arx/src/propodus/backend.
- This branch history was squashed so Decapod contains no backend/ directory in the final tree or branch history.

## Tests
- cargo fmt
- cargo check
- cargo test --test init_config_behavior
- cargo test --test cloud_backend_storage
- cargo test --test release_workflow_policy public_release_surface_has_no_private_propodus_dependency
- decapod rpc --op specs.refresh

## Validation
- decapod validate --format json remains blocked by existing workspace validation mismatch: validate reports not running in an isolated git worktree even though the branch is in a Decapod-created .decapod/workspaces worktree.
- container validation remains blocked by the existing multi-binary cargo run issue reported separately.