### PR TITLE
Add validation epoch provenance

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783387253Z",
-  "repo_signal_fingerprint": "e7226903e43e084b0456179287ea100cace1643ba5e5aeebaa825d4273736d47",
+  "generated_at": "1783388716Z",
+  "repo_signal_fingerprint": "0da3242b0dd85164b2115f135ddf9755d15c34b21714519c75f5f277b2c50f86",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/generated/validation-epoch.json
+++ b/.decapod/generated/validation-epoch.json
@@ -1,0 +1,33 @@
+{
+  "kind": "decapod.validation_epoch",
+  "active_epoch": {
+    "schema_version": "1.0.0",
+    "epoch_id": "ve_1cca8cc28a4b5f8b",
+    "evaluator_identity": "decapod-validate@0.60.16",
+    "evaluator_set_hash": "sha256:43e9610e835dcf290fd82476f9ff3546cf6cb231eaa141bce53848d0827aa854",
+    "constitution_version": "embedded-docs@0.60.16",
+    "constitution_hash": "sha256:1b5f88d1b1bcc17b489ec4ebf0b4d4ced8082ad8fd394224d607ac6c5cffc59e",
+    "validation_profile": "default",
+    "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
+    "proof_rubric": "decapod-validate/current-proof-v1",
+    "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
+    "generated_specs_manifest_hash": "sha256:a15ffcf63a78ed9ec01cf24c62619753b3fa60f34af4150d3b330282a8619ff5",
+    "generated_specs_fingerprint": "0da3242b0dd85164b2115f135ddf9755d15c34b21714519c75f5f277b2c50f86",
+    "material_hashes": {
+      "constitution:core/DECAPOD": "sha256:1b5f88d1b1bcc17b489ec4ebf0b4d4ced8082ad8fd394224d607ac6c5cffc59e",
+      "generated_spec:.decapod/generated/specs/ARCHITECTURE.md": "sha256:6fe07b94e07c6928ef69a4c7c7a8188c5d1918a5d98513d7f413ac7065b041e5",
+      "generated_spec:.decapod/generated/specs/INTENT.md": "sha256:f2a0c049066113a0ed7e378471800046c87fc883e342a0a71e53a083d80fe569",
+      "generated_spec:.decapod/generated/specs/INTERFACES.md": "sha256:a608b72399801fc7f618a8fc0bf54b8d4699ef95962672cd7f0dfe931e1aa58f",
+      "generated_spec:.decapod/generated/specs/OPERATIONS.md": "sha256:bf2f95a44e2ccfd5a14bc18ca6beb06de21231482fd441e3f425b85a1840453a",
+      "generated_spec:.decapod/generated/specs/README.md": "sha256:b27b7cee157f2277b1eabb3dceb1d0ec6078d399a5b056fddbcb8221ccdeb97e",
+      "generated_spec:.decapod/generated/specs/SECURITY.md": "sha256:b30798e0500d8ddeb927ed0a0da1923a98a929d87715ddda8d70977f320b496c",
+      "generated_spec:.decapod/generated/specs/SEMANTICS.md": "sha256:386dfd106da3a1af704fa27fd7108625ca390561f5471f3a5976f604e2bcdef4",
+      "generated_spec:.decapod/generated/specs/VALIDATION.md": "sha256:85319f6fd6c106c102d321371f85887bfe0beaef0f6fda1817566a71c6ff2f74",
+      "generated_specs_fingerprint": "0da3242b0dd85164b2115f135ddf9755d15c34b21714519c75f5f277b2c50f86",
+      "generated_specs_manifest": "sha256:a15ffcf63a78ed9ec01cf24c62619753b3fa60f34af4150d3b330282a8619ff5",
+      "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
+      "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
+    }
+  },
+  "proof_applicability": "Only proof records with this evaluator epoch count as current proof evidence."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dev/
 # Allowlist deterministic generated artifact used as container build baseline.
 !.decapod/data/
 !.decapod/data/knowledge.promotions.jsonl
+!.decapod/generated/validation-epoch.json
 !.decapod/generated/Dockerfile
 !.decapod/generated/context/
 !.decapod/generated/context/*.json

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -45,5 +45,6 @@ pub mod todo;
 pub mod trace;
 pub mod ulid;
 pub mod validate;
+pub mod validation_epoch;
 pub mod workspace;
 pub mod workunit;

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1322,6 +1322,7 @@ pub const DECAPOD_GITIGNORE_RULES: &[&str] = &[
     ".decapod/.stfolder",
     ".decapod/workspaces",
     ".decapod/generated/*",
+    "!.decapod/generated/validation-epoch.json",
     "!.decapod/data/",
     "!.decapod/data/knowledge.promotions.jsonl",
     "!.decapod/generated/Dockerfile",

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -20,6 +20,10 @@ use crate::core::project_specs::{
 };
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
+use crate::core::validation_epoch::{
+    VALIDATION_EPOCH_RECEIPT, ValidationEpochMetadata, active_validation_epoch,
+    write_active_validation_epoch_receipt,
+};
 use crate::core::workunit::{self, WorkUnitManifest, WorkUnitStatus};
 use crate::plugins::internalize::{self, DeterminismClass, InternalizationManifest, ReplayClass};
 use crate::{db, primitives, todo};
@@ -141,6 +145,7 @@ pub struct ValidationGateTiming {
 #[derive(Debug, Clone, Serialize)]
 pub struct ValidationReport {
     pub status: String,
+    pub validation_epoch: ValidationEpochMetadata,
     pub elapsed_ms: u64,
     pub pass_count: u32,
     pub fail_count: u32,
@@ -1165,6 +1170,7 @@ fn validate_generated_artifact_whitelist(
         ".decapod/data/knowledge.promotions.jsonl",
         ".decapod/generated/specs/.manifest",
         ".decapod/generated/specs/.manifest.json",
+        VALIDATION_EPOCH_RECEIPT,
         ".decapod/generated/policy/context_capsule_policy.json",
         ".decapod/generated/artifacts/provenance/kcr_trend.jsonl",
     ];
@@ -5271,6 +5277,8 @@ pub fn run_validation(
     }
 
     let elapsed = total_start.elapsed();
+    let validation_epoch = active_validation_epoch(working_root)?;
+    write_active_validation_epoch_receipt(working_root, &validation_epoch)?;
     let pass_count = ctx.pass_count.load(Ordering::Relaxed);
     let fail_count = ctx.fail_count.load(Ordering::Relaxed);
     let warn_count = ctx.warn_count.load(Ordering::Relaxed);
@@ -5283,6 +5291,7 @@ pub fn run_validation(
 
     Ok(ValidationReport {
         status: if fail_total > 0 { "fail" } else { "ok" }.to_string(),
+        validation_epoch,
         elapsed_ms: elapsed.as_millis() as u64,
         pass_count,
         fail_count: fail_total,
@@ -5315,6 +5324,11 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
         "  {} intent_version={}",
         "spec".bright_cyan(),
         intent_version.bright_white()
+    );
+    println!(
+        "  {} {}",
+        "epoch".bright_cyan(),
+        report.validation_epoch.epoch_id.bright_white()
     );
     println!(
         "  {} {}",

--- a/src/core/validation_epoch.rs
+++ b/src/core/validation_epoch.rs
@@ -1,0 +1,245 @@
+use crate::core::assets;
+use crate::core::error;
+use crate::core::project_specs::{self, LOCAL_PROJECT_SPECS, LOCAL_PROJECT_SPECS_MANIFEST};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+pub const VALIDATION_EPOCH_SCHEMA_VERSION: &str = "1.0.0";
+pub const VALIDATION_EPOCH_RECEIPT: &str = ".decapod/generated/validation-epoch.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ValidationEpochMetadata {
+    pub schema_version: String,
+    pub epoch_id: String,
+    pub evaluator_identity: String,
+    pub evaluator_set_hash: String,
+    pub constitution_version: String,
+    pub constitution_hash: String,
+    pub validation_profile: String,
+    pub validation_profile_hash: String,
+    pub proof_rubric: String,
+    pub proof_rubric_hash: String,
+    pub generated_specs_manifest_hash: String,
+    pub generated_specs_fingerprint: String,
+    pub material_hashes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ValidationEpochReceipt {
+    pub kind: String,
+    pub active_epoch: ValidationEpochMetadata,
+    pub proof_applicability: String,
+}
+
+pub fn active_validation_epoch(
+    project_root: &Path,
+) -> Result<ValidationEpochMetadata, error::DecapodError> {
+    let validation_profile =
+        std::env::var("DECAPOD_VALIDATION_PROFILE").unwrap_or_else(|_| "default".to_string());
+    let evaluator_identity = format!("decapod-validate@{}", env!("CARGO_PKG_VERSION"));
+    let proof_rubric = "decapod-validate/current-proof-v1".to_string();
+
+    let constitution_body = assets::get_doc("core/DECAPOD").unwrap_or_default();
+    let constitution_hash = sha256_hex(constitution_body.as_bytes());
+    let constitution_version = extract_version(&constitution_body)
+        .unwrap_or_else(|| format!("embedded-docs@{}", env!("CARGO_PKG_VERSION")));
+
+    let generated_specs_manifest_hash =
+        hash_specs_manifest_material(project_root.join(LOCAL_PROJECT_SPECS_MANIFEST).as_path())?;
+    let generated_specs_fingerprint = project_specs::repo_signal_fingerprint(project_root)
+        .unwrap_or_else(|_| "unavailable".to_string());
+
+    let mut material_hashes = BTreeMap::new();
+    material_hashes.insert(
+        "constitution:core/DECAPOD".to_string(),
+        constitution_hash.clone(),
+    );
+    material_hashes.insert(
+        "validation_profile".to_string(),
+        sha256_hex(validation_profile.as_bytes()),
+    );
+    material_hashes.insert(
+        "proof_rubric".to_string(),
+        sha256_hex(proof_rubric.as_bytes()),
+    );
+    material_hashes.insert(
+        "generated_specs_manifest".to_string(),
+        generated_specs_manifest_hash.clone(),
+    );
+    material_hashes.insert(
+        "generated_specs_fingerprint".to_string(),
+        generated_specs_fingerprint.clone(),
+    );
+    for spec in LOCAL_PROJECT_SPECS {
+        material_hashes.insert(
+            format!("generated_spec:{}", spec.path),
+            hash_file_if_exists(project_root.join(spec.path).as_path())?,
+        );
+    }
+
+    let evaluator_set_hash = hash_named_values(&[
+        ("evaluator_identity", evaluator_identity.as_str()),
+        ("validation_profile", validation_profile.as_str()),
+        ("proof_rubric", proof_rubric.as_str()),
+    ]);
+    let validation_profile_hash = sha256_hex(validation_profile.as_bytes());
+    let proof_rubric_hash = sha256_hex(proof_rubric.as_bytes());
+
+    let epoch_material = serde_json::json!({
+        "evaluator_identity": evaluator_identity,
+        "evaluator_set_hash": evaluator_set_hash,
+        "constitution_version": constitution_version,
+        "constitution_hash": constitution_hash,
+        "validation_profile": validation_profile,
+        "validation_profile_hash": validation_profile_hash,
+        "proof_rubric": proof_rubric,
+        "proof_rubric_hash": proof_rubric_hash,
+        "generated_specs_manifest_hash": generated_specs_manifest_hash,
+        "generated_specs_fingerprint": generated_specs_fingerprint,
+        "material_hashes": material_hashes,
+    });
+    let epoch_material_hash = sha256_hex(
+        serde_json::to_string(&epoch_material)
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    let epoch_id = format!(
+        "ve_{}",
+        &epoch_material_hash
+            .strip_prefix("sha256:")
+            .unwrap_or(&epoch_material_hash)[..16]
+    );
+
+    Ok(ValidationEpochMetadata {
+        schema_version: VALIDATION_EPOCH_SCHEMA_VERSION.to_string(),
+        epoch_id,
+        evaluator_identity,
+        evaluator_set_hash,
+        constitution_version,
+        constitution_hash,
+        validation_profile,
+        validation_profile_hash,
+        proof_rubric,
+        proof_rubric_hash,
+        generated_specs_manifest_hash,
+        generated_specs_fingerprint,
+        material_hashes,
+    })
+}
+
+pub fn write_active_validation_epoch_receipt(
+    project_root: &Path,
+    epoch: &ValidationEpochMetadata,
+) -> Result<(), error::DecapodError> {
+    let receipt = ValidationEpochReceipt {
+        kind: "decapod.validation_epoch".to_string(),
+        active_epoch: epoch.clone(),
+        proof_applicability:
+            "Only proof records with this evaluator epoch count as current proof evidence."
+                .to_string(),
+    };
+    let path = project_root.join(VALIDATION_EPOCH_RECEIPT);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+    }
+    let body = serde_json::to_string_pretty(&receipt).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "Failed to encode validation epoch receipt: {e}"
+        ))
+    })?;
+    fs::write(path, format!("{body}\n")).map_err(error::DecapodError::IoError)
+}
+
+fn extract_version(markdown: &str) -> Option<String> {
+    markdown.lines().find_map(|line| {
+        let trimmed = line.trim();
+        for prefix in ["**Version:**", "Version:", "version:"] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                let value = rest.trim().trim_matches('*').trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+        None
+    })
+}
+
+fn hash_file_if_exists(path: &Path) -> Result<String, error::DecapodError> {
+    if !path.exists() {
+        return Ok("absent".to_string());
+    }
+    let bytes = fs::read(path).map_err(error::DecapodError::IoError)?;
+    Ok(sha256_hex(&bytes))
+}
+
+fn hash_specs_manifest_material(path: &Path) -> Result<String, error::DecapodError> {
+    if !path.exists() {
+        return Ok("absent".to_string());
+    }
+    let raw = fs::read_to_string(path).map_err(error::DecapodError::IoError)?;
+    let mut value = serde_json::from_str::<serde_json::Value>(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "Invalid generated specs manifest for validation epoch: {e}"
+        ))
+    })?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("generated_at");
+    }
+    let canonical = serde_json::to_string(&value).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "Failed to canonicalize generated specs manifest for validation epoch: {e}"
+        ))
+    })?;
+    Ok(sha256_hex(canonical.as_bytes()))
+}
+
+fn hash_named_values(values: &[(&str, &str)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, value) in values {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\n");
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn specs_manifest_material_hash_ignores_generated_at() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("manifest.json");
+        fs::write(
+            &path,
+            r#"{"schema_version":"1.0.0","template_version":"scaffold-v3","generated_at":"1Z","repo_signal_fingerprint":"abc","files":[]}"#,
+        )
+        .expect("write first manifest");
+        let first = hash_specs_manifest_material(&path).expect("first hash");
+
+        fs::write(
+            &path,
+            r#"{"schema_version":"1.0.0","template_version":"scaffold-v3","generated_at":"2Z","repo_signal_fingerprint":"abc","files":[]}"#,
+        )
+        .expect("write second manifest");
+        let second = hash_specs_manifest_material(&path).expect("second hash");
+
+        assert_eq!(
+            first, second,
+            "timestamp-only specs refreshes must not create new validation epochs"
+        );
+    }
+}

--- a/src/core/workunit.rs
+++ b/src/core/workunit.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::context_capsule::DeterministicContextCapsule;
 use crate::core::error;
+use crate::core::validation_epoch::ValidationEpochMetadata;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -20,6 +21,10 @@ pub struct WorkUnitProofResult {
     pub gate: String,
     pub status: String,
     pub artifact_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evaluator_epoch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_epoch: Option<ValidationEpochMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -30,6 +35,8 @@ pub struct WorkUnitManifest {
     pub state_refs: Vec<String>,
     pub proof_plan: Vec<String>,
     pub proof_results: Vec<WorkUnitProofResult>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_epoch: Option<ValidationEpochMetadata>,
     pub status: WorkUnitStatus,
 }
 
@@ -112,6 +119,7 @@ pub fn init_workunit(
         state_refs: Vec::new(),
         proof_plan: Vec::new(),
         proof_results: Vec::new(),
+        validation_epoch: None,
         status: WorkUnitStatus::Draft,
     };
     write_workunit(project_root, &manifest)?;
@@ -209,6 +217,8 @@ pub fn record_proof_result(
         gate: gate.to_string(),
         status: status.to_string(),
         artifact_ref,
+        evaluator_epoch: None,
+        validation_epoch: None,
     });
     write_workunit(project_root, &manifest)?;
     load_workunit(project_root, task_id)

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -4,6 +4,7 @@ use crate::core::external_action::{self, ExternalCapability};
 use crate::core::state_commit;
 use crate::core::store::Store;
 use crate::core::todo;
+use crate::core::validation_epoch::{ValidationEpochMetadata, active_validation_epoch};
 use crate::plugins::federation;
 use clap::{Parser, Subcommand};
 use fancy_regex::Regex;
@@ -62,6 +63,10 @@ struct VerifyTarget {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct VerificationArtifacts {
     completed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    evaluator_epoch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    validation_epoch: Option<ValidationEpochMetadata>,
     proof_plan_results: Vec<ProofPlanResult>,
     file_artifacts: Vec<FileArtifact>,
 }
@@ -72,6 +77,10 @@ struct ProofPlanResult {
     status: String,
     command: String,
     output_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    evaluator_epoch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    validation_epoch: Option<ValidationEpochMetadata>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -567,6 +576,31 @@ fn verify_target(
 
     // Only check validate_passes if it's in the proof plan
     if validate_check_needed {
+        let active_epoch = active_validation_epoch(repo_root)?;
+        match artifacts.validation_epoch.as_ref() {
+            Some(captured_epoch) if captured_epoch.epoch_id == active_epoch.epoch_id => {}
+            Some(captured_epoch) => {
+                result.status = "fail".to_string();
+                result.proofs.push(ProofCheckResult {
+                    gate: "validate_passes".to_string(),
+                    status: "fail".to_string(),
+                    expected_output_hash: expected_hash.clone(),
+                    actual_output_hash: None,
+                    reason: Some(format!(
+                        "validation epoch changed: captured {} but active {}. Re-run `decapod todo done --validated` or `decapod qa verify capture --id {}` to recapture current proof evidence.",
+                        captured_epoch.epoch_id, active_epoch.epoch_id, target.todo_id
+                    )),
+                });
+                return Ok(result);
+            }
+            None => {
+                result.status = "unknown".to_string();
+                result.notes.push(
+                    "Missing validation_epoch provenance. Remediation: recapture verification artifacts so proof evidence is tied to the active validation epoch.".to_string(),
+                );
+                return Ok(result);
+            }
+        }
         let (validate_ok, actual_hash) =
             run_validate_and_hash(store_root, repo_root, Some(&target.todo_id))?;
         let expected = expected_hash.unwrap_or_default();
@@ -844,10 +878,13 @@ pub fn capture_baseline_for_todo(
     }
 
     let (validate_ok, output_hash) = run_validate_and_hash(&store.root, repo_root, Some(todo_id))?;
+    let validation_epoch = active_validation_epoch(repo_root)?;
 
     let ts = now_iso();
     let artifacts = VerificationArtifacts {
         completed_at: ts.clone(),
+        evaluator_epoch: Some(validation_epoch.epoch_id.clone()),
+        validation_epoch: Some(validation_epoch.clone()),
         proof_plan_results: vec![ProofPlanResult {
             proof_gate: "validate_passes".to_string(),
             status: if validate_ok {
@@ -857,6 +894,8 @@ pub fn capture_baseline_for_todo(
             },
             command: "decapod validate".to_string(),
             output_hash,
+            evaluator_epoch: Some(validation_epoch.epoch_id.clone()),
+            validation_epoch: Some(validation_epoch.clone()),
         }],
         file_artifacts,
     };

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -681,6 +681,10 @@ fn scaffold_store_and_docs_cli_behaviors() {
         "decapod init must allowlist generated Dockerfile in .gitignore"
     );
     assert!(
+        gitignore.contains("!.decapod/generated/validation-epoch.json"),
+        "decapod init must allowlist generated validation epoch receipt in .gitignore"
+    );
+    assert!(
         gitignore.contains("!.decapod/generated/context/*.json"),
         "decapod init must allowlist generated context capsule artifacts in .gitignore"
     );

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -230,6 +230,23 @@ fn validate_json_reports_self_heal_and_structured_summary() {
     assert_eq!(payload["report"]["status"], "ok");
     assert!(payload["report"]["fail_count"].as_u64().unwrap_or(1) == 0);
     assert!(payload["report"]["gate_timings"].is_array());
+    let epoch = &payload["report"]["validation_epoch"];
+    assert_eq!(epoch["schema_version"], "1.0.0");
+    let epoch_id = epoch["epoch_id"].as_str().expect("epoch_id");
+    assert!(epoch_id.starts_with("ve_"));
+    assert_eq!(epoch["validation_profile"], "default");
+    assert_eq!(
+        epoch["evaluator_identity"],
+        format!("decapod-validate@{}", env!("CARGO_PKG_VERSION"))
+    );
+
+    let receipt_path = dir.join(".decapod/generated/validation-epoch.json");
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&receipt_path).expect("validation epoch receipt should exist"),
+    )
+    .expect("validation epoch receipt should parse");
+    assert_eq!(receipt["kind"], "decapod.validation_epoch");
+    assert_eq!(receipt["active_epoch"]["epoch_id"], epoch_id);
     assert!(payload["self_heal"].is_array());
     assert!(
         !payload["self_heal"]
@@ -238,6 +255,58 @@ fn validate_json_reports_self_heal_and_structured_summary() {
             .iter()
             .any(|action| action["action"] == "heal_container_runtime_override"),
         "validate should not write container-runtime override markers automatically"
+    );
+}
+
+#[test]
+fn validation_profile_changes_validation_epoch() {
+    let (_tmp, dir, password) = setup_repo();
+
+    let default_validate = run_decapod(
+        &dir,
+        &["validate", "--format", "json"],
+        &[
+            ("DECAPOD_CONTAINER", "1"),
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        default_validate.status.success(),
+        "default validate failed: {}",
+        String::from_utf8_lossy(&default_validate.stderr)
+    );
+
+    let alternate_validate = run_decapod(
+        &dir,
+        &["validate", "--format", "json"],
+        &[
+            ("DECAPOD_CONTAINER", "1"),
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_VALIDATION_PROFILE", "alternate-proof-profile"),
+        ],
+    );
+    assert!(
+        alternate_validate.status.success(),
+        "alternate-profile validate failed: {}",
+        String::from_utf8_lossy(&alternate_validate.stderr)
+    );
+
+    let default_payload: Value =
+        serde_json::from_slice(&default_validate.stdout).expect("default validate json");
+    let alternate_payload: Value =
+        serde_json::from_slice(&alternate_validate.stdout).expect("alternate validate json");
+    assert_ne!(
+        default_payload["report"]["validation_epoch"]["epoch_id"],
+        alternate_payload["report"]["validation_epoch"]["epoch_id"],
+        "changing validation profile must create a distinct validation epoch"
+    );
+    assert_eq!(
+        alternate_payload["report"]["validation_epoch"]["validation_profile"],
+        "alternate-proof-profile"
     );
 }
 

--- a/tests/verify_mvp.rs
+++ b/tests/verify_mvp.rs
@@ -109,6 +109,27 @@ fn verify_mvp_pass_fail_unknown_flow() {
         "todo done --validated failed: {}",
         String::from_utf8_lossy(&done_validated.stderr)
     );
+    let db = Connection::open(repo.join(".decapod/data/todo.db")).unwrap();
+    let artifacts_json: String = db
+        .query_row(
+            "SELECT verification_artifacts FROM task_verification WHERE todo_id = ?1",
+            rusqlite::params![todo_id.clone()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let artifacts: Value = serde_json::from_str(&artifacts_json).unwrap();
+    let evaluator_epoch = artifacts["evaluator_epoch"]
+        .as_str()
+        .expect("verification artifact evaluator_epoch");
+    assert!(evaluator_epoch.starts_with("ve_"));
+    assert_eq!(
+        artifacts["validation_epoch"]["epoch_id"], evaluator_epoch,
+        "completed todo artifacts should record the active validation epoch"
+    );
+    assert_eq!(
+        artifacts["proof_plan_results"][0]["evaluator_epoch"], evaluator_epoch,
+        "proof records should carry evaluator epoch provenance"
+    );
 
     let verify_pass = run_cmd(repo, &["qa", "verify", "--json"]);
     assert!(

--- a/tests/workunit_publish_gate.rs
+++ b/tests/workunit_publish_gate.rs
@@ -25,8 +25,11 @@ fn write_manifest(
                 gate: gate.to_string(),
                 status: status.to_string(),
                 artifact_ref: None,
+                evaluator_epoch: None,
+                validation_epoch: None,
             })
             .collect(),
+        validation_epoch: None,
         status,
     };
 

--- a/tests/workunit_schema.rs
+++ b/tests/workunit_schema.rs
@@ -25,13 +25,18 @@ fn workunit_canonical_serialization_is_deterministic() {
                 gate: "state_commit".to_string(),
                 status: "pass".to_string(),
                 artifact_ref: Some("sha256:bbb".to_string()),
+                evaluator_epoch: None,
+                validation_epoch: None,
             },
             WorkUnitProofResult {
                 gate: "validate_passes".to_string(),
                 status: "pass".to_string(),
                 artifact_ref: Some("sha256:aaa".to_string()),
+                evaluator_epoch: None,
+                validation_epoch: None,
             },
         ],
+        validation_epoch: None,
         status: WorkUnitStatus::Claimed,
     };
 
@@ -56,7 +61,10 @@ fn workunit_canonicalization_sorts_and_dedups_contract_arrays() {
             gate: "b".to_string(),
             status: "pass".to_string(),
             artifact_ref: None,
+            evaluator_epoch: None,
+            validation_epoch: None,
         }],
+        validation_epoch: None,
         status: WorkUnitStatus::Draft,
     };
 


### PR DESCRIPTION
## Summary
- add deterministic validation epoch metadata to validate reports and the generated validation-epoch receipt
- record evaluator epoch provenance in todo verification artifacts and workunit proof records
- treat missing or stale validation epochs as non-current proof evidence during verification
- allowlist the generated validation epoch receipt and refresh generated specs fingerprint

Closes #772.

## Proof
- cargo check
- cargo test --test workunit_publish_gate --test workunit_schema
- cargo test --test validate_termination validate_
- cargo test --test validate_termination validation_profile_changes_validation_epoch
- cargo test --test verify_mvp -- --ignored
- cargo test --test core_tests scaffold_store_and_docs_cli_behaviors
- cargo test specs_manifest_material_hash_ignores_generated_at
- cargo test --test validate_termination validate_json_reports_self_heal_and_structured_summary
- target/debug/decapod validate --format json (status ok, fail_count 0)