### PR TITLE
feat: add portable project context bundles

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.65.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.65.0
+ARG DECAPOD_VERSION=0.66.0
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783911921Z",
-  "repo_signal_fingerprint": "cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a",
+  "generated_at": "1783916672Z",
+  "repo_signal_fingerprint": "3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "40b04a43228a9457ee3eba7a7887285e2738e0edf4f56ff98aa81e6b4c64eacd",
+  "spec_input_hash": "002af49a25ab4c9cefd1c07ad1c1c855df640103aa615ad45480974c0ee6e886",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "317f98ca86e1da49b21e635c492bc041c64e0c7f0e858980931e184d7f0515d2"
+      "content_hash": "53cfffedf73d0b7c9d3421ad0f632a240a719909201667783822c092067ab4ca"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "7b75d134f6f55698db505e336f035471bfac5f05a649ad4e6e0a64dbbb3136fc"
+      "content_hash": "e54d9f79070636d7b3adc9a31a4545f0be6b0bd911348acd733a2d01abecb108"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "bdf87c7a495b929edaca1e689c2a25b623a4f44fc2cbfe1e4fef54aad4562cea"
+      "content_hash": "81461f16ebd4abde395e07c4d7b83d88d52933622af2cb32fb565de8eca8963c"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "aa16bcd1a620d06a39608b360c3609c5afa72597c50743150b504ccff03418e5"
+      "content_hash": "e3e0dec2c0cc156b309a4485fe1829b402b315a12292d3b5b610445a27a3f781"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "baa06b25b761dcd91ec8b6d1edfc8d3f9826fbbec2004487fa34953efc50b1f9"
+      "content_hash": "a7122618d553c3c8ead4d23ae23ad1e7ceef86c7546cc7cebf0eb73772722182"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "550baf620705400c1250e73349dae0e6dc36c96b2e8eaf8034c7141a4db7b925"
+      "content_hash": "3d729d0eb5efa9b5fad86518f5607d3fd53c4a2207c70f38059c07e19075250c"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "22632864111ecacaf231cb48a89ff3af03147c81d0a2310900ecff0d26c46d89"
+      "content_hash": "8dad39154550fedc3543e1f101ec849f3e0a58bbc67afcb8701ea62e509adbd8"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "ae90e1c8d5081841f513cd6d8ccb2c398d5c993a83d41655f4e15e4203a1b49b"
+      "content_hash": "34d7d8fadca3d10b970ebc6507dddbe42e22e5a8953cd1ffa9caef7c3c1c48b1"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cc243900de639dc9c3d20c0c057c52ccbef13120fc34bd8bf4355326dca1f05a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (85 files), `tests/` (3 files)
+- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/core/context_bundle.rs
+++ b/src/core/context_bundle.rs
@@ -1,0 +1,223 @@
+use crate::core::context_capsule::{
+    DeterministicContextCapsule, context_capsules_dir, write_context_capsule,
+};
+use crate::core::error;
+use crate::core::project_specs::{config_input_hash, repo_signal_fingerprint, spec_input_hash};
+use crate::core::workunit::WorkUnitManifest;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const PORTABLE_CONTEXT_BUNDLE_SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextBundleEnvironment {
+    pub os: String,
+    pub arch: String,
+    pub decapod_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectIdentity {
+    pub product_name: Option<String>,
+    pub product_summary: Option<String>,
+    pub architecture_direction: Option<String>,
+    pub product_type: Option<String>,
+    pub declared_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PortableContextBundle {
+    pub schema_version: String,
+    pub capsule: DeterministicContextCapsule,
+    pub project_identity: ProjectIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workunit: Option<WorkUnitManifest>,
+    #[serde(default)]
+    pub uncertainty: Vec<String>,
+    #[serde(default)]
+    pub constraints: Vec<String>,
+    pub source_environment: ContextBundleEnvironment,
+    pub bundle_hash: String,
+}
+
+impl PortableContextBundle {
+    fn canonicalized_without_hash(&self) -> CanonicalBundle {
+        let mut uncertainty = self.uncertainty.clone();
+        uncertainty.sort();
+        uncertainty.dedup();
+        let mut constraints = self.constraints.clone();
+        constraints.sort();
+        constraints.dedup();
+        CanonicalBundle {
+            schema_version: self.schema_version.clone(),
+            capsule: self.capsule.clone(),
+            project_identity: self.project_identity.clone(),
+            workunit: self.workunit.clone(),
+            uncertainty,
+            constraints,
+            source_environment: self.source_environment.clone(),
+        }
+    }
+
+    pub fn computed_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let bytes = serde_json::to_vec(&self.canonicalized_without_hash())?;
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    pub fn with_recomputed_hash(&self) -> Result<Self, serde_json::Error> {
+        let mut out = self.clone();
+        out.bundle_hash = out.computed_hash_hex()?;
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CanonicalBundle {
+    schema_version: String,
+    capsule: DeterministicContextCapsule,
+    project_identity: ProjectIdentity,
+    workunit: Option<WorkUnitManifest>,
+    uncertainty: Vec<String>,
+    constraints: Vec<String>,
+    source_environment: ContextBundleEnvironment,
+}
+
+pub fn build_bundle(
+    project_root: &Path,
+    capsule: DeterministicContextCapsule,
+    workunit: Option<WorkUnitManifest>,
+    uncertainty: Vec<String>,
+    constraints: Vec<String>,
+) -> Result<PortableContextBundle, error::DecapodError> {
+    let config = crate::cli::DecapodProjectConfig::load(project_root)?;
+    let mut declared_capabilities = config.repo.capabilities.clone();
+    declared_capabilities.sort();
+    declared_capabilities.dedup();
+    let bundle = PortableContextBundle {
+        schema_version: PORTABLE_CONTEXT_BUNDLE_SCHEMA_VERSION.to_string(),
+        capsule,
+        project_identity: ProjectIdentity {
+            product_name: config.repo.product_name,
+            product_summary: config.repo.product_summary,
+            architecture_direction: config.repo.architecture_direction,
+            product_type: config.repo.product_type,
+            declared_capabilities,
+        },
+        workunit,
+        uncertainty,
+        constraints,
+        source_environment: ContextBundleEnvironment {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            decapod_version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        bundle_hash: String::new(),
+    };
+    let normalized = bundle.with_recomputed_hash().map_err(|e| {
+        error::DecapodError::ValidationError(format!("failed to hash context bundle: {e}"))
+    })?;
+    validate_bundle(project_root, &normalized)?;
+    Ok(normalized)
+}
+
+pub fn validate_bundle(
+    project_root: &Path,
+    bundle: &PortableContextBundle,
+) -> Result<(), error::DecapodError> {
+    if bundle.schema_version != PORTABLE_CONTEXT_BUNDLE_SCHEMA_VERSION {
+        return Err(error::DecapodError::ValidationError(format!(
+            "CONTEXT_BUNDLE_INCOMPATIBLE: schema_version {} is not supported",
+            bundle.schema_version
+        )));
+    }
+    let expected_bundle_hash = bundle.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!("CONTEXT_BUNDLE_INVALID: {e}"))
+    })?;
+    if bundle.bundle_hash != expected_bundle_hash {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_TAMPERED: bundle_hash does not match canonical contents".to_string(),
+        ));
+    }
+    let expected_capsule_hash = bundle.capsule.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!("CONTEXT_BUNDLE_INVALID: capsule hash: {e}"))
+    })?;
+    if bundle.capsule.capsule_hash != expected_capsule_hash {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_TAMPERED: capsule_hash does not match canonical contents".to_string(),
+        ));
+    }
+    let current_config = config_input_hash(project_root)?;
+    let current_specs = spec_input_hash(project_root)?;
+    if bundle.capsule.config_input_hash != current_config
+        || bundle.capsule.spec_input_hash != current_specs
+    {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_STALE: config/spec inputs differ from the receiving repository"
+                .to_string(),
+        ));
+    }
+    let config = crate::cli::DecapodProjectConfig::load(project_root)?;
+    let mut current_capabilities = config.repo.capabilities;
+    current_capabilities.sort();
+    current_capabilities.dedup();
+    if bundle.project_identity.declared_capabilities != current_capabilities
+        || bundle.capsule.capabilities != current_capabilities
+    {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_IDENTITY_MISMATCH: declared capabilities differ from canonical config"
+                .to_string(),
+        ));
+    }
+    if let Some(workunit) = &bundle.workunit
+        && bundle.capsule.task_id.as_deref() != Some(workunit.task_id.as_str())
+    {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_IDENTITY_MISMATCH: capsule task_id and workunit task_id differ"
+                .to_string(),
+        ));
+    }
+    if bundle.capsule.repo_signal_fingerprint != repo_signal_fingerprint(project_root)? {
+        return Err(error::DecapodError::ValidationError(
+            "CONTEXT_BUNDLE_STALE: repository signal fingerprint differs from the receiving repository"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub fn write_bundle(
+    project_root: &Path,
+    bundle: &PortableContextBundle,
+) -> Result<PathBuf, error::DecapodError> {
+    validate_bundle(project_root, bundle)?;
+    let dir = context_capsules_dir(project_root).join("bundles");
+    fs::create_dir_all(&dir).map_err(error::DecapodError::IoError)?;
+    let path = dir.join(format!("{}.json", bundle.bundle_hash));
+    let bytes = serde_json::to_vec_pretty(bundle).map_err(|e| {
+        error::DecapodError::ValidationError(format!("failed to serialize context bundle: {e}"))
+    })?;
+    fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+    write_context_capsule(project_root, &bundle.capsule)?;
+    Ok(path)
+}
+
+pub fn read_bundle(
+    project_root: &Path,
+    input: &Path,
+) -> Result<PortableContextBundle, error::DecapodError> {
+    let path = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        project_root.join(input)
+    };
+    let raw = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    let bundle = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!("CONTEXT_BUNDLE_INVALID: {e}"))
+    })?;
+    validate_bundle(project_root, &bundle)?;
+    Ok(bundle)
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,6 +14,7 @@ pub mod cloud_backend;
 pub mod constitution_cli;
 pub mod constitution_schema;
 pub mod container_runtime;
