### PR TITLE
docs: add research paper link to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,7 @@ jobs:
       - name: Run cargo-machete check
         run: cargo machete
       - name: Check license and duplicate dependencies
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check
+        run: cargo install cargo-deny && cargo deny check
 
   # HEALTH: consumes the shared decapod binary from setup
   health:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 Canonical Contract: [assets/constitution.json (core/DECAPOD)](assets/constitution.json#L5)
 
+Paper: [Accountable Agentic Execution](https://decapodlabs.github.io/accountable-agentic-execution/)
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
Adds link to the Accountable Agentic Execution paper after the constitution link in the README header.