### PR TITLE
fix: stabilize docs, workspace, and container contracts

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.3
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.0
+ARG DECAPOD_VERSION=0.66.3
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783916672Z",
-  "repo_signal_fingerprint": "3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20",
+  "generated_at": "1783988239Z",
+  "repo_signal_fingerprint": "cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "002af49a25ab4c9cefd1c07ad1c1c855df640103aa615ad45480974c0ee6e886",
+  "spec_input_hash": "13a7ede9164caf385f2a28161ac4cff44252546a6c52ff4d26df6069355266b7",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "53cfffedf73d0b7c9d3421ad0f632a240a719909201667783822c092067ab4ca"
+      "content_hash": "c8a2484a7defb903ff8beb34feef7052a2bc88e3a86443cb648a6254fda7f974"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "e54d9f79070636d7b3adc9a31a4545f0be6b0bd911348acd733a2d01abecb108"
+      "content_hash": "e7c3d55a03a894eb77400797bd0024e4cc77ec8e5efe06d34b7708a98dbea28e"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "81461f16ebd4abde395e07c4d7b83d88d52933622af2cb32fb565de8eca8963c"
+      "content_hash": "c00446697923956070224493293c37f59381fd95bf84e392df82e0f8a59044e0"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "e3e0dec2c0cc156b309a4485fe1829b402b315a12292d3b5b610445a27a3f781"
+      "content_hash": "20b109d8587498d96337794251344c3c748afc61e6372f517199567c5833e8f6"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "a7122618d553c3c8ead4d23ae23ad1e7ceef86c7546cc7cebf0eb73772722182"
+      "content_hash": "45508a51449c5f8a3869617b869a7e1eb826cfa4e40f057b93b982ee7e3f25ba"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "3d729d0eb5efa9b5fad86518f5607d3fd53c4a2207c70f38059c07e19075250c"
+      "content_hash": "16312a656cf9eb4a8320fde8ba9e9772614d4dbcd7342616a8594bc7b0ac5759"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "8dad39154550fedc3543e1f101ec849f3e0a58bbc67afcb8701ea62e509adbd8"
+      "content_hash": "58fe0a532e02421c5199d187002683abf695a577533b2127bb04a9d77011a5c6"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "34d7d8fadca3d10b970ebc6507dddbe42e22e5a8953cd1ffa9caef7c3c1c48b1"
+      "content_hash": "b886a8f4b515f020dbd7cfa253a3651bb6ae45b09e78b45814dc4c9bea86acb8"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3b048424f9f11203985ae356d12b85c2a11636b1171fd1cb34bf6f509f650a20`
+- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/docs/agent/command-contracts.md
+++ b/docs/agent/command-contracts.md
@@ -83,6 +83,8 @@ This document defines the normative operational contracts for the Decapod CLI.
 ### Operation: `WorkspacePublish`
 ### Operation: `ContextResolve`
 ### Operation: `ContextCapsuleQuery`
+### Operation: `ContextBundleExport`
+### Operation: `ContextBundleImport`
 ### Operation: `ContextBindings`
 ### Operation: `ConstitutionGet`
 ### Operation: `ConstitutionLinksQuery`

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -1,23 +1,11 @@
 # Model Context Protocol (MCP)
 
-Decapod supports integration with MCP-compatible agent environments to provide structured resources and tools.
+Decapod currently provides a Decapod-specific structured RPC interface over process stdin/stdout. It does not currently implement an MCP server, MCP lifecycle, MCP resource discovery, or MCP tool discovery.
 
-## Resources
+MCP adapters remain a planned integration surface. An adapter may map MCP resources and tools to Decapod operations, but that mapping is not part of the current Decapod binary contract.
 
-When connected via MCP, Decapod exposes:
-- `decapod://constitution/*`: Direct access to constitution nodes.
-- `decapod://todo/list`: The current actionable backlog.
-- `decapod://specs/intent`: The project's intent specification.
+## Current local handshake
 
