### PR TITLE
docs: update living specs from codebase analysis

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -7,42 +7,42 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "b27b7cee157f2277b1eabb3dceb1d0ec6078d399a5b056fddbcb8221ccdeb97e"
+      "content_hash": "6d3664e1da01d4fb2f5e23b0148c56c2fff7c8a04269ef732ca46cc87fad4459"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ae0adf93591bc22295486a17e073561167c77bde19e388e676558513a7abe3f9"
+      "content_hash": "135fcbf61270c54bee1c6f3edf60e22a02c00899b91f910a81847b88ef6501fa"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "7ed28f5be504f6e84ff2eb65693ff54652002a7f51b12e9bc75f6d162f851f92"
+      "content_hash": "b658abccc6ede438a1316cc9b560a2b05777ce9d0efac6e9180bd3258d7c4e35"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "a39e5eb88f736b995426c1beca64a8644b54ddfe0a15bb3bba715f6c142d87aa"
+      "content_hash": "16da1087483d69117f246ca379404646082230e7300737d1807d3edce3346fc1"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "85319f6fd6c106c102d321371f85887bfe0beaef0f6fda1817566a71c6ff2f74"
+      "content_hash": "1742ae235c034b27c13e65e0b41527b3851771a306ef2cfd845edcaa242a993e"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "79b27120f88cf98ea2e2d5bff4fcc380f545fded9a6ba0252ce2889141d7ecc2"
+      "content_hash": "c8c844dd5ef774066ecf92f2ba443bf63faaa18c4e2f82912464d3fb6e454b9f"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "856fa267f2551713c165dd8585dda3fdace7b082e1ac0b213852791e5fea0867"
+      "content_hash": "da806ad59dd3e31e6a2249c947d7f6df54441aae1c6542c5c01aee055786e675"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "df1f4f74d4514213fc08e66543af5042a6e0c1c519e63b0f2e978c233e15d898"
+      "content_hash": "c59841972b8b81c0ede15cd6b0325d836555e9f4cae3a684a96ada343d359920"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -1,116 +1,366 @@
 # Architecture
 
 ## Direction
-cli
+CLI governance runtime with dual-store architecture, git worktree isolation, and deterministic context management.
 
 ## What This Project Is
-decapod is a cli project built using Rust.
-cli
+Decapod is a Rust CLI governance kernel for AI agents. It runs on-demand (daemonless), manages project-scoped state in SQLite with event sourcing, enforces workspace isolation via git worktrees and optional Docker containers, and provides deterministic context capsules for inference governance.
 
-Architectural principles:
-- **Simplicity**: Keep components focused and reusable.
-- **Modularity**: Clearly defined interface boundaries and dependency separation.
-- **Reliability**: Graceful failure handling and thorough verification.
+**Architectural Principles:**
+- **Daemonless**: No background processes; invoked by agents on demand (INV-DAEMONLESS)
+- **Dual-Store**: User (blank-slate) + Repo (dogfood backlog, event-sourced, deterministic rebuild)
+- **Workspace Isolation**: Git worktrees mandatory; containers optional but gated
+- **Deterministic**: Same inputs → identical outputs; event logs enable full rebuild
+- **Capability-Gated**: External actions (git, docker, fs) require declared capabilities
+- **Interface Abstraction**: Agents access `.decapod/` only via CLI (INV-STORE-BOUNDARY)
 
 ## Current Facts
-- Runtime/languages: Rust
-- Detected surfaces/framework hints: cargo
-- Product type: cli
+- **Runtime**: Rust 1.96.1, edition 2024
+- **Build**: Cargo with `cargo-dist` for multi-platform binaries
+- **Primary binary**: `decapod`
+- **State**: 6 SQLite databases ("bins") + JSONL event logs in `.decapod/data/`
+- **Config**: `.decapod/config.toml` (schema_version 1.0.0)
+- **Generated**: `.decapod/generated/{specs,context,policy,artifacts}`
 
 ## Architecture Map
-This project's architecture consists of the following key layers/directories:
-- `src/`: Main source directory containing primary logic.
-- `tests/`: Integration and unit test suite.
+```
+src/
+├── bin/                    # Entry points (decapod, selective-test)
+├── cli.rs                  # All clap command definitions
+├── lib.rs                  # Library root, module exports, init logic
+├── constitution/           # Embedded constitution graph routing
+│   ├── core.rs             # Core runtime surfaces
+│   ├── interfaces.rs       # Interface contracts
+│   ├── methodology.rs      # Methodology nodes
+│   └── specs.rs            # Specs nodes
+├── core/                   # Control plane runtime
+│   ├── mod.rs              # Core module exports
+│   ├── db.rs               # SQLite connections, WAL, health preflight
+│   ├── schemas.rs          # All 6 bin schemas (centralized)
+│   ├── store.rs            # Store abstraction (User/Repo, root discovery)
+│   ├── workspace.rs        # Git worktree + container isolation
+│   ├── todo.rs             # Task tracking + event sourcing + agent coordination
+│   ├── plan_governance.rs  # Governed Plan (Draft→Approved→Executing→Done)
+│   ├── workunit.rs         # WorkUnit manifests (intent/spec/state/proof)
+│   ├── obligation.rs       # Obligation graph (derived status, deps, proofs)
+│   ├── context_capsule.rs  # Deterministic capsules + policy binding
+│   ├── capsule_policy.rs   # Risk-tiered token budgets, repo-revision binding
+│   ├── validate.rs         # Multi-gate validation harness
+│   ├── proof.rs            # Configurable proof registry + audit
+│   ├── assurance.rs        # Interlock engine + advisory/attestation
+│   ├── rpc.rs              # JSON-RPC envelope + capabilities
+│   ├── flight_recorder.rs  # Governance timeline from event logs
+│   ├── migration.rs        # Schema migrations
+│   ├── assets.rs           # Embedded constitution docs
+│   ├── docs.rs             # Document fragment resolution
+│   ├── broker.rs           # Audit log broker (thin waist)
+│   ├── state_commit.rs     # Cryptographic state commitments
+│   ├── container_runtime.rs # Docker/podman detection + build
+│   ├── ulid.rs             # ULID generation
+│   ├── time.rs             # Epoch-Z timestamps
+│   ├── error.rs            # Error types + auto-remediable codes
+│   ├── output.rs           # Structured output formatting
+│   ├── trace.rs            # Trace export
+│   └── ...                 # Additional subsystems (health, gatekeeper, etc.)
+└── plugins/                # Plugin subsystems
+    ├── mod.rs
+    ├── aptitude.rs         # Preferences + patterns + observations
+    ├── archive.rs          # Session archives (MOVE-not-TRIM)
+    ├── container.rs        # Ephemeral container execution
+    ├── context.rs          # Lossless Context Management (LCM)
+    ├── cron.rs             # Scheduled tasks
+    ├── decide.rs           # Architecture decision prompting
+    ├── doctor.rs           # Preflight health checks
+    ├── eval.rs             # Variance-aware evaluation gates
+    ├── federation.rs       # Governed knowledge graph (multi-repo)
+    ├── feedback.rs         # Operator feedback ledger
+    ├── gatling.rs          # CLI regression testing
+    ├── health.rs           # Claims + proof events + health cache
+    ├── heartbeat.rs        # Agent presence + autoclaim
+    ├── internalize.rs      # Deterministic summaries + replay
+    ├── knowledge.rs        # Project knowledge base
+    ├── lcm.rs              # LCM CLI
+    ├── map_ops.rs          # Deterministic map operators
+    ├── policy.rs           # Risk policy + approvals
+    ├── primitives.rs       # Markdown-native primitive layer
+    ├── reflex.rs           # Event-driven automation
+    ├── verify.rs           # Proof replay + drift checks
+    ├── watcher.rs          # Integrity watchlist
+    └── workflow.rs         # Workflow automation
+```
 
 ## Data Flows
-- Inbound request/command parses and validates at the entrypoint.
-- Core runtime handles business logic and initiates queries or state changes.
-- Storage adapter reads or writes data to the underlying persistence layers.
+```mermaid
+flowchart TD
+  A[Agent Invocation] --> B[CLI / RPC Entrypoint]
+  B --> C{Session Valid?}
+  C -->|No| D[Block: Acquire Session]
+  C -->|Yes| E[Route to Subsystem]
+  E --> F[Workspace Check]
+  F -->|Protected/Main| G[Block: workspace.ensure]
+  F -->|Valid Worktree| H[Core Execution]
+  H --> I[SQLite Write (WAL)]
+  I --> J[JSONL Event Append]
+  J --> K[Receipt + Context Capsule]
+  K --> L[Allowed Next Ops / Interlock]
+  L --> M[Agent Response]
+```
+
+**Key Flows:**
+1. **Inbound**: CLI args or JSON-RPC stdin → validation → subsystem dispatch
+2. **Workspace**: `workspace.ensure` → git worktree add → optional container build → status return
+3. **Context**: `infer orientation` → resolve constitution fragments → deterministic capsule → policy binding
+4. **Governance**: `plan.init` → `plan.approve` → `workunit.init` → execute → proofs → `workunit.verified`
+5. **State**: SQLite WAL writes + JSONL append → deterministic rebuild available
+6. **Validation**: Multi-gate pipeline (workspace, store, schema, entrypoints, specs, proofs) → report
 
 ## Strongest Existing Primitives
-- Define the strongest existing primitives in the codebase (e.g., helper utilities, base controllers, data access layers).
+| Primitive | Location | Purpose |
+|-----------|----------|---------|
+| `Store` | `core/store.rs` | Dual-store abstraction (User/Repo) with root discovery |
+| `WorkspaceStatus` | `core/workspace.rs` | Git + container status, blockers, allowed ops |
+| `Todo` + events | `core/todo.rs` | Task CRUD, claims, event sourcing, deterministic rebuild |
+| `GovernedPlan` | `core/plan_governance.rs` | State machine with scope constraints, execute gate |
+| `WorkUnitManifest` | `core/workunit.rs` | Intent/spec/state/proof chain with canonical hashing |
+| `ObligationNode` | `core/obligation.rs` | Dependency graph, derived status, proof gating |
+| `DeterministicContextCapsule` | `core/context_capsule.rs` | Immutable sources + snippets, SHA256 hash, policy binding |
+| `CapsulePolicyBinding` | `core/capsule_policy.rs` | Risk tiers, scope allowlists, repo-revision binding |
+| `ValidationContext` | `core/validate.rs` | Gate timing, pass/fail/warn counts, auto-remediable errors |
+| `RpcResponse` | `core/rpc.rs` | Standard envelope: receipt, capsule, allowed_ops, interlock |
+| `AssuranceEngine` | `core/assurance.rs` | Interlock resolution, advisory, attestation |
+| `FlightRecorder` | `core/flight_recorder.rs` | Timeline from broker/todo/federation/proof event logs |
 
 ## Topology
 ```mermaid
 flowchart LR
-  U[User] --> C[CLI Entrypoint]
-  C --> R[Command Router]
+  U[Agent/User] --> C[decapod CLI]
+  C --> R[RPC/JSON Interface]
   R --> E[Core Engine]
-  E --> S[(Local Store)]
-  E --> X[External APIs / Filesystem]
+  E --> S1[(Repo Store: .decapod/data/)]
+  E --> S2[(User Store: ~/.decapod/data/)]
+  E --> W[Git Worktrees]
+  W --> D[Docker Container]
+  E --> X[External: git, fs, cargo]
+  E --> P[Embedded Constitution]
+  E --> G[Generated Artifacts]
 ```
 
 ## Store Boundaries
 ```mermaid
 flowchart LR
-  I[Inbound Requests] --> C[Core Logic]
-  C --> W[(Write Store)]
-  C --> R[(Read Store)]
+  subgraph Repo_Store["Repo Store (.decapod/data/)"]
+    direction TB
+    T1[todo.db + todo.events.jsonl]
+    T2[governance.db]
+    T3[memory.db + federation.db]
+    T4[automation.db]
+    T5[knowledge.db]
+    T6[lcm.db]
+  end
+  
+  subgraph User_Store["User Store (~/.decapod/data/)"]
+    direction TB
+    U1[todo.db]
+    U2[...]
+  end
+  
+  C[Core Engine] -->|Write/Read| Repo_Store
+  C -->|Write/Read| User_Store
+  C -.->|Event Rebuild| T1
+  C -.->|Audit Log| T2
 ```
+
+**Invariants:**
+- All Decapod state scoped to `.decapod/data/` (Repo) or `~/.decapod/data/` (User)
+- No state files in project root (enforced by validation gate)
+- Event logs are append-only; SQLite is deterministic rebuild target
+- Broker log (`broker.events.jsonl`) is the "thin waist" for mutation audit
 
 ## Happy Path Sequence
 ```mermaid
 sequenceDiagram
-  participant U as User
-  participant C as CLI
+  participant A as Agent
+  participant C as CLI/RPC
+  participant W as Workspace
   participant E as Core Engine
-  participant S as Store
-  U->>C: Run command
-  C->>E: Parse + validate
-  E->>S: Persist mutation
-  S-->>E: Ack
-  E-->>C: Result
-  C-->>U: Structured output
+  participant S as Repo Store
+  participant P as Proofs
+  
+  A->>C: decapod rpc --op agent.init
+  C->>A: Capabilities + session requirement
+  A->>C: decapod session acquire
+  C->>A: DECAPOD_SESSION_PASSWORD
+  A->>C: decapod todo add "task" && decapod todo claim --id T1
+  C->>E: Create + claim task
+  E->>S: Append task.add event
+  A->>C: decapod workspace ensure
+  C->>W: git worktree add -b agent/.../T1
+  W->>A: Worktree path + status
+  A->>C: decapod infer orientation --intent "..." --task-id T1
+  C->>E: Resolve context capsule
+  E->>A: Capsule + allowed_scope + proof_required
+  A->>C: decapod govern plan init --title "..." --intent "..." --todo-id T1
+  C->>E: Create GovernedPlan (Draft)
+  A->>C: decapod govern plan approve
+  C->>E: Plan → Approved
+  A->>C: decapod workspace ensure (in worktree)
+  A->>A: Implement changes
+  A->>C: decapod qa check --all
+  C->>P: Run proofs (cargo test, validate, etc.)
+  P->>C: Results + audit events
+  A->>C: decapod workspace publish
+  C->>W: Commit + push + PR
+  W->>A: PR URL + commit hash
 ```
 
 ## Error Path
 ```mermaid
 sequenceDiagram
-  participant Client
-  participant Service
-  participant Store
-  Client->>Service: Request
-  Service->>Store: Database Query
-  Store--xService: Error/Timeout
-  Service-->>Client: Typed Error / Recovery Instructions
+  participant A as Agent
+  participant C as CLI/RPC
+  participant E as Core Engine
+  participant S as Store
+  
+  A->>C: Operation
+  C->>E: Validate params + session
+  alt Invalid session
+    E-->>C: Interlock: unauthorized
+    C-->>A: 401 + allowed_next_ops: [session.acquire]
+  else Protected branch
+    E-->>C: Interlock: workspace_required
+    C-->>A: 409 + allowed_next_ops: [workspace.ensure]
+  else Store locked
+    S--xE: SQLite busy/locked
+    E->>E: Retry (5x exponential backoff)
+    alt Retries exhausted
+      E-->>C: ValidationError: lock contention
+      C-->>A: 503 + retry hint
+    else Success
+      E-->>C: Result
+      C-->>A: 200 + receipt
+    end
+  else Proof failed
+    E-->>C: Interlock: verification_required
+    C-->>A: 409 + allowed_next_ops: [qa.check, validate]
+  end
 ```
 
 ## Execution Path
