### PR TITLE
chore: declare evidence-backed repository capabilities

### DIFF
--- a/.decapod/config.toml
+++ b/.decapod/config.toml
@@ -22,3 +22,20 @@ detected_surfaces = ["cargo"]
 external_tracker = false
 container_workspaces = true
 mode = "local"
+declared_capabilities = [
+    "authentication",
+    "authorization",
+    "background-processing",
+    "event-driven",
+    "external-integrations",
+    "persistent-state",
+    "public-api",
+    "scheduled-jobs",
+]
+
+[repo.migration_validation]
+command = "cargo"
+args = ["test", "--lib", "core::migration"]
+working_directory = "."
+timeout_seconds = 120
+expected_exit_code = 0

--- a/.decapod/config.toml
+++ b/.decapod/config.toml
@@ -23,13 +23,15 @@ external_tracker = false
 container_workspaces = true
 mode = "local"
 declared_capabilities = [
+    "agent-helper",
     "authentication",
     "authorization",
     "background-processing",
+    "control-plane",
     "event-driven",
     "external-integrations",
+    "governance-kernel",
     "persistent-state",
-    "public-api",
     "scheduled-jobs",
 ]
 

--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.64.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.65.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.64.0
+ARG DECAPOD_VERSION=0.65.0
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,16 +1,18 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783909837Z",
+  "generated_at": "1783910285Z",
   "repo_signal_fingerprint": "28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051",
   "declared_capabilities": [
+    "agent-helper",
     "authentication",
     "authorization",
     "background-processing",
+    "control-plane",
     "event-driven",
     "external-integrations",
+    "governance-kernel",
     "persistent-state",
-    "public-api",
     "scheduled-jobs"
   ],
   "capability_definition_version": "1.0.0",
@@ -23,7 +25,7 @@
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ce9ff75f704074054c61d5ad7997e1e07213817ba9479aa34e28e92bec84ed60"
+      "content_hash": "b706943c128640c9837e2342c58ceeec9c7811cf8865261499dc950ac89ce117"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
@@ -33,12 +35,12 @@
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "e57480f197b7d45c18fc5d62765c2a85d10ef83ad2be9fa928842f91f6a4db28"
+      "content_hash": "01444470b898d84b0a6fc9f07d381e427704e5866e43d84b22c07a8db33e062b"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "d210d75b93399bfdef81b947c6a578dec18f656331a29c81c5529d94c7154c41"
+      "content_hash": "6cd74397b7f62c0bec1a0ccba6b199733dd42b1af7f850f1ed8cc60dbf41bc93"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
@@ -53,7 +55,7 @@
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "c965a8e7e3ea8587d1aa2fd61404eef6efed5675ebf876d1f71632af52318c2e"
+      "content_hash": "17cb906714913830cad4c798bccb550032804a6e5dc4bc1e1b171545ea16395a"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,48 +1,59 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783904641Z",
-  "repo_signal_fingerprint": "27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf",
+  "generated_at": "1783909837Z",
+  "repo_signal_fingerprint": "28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051",
+  "declared_capabilities": [
+    "authentication",
+    "authorization",
+    "background-processing",
+    "event-driven",
+    "external-integrations",
+    "persistent-state",
+    "public-api",
+    "scheduled-jobs"
+  ],
+  "capability_definition_version": "1.0.0",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "2177ecb46474394adbbd144fc6b482c7becba772f5aab2fe93d0ab8de5fee06a"
+      "content_hash": "78ae1c8beb846f54adb65031a4208b6d5149d9508c378d5e7c5f90df82d00904"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "0272a590d98b5e6fceee21c75242cff1554efaec1668a3ad5ee72e1915c375d6"
+      "content_hash": "ce9ff75f704074054c61d5ad7997e1e07213817ba9479aa34e28e92bec84ed60"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "751074bdb7dfee44fccdcbcfdcc5c3534198b5dbec8725403672814757779b89"
+      "content_hash": "9d609017a1ccd7d87fe3c49d5e05b644ab4f66a939b5eaf67c52252ca4279c55"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "00c1550319e45729c9101936eb9af3dc07ad665eda2d0052030368b6ba90c8db"
+      "content_hash": "e57480f197b7d45c18fc5d62765c2a85d10ef83ad2be9fa928842f91f6a4db28"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "7285292d3abe60e7992680b2b99593ec243e7e801eab28a06393649530a965d6"
+      "content_hash": "d210d75b93399bfdef81b947c6a578dec18f656331a29c81c5529d94c7154c41"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "85a5cd3aede8baf7004fc7278e870d5937d587e850c9b9a871e621176e2c3c00"
+      "content_hash": "6b9f98449d3a87876db4b10cae14f9f069b065e7dd9b7ea8de655b27adcb4fcd"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "17bd17606ddaae897fe17616c0a4e95b6d9c216cf143e10c77fddd8693885d12"
+      "content_hash": "a5037c97080513ca2ced847ef2e0c945f859b5f5a73613af022665aa64d510c3"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "15ac13e2bd6604dd29cb2dc7605a39cfe84a4f1eb79da48faa4de9b704512cf0"
+      "content_hash": "c965a8e7e3ea8587d1aa2fd61404eef6efed5675ebf876d1f71632af52318c2e"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -1,5 +1,26 @@
 # Architecture
 
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+
+## Persistent State Architecture Overlay
+
+### State Ownership
+- Each entity type MUST have a designated state owner
+- State ownership boundaries MUST be explicitly documented
+- Cross-boundary state access MUST go through defined interfaces
+
+### Transaction Boundaries
+- All multi-entity mutations MUST occur within explicit transactions
+- Transaction boundaries MUST be documented in ARCHITECTURE.md
+- Compensating transactions for distributed operations
+
+### Storage Abstraction
+- Storage ownership, consistency behavior, and access boundaries MUST be explicit
+- Portability or swappable implementations are project decisions, not universal requirements
+- Migration and rollback treatment MUST match the selected storage technology
+<!-- decapod:capability-overlay:persistent-state:end -->
 ## Direction
 CLI governance runtime with dual-store architecture, git worktree isolation, and deterministic context management.
 