-## Tools
+`decapod handshake` records local declarations, scope, proof declarations, document hashes, and a deterministic artifact hash. The hash makes the recorded data tamper-evident; it does not authenticate a model provider, harness, binary, human principal, or organization.
 
-Standard Decapod operations are available as MCP tools. If your environment supports MCP, you SHOULD use these tools instead of raw CLI calls to benefit from structured parsing and better error handling.
-
-Key tools include:
-- `orientation_get`: Retrieve the orientation packet for a task.
-- `validate_repo`: Run the full project validation gate.
-- `aptitude_query`: Search the shared memory for project-specific knowledge.
-
-## Handshake
-
-In MCP sessions, ensure you have called `decapod handshake` at least once to establish your agent identity within the repository's governance log. This identity persists across tool calls and resource retrievals.
+The local session credential establishes repository-local custody and correlation for the current session. It must not be described as provider authentication.

--- a/docs/book/src/concepts/agent-first.md
+++ b/docs/book/src/concepts/agent-first.md
@@ -25,7 +25,7 @@ Agents should not just "write code"; they should maintain intent. Decapod promot
 Shared memory allows agents to learn from each other. If one agent discovers an obscure bug in a library, it can record that observation in Aptitude, which subsequent agents will automatically retrieve during context resolution.
 
 ### 4. Protocol-Native (MCP)
-By supporting the **Model Context Protocol (MCP)**, Decapod allows agents to treat the repository as a structured resource graph rather than a raw filesystem (see [Model Context Protocol (MCP)](mcp.md)).
+Decapod reserves an adapter boundary for the **Model Context Protocol (MCP)** so future integrations can expose the repository as a structured resource graph (see [Model Context Protocol (MCP)](mcp.md)). The current binary provides a Decapod-specific RPC interface; it does not itself implement MCP.
 
 
 ## Design Patterns for Agents

--- a/docs/book/src/concepts/mcp.md
+++ b/docs/book/src/concepts/mcp.md
@@ -1,37 +1,11 @@
 # Model Context Protocol (MCP)
 
-Decapod is designed to be a "Protocol First" governance layer. While it provides a rich CLI, its core value is in standardizing the context and control signals exchanged between repositories and AI models. This aligns perfectly with the **Model Context Protocol (MCP)**.
+Decapod's current agent interface is a Decapod-specific structured RPC envelope over process stdin/stdout. It is not JSON-RPC 2.0 and the binary does not currently implement an MCP server, MCP lifecycle, or native MCP resource and tool discovery.
 
-## Decapod as an MCP Provider
+MCP support is an adapter boundary tracked separately from the current runtime. Future adapters may expose Decapod resources and operations through MCP, but those bindings should not be read as capabilities of the current binary.
 
-Decapod integrates with MCP-compatible environments (like Claude Desktop or specialized IDE extensions) by acting as an MCP Server. This allows agents to access Decapod's governance kernel directly through standard protocol messages.
+## Current local handshake
 
-### Exposed MCP Resources
+`decapod handshake` records local declarations, scope, proof declarations, document hashes, and a deterministic artifact hash. That hash provides tamper-evident integrity for the recorded handshake data; it does not authenticate a model provider, harness, binary, human principal, or organization.
 