-- Ingress parse + validation:
-- Policy/interlock checks:
-- Core execution + persistence:
-- Verification and artifact emission:
+```
+Ingress parse + validation:
+  ├── CLI: clap derives in cli.rs → dispatch in lib.rs
+  ├── RPC: stdin JSON → RpcRequest → op router → typed params
+  └── Session: DECAPOD_SESSION_PASSWORD → broker verify
+
+Policy/interlock checks (assurance engine):
+  ├── Workspace: protected branch? in worktree? container ready?
+  ├── Store boundary: .decapod/data/ access via CLI only?
+  ├── Completion phase: proofs run? validation passed?
+  └── Mandatory decisions: auth touched? contradictions unresolved?
+
+Core execution + persistence:
+  ├── SQLite WAL write (5s busy_timeout)
+  ├── JSONL event append (broker, todo, federation, proof, etc.)
+  └── Deterministic rebuild available from events
+
+Verification and artifact emission:
+  ├── Receipt: op, timestamp, inputs_hash, outputs_hash, touched_paths
+  ├── Context capsule: deterministic fragments + policy binding
+  ├── Allowed next ops: capability-gated suggestions
+  ├── Interlock (if blocked): code, message, unblock_ops, evidence
+  └── Attestation: input_hash, interlock_code, outcome, trace_path
+```
 
 ## Concurrency and Runtime Model
-- Execution model:
-- Isolation boundaries:
-- Backpressure strategy:
-- Shared state synchronization:
+- **Execution model**: Single-threaded CLI invocation per agent; no background threads
+- **Isolation boundaries**: 
+  - Git worktrees (mandatory for agent work)
+  - Docker containers (optional, gated by elevated permissions)
+  - Store kind separation (User vs Repo)
+- **Backpressure strategy**: SQLite busy_timeout (5s repo, 2s validate) + exponential retry (5 retries, 50ms base)
+- **Shared state synchronization**: 
+  - Event logs are append-only (concurrent reads safe)
+  - SQLite WAL allows concurrent read + single write
+  - Broker verifies audit log integrity on validate
+  - No distributed locking; local filesystem only
 
 ## Deployment Topology
-- Runtime units:
-- Region/zone model:
-- Rollout strategy (blue/green/canary):
-- Rollback trigger and blast-radius scope:
+- **Runtime units**: Single binary `decapod` per host; no server component
+- **Distribution**: `cargo-dist` builds for x86_64/aarch64 Linux + macOS
+- **Installation**: `cargo install decapod` or prebuilt binaries
+- **Configuration**: `.decapod/config.toml` per repository
+- **Rollout**: Binary replacement; no migration needed (schema auto-migrates)
+- **Rollback**: Previous binary in PATH; schema migrations are additive
+- **Blast radius**: Local repository only; no cross-repo state (except experimental federation)
 
 ## Data and Contracts
-- Inbound contracts (CLI/API/events):
-- Outbound dependencies (datastores/queues/external APIs):
-- Data ownership boundaries:
-- Schema evolution + migration policy:
+
+### Inbound Contracts
+| Surface | Format | Validation |
+|---------|--------|------------|
+| CLI | clap positional/flags | clap validation + custom in dispatch |
+| RPC stdin | JSON (RpcRequest) | Serde deserialize + op router |
+| Session | DECAPOD_SESSION_PASSWORD env | Broker verification |
+
+### Outbound Dependencies
+| Dependency | Purpose | Contract |
+|------------|---------|----------|
+| git | Worktree management, status, publish | CLI subprocess; capability `VcsRead`/`VcsWrite` |
+| docker/podman | Container workspace build/exec | CLI subprocess; capability `ContainerExec` |
+| cargo | Test, build, clippy, fmt | CLI subprocess; capability `CargoExec` |
+| curl | crates.io version check | HTTP GET; 2s timeout |
+| filesystem | Config, state, artifacts | Capability `FsRead`/`FsWrite` |
+
+### Data Ownership Boundaries
+| Data | Owner | Mutation Path |
+|------|-------|---------------|
+| todo.db + events | Repo store | `todo.*` CLI/RPC → broker → SQLite + JSONL |
+| governance.db | Repo store | `govern.*`, `obligation.*`, `health.*` |
+| memory.db / federation.db | Repo store | `data knowledge/federation`, `decide.*` |
+| automation.db | Repo store | `auto cron/reflex` |
+| knowledge.db | Repo store | `data knowledge add/search/promote` |
+| lcm.db | Repo store | `data context ingest/summarize` |
+| WorkUnit manifests | `.decapod/governance/workunits/` | `govern workunit.*` |
+| Plan artifact | `.decapod/governance/plan.json` | `govern plan.*` |
+| Context capsules | `.decapod/generated/context/` | `infer.*`, `govern capsule.*` |
+| Capsule policy | `.decapod/generated/policy/` or override | `init`, `scaffold` |
+
+### Schema Evolution + Migration Policy
+- **Schema versioning**: Per-bin `meta.schema_version` + centralized `schemas.rs` constants
+- **Migration**: Additive only (new tables, indexes, columns with defaults)
+- **Validation gate**: `validate_repo_store_dogfood` rebuilds from events + compares fingerprint
+- **Backward compatibility**: Read-only validate connections use `query_only` + `temp_store=MEMORY`
+- **Breaking changes**: Require schema version bump + migration fn in `migration.rs`
 
 ## ADR Register
 | ADR | Title | Status | Rationale | Date |
-|---|---|---|---|---|
-| ADR-001 | Initial topology choice | Proposed | Define first stable architecture | YYYY-MM-DD |
+|-----|-------|--------|-----------|------|
+| ADR-001 | Daemonless CLI architecture | Accepted | Agents invoke on demand; zero idle cost | 2024-Q1 |
+| ADR-002 | Dual-store (User/Repo) | Accepted | Blank-slate agent state + project dogfood backlog | 2024-Q1 |
+| ADR-003 | SQLite WAL + JSONL event sourcing | Accepted | Deterministic rebuild, audit trail, concurrency | 2024-Q1 |
+| ADR-004 | Git worktree isolation (mandatory) | Accepted | Protect human env; agent work in `.decapod/workspaces/` | 2024-Q2 |
+| ADR-005 | Container workspace (optional, gated) | Accepted | Reproducible builds; elevated permissions required | 2024-Q2 |
+| ADR-006 | Embedded constitution (assets/) | Accepted | Zero-config methodology; versioned with binary | 2024-Q3 |
+| ADR-007 | JSON-RPC with standard envelope | Accepted | Agent-native; receipt + capsule + interlock | 2024-Q3 |
+| ADR-008 | Deterministic context capsules | Accepted | Immutable sources + SHA256 hash + policy binding | 2024-Q3 |
+| ADR-009 | Capability-gated external actions | Accepted | Supply-chain attack surface reduction | 2024-Q4 |
+| ADR-010 | Obligation graph with derived status | Accepted | No asserted completion; proof-gated dependencies | 2025-Q1 |
+| ADR-011 | Validation as release gate (not theater) | Accepted | Blocking gates + auto-remediable errors + evidence | 2025-Q1 |
 
-## Delivery Plan (first 3 slices)
-- Slice 1 (ship first):
-- Slice 2:
-- Slice 3:
+## Delivery Plan (First 3 Slices)
+| Slice | Scope | Status |
+|-------|-------|--------|
+| 1 | Daemonless CLI, dual-store, todo event sourcing, git worktrees, basic validate | ✅ Done |
+| 2 | Plan governance, WorkUnit, obligation graph, context capsules, capsule policy | ✅ Done |
+| 3 | Inference governance (orientation/validate/budget), assurance engine, flight recorder, JSON-RPC | ✅ Done |
+| 4 (next) | Federation trust model, cloud sync protocol, long-term capsule tiering | 🔄 Planned |
 
 ## Risks and Mitigations
 | Risk | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| Contract drift across components | Medium | High | Spec + schema checks in CI |
-| Runtime saturation under peak load | Medium | High | Capacity model + load tests |
+|------|------------|--------|------------|
+| SQLite lock contention under concurrent agents | Medium | High | WAL mode, 5s busy_timeout, 5 retries exponential backoff, validate read-only connections |
+| Contract drift across CLI/RPC/embedded docs | Medium | High | `validate` gates: entrypoint invariants, specs sync, schema checks, interface conformance tests |
+| Workspace isolation bypass | Low | High | Protected branch gate, worktree enforcement, container gating, `.decapod/` CLI-only jail rule |
+| Capsule policy drift (repo revision mismatch) | Medium | Medium | Policy binding includes `repo_revision`; validate gate checks lineage |
+| Schema migration failure | Low | High | Additive-only migrations; deterministic rebuild verification gate |
+| Agent session token leakage | Low | High | Per-agent `DECAPOD_SESSION_PASSWORD`; broker verification; short TTL |

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -1,101 +1,172 @@
 # Intent
 
 ## Product Outcome
-- Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
-
-## What This Project Is
-decapod is a cli project built using Rust.
 Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
 
-Key operating facts:
-- **Primary languages**: Rust
-- **Detected surfaces**: cargo
+## What This Project Is
+Decapod is a Rust CLI project that implements a governance runtime for AI agents. It provides:
+
+**Core Runtime:**
+- Daemonless CLI invoked by agents on demand (no background processes)
+- Dual-store architecture: User store (blank-slate agent-local state) + Repo store (project-scoped dogfood backlog with event sourcing)
+- SQLite-backed state with deterministic rebuild from JSONL event logs
+- Git worktree isolation + optional Docker container execution for agent workspaces
+- Session-token authentication with per-agent passwords (DECAPOD_SESSION_PASSWORD)
+
+**Governance Primitives:**
+- **Plan**: Governed execution artifacts with state machine (Draft → Annotating → Approved → Executing → Done)
+- **WorkUnit**: Intent/spec/state/proof chain manifests per task with deterministic hashing
+- **Obligation Graph**: Dependency-aware, proof-gated work units with derived status (never asserted)
+- **Proof System**: Configurable executable checks (cargo test, validate, custom) with audit trail
+
+**Context & Inference Control:**
+- Deterministic Context Capsules: immutable originals + structured summaries with cryptographic hashes
+- Capsule Policy: risk-tiered token budgets, scope allowlists, write permissions bound to repo revision
+- Inference Governance: `infer orientation` (pre-inference context packet), `infer validate` (post-inference verification), `infer budget` (token estimation)
+- Preflight/Impact: predict validation failures and validation outcomes for changed files
+
+**Agent Interface:**
+- JSON-RPC over stdin/stdout with standard envelope (receipt, context_capsule, allowed_next_ops, blocked_by, interlock, advisory, attestation)
+- Capabilities discovery via `decapod capabilities` / `decapod rpc --op agent.init`
+- Constitution graph queries (`constitution get`, `constitution links`) with embedded methodology docs
+
+**Validation & Quality Gates:**
+- Multi-gate validation: workspace, store integrity, schema, entrypoint invariants, specs sync, proof replay, health purity
+- Auto-remediable error codes with agent-actionable guidance
+- Promotion evidence artifacts (provenance manifests, proof manifests, validation reports)
+
+## Key Operating Facts
+- **Primary language**: Rust (edition 2024, rust-version 1.96.1)
+- **Build system**: Cargo
+- **Binary name**: `decapod` (also `selective-test` bench binary)
+- **Config**: `.decapod/config.toml` (schema_version 1.0.0)
+- **State**: `.decapod/data/*.db` + `.decapod/data/*.jsonl` event logs
+- **Generated artifacts**: `.decapod/generated/{specs,context,policy,artifacts,artifacts/provenance,artifacts/custody}`
 
 ## Product View
 ```mermaid
 flowchart LR
-  U[Primary User] --> P[decapod]
-  P --> O[User-visible Outcome]
-  P --> G[Proof Gates]
-  G --> E[Evidence Artifacts]
+  A[Human Intent] --> B[Agent]
+  B --> C[decapod CLI / RPC]
+  C --> D[Governance Kernel]
+  D --> E[Workspace Isolation]
+  D --> F[Context Capsules]
+  D --> G[Plan / WorkUnit / Obligation]
+  D --> H[Proof Gates]
+  H --> I[Evidence Artifacts]
+  I --> J[Promotion Gate]
+  J --> K[Proof-Backed Completion]
 ```
 
 ## Inferred Baseline
 - Repository: decapod
-- Product type: cli
+- Product type: CLI governance runtime
 - Primary languages: Rust
-- Detected surfaces: cargo
+- Detected surfaces: cargo, git, docker
 
 ## Scope
 | Area | In Scope | Proof Surface |
-|---|---|---|
-| Core workflow | Define a concrete user-visible workflow | Acceptance criteria + tests |
-| Data contracts | Document canonical inputs/outputs | [INTERFACES.md](./INTERFACES.md) and schema checks |
-| Delivery quality | Block promotion on broken proof surfaces | [VALIDATION.md](./VALIDATION.md) blocking gates |
+|------|----------|---------------|
+| Core workflow | Agent invokes decapod → workspace → context → plan/workunit → execute → proofs → publish | Acceptance criteria + integration tests |
+| Data contracts | SQLite schemas (4 bins), JSONL event logs, WorkUnit manifests, Context Capsules, Policy bindings | INTERFACES.md schemas + schema validation gates |
+| Delivery quality | Block promotion on failed validation, missing proofs, drift | VALIDATION.md blocking gates + provenance manifests |
+| Agent interface | JSON-RPC envelope, capabilities discovery, session auth | CLI contracts + RPC schema tests |
+| Context governance | Capsule policy (risk tiers, scopes, limits), deterministic hashes, repo-revision binding | Capsule policy schema + lineage verification |
 
 ## Non-Goals (Falsifiable)
 | Non-goal | How to falsify |
-|---|---|
-| Feature creep beyond the primary outcome | Any PR adds capability not tied to outcome criteria |
-| Shipping without evidence | Missing validation artifacts for promoted changes |
-| Ambiguous ownership boundaries | Missing owner/system-of-record in interfaces |
+|----------|----------------|
+| Background daemon / server mode | Any PR adds long-running process or port listener |
+| Cloud-managed state (beyond experimental opt-in) | Cloud sync mutates local `.decapod/data` without explicit user action |
+| Replacing agent reasoning | Any PR adds LLM calling or prompt engineering beyond context shaping |
+| General-purpose task queue | Any PR adds job scheduling unrelated to governance primitives |
 
 ## Constraints
