### PR TITLE
ci: verify public GHCR workspace image access

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.3
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.4
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.3
+ARG DECAPOD_VERSION=0.66.4
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783988239Z",
-  "repo_signal_fingerprint": "cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed",
+  "generated_at": "1784132722Z",
+  "repo_signal_fingerprint": "24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "13a7ede9164caf385f2a28161ac4cff44252546a6c52ff4d26df6069355266b7",
+  "spec_input_hash": "e3298089a143e0cb48eef29d8bf23a908b63377c924bc9c59a81c5645c226c37",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "c8a2484a7defb903ff8beb34feef7052a2bc88e3a86443cb648a6254fda7f974"
+      "content_hash": "68e1b858e43e968bbf1ab5399f21a36cf0d63079a17921faa48ca2d0e347aafb"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "e7c3d55a03a894eb77400797bd0024e4cc77ec8e5efe06d34b7708a98dbea28e"
+      "content_hash": "ec21042259df4f4ed5e22d3466e0cd0cf468952c3ef059445fbf2eaf29f89ad2"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "c00446697923956070224493293c37f59381fd95bf84e392df82e0f8a59044e0"
+      "content_hash": "1255239af6139bf5670073e0fceb265b96bc619704c7c8d2d42706756d4397c2"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "20b109d8587498d96337794251344c3c748afc61e6372f517199567c5833e8f6"
+      "content_hash": "5c5c660d03bc4cfeb182f967d388931ed08e49f84f306673202dad834f3984d5"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "45508a51449c5f8a3869617b869a7e1eb826cfa4e40f057b93b982ee7e3f25ba"
+      "content_hash": "0bb5b38f550944ddec275711ae43a1f87165dbe4167d952fd3d9a4dfe902e240"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "16312a656cf9eb4a8320fde8ba9e9772614d4dbcd7342616a8594bc7b0ac5759"
+      "content_hash": "e3e002f17c23140dd0de60c0601c11f6a14fe0adad01c50c84f004b7bbf2f982"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "58fe0a532e02421c5199d187002683abf695a577533b2127bb04a9d77011a5c6"
+      "content_hash": "1aee2fa10e66b21474feb28d2f0d320b5f7879b11808aa35c5bcb74d7d6ce0b6"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "b886a8f4b515f020dbd7cfa253a3651bb6ae45b09e78b45814dc4c9bea86acb8"
+      "content_hash": "7d61ee6fc07854e8293d3f153a747866320f4582f02682f517854ee04f0c5bf7"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,20 @@ jobs:
             DECAPOD_REVISION=${{ steps.commit.outputs.sha_short }}
             DECAPOD_BUILD_IMAGE=${{ matrix.build_image }}
             DECAPOD_RUNTIME_IMAGE=${{ matrix.runtime_image }}
+      - name: Verify anonymous GHCR pull
+        env:
+          IMAGE_TAG: ${{ github.ref_name }}${{ matrix.tag_suffix }}
+        run: |
+          set -euo pipefail
+          token="$(curl --fail-with-body --silent --show-error --location \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:decapodlabs/decapod:pull" \
+            | jq --raw-output '.token // empty')"
+          test -n "$token"
+          curl --fail-with-body --silent --show-error --location \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+            "https://ghcr.io/v2/decapodlabs/decapod/manifests/$IMAGE_TAG" \
+            >/dev/null
 
   # Build and packages all the platform-specific things
   build-local-artifacts:

--- a/tests/release_workflow_policy.rs
+++ b/tests/release_workflow_policy.rs
@@ -82,6 +82,32 @@ fn release_workflow_publishes_decapod_ghcr_image() {
 }
 
 #[test]
+fn release_workflow_verifies_anonymous_ghcr_pull() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(root.join(".github/workflows/release.yml"))
+        .expect("read release workflow");
+
+    assert!(
+        workflow.contains("name: Verify anonymous GHCR pull"),
+        "release workflow should verify the published image without caller credentials"
+    );
+    assert!(
+        workflow.contains(
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:decapodlabs/decapod:pull"
+        ),
+        "release workflow should request an anonymous pull token"
+    );
+    assert!(
+        workflow.contains("Authorization: Bearer $token"),
+        "release workflow should use the anonymous registry token for the manifest request"
+    );
+    assert!(
+        workflow.contains("https://ghcr.io/v2/decapodlabs/decapod/manifests/$IMAGE_TAG"),
+        "release workflow should fetch the exact variant tag that it just published"
+    );
+}
+
+#[test]
 fn release_workflow_can_resume_existing_github_release() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let workflow = fs::read_to_string(root.join(".github/workflows/release.yml"))


### PR DESCRIPTION
## Summary

- Add a release-time anonymous OCI manifest pull check for both GHCR image variants.
- Fail the release if the published image cannot be pulled without caller credentials.
- Refresh generated spec attestation and align the generated workspace Dockerfile with v0.66.4.

## Issue correlation

Fixes #886
Related to #793
Related to #775

#886 is the current user-facing failure: the published workspace image is private and therefore requires credentials. The check requests the anonymous GHCR pull token and fetches the exact release variant tag after the push.

#793 established the GHCR base-image publication path. This PR adds the missing public-consumer proof to that path.

#775 established that generated workspace containers must contain a runnable Decapod binary. This PR verifies the release image's exact tag is anonymously pullable before it can be treated as the workspace base image.

The existing package must be changed to Public once in GitHub Package settings; the release workflow now fails closed if that setting is absent or regresses.

## Proof

- `cargo fmt --check`
- `cargo test --test release_workflow_policy` (5 passed)
- `git diff --check`
- `DECAPOD_CONTAINER=1 decapod validate --format json` (198 passed, 0 failed)