+pub mod context_bundle;
 pub mod context_capsule;
 pub mod coplayer;
 pub mod db;

--- a/src/core/rpc.rs
+++ b/src/core/rpc.rs
@@ -164,6 +164,23 @@ pub struct ContextCapsuleQueryParams {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ContextBundleExportParams {
+    pub topic: String,
+    pub scope: String,
+    pub task_id: Option<String>,
+    pub workunit_id: Option<String>,
+    pub limit: Option<usize>,
+    pub risk_tier: Option<String>,
+    pub uncertainty: Option<Vec<String>>,
+    pub constraints: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ContextBundleImportParams {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContextBindingsParams {}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7070,6 +7070,84 @@ mod rpc_handlers {
         ))
     }
 
+    pub(crate) fn handle_context_bundle_export(
+        ctx: &RpcCtx,
+    ) -> Result<RpcResponse, error::DecapodError> {
+        let params: ContextBundleExportParams = serde_json::from_value(ctx.request.params.clone())
+            .map_err(|e| error::DecapodError::ValidationError(format!("Invalid params: {e}")))?;
+        let limit = params.limit.unwrap_or(6);
+        let resolved_policy = core::capsule_policy::resolve_capsule_policy(
+            ctx.project_root,
+            &params.scope,
+            params.risk_tier.as_deref(),
+            limit,
+            false,
+        )?;
+        let capsule = core::context_capsule::query_embedded_capsule_governed(
+            ctx.project_root,
+            &params.topic,
+            &params.scope,
+            params.task_id.as_deref(),
+            params.workunit_id.as_deref(),
+            resolved_policy.effective_limit,
+            resolved_policy.binding,
+        )?;
+        let workunit = params
+            .task_id
+            .as_deref()
+            .or(params.workunit_id.as_deref())
+            .and_then(|task_id| core::workunit::workunit_path(ctx.project_root, task_id).ok())
+            .filter(|path| path.exists())
+            .map(|_| {
+                core::workunit::load_workunit(
+                    ctx.project_root,
+                    params
+                        .task_id
+                        .as_deref()
+                        .or(params.workunit_id.as_deref())
+                        .unwrap(),
+                )
+            })
+            .transpose()?;
+        let bundle = core::context_bundle::build_bundle(
+            ctx.project_root,
+            capsule,
+            workunit,
+            params.uncertainty.unwrap_or_default(),
+            params.constraints.unwrap_or_default(),
+        )?;
+        let path = core::context_bundle::write_bundle(ctx.project_root, &bundle)?;
+        Ok(success_response(
+            ctx.request.id.clone(),
+            ctx.request.op.clone(),
+            ctx.request.params.clone(),
+            Some(serde_json::json!({"bundle": bundle, "path": path})),
+            vec![path.to_string_lossy().to_string()],
+            None,
+            vec![],
+            ctx.mandates.clone(),
+        ))
+    }
+
+    pub(crate) fn handle_context_bundle_import(
+        ctx: &RpcCtx,
+    ) -> Result<RpcResponse, error::DecapodError> {
+        let params: ContextBundleImportParams = serde_json::from_value(ctx.request.params.clone())
+            .map_err(|e| error::DecapodError::ValidationError(format!("Invalid params: {e}")))?;
+        let bundle = core::context_bundle::read_bundle(ctx.project_root, Path::new(&params.path))?;
+        let path = core::context_bundle::write_bundle(ctx.project_root, &bundle)?;
+        Ok(success_response(
+            ctx.request.id.clone(),
+            ctx.request.op.clone(),
+            ctx.request.params.clone(),
+            Some(serde_json::json!({"status": "ok", "bundle": bundle, "path": path})),
+            vec![path.to_string_lossy().to_string()],
+            None,
+            vec![],
+            ctx.mandates.clone(),
+        ))
+    }
+
     pub(crate) fn handle_context_bindings(
         ctx: &RpcCtx,
     ) -> Result<RpcResponse, error::DecapodError> {
@@ -8147,6 +8225,8 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
         "workspace.publish" => rpc_handlers::handle_workspace_publish(&rpc_ctx)?,
         "context.resolve" | "context.scope" => rpc_handlers::handle_context_resolve(&rpc_ctx)?,
         "context.capsule.query" => rpc_handlers::handle_context_capsule_query(&rpc_ctx)?,
+        "context.bundle.export" => rpc_handlers::handle_context_bundle_export(&rpc_ctx)?,
+        "context.bundle.import" => rpc_handlers::handle_context_bundle_import(&rpc_ctx)?,
         "context.bindings" => rpc_handlers::handle_context_bindings(&rpc_ctx)?,
         "constitution.get" => rpc_handlers::handle_constitution_get(&rpc_ctx)?,
         "constitution.links.query" => rpc_handlers::handle_constitution_links_query(&rpc_ctx)?,

--- a/tests/context_capsule_rpc.rs
+++ b/tests/context_capsule_rpc.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -281,4 +282,134 @@ fn rpc_context_capsule_query_write_auto_binds_workunit_state_ref() {
         has_workunit_path,
         "expected touched paths to include bound workunit manifest path"
     );
+}
+
+#[test]
+fn rpc_context_bundle_round_trip_rejects_tamper_and_stale_inputs() {
+    let (_tmp, dir) = setup_repo();
+    let init = run_decapod(
+        &dir,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            "test_bundle",
+            "--intent-ref",
+            "intent://portable-handoff",
+        ],
+    );
+    assert!(init.status.success(), "workunit init failed");
+    let params = r#"{"topic":"portable handoff","scope":"interfaces","task_id":"test_bundle","limit":4,"uncertainty":["z-unresolved","a-unresolved"],"constraints":["must preserve policy","must retain state refs"]}"#;
+
+    let exported = run_decapod(
+        &dir,
+        &["rpc", "--op", "context.bundle.export", "--params", params],
+    );
+    assert!(
+        exported.status.success(),
+        "bundle export failed: {}",
+        String::from_utf8_lossy(&exported.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&exported.stdout).expect("parse export payload");
+    let bundle = payload["result"]["bundle"].clone();
+    let bundle_path = payload["result"]["path"].as_str().expect("bundle path");
+    assert_eq!(
+        bundle["uncertainty"],
+        serde_json::json!(["z-unresolved", "a-unresolved"])
+    );
+    assert_eq!(bundle["constraints"].as_array().unwrap().len(), 2);
+    assert!(bundle["project_identity"]["declared_capabilities"].is_array());
+    assert_eq!(bundle["workunit"]["task_id"], "test_bundle");
+    assert_eq!(
+        bundle["workunit"]["intent_ref"],
+        "intent://portable-handoff"
+    );
+    assert!(
+        !bundle["bundle_hash"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty()
+    );
+
+    let imported = run_decapod(
+        &dir,
+        &[
+            "rpc",
+            "--op",
+            "context.bundle.import",
+            "--params",
+            &format!(r#"{{"path":"{bundle_path}"}}"#),
+        ],
+    );
+    assert!(
+        imported.status.success(),
+        "bundle import failed: {}",
+        String::from_utf8_lossy(&imported.stderr)
+    );
+
+    let mut incompatible = bundle.clone();
+    incompatible["schema_version"] = Value::String("9.0.0".to_string());
+    fs::write(
+        bundle_path,
+        serde_json::to_vec_pretty(&incompatible).unwrap(),
+    )
+    .expect("write incompatible bundle");
+    let incompatible_result = run_decapod(
+        &dir,
+        &[
+            "rpc",
+            "--op",
+            "context.bundle.import",
+            "--params",
+            &format!(r#"{{"path":"{bundle_path}"}}"#),
+        ],
+    );
+    assert!(!incompatible_result.status.success());
+    assert!(
+        String::from_utf8_lossy(&incompatible_result.stderr)
+            .contains("CONTEXT_BUNDLE_INCOMPATIBLE")
+    );
+
+    let mut tampered = bundle.clone();
+    tampered["bundle_hash"] = Value::String("tampered".to_string());
+    fs::write(bundle_path, serde_json::to_vec_pretty(&tampered).unwrap()).expect("tamper bundle");
+    let rejected = run_decapod(
+        &dir,
+        &[
+            "rpc",
+            "--op",
+            "context.bundle.import",
+            "--params",
+            &format!(r#"{{"path":"{bundle_path}"}}"#),
+        ],
+    );
+    assert!(
+        !rejected.status.success(),
+        "tampered bundle must be rejected"
+    );
+    assert!(String::from_utf8_lossy(&rejected.stderr).contains("CONTEXT_BUNDLE_TAMPERED"));
+
+    fs::write(bundle_path, serde_json::to_vec_pretty(&bundle).unwrap()).expect("restore bundle");
+    let config_path = dir.join(".decapod/config.toml");
+    let config_content = fs::read_to_string(&config_path).expect("read config");
+    let mut config: toml::Value = toml::from_str(&config_content).expect("parse config");
+    config["repo"]["product_summary"] = toml::Value::String("changed after export".to_string());
+    fs::write(
+        &config_path,
+        toml::to_string_pretty(&config).expect("serialize config"),
+    )
+    .expect("change config");
+    let stale = run_decapod(
+        &dir,
+        &[
+            "rpc",
+            "--op",
+            "context.bundle.import",
+            "--params",
+            &format!(r#"{{"path":"{bundle_path}"}}"#),
+        ],
+    );
+    assert!(!stale.status.success(), "stale bundle must be rejected");
+    assert!(String::from_utf8_lossy(&stale.stderr).contains("CONTEXT_BUNDLE_STALE"));
 }


### PR DESCRIPTION
Closes #851.

This dedicated Houseboat 1 slice extends the existing deterministic context capsule, policy binding, and workunit lineage surfaces with adjacent context.bundle.export and context.bundle.import RPCs.

The repository-owned versioned bundle carries:

- explicit project identity and declared capabilities;
- policy-bound deterministic capsule data and config/spec input hashes;
- workunit intent, state, proof, and task lineage when available;
- constraints, unresolved uncertainty, and source environment;
- canonical bundle and capsule hashes.

Imports fail closed for unsupported schema versions, tampered bundle or capsule hashes, stale repository/config/spec inputs, and capsule/workunit identity mismatches. Import writes only validated bundles and capsules into Decapod-generated context state.

Verification:
- cargo clippy --all-targets --all-features -- -D warnings
- context_capsule_rpc tests: 5 passed
- context_capsule_schema and rpc_golden_vectors tests passed
- decapod validate: 193 gates, 0 failures

No follow-up Issue was created because cloud/provider transport is explicitly outside Issue #851 first-slice scope.