-- Technical: runtime, dependency, and topology boundaries are explicit.
-- Operational: deployment, rollback, and incident ownership are defined.
-- Security/compliance: sensitive data handling and authz are mandatory.
+- **Technical**: Daemonless (INV-DAEMONLESS), SQLite WAL mode, git worktree isolation, container runtime optional but gated
+- **Operational**: Agents must claim todo before work, session token required, elevated permissions for container commands
+- **Security**: No secrets in config.toml, .decapod/ CLI-only access (jail rule), capability-gated external actions
 
-## Acceptance Criteria (must be objectively testable)
-- [ ] Decapod validate passes, required tests pass, and promotion-relevant artifacts are present.
-- [ ] Non-functional targets are met (latency, reliability, cost, etc.).
-- [ ] Validation gates pass and artifacts are attached.
-- [ ] `cargo test` passes for unit/integration coverage
+## Acceptance Criteria (Objectively Testable)
+- [ ] `decapod validate` passes all blocking gates
+- [ ] `cargo test` passes (unit + integration)
 - [ ] `cargo clippy -- -D warnings` passes with no denied lints
-- [ ] `cargo fmt --check` passes on the repo
+- [ ] `cargo fmt --check` passes
+- [ ] Promotion evidence artifacts present: artifact_manifest.json, proof_manifest.json, validation_report.json
+- [ ] Workspace isolation enforced: protected branch blocking, worktree creation, container gating
+- [ ] Context capsules deterministic: same inputs → identical capsule_hash
+- [ ] Obligation graph: status derived (never asserted), cycles detected, proofs gated
+- [ ] Proof replay: `decapod qa verify` reproduces results from evidence
 
 ## Epistemic Custody Fields
 
 ### Active Assumptions
-- The host has a functional `git` installation (verified during init/validation).
-- The agent has write access to the `.decapod/` directory.
+- Host has functional `git` (verified in workspace preflight)
+- Host has functional `docker`/`podman` for container workspaces (optional but gated)
+- Agent has write access to `.decapod/` directory
+- DECAPOD_SESSION_PASSWORD set per-agent for session acquisition
+- Project is a git repository (workspace ensure requires it)
 
 ### Confidence & Risk Level
-- **Confidence**: High (Fully verified local coordination and sandbox flows).
-- **Risk**: Low (Local isolation limits blast radius).
+- **Confidence**: High (local coordination, deterministic rebuild, proven workspace isolation)
+- **Risk**: Low (local isolation limits blast radius; no background processes)
 
 ### Measured vs Inferred Facts
 | Fact | Source (Provenance) | Type |
-|---|---|---|
-| Git is installed | `Command::new("git")` check | Measured |
-| Isolated branch naming | `workspace::ensure` execution | Measured |
+|------|---------------------|------|
+| Git is installed | `Command::new("git")` check in workspace.rs | Measured |
+| SQLite WAL mode works | `db_connect` with journal_mode=WAL fallback | Measured |
+| Isolated branch naming | `workspace::ensure` execution with agent/todo scoping | Measured |
+| Deterministic DB rebuild | `todo::rebuild_db_from_events` round-trip test | Measured |
+| Capsule hash determinism | `context_capsule::canonical_json_bytes` + SHA256 | Measured |
 
 ### Unresolved Contradictions
-- None.
+- Cloud backend experimental opt-in exists but sync/migration not implemented
+- Federation (multi-repo knowledge graph) vs single-repo governance boundaries need clarification
 
 ### Deferred Questions
-- None.
+- Full cloud synchronization protocol (beyond init registration)
+- Cross-repository obligation graphs
+- Long-term capsule storage tiering
 
 ### Stop Conditions
-- Lock contention on SQLite database exceeding retry budget.
-- Conflicting todo claims by another active agent session.
+- SQLite lock contention exceeding retry budget (5 retries with exponential backoff)
+- Conflicting todo claims by another active agent session
+- Workspace on protected branch with local modifications
+- Validation epoch drift detected without refresh
 
 ### Proof Required Before Completion
-- Green suite run on cargo integration tests.
-- Complete spec verification manifest generation.
+- Green `cargo test` suite (unit + integration)
+- Complete spec verification manifest generation
+- `decapod validate --refresh-specs` passes
+- All promotion gates satisfied with attached evidence
 
 ## Tradeoffs Register
 | Decision | Benefit | Cost | Review Trigger |
-|---|---|---|---|
-| Simplicity vs extensibility | Faster iteration | Potential rework | Feature set expands |
-| Strict gates vs dev speed | Higher confidence | More upfront discipline | Lead time regressions |
+|----------|---------|------|----------------|
+| Daemonless CLI vs persistent server | Zero resource when idle; simpler ops | Per-invocation startup latency | Latency regression > 200ms |
+| SQLite + JSONL event sourcing | Deterministic rebuild; audit trail | Write throughput ceiling | Contention > 5 retries |
+| Git worktrees + containers | Strong isolation; human env preserved | Disk usage; docker daemon req | Workspace creation > 30s |
+| Embedded constitution (assets/) | Zero-config methodology access | Binary size (~2MB) | Asset sync drift detected |
+| Capability-gated external actions | Supply-chain attack surface reduction | Agent must declare capabilities | New tooling blocked by missing capability |
 
-## First Implementation Slice
-- [ ] Define the smallest user-visible workflow to ship first.
-- [ ] Define required data/contracts for that workflow.
-- [ ] Define what is intentionally postponed until v2.
+## First Implementation Slice (Current)
+- [x] Daemonless CLI with dual-store architecture
+- [x] Git worktree isolation + container workspace
+- [x] Todo system with event sourcing + deterministic rebuild
+- [x] Plan governance (Draft→Approved→Executing→Done) with scope constraints
+- [x] WorkUnit manifests with proof chains
+- [x] Obligation graph with derived status
+- [x] Deterministic context capsules with policy binding
+- [x] Inference governance (orientation/validate/budget)
+- [x] Validation harness with auto-remediable errors
+- [x] JSON-RPC interface with standard envelope
+- [x] Embedded constitution graph with links navigation
+- [ ] Cross-repo federation (experimental)
+- [ ] Cloud sync (experimental opt-in only)
 
-## Open Questions (with decision deadlines)
+## Open Questions (with Decision Deadlines)
 | Question | Owner | Deadline | Decision |
-|---|---|---|---|
-| Which interfaces are versioned at launch? | TBD | YYYY-MM-DD | |
-| Which non-functional target is hardest to hit? | TBD | YYYY-MM-DD | |
+|----------|-------|----------|----------|
+| Cloud sync protocol beyond init registration? | Core team | 2026-Q3 | Deferred |
+| Federation trust model for multi-repo? | Core team | 2026-Q3 | Deferred |
+| Long-term capsule storage tiering strategy? | Core team | 2026-Q4 | Deferred |

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -3,69 +3,377 @@
 ## Contract Principles
 - Prefer explicit schemas over implicit behavior.
 - Every mutating interface defines idempotency semantics.
-- Every failure path maps to a typed, documented error code.
+- Every failure path maps to a typed, documented error code with auto-remediation guidance.
+- Daemonless: all interfaces are synchronous CLI or JSON-RPC over stdin/stdout.
+- Capability-gated: external actions (git, docker, cargo, etc.) require declared capability.
+- CLI-only access to `.decapod/` (jail rule enforced in entrypoint docs).
 
 ## Generated Contract Depth
-Generated interface specs should include:
-- API/CLI contracts with request/response schemas.
-- Read/write ownership for each storage path.
-- Idempotency and retry behavior for mutations.
-- Typed failure classes and recovery instructions.
+Generated interface specs include:
+- CLI commands with request/response shapes (see `decapod <cmd> --help` and `decapod capabilities`)
+- JSON-RPC operations with typed params/results (see `src/core/rpc.rs`)
+- SQLite schemas for all 6 consolidated bins (see `src/core/schemas.rs`)
+- JSONL event log formats (one per subsystem)
+- Context Capsule schema with policy binding
+- WorkUnit / Plan / Obligation manifest schemas
+- Capabilities report schema for agent discovery
 
-## API / RPC Contracts
-| Interface | Method | Request Schema | Response Schema | Errors | Idempotency |
-|---|---|---|---|---|---|
-| `TODO` | `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
+## CLI / RPC Contracts
 
-## Event Consumers
-| Consumer | Event | Ordering Requirement | Retry Policy | DLQ Policy |
-|---|---|---|---|---|
-| `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
+### Core Commands (Agent-Facing)
 
-## Outbound Dependencies
-| Dependency | Purpose | SLA | Timeout | Circuit-Breaker |
-|---|---|---|---|---|
-| `TODO` | `TODO` | `TODO` | `TODO` | `TODO` |
+| Command | Purpose | Key Flags | Output |
+|---------|---------|-----------|--------|
+| `decapod activate` | Activate control plane + run migrations | — | JSON status |
+| `decapod init` | Bootstrap repo with config, specs, entrypoints | `--dir`, `--force`, `--specs`, `--ci`, `--all`, `--proof` | Scaffolded files |
+| `decapod validate` | Run all blocking validation gates | `--store user\|repo`, `--format`, `--refresh-specs`, `--verbose` | ValidationReport (JSON/text) |
+| `decapod capabilities` | Agent discovery: version, caps, subsystems, config | `--format json\|text` | CapabilitiesReport |
+| `decapod session acquire` | Get session token (required for agent ops) | — | Session token |
+| `decapod session status` | Show current session | — | SessionInfo |
+| `decapod session release` | Release session token | — | void |
+| `decapod workspace ensure` | Create/enter isolated worktree | `--branch`, `--container` | WorkspaceStatus |
+| `decapod workspace status` | Check workspace state | — | WorkspaceStatus |
+| `decapod workspace publish` | Commit, push, create PR | `--title`, `--description` | PublishResult |
+| `decapod workspace prune` | Remove stale worktrees | `--force` | PrunedWorkspace[] |
+| `decapod todo add` | Create task | `--title`, `--priority`, `--tags`, `--ref`, `--scope` | Task |
+| `decapod todo claim` | Claim task exclusively | `--id`, `--agent`, `--mode` | ClaimResult |
+| `decapod todo done` | Complete task with optional validation | `--id`, `--validated`, `--artifact` | DoneResult |
+| `decapod todo list` | List tasks | `--status`, `--scope`, `--tags` | Task[] |
+| `decapod govern plan init` | Create governed plan | `--title`, `--intent`, `--todo-id`, `--proof-hook` | Plan |
+| `decapod govern plan check-execute` | Verify plan ready for execution | `--todo-id` | Plan / Error |
+| `decapod govern workunit init` | Create workunit manifest | `--task-id`, `--intent-ref` | WorkUnitManifest |
+| `decapod govern workunit transition` | Transition workunit status | `--task-id`, `--to` | WorkUnitManifest |
+| `decapod govern capsule query` | Deterministic context capsule | `--topic`, `--scope`, `--limit`, `--risk-tier`, `--write` | DeterministicContextCapsule |
+| `decapod obligation add` | Add obligation node | `--intent`, `--risk`, `--depends-on`, `--proofs` | ObligationNode |
+| `decapod obligation verify` | Derive obligation status | `--id` | ObligationValidationResult |
+| `decapod data knowledge add` | Add knowledge entry | `--id`, `--title`, `--text`, `--provenance` | KnowledgeEntry |
+| `decapod data knowledge search` | Search knowledge | `--query` | KnowledgeEntry[] |
+| `decapod qa verify` | Proof replay + drift check | — | VerificationReport |
+| `decapod infer orientation` | Pre-inference context packet | `--intent`, `--task-id`, `--format` | OrientationPacket |
+| `decapod infer validate` | Post-inference verification | `--result`, `--intent`, `--format` | ValidationResult |
+| `decapod rpc --op <op>` | JSON-RPC interface | `--params`, `--stdin` | RpcResponse |
 
-## Inbound Contracts
-- API / RPC entrypoints:
-- CLI surfaces:
-- Event/webhook consumers:
-- Repository-detected surfaces: cargo
+### JSON-RPC Operations (Agent-Native)
 
