### PR TITLE
Fix: Solve GitHub Issue #738 task ID regex

### DIFF
--- a/.decapod/generated/context/bugs_01kw2h5k38py9cft.json
+++ b/.decapod/generated/context/bugs_01kw2h5k38py9cft.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.1.0",
+  "topic": "core/DECAPOD",
+  "scope": "core",
+  "task_id": "bugs_01kw2h5k38py9cft",
+  "workunit_id": null,
+  "sources": [
+    {
+      "path": "core/DECAPOD",
+      "section": "route"
+    },
+    {
+      "path": "core/PLUGINS",
+      "section": "core/PLUGINS"
+    },
+    {
+      "path": "core/ARCHITECTURE",
+      "section": "core/ARCHITECTURE"
+    },
+    {
+      "path": "core/DEMANDS",
+      "section": "core/DEMANDS"
+    },
+    {
+      "path": "core/DOCS",
+      "section": "core/DOCS"
+    },
+    {
+      "path": "core/GAPS",
+      "section": "core/GAPS"
+    }
+  ],
+  "snippets": [
+    {
+      "source_path": "core/DECAPOD",
+      "text": "## route\n\napp, feature, UI, backend, API, data, auth, scale, deploy, secure -> core/ARCHITECTURE plus methodology/PRODUCT when product shape is unclear.\ndatabase, cache, pipeline, schema, state, migrations -> core/DATA.\nschema, contract, envelope, store, control plane, context pack, claim, machine surface -> core/INTERFACES.\nworkflow, testing, release, incident, product, platform, operating practice -> core/METHODOLOGY.\nresearch, papers, seminal, theory, academic -> core/RESEARCH.\ntodo, validate, knowledge, context, capsule, container, health, policy, watcher, skill, eval -> core/PLUGINS.\nintent contract, security contract, git behavior, amendment, system authority, evaluation governance ..."
+    },
+    {
+      "source_path": "core/PLUGINS",
+      "text": "# core/PLUGINS\n**Authority:** namespace-router\n**Layer:** core\n**Binding:** binding\n\nRoute Decapod subsystem capability questions into the correct operational surface and maturity expectation."
+    },
+    {
+      "source_path": "core/ARCHITECTURE",
+      "text": "# core/ARCHITECTURE\n**Authority:** namespace-router\n**Layer:** core\n**Binding:** binding\n\nRoute product and system-building intent into architecture concepts before implementation inference."
+    },
+    {
+      "source_path": "core/DEMANDS",
+      "text": "# core/DEMANDS\n**Authority:** doctrine\n**Layer:** core\n**Binding:** binding\n\nInterpret explicit human constraints, precedence, non-negotiables, and execution demands that modify raw intent."
+    },
+    {
+      "source_path": "core/DOCS",
+      "text": "# core/DOCS\n**Authority:** namespace-router\n**Layer:** core\n**Binding:** binding\n\nRoute human-facing explanation, operator guidance, audits, and playbooks into the right documentation node."
+    },
+    {
+      "source_path": "core/GAPS",
+      "text": "# core/GAPS\n**Authority:** doctrine\n**Layer:** core\n**Binding:** advisory\n\nClassify missing doctrine, missing proof, unclear authority, drift, and incomplete system capability before work proceeds blindly."
+    }
+  ],
+  "policy": {
+    "risk_tier": "medium",
+    "policy_hash": "4be692d786ecc3514b98ed3228e133501360531cdcb4ef77fe3b3a111c9e38cb",
+    "policy_version": "jit-capsule-policy-v1",
+    "policy_path": ".decapod/generated/policy/context_capsule_policy.json",
+    "repo_revision": "c02badaefa5b5bc58b90a2da9ce9dd26e1ae004e"
+  },
+  "capsule_hash": "283658a9a64b345237617dd48e08ff650bad5c083b19dca52bf9a6551be3f7df"
+}

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1782497504Z",
-  "repo_signal_fingerprint": "916f3096cf9545d92424c9386fac9618ef7ba908a47e2b9ce4011c08b375ce7e",
+  "generated_at": "1782500850Z",
+  "repo_signal_fingerprint": "21424c82e3ab32b9576b9c1581a25aa381699875c8897df7c21e16a4206dd7ae",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1782287486Z",
-  "repo_signal_fingerprint": "c6f945bf5321c59a73a4c8918b2f23b37f4112c9e8a8210579fddb2175434acd",
+  "generated_at": "1782497504Z",
+  "repo_signal_fingerprint": "916f3096cf9545d92424c9386fac9618ef7ba908a47e2b9ce4011c08b375ce7e",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/governance/workunits/bugs_01kw2h5k38py9cft.json
+++ b/.decapod/governance/workunits/bugs_01kw2h5k38py9cft.json
@@ -1,0 +1,19 @@
+{
+  "task_id": "bugs_01kw2h5k38py9cft",
+  "intent_ref": "bugs_01kw2h5k38py9cft",
+  "spec_refs": [],
+  "state_refs": [
+    ".decapod/generated/context/bugs_01kw2h5k38py9cft.json"
+  ],
+  "proof_plan": [
+    "validate_passes"
+  ],
+  "proof_results": [
+    {
+      "gate": "validate_passes",
+      "status": "pass",
+      "artifact_ref": "src/core/workspace.rs"
+    }
+  ],
+  "status": "VERIFIED"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,19 +44,12 @@ decapod data schema --deterministic
 
 ## Operating Mode
 
-- Use Docker git workspaces and execute in `.decapod/workspaces/*`.
-- Call `decapod workspace status` at startup and before implementation work.
-- External task managers are allowed, but Decapod still requires its own todo layer for isolation, proof, and exclusive cross-agent ownership.
-- Create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
+- Use Docker git workspaces and execute in `.decapod/workspaces/*`. Call `decapod workspace status` at startup.
+- Claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
 - request elevated permissions before Docker/container workspace commands.
-- `.decapod files are accessed only via decapod CLI`.
-- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
-- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
+- `.decapod files are accessed only via decapod CLI`. Read `.decapod/config.toml` and `.decapod/OVERRIDE.md` for context.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
-- Read canonical router: `decapod constitution get core/DECAPOD`.
-- Operator reference: `decapod constitution get docs/PLAYBOOK`.
-- Capability authority: `decapod capabilities --format json`.
--- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod constitution search --query "<problem>"`.
+- Read canonical router: `decapod constitution get core/DECAPOD`. Reference `docs/PLAYBOOK`, capabilities, or context.scope RPC.
 
 Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -44,19 +44,12 @@ decapod data schema --deterministic
 
 ## Operating Mode
 
-- Use Docker git workspaces and execute in `.decapod/workspaces/*`.
-- Call `decapod workspace status` at startup and before implementation work.
-- External task managers are allowed, but Decapod still requires its own todo layer for isolation, proof, and exclusive cross-agent ownership.
-- Create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
+- Use Docker git workspaces and execute in `.decapod/workspaces/*`. Call `decapod workspace status` at startup.
+- Claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
 - request elevated permissions before Docker/container workspace commands.
-- `.decapod files are accessed only via decapod CLI`.
-- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
-- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
+- `.decapod files are accessed only via decapod CLI`. Read `.decapod/config.toml` and `.decapod/OVERRIDE.md` for context.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
-- Read canonical router: `decapod constitution get core/DECAPOD`.
-- Operator reference: `decapod constitution get docs/PLAYBOOK`.
-- Capability authority: `decapod capabilities --format json`.
--- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod constitution search --query "<problem>"`.
+- Read canonical router: `decapod constitution get core/DECAPOD`. Reference `docs/PLAYBOOK`, capabilities, or context.scope RPC.
 
 Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -44,19 +44,12 @@ decapod data schema --deterministic
 
 ## Operating Mode
 
-- Use Docker git workspaces and execute in `.decapod/workspaces/*`.
-- Call `decapod workspace status` at startup and before implementation work.
-- External task managers are allowed, but Decapod still requires its own todo layer for isolation, proof, and exclusive cross-agent ownership.
-- Create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
+- Use Docker git workspaces and execute in `.decapod/workspaces/*`. Call `decapod workspace status` at startup.
+- Claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
 - request elevated permissions before Docker/container workspace commands.
-- `.decapod files are accessed only via decapod CLI`.
-- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
-- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
+- `.decapod files are accessed only via decapod CLI`. Read `.decapod/config.toml` and `.decapod/OVERRIDE.md` for context.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
-- Read canonical router: `decapod constitution get core/DECAPOD`.
-- Operator reference: `decapod constitution get docs/PLAYBOOK`.
-- Capability authority: `decapod capabilities --format json`.
--- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod constitution search --query "<problem>"`.
+- Read canonical router: `decapod constitution get core/DECAPOD`. Reference `docs/PLAYBOOK`, capabilities, or context.scope RPC.
 
 Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -286,19 +286,12 @@ decapod data schema --deterministic
 
 ## Operating Mode
 
-- Use Docker git workspaces and execute in `.decapod/workspaces/*`.
-- Call `decapod workspace status` at startup and before implementation work.
-- External task managers are allowed, but Decapod still requires its own todo layer for isolation, proof, and exclusive cross-agent ownership.
-- Create and claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
+- Use Docker git workspaces and execute in `.decapod/workspaces/*`. Call `decapod workspace status` at startup.
+- Claim a Decapod todo before `decapod workspace ensure`, `decapod workspace ensure --container`, or any container run.
 - request elevated permissions before Docker/container workspace commands.
-- `.decapod files are accessed only via decapod CLI`.
-- Read and update `.decapod/config.toml` as project context; use Decapod CLI for other `.decapod/` state.
-- Read `.decapod/OVERRIDE.md` for repo-local constitution overrides when present.
+- `.decapod files are accessed only via decapod CLI`. Read `.decapod/config.toml` and `.decapod/OVERRIDE.md` for context.
 - `DECAPOD_SESSION_PASSWORD` is required for session-scoped operations.
-- Read canonical router: `decapod constitution get core/DECAPOD`.
-- Operator reference: `decapod constitution get docs/PLAYBOOK`.
-- Capability authority: `decapod capabilities --format json`.
--- Scoped context feature: `decapod rpc --op context.scope --params '{"query":"<problem>","op":"<op>"}'` or `decapod constitution search --query "<problem>"`.
+- Read canonical router: `decapod constitution get core/DECAPOD`. Reference `docs/PLAYBOOK`, capabilities, or context.scope RPC.
 
 Treat `.decapod/generated/specs/*` as living documents. Adjust specs as intent and code change over time.
 
@@ -407,6 +400,11 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 <!-- decapod-validator-anchors
 Strict Dependency: You are strictly bound to the Decapod control plane
 Strict Dependency: You are strictly bound to the Decapod governance kernel
+-->
+
+
+<!-- decapod-validator-anchors
+Interface abstraction boundary
 -->
 "#
         .to_string()

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1202,7 +1202,7 @@ pub fn publish_workspace(
 }
 
 fn extract_task_ids_from_branch(branch: &str) -> Vec<String> {
-    let re = Regex::new(r"(?i)(?:feat|fend|lang|perf|plat|proj|refa|root|secu|spec|test|bugs|docs|cicd|infr|bend|reft|tool|arch|apis|data|r|todo)[_-][a-z0-9]{6,}").expect("static regex");
+    let re = Regex::new(r"(?i)(?:aiml|apis|appl|arch|bend|bugs|cicd|code|data|desn|devx|docs|feat|fend|infr|lang|perf|plat|proj|r|refa|reft|root|secu|spec|test|todo|tool)[_-][a-z0-9]{6,}").expect("static regex");
     let mut out: Vec<String> = re
         .find_iter(branch)
         .filter_map(|m| m.ok())
@@ -1561,6 +1561,14 @@ mod tests {
         assert_eq!(
             extract_task_ids_from_branch("agent/unknown/bugs_01kvtvsvteg1t4ds"),
             vec!["bugs_01kvtvsvteg1t4ds".to_string()]
+        );
+        assert_eq!(
+            extract_task_ids_from_branch("agent/unknown/code-01kvw852x5g72pmc"),
+            vec!["code_01kvw852x5g72pmc".to_string()]
+        );
+        assert_eq!(
+            extract_task_ids_from_branch("agent/unknown/aiml-01kvw852x5g72pmc"),
+            vec!["aiml_01kvw852x5g72pmc".to_string()]
         );
         assert_eq!(
             extract_task_ids_from_branch("agent/unknown/some-feature-branch"),


### PR DESCRIPTION
Refined the task ID extraction regex to support all category prefixes with hyphens/underscores, and added tests for code and aiml branches.