### PR TITLE
fix: close Issue 845 projection provenance gaps

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.64.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.65.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.64.0
+ARG DECAPOD_VERSION=0.65.0
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,48 +1,52 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783904641Z",
-  "repo_signal_fingerprint": "27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf",
+  "generated_at": "1783911561Z",
+  "repo_signal_fingerprint": "cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a",
+  "declared_capabilities": [],
+  "capability_definition_version": "1.0.0",
+  "config_input_hash": "a2913b26b0254cf9c659efe260fa25673dbec7d23dc6bddb7ab6f85ecee29f01",
+  "spec_input_hash": "9b8d0f6985ceee412d6d49f8f302b62c9b757845211ffd853b8a8ceca8d64fa9",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "2177ecb46474394adbbd144fc6b482c7becba772f5aab2fe93d0ab8de5fee06a"
+      "content_hash": "317f98ca86e1da49b21e635c492bc041c64e0c7f0e858980931e184d7f0515d2"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "0272a590d98b5e6fceee21c75242cff1554efaec1668a3ad5ee72e1915c375d6"
+      "content_hash": "e06a8c2592df03fd8a9474f1f5ce65ce0e9bed186a3ba5bf624636d9a4f37a42"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "751074bdb7dfee44fccdcbcfdcc5c3534198b5dbec8725403672814757779b89"
+      "content_hash": "0ec25ec29576e8903b0370123509af33b26e0d5f268b20326a7dedbaca7a4baa"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "00c1550319e45729c9101936eb9af3dc07ad665eda2d0052030368b6ba90c8db"
+      "content_hash": "35bf8d86753d4efd458174b9258f637548b513f05fabaf70be93d56a8a30f623"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "7285292d3abe60e7992680b2b99593ec243e7e801eab28a06393649530a965d6"
+      "content_hash": "c85d2be053a1f94c58fa56b87b04fa229c77e6045a8c6347d6923610bafd8520"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "85a5cd3aede8baf7004fc7278e870d5937d587e850c9b9a871e621176e2c3c00"
+      "content_hash": "6350cc0f0b232a69ce65ca4b2b690ebee250bbc28d36fbc984d7e50abfd4b97e"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "17bd17606ddaae897fe17616c0a4e95b6d9c216cf143e10c77fddd8693885d12"
+      "content_hash": "c18255c7ee725c6706a39bddc351fa8da0e563574a9a23fda91a5a08c0797a8c"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "15ac13e2bd6604dd29cb2dc7605a39cfe84a4f1eb79da48faa4de9b704512cf0"
+      "content_hash": "15ecb25f899452d9e20030db10f8e1cc1f7f29783cb7eb6dc2a40b3c0757fbf6"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -368,7 +368,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -174,7 +174,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -394,7 +394,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -239,7 +239,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -214,7 +214,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,5 +1,9 @@
 # Semantics
 
+## Capability Semantics
+
+Capability labels are canonicalized for deterministic projection but preserve their human-defined meaning. Recognized packs contribute obligations and negative constraints; unknown labels remain valid context. Persistent-state semantics require migration treatment and executable validation, while event-driven/background-processing semantics require the project to declare delivery, retry, idempotency, and recovery behavior rather than inheriting universal guarantees.
+
 ## State Machines
 
 ### Workspace State

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -270,7 +270,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -288,7 +288,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `27cc0f02dc7957543cdbdf24ea2c9c76ba799689d10f465ebee32f3aa6ef28bf`
+- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/core/context_capsule.rs
+++ b/src/core/context_capsule.rs
@@ -1,5 +1,8 @@
 use crate::core::capsule_policy::CapsulePolicyBinding;
