### PR TITLE
Fix AARCH64 Linux cross-compilation linking failures

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.63.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.63.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.63.0
+ARG DECAPOD_VERSION=0.63.1
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.62.7
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.63.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.62.7
+ARG DECAPOD_VERSION=0.63.1
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783495105Z",
-  "repo_signal_fingerprint": "735f3c4f0acfdd369b0052eb33d4e52b071966dd9a56e2f185dfc8aab5e916d5",
+  "generated_at": "1783557486Z",
+  "repo_signal_fingerprint": "0dee7bed016554cf2a1d061ee4f35e3a4186aa5b72c849f62b04a8508015dbca",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783552379Z",
-  "repo_signal_fingerprint": "05d9d722f387edd298efd26fa7d373f1f2f2d9e21fffa940cd6790eab3101973",
+  "generated_at": "1783557736Z",
+  "repo_signal_fingerprint": "ecb6ef3586c57872d6cbfed0bae590688cca57374212ae529519c292ab06f402",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
     steps:
       - name: enable windows longpaths
         run: |


### PR DESCRIPTION
Define CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER to cross-compile cleanly on the aarch64 release target