-- **Constitution:** Browsable nodes of the technology and methodology graph (see [Repository Constitution](constitution.md)).
-- **Tasks:** The current todo list and ownership state (see [Single-Agent Workflow](../workflows/single-agent.md)).
-- **Specs:** The living specifications (`INTENT.md`, `ARCHITECTURE.md`, etc.) for the project (see [Explicit Intent](intent.md) and [Artifact Reference](../reference/artifacts.md)).
-- **Context Capsules:** Deterministic snapshots of repo state used for inference (see [Agent-First Architecture](agent-first.md)).
-
-### Exposed MCP Tools
-
-Decapod exposes its core CLI capabilities as MCP Tools, allowing agents to perform operations detailed in the [CLI Reference](../reference/cli.md):
-- `todo_add` / `todo_claim`
-- `workspace_ensure`
-- `constitution_search`
-- `validate`
-
-
-## Benefits of MCP Integration
-
-1.  **Lower Friction:** Agents don't need to "learn" CLI flags if they can call structured tools via MCP.
-2.  **Rich Context:** MCP allows for richer metadata (like URIs and structured resources) to be passed alongside documentation.
-3.  **Discovery:** MCP-native agents can automatically discover Decapod's capabilities as soon as they connect to the repository.
-
-## Handshaking and Identity
-
-Decapod uses its `handshake` command to generate a deterministic identity artifact. In an MCP context, this ensures that the agent provider and the local governance kernel have a shared, cryptographically verifiable understanding of which agent is operating on which task.
-
-## Future Direction
-
-We are actively expanding Decapod's MCP surface to support native resource templates and more granular tool definitions, making Decapod the standard "Governance MCP" for any repository it manages.
+The repository-local session credential establishes local custody and correlation for the current session. It is not external provider authentication. See [Identity and provenance](https://github.com/DecapodLabs/decapod/issues/876) and [the interoperability profile](https://github.com/DecapodLabs/decapod/issues/870) for the boundaries future adapters must preserve.

--- a/src/core/docs_cli.rs
+++ b/src/core/docs_cli.rs
@@ -140,7 +140,7 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
             Ok(DocsRunResult::default())
         }
         DocsCommand::Show { path, source } => {
-            let normalized_path = path.strip_prefix("embedded/").unwrap_or(&path).to_string();
+            let normalized_path = normalize_agent_doc_path(&path);
 
             if !normalized_path.starts_with("docs/agent/") {
                 return Err(error::DecapodError::ValidationError(format!(
@@ -281,6 +281,20 @@ pub fn run_docs_cli(cli: DocsCli) -> Result<DocsRunResult, error::DecapodError> 
             Ok(DocsRunResult::default())
         }
     }
+}
+
+fn normalize_agent_doc_path(path: &str) -> String {
+    let path = path.strip_prefix("embedded/").unwrap_or(path);
+    if path.starts_with("docs/agent/") {
+        return path.to_string();
+    }
+
+    let short_name = path.strip_suffix(".md").unwrap_or(path);
+    if !short_name.contains('/') {
+        return format!("docs/agent/{short_name}.md");
+    }
+
+    path.to_string()
 }
 
 /// Helper function to find the .decapod repo root

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -6211,9 +6211,15 @@ mod tests {
     }
 
     #[test]
-    fn git_workspace_context_accepts_decapod_worktree_when_main_root_is_worktree() {
+    fn issue_757_workspace_status_and_validate_agree_on_decapod_worktree() {
         let (_tmp, _main_root, wt_path) = decapod_worktree_fixture();
         let ctx = ValidationContext::new();
+
+        let status = crate::workspace::get_workspace_status(&wt_path)
+            .expect("workspace status should resolve the isolated worktree");
+        assert!(status.git.in_worktree);
+        assert!(!status.git.is_main_repo);
+        assert!(status.can_work);
 
         validate_git_workspace_context(&ctx, &wt_path, &wt_path)
             .expect("workspace context validation");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6441,6 +6441,30 @@ fn run_workspace_command(
         WorkspaceCommand::Ensure { branch, container } => {
             let agent_id =
                 std::env::var("DECAPOD_AGENT_ID").unwrap_or_else(|_| "unknown".to_string());
+            // A dirty protected checkout is an actionable orchestration blocker. Report it in
+            // the same JSON shape as a successful ensure instead of returning only a human error
+            // and leaving callers without machine-readable next actions.
+            if let Ok(status) = workspace::get_workspace_status(project_root)
+                && status.git.is_protected
+                && status.git.has_local_mods
+                && !status.git.in_worktree
+            {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": "pending",
+                        "branch": status.git.current_branch,
+                        "is_protected": status.git.is_protected,
+                        "can_work": status.can_work,
+                        "in_container": status.container.in_container,
+                        "docker_available": status.container.docker_available,
+                        "worktree_path": status.git.worktree_path,
+                        "blockers": status.blockers,
+                        "required_actions": status.required_actions,
+                    })
+                );
+                return Ok(());
+            }
             let config = if branch.is_some() || container {
                 Some(workspace::WorkspaceConfig {
                     branch,

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -1429,7 +1429,7 @@ fn build_container_script(
          git config --global user.name \"${DECAPOD_GIT_USER_NAME:-Decapod Agent}\"\n\
          git config --global user.email \"${DECAPOD_GIT_USER_EMAIL:-agent@decapod.local}\"\n\
          if ! command -v decapod >/dev/null 2>&1 && [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then\n\
-           decapod() { cargo run --quiet -- \"$@\"; }\n\
+           decapod() { cargo run --quiet --bin decapod -- \"$@\"; }\n\
          fi\n\
          if command -v decapod >/dev/null 2>&1; then\n\
            decapod version >/dev/null 2>&1 || true\n\
@@ -1574,7 +1574,7 @@ mod tests {
         );
         assert!(joined.contains("-v /tmp/repo/.decapod:/tmp/repo/.decapod/workspaces/w1/.decapod"));
         assert!(joined.contains("DECAPOD_LOCAL_ONLY=1"));
-        assert!(joined.contains("decapod() { cargo run --quiet -- \"$@\"; }"));
+        assert!(joined.contains("decapod() { cargo run --quiet --bin decapod -- \"$@\"; }"));
         assert!(joined.contains("git_safe checkout -B 'ahr/branch'"));
         assert!(!joined.contains("git_safe fetch --no-write-fetch-head origin 'master'"));
         assert!(!joined.contains("git_safe rebase origin/'master'"));

--- a/tests/doc_alignment.rs
+++ b/tests/doc_alignment.rs
@@ -85,3 +85,26 @@ fn test_config_schema_alignment() {
         );
     }
 }
+
+#[test]
+fn test_mcp_docs_match_current_adapter_boundary() {
+    let agent_mcp = fs::read_to_string("docs/agent/mcp.md").expect("read agent MCP docs");
+    let book_mcp = fs::read_to_string("docs/book/src/concepts/mcp.md").expect("read book MCP docs");
+    let agent_first =
+        fs::read_to_string("docs/book/src/concepts/agent-first.md").expect("read agent-first docs");
+
+    for docs in [&agent_mcp, &book_mcp, &agent_first] {
+        assert!(
+            docs.contains("adapter") || docs.contains("adapter boundary"),
+            "MCP documentation must identify the adapter boundary"
+        );
+        assert!(
+            docs.contains("does not") || docs.contains("not part"),
+            "MCP documentation must state the current implementation boundary"
+        );
+    }
+
+    assert!(agent_mcp.contains("tamper-evident"));
+    assert!(agent_mcp.contains("does not authenticate a model provider"));
+    assert!(!agent_first.contains("By supporting the **Model Context Protocol (MCP)**"));
+}

--- a/tests/external_tracker_compatibility.rs
+++ b/tests/external_tracker_compatibility.rs
@@ -34,6 +34,7 @@ fn setup_repo(dir: &std::path::Path) {
     let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["init", "--force"])
         .current_dir(dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .output()
         .expect("decapod init");
     assert!(init_out.status.success(), "init failed");
@@ -78,6 +79,7 @@ fn test_external_tracker_env_var_relaxation() {
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["workspace", "ensure"])
         .current_dir(&worktree_dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .output()
         .expect("workspace ensure");
 
@@ -103,6 +105,7 @@ fn test_external_tracker_env_var_relaxation() {
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["workspace", "ensure"])
         .current_dir(&worktree_dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .env("BEADS_TASK_ID", "123")
         .output()
         .expect("workspace ensure with env");
@@ -153,6 +156,7 @@ fn test_external_tracker_config_toml_relaxation() {
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["workspace", "ensure"])
         .current_dir(&worktree_dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .output()
         .expect("workspace ensure with config.toml");
 
@@ -182,11 +186,17 @@ fn test_workspace_ensure_json_orchestration_data() {
     let out = Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(["workspace", "ensure", "--container"])
         .current_dir(dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .output()
         .expect("workspace ensure --container");
 
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "workspace ensure --container must return orchestration JSON: {error}; stdout={stdout:?}; stderr={:?}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
 
     // Status should be pending/ok depending on blockers
     // But importantly, it should contain blockers and required_actions
@@ -205,8 +215,8 @@ fn test_workspace_ensure_json_orchestration_data() {
         "should have blockers for protected branch + container request"
     );
 
-    // Check for resolve_hint if container environment is being prepared
-    // In this test environment, it might just be the "on protected branch" blocker
+    // A workspace blocker may be either the protected-branch cleanup gate or a
+    // container-preparation action, depending on whether the fixture is dirty.
     let has_workspace_blocker = blockers.iter().any(|b| b["kind"] == "workspace_required");
     if has_workspace_blocker {
         let blocker = blockers
@@ -214,10 +224,11 @@ fn test_workspace_ensure_json_orchestration_data() {
             .find(|b| b["kind"] == "workspace_required")
             .unwrap();
         let hint = blocker["resolve_hint"].as_str().unwrap();
-        // It should start with either docker or podman
         assert!(
-            hint.starts_with("docker ") || hint.starts_with("podman "),
-            "hint should use detected runtime: {hint}"
+            hint.starts_with("docker ")
+                || hint.starts_with("podman ")
+                || hint.starts_with("Commit/stash/discard local changes"),
+            "workspace blocker should expose an actionable hint: {hint}"
         );
     }
 }

--- a/tests/gatling.rs
+++ b/tests/gatling.rs
@@ -81,6 +81,7 @@ fn setup_workspace() -> (TempDir, PathBuf) {
     let session = Command::new(&exe)
         .args(["session", "acquire"])
         .current_dir(&dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .output()
         .expect("decapod session acquire");
     assert!(
@@ -98,6 +99,7 @@ fn run(dir: &PathBuf, args: &[&str]) -> (bool, String) {
     let out = Command::new(resolve_decapod_bin())
         .args(args)
         .current_dir(dir)
+        .env("XDG_CONFIG_HOME", dir.join(".config"))
         .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
         .output()
         .expect("failed to run decapod");
@@ -290,6 +292,8 @@ fn t030_docs() {
     let (_tmp, dir) = setup_workspace();
     // T030
     ok(&dir, &["docs", "show", "docs/agent/api-index.md"]);
+    // T030a: short agent-doc names are normalized to docs/agent/*.md
+    ok(&dir, &["docs", "show", "api-index"]);
     // T031
     ok(&dir, &["docs", "show", "docs/agent/README.md"]);
     // T032

--- a/tests/substrate_integrity.rs
+++ b/tests/substrate_integrity.rs
@@ -5,7 +5,9 @@ use tempfile::TempDir;
 
 fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process::Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_decapod"));
-    cmd.current_dir(dir).args(args);
+    cmd.current_dir(dir)
+        .args(args)
+        .env("XDG_CONFIG_HOME", dir.join(".config"));
     for (k, v) in envs {
         cmd.env(k, v);
     }


### PR DESCRIPTION
## Summary

This single PR closes five small, cohesive issue surfaces:

- Fixes #868: normalize shorthand decapod docs show agent-document paths and cover the path contract.
- Fixes #869: align agent/book MCP documentation with the current Decapod-specific RPC and tamper-evident handshake boundaries.
- Fixes #759: select the decapod binary explicitly in generated container commands.
- Fixes #850: isolate XDG config state in flaky integration fixtures and preserve machine-readable workspace blocker output.
- Fixes #757: prove workspace status and validation agree on isolated Decapod worktrees.

Generated specs were refreshed through the Decapod RPC. Focused docs, external-tracker, substrate-integrity, gatling, workspace-consistency, and container unit tests pass.

Validation note: the remaining full decapod validate failure is the environment-only container proof gate. Container preparation could not pull ghcr.io/decapodlabs/decapod:v0.66.3 due registry authorization, and local Podman could not initialize because its runtime directory is read-only.

Issue #774 was reviewed as a duplicate workspace-consistency surface and is intentionally not included separately.