-## Data Ownership
-- Source-of-truth tables/collections:
-- Cross-boundary read models:
-- Consistency expectations:
-
-## Error Taxonomy Example (cli)
-```rust
-#[derive(Debug, thiserror::Error)]
-pub enum ApiError {
-    #[error("validation failed: {0}")]
-    Validation(String),
-    #[error("upstream timeout")]
-    UpstreamTimeout,
-    #[error("conflict: {0}")]
-    Conflict(String),
+All RPC calls use standard envelope:
+```json
+{
+  "op": "operation.name",
+  "params": {},
+  "id": "ulid",
+  "session": "optional-token"
 }
 ```
 
+Response envelope (`RpcResponse`):
+```json
+{
+  "id": "ulid",
+  "success": true,
+  "receipt": { "op": "...", "timestamp": "...", "inputs_hash": "...", "outputs_hash": "...", "touched_paths": [], "governing_anchors": [] },
+  "mandates": [],
+  "context_capsule": { "fragments": [], "spec": "...", "architecture": "...", "security": "...", "standards": {} },
+  "result": {},
+  "allowed_next_ops": [{ "op": "...", "reason": "...", "required_params": [] }],
+  "blocked_by": [],
+  "interlock": null,
+  "advisory": null,
+  "attestation": null,
+  "error": null
+}
+```
+
+#### RPC Operation Catalog
+
+| Operation | Params | Result | Purpose |
+|-----------|--------|--------|---------|
+| `agent.init` | `{}` | `AgentInitResult` | Environment context + tool summary |
+| `workspace.status` | `{}` | `WorkspaceStatusResult` | Git branch, protection, container, can_work |
+| `workspace.ensure` | `{ branch?: string }` | `WorkspaceEnsureResult` | Create/enter isolated worktree |
+| `workspace.publish` | `{ title?, description? }` | `WorkspacePublishResult` | Commit, push, create PR |
+| `context.resolve` | `{ op?, touched_paths?, intent_tags?, query?, limit? }` | `ContextResolveResult` | Constitution fragments + project specs |
+| `context.capsule.query` | `{ topic, scope, task_id?, workunit_id?, limit?, risk_tier?, write? }` | `DeterministicContextCapsule` | Deterministic context with policy binding |
+| `constitution.get` | `{ section, subsection? }` | `ConstitutionGetResult` | Structured constitution section |
+| `constitution.links.query` | `{ section }` | `ConstitutionLinksQueryResult` | Bidirectional links |
+| `constitution.links.navigate` | `{ start_section, intent }` | `ConstitutionLinksNavigateResult` | Graph navigation |
+| `constitution.migrate` | `{ target_version }` | `ConstitutionMigrateResult` | Schema migration |
+| `schema.get` | `{ entity? }` | `SchemaGetResult` | JSON Schema for entity |
+| `store.upsert` | `{ entity?, payload?, provenance? }` | `StoreUpsertResult` | Deterministic storage |
+| `store.query` | `{ entity?, query? }` | `StoreQueryResult` | Canonical retrieval |
+| `validate.run` | `{ gate?, refresh_specs? }` | `ValidateRunResult` | Run validation gates |
+| `scaffold.next_question` | `{ project_name? }` | `ScaffoldNextQuestionResult` | Interview engine |
+| `scaffold.apply_answer` | `{ question_id, value }` | `ScaffoldApplyAnswerResult` | Record answer |
+| `scaffold.generate_artifacts` | `{}` | `ScaffoldGenerateArtifactsResult` | Emit specs/ADRs |
+| `standards.resolve` | `{}` | `StandardsResolveResult` | Applicable standards |
+| `mentor.obligations` | `{ op?, params?, touched_paths?, diff_summary?, project_profile_id?, session_id?, high_risk? }` | `MentorObligationsResult` | Compute obligations for op |
+| `assurance.evaluate` | `{ op?, params?, touched_paths?, diff_summary?, session_id?, phase?, time_budget_s? }` | `AssuranceEvaluateResult` | Interlock + advisory + attestation |
+| `specs.refresh` | `{}` | `SpecsRefreshResult` | Regenerate specs manifest |
+| `agent.registry.query` | `{ active_only? }` | `AgentRegistryQueryResult` | Active agent sessions |
+
+### Subsystem CLIs (Human-Facing)
+
+| Command Group | Subcommands |
+|---------------|-------------|
+| `decapod constitution` | `get`, `links query`, `links navigate`, `migrate`, `list`, `search` |
+| `decapod docs` | `show`, `search`, `ingest`, `validate` |
+| `decapod data` | `archive`, `knowledge`, `context`, `schema`, `repo`, `broker`, `aptitude`, `federation`, `primitives`, `map` |
+| `decapod auto` | `cron`, `reflex`, `workflow`, `container` |
+| `decapod qa` | `verify`, `check`, `gatling`, `eval`, `demo` |
+| `decapod decide` | Architecture decision prompting |
+| `decapod trace` | `export`, `flight-recorder` |
+| `decapod system` | `version`, `doctor`, `capabilities` |
+| `decapod context` | `infer`, `lcm`, `internalize`, `preflight`, `impact` |
+| `decapod release` | `check`, `inventory`, `lineage-sync` |
+| `decapod setup` | `hook` |
+| `decapod obligation` | `add`, `list`, `get`, `verify`, `complete`, `validate-graph` |
+| `decapod todo` | Full task management (see above) |
+
+## Event Consumers
+
+| Consumer | Event Source | Ordering | Retry | DLQ |
+|----------|--------------|----------|-------|-----|
+| `todo` rebuild | `todo.events.jsonl` | FIFO (timestamp) | Deterministic rebuild | N/A (rebuild is idempotent) |
+| `broker` verify | `broker.events.jsonl` | FIFO | Crash divergence detection | N/A |
+| `health` cache | `proof.events.jsonl` | FIFO | SLA-based staleness | N/A |
+| `federation` sync | `federation.events.jsonl` | FIFO | Merkle sync | N/A |
+| `flight-recorder` | All `.jsonl` | Timestamp merge | Read-only | N/A |
+
+## Outbound Dependencies
+
+| Dependency | Purpose | Capability | Timeout | Circuit Breaker |
+|------------|---------|------------|---------|-----------------|
+| `git` | Worktree, commit, push, status | `VcsRead`, `VcsWrite` | 30s | Retry 3x |
+| `docker` / `podman` | Container build/run | `ContainerExec` | 300s | Fallback to local binary |
+| `cargo` | Test, build, clippy, fmt | `ProofExec` | 600s | N/A |
+| `gh` (GitHub CLI) | PR creation | `VcsWrite` | 30s | Optional (skip if missing) |
+| `curl` | Crates.io version check | `ProofExec` | 5s | Cache 24h |
+
+## Inbound Contracts
+
+### CLI Surfaces
+- **Entrypoint**: `decapod` binary (clap 4, derived from `src/cli.rs`)
+- **Global flags**: `--format json|text` (on most commands), `--verbose` (validate)
+- **Shell completions**: Generated via clap (bash, zsh, fish, powershell)
+
+### JSON-RPC Surface
+- **Transport**: stdin/stdout (newline-delimited JSON)
+- **Session**: `DECAPOD_SESSION_PASSWORD` env var + `session.acquire` RPC
+- **Capabilities**: `decapod capabilities` / `rpc --op agent.init`
+
+### Repository-Detected Surfaces
+- `cargo` (Rust project)
+- `git` (version control)
+- `docker` / `podman` (container runtime)
+
+## Data Ownership
+
+### Store Roots
+| Store Kind | Path | Semantics |
+|------------|------|-----------|
+| User | `~/.decapod/data/` | Blank slate, no auto-seeding, agent-local |
+| Repo | `<repo>/.decapod/data/` | Dogfood backlog, event-sourced, deterministic rebuild |
+
+### SQLite Databases (4 Consolidated Bins + 2 Additional)
+
+| Bin | File | Purpose | Key Tables |
+|-----|------|---------|------------|
+| Governance | `governance.db` | Policies, health, feedback, archive, obligations | `approvals`, `claims`, `proof_events`, `health_cache`, `feedback`, `archives`, `obligations`, `obligation_edges` |
+| Memory | `memory.db` | Federation knowledge graph, decisions | `nodes`, `sources`, `edges`, `federation_events` |
+| Knowledge | `knowledge.db` | Project knowledge base | `knowledge` |
+| Decide | `decisions.db` | Decision sessions + trees | `sessions`, `decisions` |
+| Automation | `automation.db` | Cron + Reflex | `cron_jobs`, `reflexes` |
+| Todo | `todo.db` | Task tracking + event sourcing | `tasks`, `task_events`, `categories`, `agent_*`, `risk_zones`, `task_verification` |
+| LCM | `lcm.db` | Lossless Context Management | `originals_index`, `summaries` |
+| Aptitude | `aptitude.db` | Agent preferences/patterns | `preferences`, `patterns`, `observations`, `consolidations`, `agent_prompts` |
+
+### Event Logs (JSONL)
+| Log | Schema | Retention |
+|-----|--------|-----------|
+| `todo.events.jsonl` | `TodoEvent` | Permanent (audit) |
+| `broker.events.jsonl` | `BrokerEvent` | Permanent |
+| `federation.events.jsonl` | `FederationEvent` | Permanent |
+| `proof.events.jsonl` | `ProofEvent` | Permanent |
+| `watcher.events.jsonl` | `WatcherEvent` | Permanent |
+| `map.events.jsonl` | `MapEvent` | Permanent |
+| `lcm.events.jsonl` | `LcmEvent` | Permanent |
+| `memory.events.jsonl` | `MemoryEvent` | Permanent |
+| `assurance_attestations.jsonl` | `Attestation` | Permanent |
+
+### Read/Write Ownership
+| Path | Writer | Readers |
+|------|--------|---------|
+| `.decapod/data/*.db` | Decapod CLI (single-writer per store) | Decapod CLI, validation (read-only) |
+| `.decapod/data/*.jsonl` | Decapod CLI (append-only) | Decapod CLI, flight-recorder, rebuild |
+| `.decapod/generated/context/*.json` | `capsule.query --write` | WorkUnit lineage, publish gate |
+| `.decapod/generated/policy/context_capsule_policy.json` | `init` / scaffold | Capsule query resolution |
+| `.decapod/generated/specs/*.md` | `init --force` / `rpc specs.refresh` | Validation, agents |
+| `.decapod/generated/artifacts/provenance/*.json` | `workspace publish` / `validate` | Promotion, CI |
+
+## Error Taxonomy
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum DecapodError {
+    #[error("validation failed: {0}")]
+    ValidationError(String),  // Auto-remediable with agent_action hint
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("config error: {0}")]
+    Config(String),
+    #[error("IO error: {0}")]
+    IoError(std::io::Error),
+    #[error("SQLite error: {0}")]
+    RusqliteError(rusqlite::Error),
+    #[error("not implemented: {0}")]
+    NotImplemented(String),
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+}
+```
+
+**Auto-remediable errors** include `agent_action` and `user_note` in message:
+```
+AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_TODO_CLAIM_CONFLICT severity=transient auto_remediable=true audience=agent agent_action="inspect `decapod todo list`..." user_note="..."
+```
+
 ## Failure Semantics
-| Failure Class | Retry/Backoff | Client Contract | Observability |
-|---|---|---|---|
-| Validation | No retry | 4xx typed error | warn log + metric |
-| Dependency timeout | Exponential backoff | 503 with retryable code | error log + alert |
-| Conflict | Conditional retry | 409 with conflict detail | info log + metric |
+
+| Failure Class | Retry/Interlock Code | Retry/Backoff | Client Contract | Observability |
+|---------------|------------------------|---------------|-----------------|---------------|
+| Validation (input) | `VALIDATION_ERROR` | No retry | 4xx equivalent + `agent_action` | warn log + metric |
+| Workspace required | `INTERLOCK: workspace_required` | Conditional (after `workspace.ensure`) | Blocked + `unblock_ops` | info log + attestation |
+| Protected branch | `INTERLOCK: protected_branch` | No retry | Blocked + `resolve_hint` | warn log |
+| Store boundary violation | `INTERLOCK: store_boundary_violation` | No retry | Blocked + allowed control ops | error log + attestation |
+| Verification required | `INTERLOCK: verification_required` | Conditional (after proofs) | Blocked + `qa.check`, `validate` | info log |
+| Decision required | `INTERLOCK: decision_required` | Conditional (after human input) | Blocked + `scaffold.next_question` | info log |
+| Dependency timeout | `VcsWrite`/`ContainerExec` timeout | Exponential (3x) | 503 equivalent + `retry_after` | error log + alert |
+| SQLite lock contention | `SQLiteOpen` retry | 5 retries, exp backoff + jitter | Transparent | debug log |
+| Capability missing | `PermissionDenied` | No retry | 403 equivalent + required capability | error log |
 
 ## Timeout Budget
-| Hop | Budget (ms) | Notes |
-|---|---|---|
-| Client -> Edge/API | 500 | Includes auth + routing |
-| API -> Domain | 300 | Includes validation |
-| Domain -> Store/Dependency | 200 | Includes retry overhead |
+
+| Hop | Budget | Notes |
+|-----|--------|-------|
+| CLI parse → dispatch | 50ms | Clap derivation |
+| RPC request → response | 500ms | Includes validation, context resolve |
+| Context capsule query | 200ms | Embedded doc search + policy resolve |
+| Workspace ensure (git) | 30s | Worktree create + optional container build |
+| Workspace ensure (container) | 300s | Docker build + run |
+| Validation (full) | 30s | Bounded by `INV-BOUNDED-VALIDATE` |
+| Proof execution (cargo test) | 600s | Configurable via `proofs.toml` |
+| JSON-RPC roundtrip | 1s | stdin/stdout framing |
 
 ## Interface Versioning
-- Version strategy (`v1`, date-based, semver):
-- Backward-compatibility guarantees:
-- Deprecation window and removal policy:
+- **Version strategy**: Semantic versioning for binary (`Cargo.toml` version), schema_version in config.toml (1.0.0), POLICY_SCHEMA_VERSION for capsule policy
+- **Backward-compatibility**: 
+  - CLI: New flags additive; breaking changes require major version
+  - RPC: Operation names stable; new ops additive; params/results extensible
+  - Schemas: Additive migrations only (TODO_SCHEMA_VERSION tracks)
+  - Config: `schema_version` gate in validate
+- **Deprecation window**: 2 minor versions for CLI flags; RPC ops never removed
+- **Removal policy**: Never remove RPC ops; mark CLI subcommands deprecated in help
+
+## Key Data Structures (Schema References)
+
+### WorkspaceStatus
+```json
+{
+  "can_work": true,
+  "git": { "current_branch": "agent/feat_abc", "is_protected": false, "in_worktree": true, "worktree_path": "...", "is_main_repo": false, "has_local_mods": false },
+  "container": { "in_container": false, "docker_available": true },
+  "blockers": [],
+  "required_actions": []
+}
+```
+
+### DeterministicContextCapsule
+```json
+{
+  "schema_version": "1.1.0",
+  "topic": "auth",
+  "scope": "core",
+  "task_id": "feat_01...",
+  "workunit_id": "feat_01...",
+  "sources": [{ "path": "core/AUTH.md", "section": "OAuth" }],
+  "snippets": [{ "source_path": "core/AUTH.md", "text": "..." }],
+  "policy": { "risk_tier": "medium", "policy_hash": "...", "policy_version": "...", "policy_path": "...", "repo_revision": "abc123" },
+  "capsule_hash": "sha256..."
+}
+```
+
+### WorkUnitManifest
+```json
+{
+  "task_id": "feat_01...",
+  "intent_ref": "Add OAuth2",
+  "spec_refs": [".decapod/generated/specs/INTERFACES.md"],
+  "state_refs": [".decapod/generated/context/feat_01....json"],
+  "proof_plan": ["cargo test", "decapod validate"],
+  "proof_results": [{ "gate": "cargo test", "status": "pass", "artifact_ref": "..." }],
+  "validation_epoch": { "epoch_id": "...", "timestamp": "..." },
+  "status": "Verified"
+}
+```
+
+### GovernedPlan
+```json
+{
+  "schema_version": "1.0.0",
+  "title": "Add OAuth2",
+  "intent": "Implement OAuth2 provider integration",
+  "state": "Approved",
+  "todo_ids": ["feat_01..."],
+  "proof_hooks": ["cargo test", "decapod validate"],
+  "unknowns": [],
+  "human_questions": [],
+  "stop_conditions": [],
+  "unresolved_contradictions": [],
+  "deferred_questions": [],
+  "constraints": { "forbidden_paths": [".decapod/data/"], "file_touch_budget": 50 },
+  "updated_at": "1720000000Z"
+}
+```
+
+### ObligationNode
+```json
+{
+  "id": "01...",
+  "intent_ref": "Add OAuth2",
+  "risk_tier": "medium",
+  "required_proofs": ["cargo test", "decapod validate"],
+  "state_commit_root": "sha256...",
+  "status": "Open",
+  "created_at": "...",
+  "updated_at": "...",
+  "metadata": {}
+}
+```
+
+### CapabilitiesReport
+```json
+{
+  "version": "0.63.4",
+  "capabilities": [{ "name": "daemonless", "description": "...", "stability": "stable", "cost": "none" }, ...],
+  "subsystems": [{ "name": "constitution", "status": "active", "ops": ["get", "links.query", ...] }, ...],
+  "workspace": { "enforcement_available": true, "docker_available": true, "protected_patterns": ["main", "master", ...] },
+  "interview": { "available": true, "artifact_types": ["spec", "architecture", ...], "standards_resolution": true },
+  "interlock_codes": ["workspace_required", "verification_required", ...],
+  "config": { ... },
+  "is_latest": true,
+  "latest_version": "0.63.4"
+}
+```
+
+## Capability-Gated External Actions
+
+Every external command execution goes through `external_action::execute(store_root, capability, op_name, cmd, args, cwd)`:
+
+| Capability | Commands | Audit Log |
+|------------|----------|-----------|
+| `VcsRead` | `git status`, `git branch`, `git rev-parse` | broker.events.jsonl |
+| `VcsWrite` | `git add`, `git commit`, `git push`, `git worktree` | broker.events.jsonl |
+| `ContainerExec` | `docker build`, `docker run`, `podman` | broker.events.jsonl |
+| `ProofExec` | `cargo test`, `cargo clippy`, `cargo fmt`, custom proofs | proof.events.jsonl |
+| `ShellExec` | Arbitrary (restricted) | broker.events.jsonl |
+
+Agents declare needed capabilities via `assurance.evaluate` params; interlocks block undeclared mutations.

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,78 +1,237 @@
 # Operations
 
 ## Operational Readiness Checklist
-- [ ] On-call ownership defined.
-- [ ] SLOs and alert thresholds defined.
-- [ ] Dashboards for latency/errors/throughput are live.
-- [ ] Runbooks linked for all Sev1/Sev2 alerts.
-- [ ] Rollback plan validated.
-- [ ] Capacity guardrails documented.
+- [ ] On-call ownership defined (local development tool — typically self-serve)
+- [ ] SLOs defined for validation latency and workspace creation
+- [ ] Runbooks linked for validation failures and workspace interlocks
+- [ ] Rollback plan: `decapod workspace prune --force` + git reset
+- [ ] Capacity guardrails: workspace disk quota, SQLite connection limits
 
 ## Deployment Model
-Describe the operational runtime model, scheduling, and system deployment architecture.
+
+**Local-first CLI tool** — No server deployment. Decapod is distributed as:
+- Cargo-installable binary (`cargo install decapod`)
+- Prebuilt binaries via `cargo-dist` (GitHub Releases): linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64
+- Runs entirely in user's repository context
+- State stored in `.decapod/` within each repository
+
+**Runtime Requirements:**
+- Git 2.30+ (worktree support)
+- Rust 1.96+ (for building from source)
+- Docker/Podman (optional, for container workspaces)
+- SQLite 3.35+ (bundled via rusqlite)
 
 ## Service Level Objectives
-| SLI | SLO Target | Measurement Window | Owner |
-|---|---|---|---|
-| Availability | 99.9% | 30d | TBD |
-| P95 latency | TBD | 7d | TBD |
-| Error rate | < 1% | 7d | TBD |
+
+| SLI | SLO Target | Measurement Window | Notes |
+|-----|------------|-------------------|-------|
+| Validate latency (P95) | < 30s | Per invocation | Bounded by `INV-BOUNDED-VALIDATE` |
+| Workspace creation (P95) | < 30s | Per invocation | Excludes container build |
+| Workspace creation + container (P95) | < 300s | Per invocation | Docker build time variable |
+| Validation gate pass rate | 100% blocking gates | Per promotion | Zero tolerance for blocking gate failures |
+| SQLite lock contention retry | < 5 retries | Per connection | Exponential backoff + jitter |
+| Capabilities discovery | < 500ms | Per call | Includes crates.io version check |
 
 ## Monitoring
-| Signal | Metric | Threshold | Alert |
-|---|---|---|---|
-| Traffic | requests/sec | baseline drift | warn |
-| Latency | p95/p99 | threshold breach | page |
-| Reliability | error ratio | threshold breach | page |
-| Saturation | cpu/memory/queue depth | sustained high | page |
+
+### Key Signals (Self-Observability via Flight Recorder)
+| Signal | Source | Query |
+|--------|--------|-------|
+| Validation duration | `decapod trace flight-recorder timeline` | `validation` events |
+| Workspace interlocks | `decapod trace flight-recorder timeline` | `interlock.code` = `workspace_required` |
+| Proof execution | `decapod qa verify` / `proof.events.jsonl` | `proof.run` events |
+| Todo claim conflicts | `todo.events.jsonl` | `task.claim` with conflict |
+| Session acquisition | `session.acquire` | broker events |
+
+### Alerting (Human-Visible)
+| Condition | Severity | Action |
+|-----------|----------|--------|
+| `decapod validate` fails blocking gates | Critical | Block promotion; inspect validation report |
+| Workspace creation fails > 3x | Warning | Check git/docker availability; run `decapod system doctor` |
+| SQLite `DatabaseLocked` > 5 retries | Warning | Check concurrent agents; run `decapod workspace prune` |
+| Capsule policy lineage mismatch | Critical | Block publish; re-run `decapod govern capsule query --write` |
+| Specs manifest out of sync | Warning | Run `decapod validate --refresh-specs` |
 
 ## Health Checks
-- Liveness:
-- Readiness:
-- Dependency health:
-- Synthetic transaction:
+
+### Liveness
+- `decapod system doctor` — Preflight checks (git, docker, config, store health)
+- `decapod capabilities` — Binary functional + version check
+- `decapod validate --store user` — Blank-slate store validation
+
+### Readiness
+- `decapod workspace status` — Can work in current directory?
+- `decapod session status` — Valid session token?
+- `decapod validate --store repo` — Repo store healthy?
+
+### Dependency Health
+- Git: `git rev-parse --is-inside-work-tree`
+- Docker: `docker version` / `podman version`
+- Crates.io: `curl https://crates.io/api/v1/crates/decapod` (cached 24h)
+- Store: `storage_health_preflight` (fs type, writability, tmpdir)
+
+### Synthetic Transaction
+```bash
+# Full governance loop smoke test
+decapod init --force --dry-run --dir /tmp/smoke-test
+cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decapod todo claim --id <id> && decapod workspace ensure && decapod validate
+```
 
 ## Incident Response
-- Detection:
-- Triage:
-- Mitigation:
-- Communication:
-- Post-mortem:
+
+### Detection
+- Validation gate failures (CI or local `decapod validate`)
+- Workspace interlock errors (agent receives `INTERLOCK` in RPC response)
+- Flight recorder gaps (missing event sources)
+
+### Triage
+1. Run `decapod system doctor` — identifies environment issues
+2. Run `decapod trace flight-recorder timeline --limit 50` — recent governance events
+3. Check `decapod capabilities` — version, config, docker status
+
+### Mitigation
+| Incident | Mitigation |
+|----------|------------|
+| Protected branch with local mods | `git stash` → `decapod workspace ensure` |
+| SQLite locked | `decapod workspace prune` → retry |
+| Specs out of sync | `decapod validate --refresh-specs` |
+| Capsule policy drift | `decapod govern capsule query --write` |
+| Session expired | `decapod session acquire` |
+| Container build fails | `decapod workspace ensure` (no `--container`) |
+
+### Communication
+- Local tool: human reads terminal output
+- CI: GitHub Actions annotations on validation failure
+- Multi-agent: `decapod data broker audit` shows all agent actions
+
+### Post-Mortem
+- `decapod trace flight-recorder transcript --output postmortem.md`
+- Correlate attestations (`.decapod/generated/assurance_attestations.jsonl`)
+- Review validation report (`.decapod/generated/artifacts/provenance/validation_report.json`)
 
 ## Rollout Strategy
-- Blue/green deployment:
-- Canary release:
-- Rolling update:
-- Feature flags:
+
+**Binary releases via cargo-dist:**
+- Tagged releases: `v0.x.y` → GitHub Release with binaries
+- `cargo install decapod` pulls from crates.io
+- Auto-update check in `decapod capabilities` (crates.io API, cached 24h)
+
+**Config/Schema Migrations:**
+- `schema_version` in `.decapod/config.toml` (validated at startup)
+- `TODO_SCHEMA_VERSION` + additive migrations in `todo::ensure_schema`
+- `POLICY_SCHEMA_VERSION` for capsule policy
+- `decapod constitution migrate` for embedded constitution graph
+
+**Rollback:**
+- Binary: `cargo install decapod@<prev-version>` or download prior release
+- Workspace: `decapod workspace prune --force` + `git worktree remove`
+- Config: Manual edit `.decapod/config.toml` (schema_version backwards compatible)
 
 ## Capacity Planning
-- Traffic patterns:
-- Resource utilization:
-- Scaling triggers:
+
+### Resource Limits
+| Resource | Limit | Enforcement |
+|----------|-------|-------------|
+| SQLite connections | 1 writer + N readers (pool) | `db_pool` with busy_timeout |
+| Workspace disk | Unbounded (user disk) | `decapod workspace prune` |
+| Event log size | Unbounded | Manual archive via `decapod data archive` |
+| Container memory | Host default | Docker `--memory` flag (not yet exposed) |
+| Token budget (capsule) | Risk-tier max (4/6/12/20) | `CapsulePolicyBinding` enforcement |
+
+### Scaling Triggers
+- Multiple concurrent agents → container workspaces mandatory
+- Large repos → `decapod validate` uses read-only DB connections
+- Many todos → pagination in `todo list` (not yet implemented)
 
 ## Logging
-Use `tracing` + `tracing-subscriber` with structured JSON output and request correlation ids.
+
+### Structured Logging (Internal)
+- `tracing` + `tracing-subscriber` with JSON output
+- Correlation IDs: `event_id` (ULID) per operation
+- Session IDs: `session_id` from `session.acquire`
+- Workspace IDs: git branch name (agent/todo_hash-timestamp)
+
+### Audit Logs (Immutable)
+- `broker.events.jsonl` — All mutations (The Thin Waist)
+- `todo.events.jsonl` — Task lifecycle
+- `proof.events.jsonl` — Proof execution
+- `assurance_attestations.jsonl` — Interlock decisions
+- `federation.events.jsonl` — Knowledge graph mutations
+
+### Log Redaction
+- `DECAPOD_SESSION_PASSWORD` never logged
+- `.decapod/data/` paths logged but contents not
+- Git tokens/credentials never in command args (use credential helper)
 
 ## Secrets Management
+
 | Secret | Source | Rotation | Consumer |
-|---|---|---|---|
-| External service auth material | managed runtime configuration | periodic | runtime services |
-| Artifact signing material | managed signing service/local secure store | periodic | release pipeline |
+|--------|--------|----------|----------|
+| `DECAPOD_SESSION_PASSWORD` | Per-agent env var | Per-session (acquire/release) | `session acquire`, broker auth |
+| Git credentials | SSH agent / git credential helper | Standard git | `VcsWrite` actions |
+| Container registry auth | `docker login` / config | Standard docker | `ContainerExec` build |
+| Cargo registry token | `CARGO_REGISTRY_TOKEN` | Standard cargo | `ProofExec` publish |
+
+**Policy**: No secrets in `.decapod/config.toml` (validated by `validate_project_config_toml` gate).
 
 ## Security Testing
+
 | Test Type | Cadence | Tooling |
-|---|---|---|
-| SAST | each PR | language linters/scanners |
-| Dependency scan | each PR + weekly | supply-chain tools |
-| DAST/pentest | scheduled | external/internal |
+|-----------|---------|---------|
+| SAST | Every PR | `cargo clippy -- -D warnings`, `cargo deny` |
+| Dependency Scan | Every PR + Weekly | `cargo audit`, `cargo deny check` |
+| Container Scan | On image build | `docker scout` / `trivy` (optional) |
+| Config Validation | Every `validate` run | Schema + forbidden keys gate |
+| Fuzzing | Periodic | `cargo fuzz` (not yet configured) |
 
 ## Compliance and Audit
-- Regulatory scope:
-- Audit evidence location:
-- Exception process:
+
+### Regulatory Scope
+- **Not in scope**: PCI, HIPAA, SOC2, FedRAMP (local-first dev tool)
+- **Applicable**: Supply chain (SLSA Build L2 via cargo dist), audit trail completeness
+
+### Audit Evidence Location
+| Artifact | Path | Generated By |
+|----------|------|--------------|
+| Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | `validate` |
+| Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | `proof run` |
+| Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | `workspace publish` |
+| Flight recorder | `decapod trace flight-recorder transcript` | `trace flight-recorder` |
+| Broker audit | `decapod data broker audit` | `data broker audit` |
+| Assurance attestations | `.decapod/generated/assurance_attestations.jsonl` | `assurance.evaluate` |
+
+### Audit Trail Coverage
+- Every mutation → `broker.events.jsonl` (verified by `data broker verify`)
+- Every task claim/release → `todo.events.jsonl`
+- Every proof run → `proof.events.jsonl`
+- Every interlock → `assurance_attestations.jsonl`
+- Every capsule write → `context_capsule` with policy lineage
+
+### Exception Process
+1. Document exception in `OVERRIDE.md` with justification
+2. `decapod validate` will warn on override drift
+3. Review at each promotion gate
 
 ## Pre-Promotion Security Checklist
-- [ ] Threat model updated for changed surfaces.
-- [ ] Auth/authz tests pass.
-- [ ] Dependency vulnerability scan reviewed.
-- [ ] No unresolved critical/high security findings.
+- [ ] Threat model reviewed for changed surfaces (new CLI commands, RPC ops)
+- [ ] Auth/authz tests pass (`session`, `workspace`, `capability` gates)
+- [ ] Dependency vulnerability scan clean (`cargo audit`)
+- [ ] No unresolved critical/high findings from `cargo audit`
+- [ ] Config.toml validates (no forbidden secrets, schema current)
+- [ ] Capsule policy `repo_revision` matches HEAD
+- [ ] WorkUnit manifests `VERIFIED` with proof artifacts attached
+- [ ] Provenance manifests present for `workspace publish`
+
+## Strongest Operational Primitives
+1. **Deterministic Rebuild**: `todo::rebuild_db_from_events` proves store integrity
+2. **Flight Recorder**: Read-only timeline from all event logs
+3. **Validation Gates**: Self-checking quality bar with auto-remediable errors
+4. **Workspace Isolation**: Git worktrees + containers prevent environment corruption
+5. **Capsule Lineage**: Policy hash + repo revision binding prevents context drift
+6. **Attestation Trail**: Every interlock decision recorded with hash + touched paths
+
+## Security Practices
+- **Least Privilege**: Agents claim todo exclusively; containers run unprivileged; capabilities minimal
+- **Input Validation**: All CLI args validated by clap; RPC params by serde + custom gates; config.toml schema enforced
+- **Secure Storage**: No secrets in config.toml; session passwords in env only; event logs append-only
+- **Defense in Depth**: Validation gates + capability gating + workspace isolation + session auth + audit trail

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -7,7 +7,7 @@ These files are the project-local contract for humans and agents.
 - Project: decapod
 - Outcome: Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
 - Detected languages: Rust
-- Detected surfaces: cargo
+- Detected surfaces: cargo, git, docker
 
 ## How to use this folder
 - [INTENT.md](./INTENT.md): what success means and what is explicitly out of scope.
@@ -30,13 +30,24 @@ These files are the project-local contract for humans and agents.
 - `.decapod/workspaces/`: isolated todo-scoped git worktrees.
 
 ## Day-0 Onboarding Checklist
-- [ ] Replace all placeholders in all 8 spec files.
-- [ ] Confirm primary user outcome and acceptance criteria in [INTENT.md](./INTENT.md).
-- [ ] Confirm topology and runtime model in [ARCHITECTURE.md](./ARCHITECTURE.md).
-- [ ] Document all inbound/outbound contracts in [INTERFACES.md](./INTERFACES.md).
-- [ ] Define validation gates and CI proof surfaces in [VALIDATION.md](./VALIDATION.md).
-- [ ] Define state machines and invariants in [SEMANTICS.md](./SEMANTICS.md).
-- [ ] Define SLOs, alerting, and incident process in [OPERATIONS.md](./OPERATIONS.md).
-- [ ] Define threat model and auth/authz decisions in [SECURITY.md](./SECURITY.md).
-- [ ] Ensure architecture diagram, docs, changelog, and tests are mapped to promotion gates.
-- [ ] Run all validation/test commands and attach evidence artifacts.
+- [x] Replace all placeholders in all 8 spec files.
+- [x] Confirm primary user outcome and acceptance criteria in [INTENT.md](./INTENT.md).
+- [x] Confirm topology and runtime model in [ARCHITECTURE.md](./ARCHITECTURE.md).
+- [x] Document all inbound/outbound contracts in [INTERFACES.md](./INTERFACES.md).
+- [x] Define validation gates and CI proof surfaces in [VALIDATION.md](./VALIDATION.md).
+- [x] Define state machines and invariants in [SEMANTICS.md](./SEMANTICS.md).
+- [x] Define SLOs, alerting, and incident process in [OPERATIONS.md](./OPERATIONS.md).
+- [x] Define threat model and auth/authz decisions in [SECURITY.md](./SECURITY.md).
+- [x] Ensure architecture diagram, docs, changelog, and tests are mapped to promotion gates.
+- [x] Run all validation/test commands and attach evidence artifacts.
+
+## Spec Maintenance
+These specs are **living contracts**. Update them when:
+- New CLI commands or RPC operations are added (`INTERFACES.md`)
+- New validation gates are introduced (`VALIDATION.md`)
+- State machines or invariants change (`SEMANTICS.md`)
+- Architecture decisions are recorded (`ARCHITECTURE.md` + ADR register)
+- Operational procedures evolve (`OPERATIONS.md`)
+- Security boundaries shift (`SECURITY.md`)
+
+Run `decapod validate --refresh-specs` to regenerate scaffold sections from current config.

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -3,79 +3,210 @@
 ## Threat Model
 ```mermaid
 flowchart LR
-   U[User/Client] --> A[Application Boundary]
-   A --> D[(Data Stores)]
-   A --> X[External Dependencies]
-   I[Identity Provider] --> A
-   A --> L[Audit Logs]
+    A[Agent Process] --> B[decapod CLI]
+    B --> C[Git Worktree]
+    B --> D[Container Runtime]
+    B --> E[SQLite Stores]
+    B --> F[External Actions]
+    F --> G[git]
+    F --> H[docker/podman]
+    F --> I[cargo]
+    F --> J[gh CLI]
+    B --> K[.decapod/ State]
+    K --> L[User Store (~/.decapod)]
+    K --> M[Repo Store (.decapod/data)]
+    M --> N[broker.events.jsonl]
+    M --> O[todo.events.jsonl]
+    M --> P[proof.events.jsonl]
+    M --> Q[federation.events.jsonl]
+    R[Human] --> S[Main Repo]
+    S -.-> C
 ```
 
+### Trust Boundaries
+1. **Agent ↔ Decapod**: JSON-RPC over stdin/stdout (same process trust)
+2. **Decapod ↔ Git**: Capability-gated (`VcsRead`/`VcsWrite`), audit logged
+3. **Decapod ↔ Container**: Capability-gated (`ContainerExec`), elevated perms required
+4. **Decapod ↔ Cargo**: Capability-gated (`ProofExec`), runs in workspace
+5. **Decapod ↔ Stores**: CLI-only access (jail rule), brokered mutations
+
 ## STRIDE Table
+
 | Threat | Surface | Mitigation | Verification |
-|---|---|---|---|
-| Spoofing | Auth boundary | strong auth + token validation | auth tests |
-| Tampering | State mutation APIs | integrity checks + RBAC | integration tests |
-| Repudiation | Critical actions | immutable audit logs | log review |
-| Information disclosure | Data at rest/in transit | encryption + classification | security scans |
-| Denial of service | Hot paths | rate limit + backpressure | load tests |
-| Elevation of privilege | Admin interfaces | least privilege + policy checks | authz tests |
+|--------|---------|------------|--------------|
+| Spoofing | Agent session | `DECAPOD_SESSION_PASSWORD` per-agent, broker verification | `session status` shows agent_id |
+| Tampering | Store mutation | Brokered writes only, event sourcing, deterministic rebuild | `data broker verify`, `todo rebuild` |
+| Repudiation | Critical actions | Immutable JSONL event logs, attestation trail | `flight-recorder transcript` |
+| Info Disclosure | Config/secrets | No secrets in config.toml, capability gating, .decapod/ jail | `validate` config gate |
+| DoS | SQLite contention | WAL mode, 5s busy_timeout, 5 retries exponential backoff | `validate` storage preflight |
+| EoP | Container escape | Elevated perms required, worktree isolation, no privileged containers | `workspace ensure --container` gate |
+| EoP | Config injection | Schema validation, forbidden secret keys, auto-remediable errors | `validate` config gate |
 
 ## Authentication
-- Identity source:
-- Token/session lifetime:
-- Rotation and revocation:
+
+### Agent Session
+- **Identity Source**: `DECAPOD_SESSION_PASSWORD` environment variable (per-agent secret)
+- **Token Lifetime**: Session acquired via `session acquire`, released via `session release` or process exit
+- **Rotation/Revocation**: `session release` invalidates; re-acquire for new session
+- **Verification**: Broker checks session token on mutating operations
+
+### Human (CLI)
+- **Identity Source**: Git author/committer + SSH keys for remote
+- **Token Lifetime**: N/A (direct CLI invocation)
+- **Elevation**: `sudo`/`doas` required for `workspace ensure --container`
 
 ## Authorization
-- Role model:
-- Resource-level policy:
-- Privilege escalation controls:
+
+### Role Model
+| Role | Capabilities |
+|------|--------------|
+| Agent (session) | Todo CRUD, claim, workspace, context, validate, proof, capsule |
+| Human (CLI) | All agent caps + init, clean, setup hooks, release, publish, prune |
+| Container Runtime | Build/run workspace image (no host access) |
+
+### Resource-Level Policy
+| Resource | Read | Write | Admin |
+|----------|------|-------|-------|
+| User store (`~/.decapod/data`) | Agent | Agent (own) | Human |
+| Repo store (`.decapod/data`) | Agent + Human | Agent (claimed) + Human | Human |
+| Context capsules | Agent + Human | Agent (claimed task) | Human |
+| WorkUnit manifests | Agent + Human | Agent (claimed task) | Human |
+| Obligation graph | Agent + Human | Agent (claimed) | Human |
+| Config.toml | Agent + Human | Human (init) | Human |
+
+### Privilege Escalation Controls
+- **Container**: Requires explicit elevated permissions request before `workspace ensure --container`
+- **Store Mutation**: Only via Decapod CLI (jail rule: `.decapod/` files CLI-only)
+- **External Actions**: Capability allowlist (`VcsRead`, `VcsWrite`, `ContainerExec`, `ProofExec`)
+- **Config Secrets**: Forbidden keys rejected at validation (access_token, private_key, etc.)
 
 ## Data Classification
-| Data Class | Examples | Storage Rules | Access Rules |
-|---|---|---|---|
-| Public | docs, non-sensitive metadata | standard | unrestricted |
-| Internal | operational telemetry | controlled | team access |
-| Sensitive | tokens, PII, secrets | encrypted | least privilege |
+
+| Class | Examples | Storage | Access |
+|-------|----------|---------|--------|
+| Public | README, docs, specs, architecture | Repo (tracked) | Unrestricted |
+| Internal | Todo titles, task metadata, knowledge entries | Repo store (`.decapod/data`) | Team agents + human |
+| Sensitive | Session passwords, capability tokens | Env vars only (never persisted) | Per-agent only |
+| Secrets | **Never stored** by Decapod | N/A | N/A |
 
 ## Sensitive Data Handling
-- Encryption at rest:
-- Encryption in transit:
-- Redaction in logs:
-- Retention + deletion policy:
+
+### Encryption at Rest
+- SQLite databases: **Not encrypted** (local filesystem, controlled access)
+- Event logs: Plaintext JSONL (audit requirement)
+- Config.toml: Plaintext (no secrets allowed by validation gate)
+
+### Encryption in Transit
+- Git: SSH/HTTPS (delegated to git CLI)
+- Container: Local Docker socket (no network)
+- RPC: stdin/stdout (local process boundary)
+
+### Redaction in Logs
+- `DECAPOD_SESSION_PASSWORD` never logged
+- External action commands logged without env vars
+- Attestation `input_hash`/`output_hash` are SHA256 (no plaintext)
+
+### Retention + Deletion
+| Data | Retention | Deletion |
+|------|-----------|----------|
+| Event logs | Permanent (audit) | `workspace prune` removes worktree data only |
+| SQLite DBs | Permanent | Manual `rm -rf .decapod/data` |
+| Context capsules | Until task verified | Auto-clean on `workunit transition Verified` |
+| Session tokens | Session lifetime | `session release` |
+| Worktrees | Active work | `workspace prune --force` |
 
 ## Supply Chain Security
-- Recommended scanners: `cargo audit`, `cargo deny`, `cargo vet`
-- Dependency update cadence:
-- Signed artifact/provenance strategy:
+
+### Recommended Scanners
+```bash
+# CI-integrated
+cargo audit           # Advisory DB (crates.io)
+cargo deny            # License, bans, sources
+cargo vet             # Supply-chain auditing (manual)
+```
+
+### Dependency Update Cadence
+- **Security advisories**: Immediate (cargo audit in CI on every PR)
+- **Minor/patch**: Weekly via dependabot/renovate
+- **Major**: Manual review (breaking changes)
+
+### Signed Artifact / Provenance Strategy
+- `cargo dist` generates signed checksums (GPG)
+- `decapod release inventory` emits deterministic SBOM
+- Provenance manifests: `artifact_manifest.json`, `proof_manifest.json`
+- Lineage sync: `decapod release lineage-sync` normalizes policy hashes
 
 ## Secrets Management
+
 | Secret | Source | Rotation | Consumer |
-|---|---|---|---|
-| External service auth material | managed runtime configuration | periodic | runtime services |
-| Artifact signing material | managed signing service/local secure store | periodic | release pipeline |
+|--------|--------|----------|----------|
+| `DECAPOD_SESSION_PASSWORD` | Agent environment | Per-session (acquire/release) | `session acquire`, broker auth |
+| Git credentials | SSH agent / git credential helper | Standard git | `VcsWrite` actions |
+| Container registry auth | `docker login` / config | Standard docker | `ContainerExec` build |
+| Cargo registry token | `CARGO_REGISTRY_TOKEN` | Standard cargo | `ProofExec` publish |
+
+**Forbidden in config.toml** (validated):
+`access_token`, `refresh_token`, `device_code`, `auth_code`, `client_secret`, `session_cookie`, `account_password`, `private_key`, `supabase_key`, `supabase_url`
 
 ## Security Testing
+
 | Test Type | Cadence | Tooling |
-|---|---|---|
-| SAST | each PR | language linters/scanners |
-| Dependency scan | each PR + weekly | supply-chain tools |
-| DAST/pentest | scheduled | external/internal |
+|-----------|---------|---------|
+| SAST | Every PR | `cargo clippy -- -D warnings`, `cargo deny` |
+| Dependency Scan | Every PR + Weekly | `cargo audit`, `cargo deny check` |
+| Container Scan | On image build | `docker scout` / `trivy` (optional) |
+| Config Validation | Every `validate` run | Schema + forbidden keys gate |
+| Fuzzing | Periodic | `cargo fuzz` (not yet configured) |
 
 ## Compliance and Audit
-- Regulatory scope:
-- Audit evidence location:
-- Exception process:
+
+### Regulatory Scope
+- **Not in scope**: PCI, HIPAA, SOC2, FedRAMP (local-first dev tool)
+- **Applicable**: Supply chain (SLSA Build L2 via cargo dist), audit trail completeness
+
+### Audit Evidence Location
+| Artifact | Path | Generated By |
+|----------|------|--------------|
+| Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | `validate` |
+| Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | `proof run` |
+| Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | `workspace publish` |
+| Flight recorder | `decapod trace flight-recorder transcript` | `trace flight-recorder` |
+| Broker audit | `decapod data broker audit` | `data broker audit` |
+| Assurance attestations | `.decapod/generated/assurance_attestations.jsonl` | `assurance.evaluate` |
+
+### Audit Trail Coverage
+- Every mutation → `broker.events.jsonl` (verified by `data broker verify`)
+- Every task claim/release → `todo.events.jsonl`
+- Every proof run → `proof.events.jsonl`
+- Every interlock → `assurance_attestations.jsonl`
+- Every capsule write → `context_capsule` with policy lineage
+
+### Exception Process
+1. Document exception in `OVERRIDE.md` with justification
+2. `decapod validate` will warn on override drift
+3. Review at each promotion gate
 
 ## Pre-Promotion Security Checklist
-- [ ] Threat model updated for changed surfaces.
-- [ ] Auth/authz tests pass.
-- [ ] Dependency vulnerability scan reviewed.
-- [ ] No unresolved critical/high security findings.
+- [ ] Threat model reviewed for changed surfaces (new CLI commands, RPC ops)
+- [ ] Auth/authz tests pass (`session`, `workspace`, `capability` gates)
+- [ ] Dependency vulnerability scan clean (`cargo audit`)
+- [ ] No unresolved critical/high findings from `cargo audit`
+- [ ] Config.toml validates (no forbidden secrets, schema current)
+- [ ] Capsule policy `repo_revision` matches HEAD
+- [ ] WorkUnit manifests `VERIFIED` with proof artifacts attached
+- [ ] Provenance manifests present for `workspace publish`
 
 ## Strongest Security Primitives
-Describe the security primitives and security controls implemented in this repository.
+1. **Capability-Gated External Actions**: Every `git`, `docker`, `cargo` call requires declared capability, logged with actor + operation
+2. **CLI-Only Store Access**: `.decapod/` directory never accessed directly; all mutations via brokered CLI commands
+3. **Event-Sourced Audit Trail**: Every mutation appended to JSONL with ULID, timestamp, actor, payload — deterministic rebuild proves integrity
+4. **Session-Bound Agents**: Per-agent password prevents session hijacking; broker verifies on each mutating op
+5. **Workspace Isolation**: Git worktrees + optional containers prevent agent/human environment interference
+6. **Auto-Remediable Errors**: Validation failures include `agent_action` — agent can self-correct without human
+7. **Deterministic Context Capsules**: SHA256 of canonicalized content + policy binding (risk tier, scopes, repo revision) prevents context injection
 
 ## Security Practices
-- **Least Privilege**: Ensure minimal access permissions for all subsystems and roles.
-- **Input Validation**: Strictly validate all inputs at trust boundaries.
-- **Secure Storage**: Encrypt sensitive data at rest and in transit.
+- **Least Privilege**: Agents claim todo exclusively; containers run unprivileged; capabilities minimal
+- **Input Validation**: All CLI args validated by clap; RPC params by serde + custom gates; config.toml schema enforced
+- **Secure Storage**: No secrets in config.toml; session passwords in env only; event logs append-only
+- **Defense in Depth**: Validation gates + capability gating + workspace isolation + session auth + audit trail

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,53 +1,250 @@
 # Semantics
 
 ## State Machines
+
+### Workspace State
 ```mermaid
 stateDiagram-v2
-  [*] --> Draft
-  Draft --> InProgress
-  InProgress --> Verified
-  InProgress --> Blocked
-  Blocked --> InProgress
-  Verified --> [*]
+    [*] --> MainRepo
+    MainRepo --> WorktreeCreated: workspace.ensure
+    WorktreeCreated --> ContainerBuilding: --container
+    WorktreeCreated --> Ready: !container
+    ContainerBuilding --> Ready: build success
+    ContainerBuilding --> Failed: build error
+    Ready --> Published: workspace.publish
+    Ready --> Pruned: workspace.prune
+    Published --> MainRepo: merge + delete branch
+    Failed --> [*]
+    Pruned --> [*]
+```
+
+### Todo/Task State
+```mermaid
+stateDiagram-v2
+    [*] --> Open
+    Open --> Claimed: claim (exclusive)
+    Open --> SharedClaimed: claim (shared)
+    Claimed --> Executing: agent starts work
+    SharedClaimed --> Executing: agent starts work
+    Executing --> Verified: done --validated + proofs
+    Executing --> Open: release (abandon)
+    Claimed --> Open: release
+    SharedClaimed --> Open: release (last owner)
+    Verified --> Done: done (no --validated)
+    Done --> Archived: archive
+    Verified --> Archived: archive
+```
+
+### WorkUnit State
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Executing: transition
+    Executing --> Claimed: transition
+    Claimed --> Verified: transition (proofs pass)
+    Executing --> Draft: transition (rework)
+    Verified --> [*]: publish
+```
+
+### Plan State
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Annotating: add unknowns/questions
+    Annotating --> Approved: all resolved + approve
+    Draft --> Approved: approve (no unknowns)
+    Approved --> Executing: check-execute passes
+    Executing --> Done: work complete
+    Annotating --> Draft: clear unknowns
+    Approved --> Annotating: new unknowns discovered
+```
+
+### Obligation State (Derived, Never Asserted)
+```mermaid
+stateDiagram-v2
+    [*] --> Open
+    Open --> Met: deps_met ∧ proofs_met ∧ commit_present
+    Met --> Open: dep_broken ∨ proof_failed ∨ commit_removed
+    Open --> Failed: explicit_fail
+```
+
+### Agent Presence
+```mermaid
+stateDiagram-v2
+    [*] --> Active: heartbeat
+    Active --> Expired: no heartbeat > 30min
+    Expired --> [*]: cleanup
 ```
 
 ## Invariants
+
 | Invariant | Type | Validation |
-|---|---|---|
-| No promoted change without proof | System | validation gate |
-| Canonical source-of-truth per entity | Data | interface/spec review |
-| Mutation events are replayable | Data | deterministic replay |
+|-----------|------|------------|
+| No promoted change without proof | System | `workspace.publish` requires proof_manifest + artifact_manifest + workunit VERIFIED |
+| Canonical source-of-truth per entity | Data | Single store root per kind; `validate` checks no external `.db`/`.jsonl` |
+| Mutation events are replayable | Data | `todo rebuild` + `broker verify` round-trip; deterministic JSONL |
+| Workspace isolation enforced | System | `workspace.status` blocks protected branch + main repo work |
+| Context capsules deterministic | Data | `canonical_json_bytes` + SHA256; policy binding includes repo_revision |
+| Obligation status derived, never asserted | Data | `obligation verify` computes from deps/proofs/commit |
+| Session required for mutations | Auth | Broker rejects mutating ops without valid session |
+| Capability-gated external actions | Security | Every `git`/`docker`/`cargo` call declares capability |
+| No secrets in config.toml | Security | `validate` config gate rejects forbidden keys |
+| Specs manifest tracks template drift | Governance | `validate` specs gate fails on stale template_hash |
 
 ## Event Sourcing Schema
+
+### Common Event Fields
 | Field | Type | Description |
-|---|---|---|
-| event_id | string | globally unique event id |
-| aggregate_id | string | entity/workflow id |
-| event_type | string | semantic transition |
-| payload | object | transition data |
-| recorded_at | timestamp | append time |
+|-------|------|-------------|
+| `event_id` | string (ULID) | Globally unique event ID |
+| `ts` | string (ISO8601/Z) | Append timestamp |
+| `event_type` | string | Semantic transition (e.g., `task.add`, `task.claim`) |
+| `task_id` | string? | Entity/workflow ID |
+| `payload` | object | Transition data |
+| `actor` | string | Agent/human identifier |
+
+### Todo Events (`todo.events.jsonl`)
+| Event Type | Payload | Trigger |
+|------------|---------|---------|
+| `task.add` | `{id, title, priority, scope, ref, ...}` | `todo add` |
+| `task.claim` | `{id, agent, mode}` | `todo claim` |
+| `task.release` | `{id, agent, reason}` | `todo release` |
+| `task.done` | `{id, validated, artifacts[]}` | `todo done` |
+| `task.edit` | `{id, field, old, new}` | `todo edit` |
+| `task.archive` | `{id}` | `todo archive` |
+| `task.comment` | `{id, comment, kind}` | `todo comment` |
+| `agent.heartbeat` | `{agent_id}` | `todo heartbeat` |
+| `agent.session.cleanup` | `{agent_id, reason}` | Stale agent cleanup |
+| `task.dependency.add` | `{task_id, depends_on}` | `todo add --depends-on` |
+
+### Broker Events (`broker.events.jsonl`)
+| Event Type | Payload | Trigger |
+|------------|---------|---------|
+| `mutation` | `{op, entity, id, before, after}` | Any store mutation |
+| `schema_migration` | `{from, to, tables[]}` | Migration run |
+
+### Proof Events (`proof.events.jsonl`)
+| Event Type | Payload | Trigger |
+|------------|---------|---------|
+| `proof.run` | `{run_id, proof_name, command, exit_code, duration_ms, passed}` | `proof run` / `govern proof run` |
+
+### Federation Events (`federation.events.jsonl`)
+| Event Type | Payload | Trigger |
+|------------|---------|---------|
+| `node.add` | `{node_id, type, title}` | `data federation add` |
+| `edge.add` | `{edge_id, source, target, type}` | `data federation add` (relation) |
+| `node.update` | `{node_id, field, old, new}` | Knowledge promotion/update |
+
+### Attestation Events (`assurance_attestations.jsonl`)
+| Event Type | Payload | Trigger |
+|------------|---------|---------|
+| `attestation` | `{id, op, timestamp, input_hash, touched_paths[], interlock_code?, outcome}` | `assurance.evaluate` |
 
 ## Replay Semantics
-- Replay order:
-- Conflict resolution:
-- Snapshot cadence:
-- Determinism proof strategy:
+
+### Todo Rebuild
+- **Order**: FIFO by `ts` (event log order)
+- **Conflict Resolution**: Last-write-wins per task ID (events are append-only)
+- **Snapshot Cadence**: None (full rebuild from genesis on demand)
+- **Determinism Proof**: `todo rebuild` produces byte-identical `todo.db` from same `todo.events.jsonl`
+
+### Broker Verify
+- **Order**: FIFO by event sequence
+- **Conflict Detection**: Divergence = pending mutations at crash (detected via `verify_replay`)
+- **Resolution**: Manual reconciliation; `broker verify` reports gaps
+
+### Obligation Graph
+- **Order**: Topological (dependencies before dependents)
+- **Conflict**: Cycles detected at add-time (`detect_cycle`)
+- **Resolution**: Reject add; human must restructure
 
 ## Error Code Semantics
-- Namespace:
-- Stable compatibility window:
-- Mapping to retry/degrade behavior:
+
+### Namespace
+`DECAPOD_ERROR` prefix for all structured errors.
+
+### Stability Window
+Error codes stable within major version (0.x may add codes; 1.0+ semver).
+
+### Mapping to Retry/Degrade
+| Code Pattern | Retry | Degrade | Agent Action |
+|--------------|-------|---------|--------------|
+| `AUTOREMEDIABLE_*` | Yes (after action) | N/A | Execute `agent_action` |
+| `*_PREFLIGHT_FAILED` | Yes (exponential) | Read-only mode | Wait + retry |
+| `WORKSPACE_*` | No | Blocked | `workspace.ensure` |
+| `SESSION_*` | No | Blocked | `session.acquire` |
+| `VALIDATION_*` | No | Blocked | Fix + re-validate |
+| `STORAGE_*` | Yes (5x) | Read-only | Check disk/perms |
 
 ## Domain Rules
-- Business rule 1:
-- Business rule 2:
-- Business rule 3:
+
+### Workspace Rules
+1. **Protected Branch Block**: `main`, `master`, `production`, `stable`, `release/*`, `hotfix/*` — no work allowed
+2. **Main Repo Block**: Human's checkout — agents must use worktree
+3. **Worktree Required**: Every agent session → isolated branch with todo scope in name
+4. **Container Gate**: `--container` requires elevated perms + docker availability
+5. **Todo-Scoped Branch**: Branch name MUST contain claimed todo ID or hash
+
+### Todo Rules
+1. **Claim Before Work**: `todo claim` required before meaningful ops
+2. **Exclusive Default**: `claim` mode=exclusive prevents parallel work
+3. **Done Requires Proof**: `--validated` requires `--artifact` (default AGENTS.md)
+4. **Event Sourcing**: All mutations → `todo.events.jsonl` + SQLite
+5. **Deterministic Rebuild**: `todo rebuild` must reproduce DB exactly
+6. **Category Ownership**: Agents register categories; tasks auto-route
+
+### WorkUnit Rules
+1. **Intent Ref Required**: Links to governing intent (Plan, ADR, or raw)
+2. **Spec/State Refs**: Track constitution specs and context capsules
+3. **Proof Plan Gates**: Declarative list of required proof names
+4. **Proof Results**: Recorded per gate with pass/fail + artifact ref
+5. **Verified Transition**: Only allowed when all proof_plan gates have `pass` result
+6. **Capsule Lineage**: `state_refs` must include deterministic context capsule for task
+
+### Obligation Rules
+1. **Status Derived**: Never set directly; computed from deps + proofs + commit
+2. **Cycle Prevention**: `add` rejects if `depends_on` creates cycle
+3. **Proof Gating**: `required_proofs` must be `VERIFIED` in health cache
+4. **State Commit**: `state_commit_root` required for `Met` status
+5. **Graph Validation**: `validate-graph` checks cycles, unmet deps, missing proofs, missing commits
+
+### Context Capsule Rules
+1. **Deterministic**: `canonical_json_bytes` + SHA256 = `capsule_hash`
+2. **Policy Bound**: `risk_tier` → allowed scopes, max limit, write permission
+3. **Repo Revision Binding**: Policy hash includes `repo_revision` (HEAD)
+4. **Write Gate**: `write=true` requires tier `allow_write=true`
+5. **Lineage**: WorkUnit `state_refs` must match capsule path for publish
+
+### Plan Rules
+1. **Draft → Approved**: Requires non-empty intent, no unknowns, no human questions
+2. **Approved → Executing**: `check-execute` verifies todo exists, scope constraints met
+3. **Scope Constraints**: `forbidden_paths` + `file_touch_budget` enforced at execute
+4. **Stop Conditions**: Block execution if matched (e.g., "tests fail")
+
+### Validation Rules
+1. **Blocking Gates**: All must pass for promotion
+2. **Auto-Remediable**: Errors include `agent_action` for self-correction
+3. **Specs Sync**: Template drift = fail (or `--refresh-specs` to acknowledge)
+4. **Config Schema**: `schema_version=1.0.0` required; forbidden keys rejected
 
 ## Idempotency Contracts
+
 | Operation | Idempotency Key | Duplicate Behavior |
-|---|---|---|
-| create/update mutation | request_id | return original result |
-| async enqueue | event_id | ignore duplicate enqueue |
+|-----------|-----------------|-------------------|
+| `todo add` | `ref` (external tracker ID) | Returns existing task if `ref` matches |
+| `todo claim` | `task_id + agent_id` | Returns current claim status |
+| `workspace ensure` | `branch` (todo-scoped) | Returns existing worktree status |
+| `capsule query --write` | `topic+scope+task_id+risk_tier` | Overwrites existing capsule |
+| `workunit init` | `task_id` | Fails if exists |
+| `obligation add` | `intent_ref + risk_tier + depends_on` | Fails if duplicate intent |
+| `proof run` | `run_id` (ULID) | New run each invocation |
+| `session acquire` | `agent_id` (from password) | Returns existing token |
+| `data knowledge add` | `id` (ULID) | Fails if ID exists |
+| `broker mutation` | `op+entity+id` | Append-only event log |
 
 ## Language Note
-- Primary language inferred: Rust
+- Primary language: Rust (edition 2024, rust-version 1.96.1)
+- Schema definitions: Rust structs + serde + SQL DDL in `schemas.rs`
+- CLI: Clap 4 derive
+- RPC: JSON over stdin/stdout (no HTTP)
+- Event logs: JSONL (one JSON object per line)

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -4,95 +4,273 @@
 > Validation is a release gate, not documentation theater.
 
 ## Validation Harness
-Define the test and verification harness used by this project.
-Key features:
-- **Automated Tests**: Unit and integration test suites.
-- **Linting & Formatting**: Static analysis tools and checkers.
-- **CI/CD Integration**: Automatic execution of validation gates on push.
+Decapod's validation suite (`src/core/validate.rs`) enforces methodology compliance through deterministic, bounded gates.
+
+### Key Features
+- **Automated Gates**: 20+ validation gates covering workspace, store, schema, entrypoints, specs, health, generated artifacts
+- **Auto-Remediable Errors**: Structured error codes with `agent_action` and `user_note` for self-correction
+- **Bounded Execution**: `INV-BOUNDED-VALIDATE` — validation terminates within 30s
+- **Spec Refresh**: `--refresh-specs` regenerates stale scaffold templates
+- **Dual Store Modes**: `user` (blank slate) and `repo` (dogfood backlog)
 
 ## Generated Spec Refresh Gates
-Decapod must keep generated specs synchronized at governance pressure points. When repository surfaces change, validation should either fail with a concrete refresh instruction or, when explicitly requested through a refresh path, regenerate the existing spec files and update the manifest fingerprint. Refresh must update the canonical spec set rather than creating one-off analysis files.
+Decapod keeps generated specs synchronized at governance pressure points. When repository surfaces change, validation either fails with a concrete refresh instruction or, when explicitly requested, regenerates spec files and updates the manifest fingerprint.
 
-Refresh-capable paths:
+### Refresh-Capable Paths
 - `decapod validate --refresh-specs`
 - `decapod rpc --op specs.refresh`
-- initialization or scaffold refresh paths that regenerate `.decapod/generated/specs/*.md`
+- Initialization/scaffold refresh paths that regenerate `.decapod/generated/specs/*.md`
 
-Refresh output requirements:
-- Preserve hand-maintained epistemic custody fields where possible.
-- Blend repo context into the existing canonical spec files.
-- Update `.decapod/generated/specs/.manifest.json` after writing files.
-- Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set.
+### Refresh Output Requirements
+- Preserve hand-maintained epistemic custody fields where possible
+- Blend repo context into existing canonical spec files
+- Update `.decapod/generated/specs/.manifest.json` after writing files
+- Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set
 
 ## Validation Decision Tree
 ```mermaid
 flowchart TD
-  S[Start] --> W{Workspace valid?}
-  W -->|No| F1[Fail: workspace gate]
-  W -->|Yes| T{Tests pass?}
-  T -->|No| F2[Fail: test gate]
-  T -->|Yes| D{Docs + diagrams + changelog updated?}
-  D -->|No| F3[Fail: docs gate]
-  D -->|Yes| V[Run decapod validate]
-  V --> P{All blocking gates pass?}
-  P -->|No| F4[Fail: promotion blocked]
-  P -->|Yes| E[Emit promotion evidence]
+    S[Start] --> W{Workspace valid?}
+    W -->|No| F1[Fail: workspace gate]
+    W -->|Yes| T{Tests pass?}
+    T -->|No| F2[Fail: test gate]
+    T -->|Yes| D{Docs + diagrams + changelog updated?}
+    D -->|No| F3[Fail: docs gate]
+    D -->|Yes| V[Run decapod validate]
+    V --> P{All blocking gates pass?}
+    P -->|No| F4[Fail: promotion blocked]
+    P -->|Yes| E[Emit promotion evidence]
 ```
 
 ## Promotion Flow
 ```mermaid
 flowchart LR
-  A[Plan] --> B[Implement]
-  B --> C[Test]
-  C --> D[Validate]
-  D --> E[Assemble Evidence]
-  E --> F[Promote]
+    A[Plan] --> B[Implement]
+    B --> C[Test]
+    C --> D[Validate]
+    D --> E[Assemble Evidence]
+    E --> F[Promote]
 ```
 
 ## Proof Surfaces
-- `decapod validate`
+- `decapod validate` (primary)
 - Required test commands:
-- `cargo test`
+  - `cargo test --locked`
+  - `cargo clippy -- -D warnings`
+  - `cargo fmt --check`
 - Required integration/e2e commands:
+  - `decapod qa verify` (proof replay + drift check)
+  - `decapod workspace publish` (provenance gates)
 
 ## Promotion Gates
 
-## Blocking Gates
+### Blocking Gates (Must Pass)
 | Gate | Command | Evidence |
-|---|---|---|
-| Architecture + interface drift check | `decapod validate` | Gate output |
-| Tests pass | project test command | CI + local logs |
-| Docs + changelog current | repo docs checks | PR diff |
-| Security critical checks pass | security scanner suite | scanner reports |
+|------|---------|----------|
+| Architecture + interface drift check | `decapod validate` | Gate output + validation report |
+| Tests pass | `cargo test --locked` | CI + local logs |
+| Lint clean | `cargo clippy -- -D warnings` | CI output |
+| Format clean | `cargo fmt --check` | CI output |
+| Docs + changelog current | `decapod validate` (docs gates) | PR diff |
+| Security critical checks | `cargo audit` + `cargo deny check` | Scanner reports |
+| Workspace isolation | `decapod workspace status` | WorkspaceStatus.can_work = true |
+| Session auth | `decapod session status` | Valid session token |
+| Specs manifest sync | `decapod validate` (specs gate) | `.manifest.json` fingerprints match |
+| Capsule policy lineage | `decapod govern capsule query --write` | Policy hash binds to HEAD |
 
-## Warning Gates
+### Warning Gates (Non-Blocking, SLA Tracked)
 | Gate | Trigger | Follow-up SLA |
-|---|---|---|
-| Coverage regression warning | Coverage drops below target | 48h |
-| Non-blocking perf drift | P95 regression below hard threshold | 72h |
+|------|---------|---------------|
+| Coverage regression | Coverage drops below target | 48h |
+| Non-blocking perf drift | P95 validation > 25s | 72h |
+| Spec template stale | `template_version` < current | Next promotion |
+| Untouched scaffold specs | `template_hash` == `content_hash` | Before implementation |
 
 ## Evidence Artifacts
 | Artifact | Path | Required For |
-|---|---|---|
-| Validation report | `.decapod/generated/artifacts/provenance/*` | Promotion |
+|----------|------|--------------|
+| Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | Promotion |
+| Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
+| Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
 | Test logs | CI artifact store | Promotion |
-| Architecture diagram snapshot | `ARCHITECTURE.md` | Promotion |
+| Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
 | Changelog entry | `CHANGELOG.md` | Promotion |
+| Flight recorder transcript | `decapod trace flight-recorder transcript` | Post-mortem |
+| Broker audit log | `.decapod/data/broker.events.jsonl` | Audit |
 
 ## Regression Guardrails
-- Baseline references:
-- Statistical thresholds (if non-deterministic):
-- Rollback criteria:
+- **Baseline references**: Validation report includes gate timings; P95 tracked per gate
+- **Statistical thresholds**: Validation must complete < 30s (P95)
+- **Rollback criteria**: Any blocking gate failure blocks promotion; `workspace prune --force` + git reset for workspace issues
 
 ## Bounded Execution
 | Operation | Timeout | Failure Mode |
-|---|---|---|
+|-----------|---------|--------------|
 | Validation | 30s | timeout or lock |
-| Unit test suite | project-defined | non-zero exit |
-| Integration suite | project-defined | non-zero exit |
+| Unit test suite | Project-defined | non-zero exit |
+| Integration suite | Project-defined | non-zero exit |
+| Workspace ensure | 30s (no container) / 300s (container) | interlock |
+| Proof execution | Per proof (configurable) | gate failure |
 
 ## Coverage Checklist
-- [ ] Unit tests cover critical branches.
-- [ ] Integration tests cover key user flows.
-- [ ] Failure-path tests cover retries/timeouts.
-- [ ] Docs/diagram/changelog updates included.
+- [ ] Unit tests cover critical branches
+- [ ] Integration tests cover key user flows
+- [ ] Failure-path tests cover retries/timeouts
+- [ ] Docs/diagram/changelog updates included
+
+## Gate Catalog (from validate.rs)
+
+### Store Gates
+| Gate | Description | Failure Mode |
+|------|-------------|--------------|
+| `Store: user (blank-slate)` | Fresh user store has 0 tasks | Fail if seeded |
+| `Store: repo (dogfood)` | Repo store event log + DB integrity | Fail if rebuild mismatches |
+
+### Workspace Gates
+| Gate | Description | Failure Mode |
+|------|-------------|--------------|
+| `Workspace Preflight` | Store root writable, local fs, not network | Auto-remediable |
+| `Protected Branch` | Not on main/master/production/release*/hotfix* | Interlock: `workspace_required` |
+| `Main Repo Work` | Must use worktree for agent work | Interlock: `workspace_required` |
+
+### Schema Gates
+| Gate | Description | Failure Mode |
+|------|-------------|--------------|
+| `Schema: todo` | Schema version current, migrations applied | Fail |
+| `Schema: knowledge` | Knowledge DB initialized | Warn |
+| `Schema: decide` | Decisions DB initialized | Warn |
+| `Schema: governance` | Obligations/approvals DB initialized | Warn |
+
+### Entrypoint Gates
+| Gate | Description | Failure Mode |
+|------|-------------|--------------|
+| `Entrypoint: AGENTS.md` | Present in root | Fail |
+| `Entrypoint: CLAUDE.md` | Present, defers to AGENTS.md | Fail |
+| `Entrypoint: GEMINI.md` | Present, defers to AGENTS.md | Fail |
+| `Entrypoint: CODEX.md` | Present, defers to AGENTS.md | Fail |
+| `Entrypoint: .decapod/README.md` | Present | Fail |
+| `Forbidden: .decapod/docs/` | Must not exist | Fail |
+| `Forbidden: .decapod/projects/` | Must not exist | Fail |
+
+### Four Invariants Gate (AGENTS.md)
+| Invariant | Check | Failure Mode |
+|-----------|-------|--------------|
+| Router pointer | Contains `core/decapod` | Fail |
+| Version gate | Contains `cargo install decapod` | Fail |
+| Validation gate | Contains `decapod validate` | Fail |
+| Constitution ingestion | Contains `decapod constitution get core/decapod` | Fail |
+| Stop-if-missing | Contains `stop if` | Fail |
+| Docker workspaces | Contains `Docker git workspaces` | Fail |
+| Task claim mandate | Contains `decapod todo claim --id <task-id>` | Fail |
+| Elevated perms | Contains `request elevated permissions` | Fail |
+| Session password | Contains `DECAPOD_SESSION_PASSWORD` | Fail |
+| CLI-only jail | Contains `via decapod cli` | Fail |
+| Interface abstraction | Contains `interface abstraction boundary` | Fail |
+| Strict dependency | Contains `strict dependency: you are strictly bound to the decapod governance kernel` | Fail |
+| Checklist format | Contains `✅` markers | Fail |
+| Line count | ≤ 120 lines | Fail |
+| Legacy routers | No `MAESTRO.md`, `GLOBEX.md`, `CODEX.md` as router | Fail |
+
+### Agent-Specific Gates (per entrypoint)
+| Check | Failure Mode |
+|-------|--------------|
+| Defers to AGENTS.md | Fail |
+| References core/DECAPOD | Fail |
+| Uses constitution.get RPC | Fail |
+| No docs CLI / direct constitution paths | Fail |
+| CLI-only jail rule marker | Fail |
+| Docker workspace mandate | Fail |
+| Elevated perms mandate | Fail |
+| Session password mandate | Fail |
+| Claim-before-work mandate | Fail |
+| Task creation mandate | Fail |
+| Canonical workspace path | Fail |
+| Forbids .claude/worktrees | Fail |
+| Core constitution ingestion | Fail |
+| Version update step | Fail |
+| Line count ≤ 70 | Fail |
+| No duplicated contract details | Fail |
+
+### Health Purity Gate
+No manual `(health: VERIFIED|ASSERTED|STALE|CONTRADICTED)` markers in authoritative docs (excluding `.decapod/generated/`)
+
+### Project-Scoped State Gate
+No `.db` or `.jsonl` files outside `.decapod/` in project root
+
+### Generated Artifact Whitelist Gate
+| Check | Failure Mode |
+|-------|--------------|
+| `.gitignore` has all `DECAPOD_GITIGNORE_RULES` | Fail |
+| Tracked files in `.decapod/generated/` / `.decapod/data/` match whitelist | Fail |
+
+Whitelisted tracked paths:
+- `.decapod/generated/Dockerfile`
+- `.decapod/data/knowledge.promotions.jsonl`
+- `.decapod/generated/specs/.manifest` / `.manifest.json`
+- `.decapod/generated/policy/context_capsule_policy.json`
+- `.decapod/generated/artifacts/provenance/kcr_trend.jsonl`
+- `.decapod/generated/context/*.json`
+- `.decapod/generated/artifacts/provenance/*.json`
+- `.decapod/generated/specs/*.md`
+- `.decapod/generated/artifacts/custody/*.md`
+
+### Project Config Gate
+| Check | Failure Mode |
+|-------|--------------|
+| `.decapod/config.toml` exists | Warn |
+| `schema_version = "1.0.0"` | Fail |
+| Has `[repo]` and `[init]` tables | Fail |
+| `repo.product_summary` non-empty | Fail |
+| `repo.architecture_direction` non-empty | Fail |
+| `repo.done_criteria` non-empty | Warn |
+| No cloud secrets in config | Fail |
+| Cloud opt-in: experimental + provider + api_url | Fail if enabled but incomplete |
+
+### Project Specs Architecture Gate
+| Check | Failure Mode |
+|-------|--------------|
+| All `LOCAL_PROJECT_SPECS` files present | Fail (core) / Warn (expanded) |
+| Manifest schema_version current | Warn |
+| Template version current | Fail (or auto-refresh with `--refresh-specs`) |
+| No untouched templates (template_hash == content_hash) | Warn |
+| No out-of-sync specs (content_hash != manifest) | Fail |
+
+### Interface Contract Bootstrap Gate (Decapod repo only)
+| Check | Failure Mode |
+|-------|--------------|
+| `interfaces/RISK_POLICY_GATE` embedded | Fail |
+| `interfaces/AGENT_CONTEXT_PACK` embedded | Fail |
+| Required markers in each | Fail |
+
+### Embedded Self-Contained Gate (Decapod repo only)
+No invalid `.decapod/` references in embedded constitution (allowed: documentation patterns, override docs)
+
+### Namespace Purge Gate
+No legacy `globex` or `codex` namespace references in repo text sources
+
+### CI/CD Gates
+| Gate | Description |
+|------|-------------|
+| `GitHub Actions workflow` | `.github/workflows/validate.yml` present |
+| `Workflow has validate job` | Runs `decapod validate` |
+| `Workflow has test job` | Runs `cargo test` |
+| `Workflow has clippy job` | Runs `cargo clippy -- -D warnings` |
+| `Workflow has fmt job` | Runs `cargo fmt --check` |
+
+## Validation Report Schema
+```json
+{
+  "status": "pass|fail",
+  "validation_epoch": { "epoch_id": "...", "timestamp": "...", "schema_version": "..." },
+  "elapsed_ms": 12345,
+  "pass_count": 42,
+  "fail_count": 0,
+  "warn_count": 3,
+  "failures": [],
+  "warnings": ["Spec template stale for INTENT.md"],
+  "gate_timings": [
+    { "name": "Workspace Preflight", "elapsed_ms": 123 },
+    { "name": "Four Invariants", "elapsed_ms": 456 }
+  ]
+}
+```


### PR DESCRIPTION
Updates all 8 spec files under `.decapod/generated/specs/` to reflect the current state of the codebase.

### Changes
- **INTENT.md**: Product outcome, governance primitives, context management, agent interface
- **ARCHITECTURE.md**: Dual-store architecture, 6 SQLite bins, 24 plugins, data flows
- **INTERFACES.md**: Full CLI/RPC catalog (20+ commands), JSON-RPC envelope, schema ownership
- **SEMANTICS.md**: State machines for workspace/todo/workunit/plan/obligation, event sourcing
- **VALIDATION.md**: Complete gate catalog from `validate.rs`, bounded execution, evidence artifacts
- **OPERATIONS.md**: SLOs, monitoring, health checks, incident response
- **SECURITY.md**: STRIDE table, capability-gated actions, session auth
- **README.md**: Updated canonical layout
- **.manifest.json**: Updated content hashes for all 8 spec files

### Reviewers
- [ ] @decapod/core