-use crate::core::{assets, docs, error, project_specs::repo_signal_fingerprint};
+use crate::core::{
+    assets, docs, error,
+    project_specs::{config_input_hash, repo_signal_fingerprint, spec_input_hash},
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -34,6 +37,10 @@ pub struct DeterministicContextCapsule {
     pub capsule_hash: String,
     #[serde(default)]
     pub repo_signal_fingerprint: String,
+    #[serde(default)]
+    pub config_input_hash: String,
+    #[serde(default)]
+    pub spec_input_hash: String,
 }
 
 impl DeterministicContextCapsule {
@@ -60,6 +67,8 @@ impl DeterministicContextCapsule {
             snippets,
             capabilities,
             policy: self.policy.clone(),
+            config_input_hash: self.config_input_hash.clone(),
+            spec_input_hash: self.spec_input_hash.clone(),
         }
     }
 
@@ -93,6 +102,10 @@ struct CanonicalCapsule {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     capabilities: Vec<String>,
     policy: CapsulePolicyBinding,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    config_input_hash: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    spec_input_hash: String,
 }
 
 fn capsule_schema_version_default() -> String {
@@ -194,6 +207,8 @@ pub fn query_embedded_capsule_governed(
         policy,
         capsule_hash: String::new(),
         repo_signal_fingerprint: repo_signal_fingerprint(repo_root).unwrap_or_default(),
+        config_input_hash: config_input_hash(repo_root).unwrap_or_default(),
+        spec_input_hash: spec_input_hash(repo_root).unwrap_or_default(),
     };
 
     capsule.with_recomputed_hash().map_err(|e| {

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -171,6 +171,12 @@ pub struct ProjectSpecsManifest {
     pub declared_capabilities: Vec<String>,
     #[serde(default)]
     pub capability_definition_version: String,
+    /// Hash of the canonical, parsed `.decapod/config.toml` input.
+    #[serde(default)]
+    pub config_input_hash: String,
+    /// Hash of the ordered living-spec inputs, excluding this manifest.
+    #[serde(default)]
+    pub spec_input_hash: String,
     pub files: Vec<ProjectSpecManifestEntry>,
 }
 
@@ -178,6 +184,32 @@ pub fn hash_text(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+pub fn config_input_hash(project_root: &Path) -> Result<String, error::DecapodError> {
+    let config = crate::cli::DecapodProjectConfig::load(project_root)?;
+    let canonical = serde_json::to_vec(&config).map_err(|e| {
+        error::DecapodError::ValidationError(format!("Failed to canonicalize config.toml: {e}"))
+    })?;
+    Ok(hash_text(&String::from_utf8_lossy(&canonical)))
+}
+
+pub fn spec_input_hash(project_root: &Path) -> Result<String, error::DecapodError> {
+    let mut hasher = Sha256::new();
+    for spec in LOCAL_PROJECT_SPECS {
+        let path = project_root.join(spec.path);
+        if !path.exists() {
+            hasher.update(spec.path.as_bytes());
+            hasher.update(b"\0absent\n");
+            continue;
+        }
+        let body = fs::read_to_string(path).map_err(error::DecapodError::IoError)?;
+        hasher.update(spec.path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(hash_text(&body).as_bytes());
+        hasher.update(b"\n");
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn repo_signal_requires_content_hash(rel_path: &str) -> bool {
@@ -359,6 +391,8 @@ pub fn refresh_specs_manifest(
             declared_capabilities,
         );
     let repo_signal_fingerprint = repo_signal_fingerprint(project_root)?;
+    let config_input_hash = config_input_hash(project_root)?;
+    let spec_input_hash = spec_input_hash(project_root)?;
     let generated_at = existing
         .as_ref()
         .filter(|manifest| {
@@ -367,6 +401,8 @@ pub fn refresh_specs_manifest(
                 && manifest.repo_signal_fingerprint == repo_signal_fingerprint
                 && manifest.declared_capabilities == canonical_capabilities
                 && manifest.capability_definition_version == CAPABILITY_DEFINITION_VERSION
+                && manifest.config_input_hash == config_input_hash
+                && manifest.spec_input_hash == spec_input_hash
                 && manifest.files == manifest_entries
         })
         .map(|manifest| manifest.generated_at.clone())
@@ -378,6 +414,8 @@ pub fn refresh_specs_manifest(
         repo_signal_fingerprint,
         declared_capabilities: canonical_capabilities,
         capability_definition_version: CAPABILITY_DEFINITION_VERSION.to_string(),
+        config_input_hash,
+        spec_input_hash,
         files: manifest_entries,
     };
 

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -13,8 +13,8 @@ use crate::core::project_specs::{
     LOCAL_PROJECT_SPECS_INTENT, LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
     LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_OPERATIONS,
     LOCAL_PROJECT_SPECS_README, LOCAL_PROJECT_SPECS_SECURITY, LOCAL_PROJECT_SPECS_SEMANTICS,
-    LOCAL_PROJECT_SPECS_VALIDATION, ProjectSpecManifestEntry, ProjectSpecsManifest, hash_text,
-    read_specs_manifest, repo_signal_fingerprint,
+    LOCAL_PROJECT_SPECS_VALIDATION, ProjectSpecManifestEntry, ProjectSpecsManifest,
+    config_input_hash, hash_text, read_specs_manifest, repo_signal_fingerprint, spec_input_hash,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -1292,6 +1292,8 @@ pub fn refresh_project_specs(
             .map(|seed| CapabilityRegistry::canonicalize_capabilities(&seed.capabilities))
             .unwrap_or_default(),
         capability_definition_version: CAPABILITY_DEFINITION_VERSION.to_string(),
+        config_input_hash: config_input_hash(project_root)?,
+        spec_input_hash: spec_input_hash(project_root)?,
         files: manifest_entries,
     };
 
@@ -1816,6 +1818,16 @@ pub fn scaffold_project_entrypoints(
                 repo_signal_fingerprint: repo_signal_fingerprint(&opts.target_dir)?,
                 declared_capabilities: opts.capabilities.clone(),
                 capability_definition_version: CAPABILITY_DEFINITION_VERSION.to_string(),
+                config_input_hash: if opts.target_dir.join(".decapod/config.toml").exists() {
+                    config_input_hash(&opts.target_dir)?
+                } else {
+                    String::new()
+                },
+                spec_input_hash: if opts.target_dir.join(".decapod/config.toml").exists() {
+                    spec_input_hash(&opts.target_dir)?
+                } else {
+                    String::new()
+                },
                 files: manifest_entries,
             };
             let manifest_path = opts.target_dir.join(LOCAL_PROJECT_SPECS_MANIFEST);

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -15,7 +15,7 @@ use crate::core::project_specs::{
     LOCAL_PROJECT_SPECS_INTENT, LOCAL_PROJECT_SPECS_INTERFACES, LOCAL_PROJECT_SPECS_MANIFEST,
     LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_OPERATIONS,
     LOCAL_PROJECT_SPECS_SECURITY, LOCAL_PROJECT_SPECS_SEMANTICS, LOCAL_PROJECT_SPECS_VALIDATION,
-    hash_text, read_specs_manifest, repo_signal_fingerprint,
+    config_input_hash, hash_text, read_specs_manifest, repo_signal_fingerprint, spec_input_hash,
 };
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
@@ -3895,7 +3895,7 @@ fn run_migration_validation(
 fn validate_projection_consistency(
     ctx: &ValidationContext,
     main_root: &Path,
-    _working_root: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Projection Consistency Gate");
 
@@ -3942,6 +3942,10 @@ fn validate_projection_consistency(
             .flatten()
             .filter_map(|value| value.as_str().map(str::to_string))
             .collect();
+        declared_capabilities =
+            crate::core::capabilities::CapabilityRegistry::canonicalize_capabilities(
+                &declared_capabilities,
+            );
         migration_validation = config
             .get("repo")
             .and_then(|repo| repo.get("migration_validation"))
@@ -4052,6 +4056,49 @@ fn validate_projection_consistency(
                 });
             }
         }
+        let expected_config_hash = config_input_hash(main_root)?;
+        let expected_spec_hash = spec_input_hash(main_root)?;
+        for (field, expected) in [
+            ("config_input_hash", expected_config_hash.as_str()),
+            ("spec_input_hash", expected_spec_hash.as_str()),
+        ] {
+            match manifest.get(field).and_then(|v| v.as_str()) {
+                Some(actual) if actual == expected => {}
+                Some(actual) => findings.push(ProjectionFinding {
+                    surface: ".decapod/generated/specs/.manifest.json".to_string(),
+                    kind: SurfaceKind::Authority,
+                    expected: format!("{field}={expected}"),
+                    observed: format!("{field}={actual}"),
+                    remediation: "Refresh the living specs manifest from the canonical config and specs inputs".to_string(),
+                }),
+                None => findings.push(ProjectionFinding {
+                    surface: ".decapod/generated/specs/.manifest.json".to_string(),
+                    kind: SurfaceKind::Authority,
+                    expected: format!("{field} must be present"),
+                    observed: "missing".to_string(),
+                    remediation: "Refresh the living specs manifest to record canonical input hashes".to_string(),
+                }),
+            }
+        }
+        let manifest_capabilities = manifest
+            .get("declared_capabilities")
+            .and_then(|v| v.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            });
+        if manifest_capabilities.as_ref() != Some(&declared_capabilities) {
+            findings.push(ProjectionFinding {
+                surface: ".decapod/generated/specs/.manifest.json".to_string(),
+                kind: SurfaceKind::Authority,
+                expected: format!("declared_capabilities={declared_capabilities:?}"),
+                observed: format!("declared_capabilities={manifest_capabilities:?}"),
+                remediation: "Refresh the living specs manifest from .decapod/config.toml"
+                    .to_string(),
+            });
+        }
         if let Some(files) = manifest.get("files").and_then(|v| v.as_array()) {
             for entry in files {
                 let path = entry.get("path").and_then(|v| v.as_str()).unwrap_or("");
@@ -4121,6 +4168,18 @@ fn validate_projection_consistency(
                     remediation: "Run `decapod todo done --validated --artifact <path>` or `decapod qa verify capture` to generate proof artifacts".to_string(),
                 });
             }
+            if has_artifact && has_proof && has_intent {
+                let epoch = active_validation_epoch(main_root)?;
+                for message in crate::validate_projection_provenance(main_root, &epoch.epoch_id) {
+                    findings.push(ProjectionFinding {
+                        surface: ".decapod/generated/artifacts/provenance/".to_string(),
+                        kind: SurfaceKind::Evidence,
+                        expected: "schema-valid provenance bound to one task, session, and active validation epoch".to_string(),
+                        observed: message,
+                        remediation: "Regenerate provenance using the current validated task/session/epoch".to_string(),
+                    });
+                }
+            }
         }
     }
 
@@ -4131,17 +4190,76 @@ fn validate_projection_consistency(
             let path = entry.path();
             if path.extension().and_then(|s| s.to_str()) == Some("json") {
                 let raw = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
-                let capsule: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
-                    error::DecapodError::ValidationError(format!(
-                        "Invalid context capsule {}: {}",
-                        path.display(),
-                        e
-                    ))
-                })?;
-                if let Some(fp) = capsule
-                    .get("repo_signal_fingerprint")
-                    .and_then(|v| v.as_str())
-                    && fp != current_fp
+                let capsule: DeterministicContextCapsule =
+                    serde_json::from_str(&raw).map_err(|e| {
+                        error::DecapodError::ValidationError(format!(
+                            "Invalid context capsule {}: {}",
+                            path.display(),
+                            e
+                        ))
+                    })?;
+                let expected_config_hash = config_input_hash(main_root)?;
+                let expected_spec_hash = spec_input_hash(main_root)?;
+                for (field, actual, expected) in [
+                    (
+                        "config_input_hash",
+                        capsule.config_input_hash.as_str(),
+                        expected_config_hash.as_str(),
+                    ),
+                    (
+                        "spec_input_hash",
+                        capsule.spec_input_hash.as_str(),
+                        expected_spec_hash.as_str(),
+                    ),
+                ] {
+                    if actual.is_empty() || actual != expected {
+                        findings.push(ProjectionFinding {
+                            surface: format!(
+                                ".decapod/generated/context/{}",
+                                path.file_name().unwrap().to_string_lossy()
+                            ),
+                            kind: SurfaceKind::Authority,
+                            expected: format!("{field}={expected}"),
+                            observed: if actual.is_empty() {
+                                "missing".to_string()
+                            } else {
+                                actual.to_string()
+                            },
+                            remediation:
+                                "Regenerate the context capsule from current config/spec inputs"
+                                    .to_string(),
+                        });
+                    }
+                }
+                match capsule.computed_hash_hex() {
+                    Ok(expected) if expected == capsule.capsule_hash => {}
+                    Ok(expected) => findings.push(ProjectionFinding {
+                        surface: format!(
+                            ".decapod/generated/context/{}",
+                            path.file_name().unwrap().to_string_lossy()
+                        ),
+                        kind: SurfaceKind::Evidence,
+                        expected: format!("capsule_hash={expected}"),
+                        observed: format!("capsule_hash={}", capsule.capsule_hash),
+                        remediation:
+                            "Regenerate the context capsule so its content hash is recomputed"
+                                .to_string(),
+                    }),
+                    Err(error) => findings.push(ProjectionFinding {
+                        surface: format!(
+                            ".decapod/generated/context/{}",
+                            path.file_name().unwrap().to_string_lossy()
+                        ),
+                        kind: SurfaceKind::Evidence,
+                        expected: "capsule hash input must be canonical JSON".to_string(),
+                        observed: error.to_string(),
+                        remediation:
+                            "Rewrite the context capsule through the Decapod context query"
+                                .to_string(),
+                    }),
+                }
+                if !capsule.repo_signal_fingerprint.is_empty()
+                    && capsule.repo_signal_fingerprint != current_fp
                 {
                     findings.push(ProjectionFinding {
                         surface: format!(
@@ -4150,12 +4268,42 @@ fn validate_projection_consistency(
                         ),
                         kind: SurfaceKind::Projection,
                         expected: format!("repo_signal_fingerprint {current_fp}"),
-                        observed: format!("stale fingerprint {fp}"),
+                        observed: format!("stale fingerprint {}", capsule.repo_signal_fingerprint),
                         remediation: "Regenerate context capsule with current repo signal"
                             .to_string(),
                     });
                 }
             }
+        }
+    }
+
+    if working_root.exists()
+        && working_root
+            .to_string_lossy()
+            .contains(".decapod/workspaces")
+    {
+        let status = workspace::get_workspace_status(working_root)?;
+        let worktree_path_valid = status
+            .git
+            .worktree_path
+            .as_ref()
+            .is_some_and(|path| path.exists());
+        if !status.git.in_worktree || !worktree_path_valid || status.git.is_protected {
+            findings.push(ProjectionFinding {
+                surface: "workspace".to_string(),
+                kind: SurfaceKind::Authority,
+                expected: "live todo-owned worktree on an unprotected branch".to_string(),
+                observed: format!(
+                    "branch={}, in_worktree={}, worktree_path_valid={}, protected={}",
+                    status.git.current_branch,
+                    status.git.in_worktree,
+                    worktree_path_valid,
+                    status.git.is_protected
+                ),
+                remediation:
+                    "Recreate the workspace with `decapod workspace ensure` and rerun validation"
+                        .to_string(),
+            });
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4157,6 +4157,70 @@ fn validate_intent_convergence_manifest(
     Ok(lineage)
 }
 
+/// Projection-only provenance validation. Release validation owns the three
+/// manifest schemas; this adapter adds the identity binding required when a
+/// repository contains completed task state.
+pub(crate) fn validate_projection_provenance(
+    project_root: &Path,
+    expected_epoch: &str,
+) -> Vec<String> {
+    let base = project_root.join(".decapod/generated/artifacts/provenance");
+    let manifests = [
+        (
+            "artifact_manifest.json",
+            validate_artifact_manifest(project_root, &base.join("artifact_manifest.json")),
+        ),
+        (
+            "proof_manifest.json",
+            validate_proof_manifest(project_root, &base.join("proof_manifest.json")),
+        ),
+        (
+            "intent_convergence_checklist.json",
+            validate_intent_convergence_manifest(
+                project_root,
+                &base.join("intent_convergence_checklist.json"),
+            ),
+        ),
+    ];
+    let mut errors = Vec::new();
+    for (name, validation) in manifests {
+        let path = base.join(name);
+        if let Err(error) = validation {
+            errors.push(format!("{name}: {error}"));
+            continue;
+        }
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                errors.push(format!("{name}: cannot read validated manifest: {error}"));
+                continue;
+            }
+        };
+        let value: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(error) => {
+                errors.push(format!("{name}: invalid JSON: {error}"));
+                continue;
+            }
+        };
+        for field in ["task_id", "session_id", "validation_epoch"] {
+            let present = value
+                .get(field)
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| !v.is_empty());
+            if !present {
+                errors.push(format!("{name}: missing non-empty {field}"));
+            }
+        }
+        if value.get("validation_epoch").and_then(|v| v.as_str()) != Some(expected_epoch) {
+            errors.push(format!(
+                "{name}: validation_epoch does not match active epoch {expected_epoch}"
+            ));
+        }
+    }
+    errors
+}
+
 fn build_release_inventory(project_root: &Path) -> Result<serde_json::Value, error::DecapodError> {
     let mut paths = Vec::new();
     let mut roots = vec!["src", "tests"];

--- a/tests/context_capsule_schema.rs
+++ b/tests/context_capsule_schema.rs
@@ -38,6 +38,8 @@ fn context_capsule_canonical_serialization_is_deterministic() {
         policy: Default::default(),
         capsule_hash: String::new(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     };
 
     let bytes1 = capsule.canonical_json_bytes().expect("serialize #1");
@@ -69,6 +71,8 @@ fn context_capsule_with_recomputed_hash_is_stable() {
         policy: Default::default(),
         capsule_hash: "wrong".to_string(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     };
 
     let normalized1 = base.with_recomputed_hash().expect("normalize #1");

--- a/tests/projection_consistency.rs
+++ b/tests/projection_consistency.rs
@@ -260,6 +260,43 @@ fn projection_validation_catches_stale_context_capsule_while_normal_passes() {
 }
 
 #[test]
+fn projection_validation_rejects_manifest_capability_and_hash_drift() {
+    let (_tmp, dir, password) = setup_repo();
+    let refresh = run_decapod(
+        &dir,
+        &["rpc", "--op", "specs.refresh"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(refresh.status.success());
+
+    set_capabilities(&dir, &["control-plane"]);
+    let result = run_validate(&dir, &password, true);
+    assert!(!result.status.success());
+    let output = String::from_utf8_lossy(&result.stdout);
+    assert!(output.contains("config_input_hash") || output.contains("declared_capabilities"));
+}
+
+#[test]
+fn projection_validation_rejects_missing_capsule_provenance_and_hash() {
+    let (_tmp, dir, password) = setup_repo();
+    let mut capsule = get_valid_context_capsule(&dir, &password);
+    capsule.as_object_mut().unwrap().remove("config_input_hash");
+    capsule.as_object_mut().unwrap().remove("spec_input_hash");
+    capsule["capsule_hash"] = serde_json::Value::String("tampered".to_string());
+    write_context_capsule(&dir, &capsule);
+
+    let result = run_validate(&dir, &password, true);
+    assert!(!result.status.success());
+    let output = String::from_utf8_lossy(&result.stdout);
+    assert!(output.contains("config_input_hash"));
+    assert!(output.contains("capsule_hash"));
+}
+
+#[test]
 fn capability_survives_config_context_spec_deterministically() {
     let (_tmp, dir, _password) = setup_repo();
 
@@ -567,6 +604,16 @@ fn persistent_state_activates_executable_migration_gate() {
         "sh",
         &["-c", "grep -q 'CREATE TABLE' migrations/001_initial.sql"],
     );
+    let refresh_after_config = run_decapod(
+        &dir,
+        &["rpc", "--op", "specs.refresh"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(refresh_after_config.status.success());
     let projections3 = run_validate(&dir, &password, true);
     assert!(
         projections3.status.success(),

--- a/tests/release_check_policy.rs
+++ b/tests/release_check_policy.rs
@@ -78,6 +78,8 @@ fn setup_release_fixture(changelog_unreleased: &str) -> (TempDir, PathBuf) {
         policy: CapsulePolicyBinding::default(),
         capsule_hash: String::new(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     }
     .with_recomputed_hash()
     .expect("compute capsule hash");

--- a/tests/validate_optional_artifact_gates.rs
+++ b/tests/validate_optional_artifact_gates.rs
@@ -428,6 +428,8 @@ fn validate_fails_on_verified_workunit_capsule_without_state_ref_binding() {
         policy: Default::default(),
         capsule_hash: String::new(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     };
     capsule = capsule
         .with_recomputed_hash()
@@ -498,6 +500,8 @@ fn validate_fails_on_context_capsule_hash_mismatch_if_present() {
         policy: Default::default(),
         capsule_hash: String::new(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     };
     capsule.capsule_hash = "wrong_hash".to_string();
     fs::write(

--- a/tests/workunit_publish_gate.rs
+++ b/tests/workunit_publish_gate.rs
@@ -61,6 +61,8 @@ fn write_capsule(root: &std::path::Path, task_id: &str) {
         },
         capsule_hash: String::new(),
         repo_signal_fingerprint: "test_fingerprint".to_string(),
+        config_input_hash: String::new(),
+        spec_input_hash: String::new(),
     };
     write_context_capsule(root, &capsule).expect("write capsule");
 }


### PR DESCRIPTION
Closes #845.\n\nThis PR binds manifest capability provenance to canonical config input, records config/spec hashes in manifests and capsules, recomputes capsule hashes, validates provenance schema and task/session/epoch identity, checks workspace branch/worktree liveness, and adds negative regression coverage for manifest drift and missing or tampered capsule fields.\n\nThe existing capability semantics contract is preserved in SEMANTICS.md and generated living-spec attestations were refreshed.\n\nVerification: cargo check; projection_consistency tests (7 passed); decapod validate (198 gates, 0 failures).