@@ -12,6 +33,12 @@ Decapod is a Rust CLI governance kernel for AI agents. It runs on-demand (daemon
 - **Workspace Isolation**: Git worktrees mandatory; containers optional but gated
 - **Deterministic**: Same inputs → identical outputs; event logs enable full rebuild
 - **Capability-Gated**: External actions (git, docker, fs) require declared capabilities
+
+## Capability Ownership
+
+Declared capabilities are repository-shaping context, not a closed feature taxonomy. The current codebase owns authentication and authorization boundaries, durable SQLite/JSONL state, event-ledger rebuilds, workflow and scheduled automation, external tool integrations, and stable CLI/JSON-RPC interfaces. Each surface must retain an explicit owner, invariant, and proof path; capability labels must not silently select storage, queue, deployment, or service-level architecture.
+
+Persistent state is proven by the configured `[repo.migration_validation]` command in `.decapod/config.toml`; migration directory presence is discovery evidence only.
 - **Interface Abstraction**: Agents access `.decapod/` only via CLI (INV-STORE-BOUNDARY)
 
 ## Current Facts
@@ -368,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -5,13 +5,15 @@
 
 ## Declared Capability Surfaces
 
+- `agent-helper`
 - `authentication`
 - `authorization`
 - `background-processing`
+- `control-plane`
 - `event-driven`
 - `external-integrations`
+- `governance-kernel`
 - `persistent-state`
-- `public-api`
 - `scheduled-jobs`
 
 <!-- decapod:declared-capabilities:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -1,5 +1,20 @@
 # Intent
 
+
+<!-- decapod:declared-capabilities:start -->
+
+## Declared Capability Surfaces
+
+- `authentication`
+- `authorization`
+- `background-processing`
+- `event-driven`
+- `external-integrations`
+- `persistent-state`
+- `public-api`
+- `scheduled-jobs`
+
+<!-- decapod:declared-capabilities:end -->
 ## Product Outcome
 Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
 
@@ -174,7 +189,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -1,5 +1,27 @@
 # Interfaces
 
+
+<!-- decapod:capability-overlay:public-api:start -->
+
+
+## Public API Capability Overlay
+
+### API Contract Requirements
+- All public endpoints MUST define explicit request/response schemas
+- Versioning strategy MUST be documented (URL path or header-based)
+- All public endpoints MUST implement idempotency for mutating operations
+- Rate limiting and pagination MUST be implemented for list endpoints
+
+### Compatibility Guarantees
+- Backward-compatible changes ONLY within a version
+- Breaking changes require new version (v1, v2, etc.)
+- Deprecation and removal policy MUST be selected for this project and proven against its consumers
+
+### Security Requirements
+- All public endpoints MUST implement authentication
+- Abuse-control enforcement point MUST be a documented project decision
+- Input validation MUST reject malformed requests with typed errors
+<!-- decapod:capability-overlay:public-api:end -->
 ## Contract Principles
 - Prefer explicit schemas over implicit behavior.
 - Every mutating interface defines idempotency semantics.
@@ -19,6 +41,10 @@ Generated interface specs include:
 - Capabilities report schema for agent discovery
 
 ## CLI / RPC Contracts
+
+### Declared Capability Configuration
+
+`.decapod/config.toml` may declare `repo.declared_capabilities` as a sorted, deduplicated list. The legacy `repo.capabilities` spelling remains readable for compatibility. Capability declarations shape context and generated specifications but do not grant external-action permissions by themselves; runtime authorization remains governed by the action capability and session/policy checks.
 
 ### Core Commands (Agent-Facing)
 
@@ -394,7 +420,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -1,27 +1,5 @@
 # Interfaces
 
-
-<!-- decapod:capability-overlay:public-api:start -->
-
-
-## Public API Capability Overlay
-
-### API Contract Requirements
-- All public endpoints MUST define explicit request/response schemas
-- Versioning strategy MUST be documented (URL path or header-based)
-- All public endpoints MUST implement idempotency for mutating operations
-- Rate limiting and pagination MUST be implemented for list endpoints
-
-### Compatibility Guarantees
-- Backward-compatible changes ONLY within a version
-- Breaking changes require new version (v1, v2, etc.)
-- Deprecation and removal policy MUST be selected for this project and proven against its consumers
-
-### Security Requirements
-- All public endpoints MUST implement authentication
-- Abuse-control enforcement point MUST be a documented project decision
-- Input validation MUST reject malformed requests with typed errors
-<!-- decapod:capability-overlay:public-api:end -->
 ## Contract Principles
 - Prefer explicit schemas over implicit behavior.
 - Every mutating interface defines idempotency semantics.

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,5 +1,48 @@
 # Operations
 
+
+<!-- decapod:capability-overlay:background-processing:start -->
+
+
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+
+## Persistent State Operations Overlay
+
+### Backup & Recovery
+- Backup scope, schedule, retention, and restore evidence MUST be selected for the project
+- Recovery point objectives MUST be explicit project decisions, not assumed values
+- Recovery time objectives MUST be explicit project decisions, not assumed values
+- Restore verification cadence MUST be recorded with the operational proof plan
+
+### Migration Operations
+- All schema changes via migration files
+- Migration rollback procedures documented
+- Zero-downtime migration strategy for production
+- Migration health checks and rollback triggers
+<!-- decapod:capability-overlay:persistent-state:end -->
+## Background Processing Operations Overlay
+
+### Queue Visibility
+- Queue depth, processing rate, and latency MUST be monitored
+- Dead letter queue MUST be visible and alerted
+- Worker health and processing rate metrics required
+
+### Shutdown Behavior
+- Graceful shutdown: stop accepting new work, finish current job
+- Drain behavior and timeout MUST be selected for the deployment
+- Termination and requeue behavior MUST be selected and proven for the deployment
+
+### Worker Health
+- Worker liveness and readiness probes
+- Queue depth alerts for backpressure detection
+- Processing latency percentiles (p50, p95, p99)
+<!-- decapod:capability-overlay:background-processing:end -->
+## Capability Operations
+
+Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.
+
 ## Operational Readiness Checklist
 - [ ] On-call ownership defined (local development tool — typically self-serve)
 - [ ] SLOs defined for validation latency and workspace creation
@@ -239,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -1,5 +1,30 @@
 # Security
 
+
+<!-- decapod:capability-overlay:public-api:start -->
+
+
+## Public API Security Overlay
+
+### Authentication Requirements
+- All public endpoints MUST validate authentication tokens
+- Token validation MUST include expiry, revocation, and scope checks
+- Anonymous access MUST be explicitly documented and justified
+
+### Input Validation
+- All request bodies MUST be validated against schemas
+- Reject requests with unknown fields (strict schema validation)
+- Size limits MUST be enforced on all request bodies
+
+### Rate Limiting
+- Limits and enforcement boundaries MUST be selected for this deployment
+- Clustered enforcement behavior MUST be documented when applicable
+- Client-visible throttling behavior MUST be part of the contract when applicable
+<!-- decapod:capability-overlay:public-api:end -->
+## Capability Security Boundaries
+
+Authentication establishes the agent session; authorization and external-action capability checks independently constrain mutations such as Git, Cargo, and container execution. Declared repository capabilities are intent context only and never bypass session, policy, workspace, or proof gates. Secrets remain environment/session material and are not placed in `.decapod/config.toml`.
+
 ## Threat Model
 ```mermaid
 flowchart LR
@@ -214,7 +239,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -1,26 +1,5 @@
 # Security
 
-
-<!-- decapod:capability-overlay:public-api:start -->
-
-
-## Public API Security Overlay
-
-### Authentication Requirements
-- All public endpoints MUST validate authentication tokens
-- Token validation MUST include expiry, revocation, and scope checks
-- Anonymous access MUST be explicitly documented and justified
-
-### Input Validation
-- All request bodies MUST be validated against schemas
-- Reject requests with unknown fields (strict schema validation)
-- Size limits MUST be enforced on all request bodies
-
-### Rate Limiting
-- Limits and enforcement boundaries MUST be selected for this deployment
-- Clustered enforcement behavior MUST be documented when applicable
-- Client-visible throttling behavior MUST be part of the contract when applicable
-<!-- decapod:capability-overlay:public-api:end -->
 ## Capability Security Boundaries
 
 Authentication establishes the agent session; authorization and external-action capability checks independently constrain mutations such as Git, Cargo, and container execution. Declared repository capabilities are intent context only and never bypass session, policy, workspace, or proof gates. Secrets remain environment/session material and are not placed in `.decapod/config.toml`.

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,5 +1,47 @@
 # Semantics
 
+
+<!-- decapod:capability-overlay:background-processing:start -->
+
+
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+
+## Persistent State Semantics Overlay
+
+### Transaction Semantics
+- All multi-entity operations MUST be atomic
+- Read-after-write consistency within transaction boundaries
+- Eventual consistency windows MUST be documented
+
+### Migration Semantics
+- Schema migrations MUST be backward-compatible
+- Migration rollback procedures MUST be documented
+- Data integrity checks post-migration
+
+### Recovery Semantics
+- Point-in-time recovery capability
+- Recovery objectives MUST be selected for the project and recorded as proof obligations
+- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
+<!-- decapod:capability-overlay:persistent-state:end -->
+## Background Processing Semantics Overlay
+
+### Retry Semantics
+- Retry and backoff behavior MUST be selected and documented for each work class
+- Poison-work handling MUST be selected and documented for each work class
+- Retry MUST preserve the declared side-effect and idempotency semantics
+
+### Idempotency
+- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
+- Deduplication or compensation mechanisms are project decisions and require proof
+- Duplicate execution MUST follow the job's declared duplicate-handling semantics
+
+### Poison Message Handling
+- Messages failing after max retries go to dead letter queue
+- DLQ MUST be monitored and alerted
+- Manual replay capability for DLQ messages
+<!-- decapod:capability-overlay:background-processing:end -->
 ## State Machines
 
 ### Workspace State
@@ -266,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -1,5 +1,68 @@
 # Validation
 
+
+<!-- decapod:capability-overlay:background-processing:start -->
+
+
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+
+
+<!-- decapod:capability-overlay:public-api:start -->
+
+
+## Public API Validation Overlay
+
+### Contract Tests
+- All public endpoints MUST have contract tests
+- Request/response schema validation on every request
+- Compatibility regression tests for each version
+
+### Security Tests
+- Authentication bypass tests
+- Malformed input handling tests
+- Rate limit enforcement tests
+- Token expiry/revocation tests
+<!-- decapod:capability-overlay:public-api:end -->
+## Persistent State Validation Overlay
+
+### Migration Proof Command
+- Configure `repo.migration_validation.command` and its arguments as the executable migration proof; file presence is not proof
+- The configured command MUST define its working directory, timeout, expected exit code, and evidence output
+
+### Migration Tests
+- All migrations MUST have integration tests
+- Rollback procedures MUST be tested
+- Data integrity checks post-migration
+
+### Persistence Integration Tests
+- Repository abstraction tested against real database
+- Transaction boundary tests
+- Concurrency conflict tests
+- Data integrity validation after recovery
+<!-- decapod:capability-overlay:persistent-state:end -->
+## Background Processing Validation Overlay
+
+### Duplicate Delivery Tests
+- Same message delivered multiple times MUST produce same result
+- Idempotency key verification
+- Verify the declared delivery guarantee; do not claim exactly-once behavior without proof
+
+### Retry Tests
+- Configured retry/backoff policy verified
+- Configured retry bound or unbounded policy verified
+- Poison-work handling verified when the project declares it
+
+### Shutdown Tests
+- Graceful drain on signal
+- In-flight job completion or safe requeue
+- No data loss on forced termination
+<!-- decapod:capability-overlay:background-processing:end -->
+## Capability Proof Requirements
+
+When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.
+
 ## Validation Philosophy
 > Validation is a release gate, not documentation theater.
 
@@ -288,7 +351,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `28eee4513cb6544f57ad1253f9f4d48562c520bb1dbd674824769cb0b09f9051`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -8,23 +8,6 @@
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
-
-<!-- decapod:capability-overlay:public-api:start -->
-
-
-## Public API Validation Overlay
-
-### Contract Tests
-- All public endpoints MUST have contract tests
-- Request/response schema validation on every request
-- Compatibility regression tests for each version
-
-### Security Tests
-- Authentication bypass tests
-- Malformed input handling tests
-- Rate limit enforcement tests
-- Token expiry/revocation tests
-<!-- decapod:capability-overlay:public-api:end -->
 ## Persistent State Validation Overlay
 
 ### Migration Proof Command


### PR DESCRIPTION
## Summary

Declare the repository capabilities evidenced by Decapod's current codebase and align the living generated specifications.

## Changes

- Added canonical `repo.declared_capabilities` entries for authentication, authorization, background processing, control-plane orchestration, event-driven state, external integrations, governance-kernel behavior, persistent state, scheduled jobs, and agent-helper surfaces.
- Removed `public-api` after review because Decapod's CLI/JSON-RPC interface is an agent machine interface rather than a public product API.
- Configured the persistent-state migration proof command using the existing validation model.
- Refreshed the generated specs and manifest, adding capability ownership, security boundaries, interface semantics, operational obligations, and executable migration-proof requirements.
- Refreshed the generated Decapod Dockerfile version metadata.

## Verification

`decapod validate --refresh-specs --format json` passes with 193 gates and zero failures.
