### PR TITLE
ci: verify public GHCR workspace image access

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.3
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.4
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.3
+ARG DECAPOD_VERSION=0.66.4
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/context/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/generated/context/bugs_01kxk92eec5zvxc2.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "1.1.0",
+  "topic": "GHCR workspace image public anonymous pulls",
+  "scope": "interfaces",
+  "task_id": "bugs_01kxk92eec5zvxc2",
+  "workunit_id": null,
+  "sources": [
+    {
+      "path": "interfaces/AGENT_CONTEXT_PACK",
+      "section": "interfaces/AGENT_CONTEXT_PACK"
+    },
+    {
+      "path": "interfaces/ARCHITECTURE_FOUNDATIONS",
+      "section": "interfaces/ARCHITECTURE_FOUNDATIONS"
+    },
+    {
+      "path": "interfaces/CLAIMS",
+      "section": "interfaces/CLAIMS"
+    },
+    {
+      "path": "interfaces/CONTROL_PLANE",
+      "section": "interfaces/CONTROL_PLANE"
+    },
+    {
+      "path": "interfaces/DEMANDS_SCHEMA",
+      "section": "interfaces/DEMANDS_SCHEMA"
+    },
+    {
+      "path": "interfaces/DOC_RULES",
+      "section": "interfaces/DOC_RULES"
+    }
+  ],
+  "snippets": [
+    {
+      "source_path": "interfaces/AGENT_CONTEXT_PACK",
+      "text": "# interfaces/AGENT_CONTEXT_PACK\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes retrieved snippets, task scope, authority ordering, bounded context, and agent pre-inference consumption.\n\n## ambiguity\n\nStop inference if the retrieved context is contradictory or insufficient to safely execute the task."
+    },
+    {
+      "source_path": "interfaces/ARCHITECTURE_FOUNDATIONS",
+      "text": "# interfaces/ARCHITECTURE_FOUNDATIONS\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes foundational architecture vocabulary: boundary, state, interface, runtime, deployment, and data flow.\n\n## ambiguity\n\nStop inference if the basic relationship between state and interface is undefined for a new component."
+    },
+    {
+      "source_path": "interfaces/CLAIMS",
+      "text": "# interfaces/CLAIMS\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes claim type, evidence, verification status, stale claim risk, and mapping claims to proof.\n\n## ambiguity\n\nStop inference if a claim is made without a corresponding proof surface or verification artifact."
+    },
+    {
+      "source_path": "interfaces/CONTROL_PLANE",
+      "text": "# interfaces/CONTROL_PLANE\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes operation sequencing, receipts, allowed next operations, and mutation boundaries.\n\n## ambiguity\n\nStop inference if an RPC response indicates a 'blocked_by' state without a clear resolution hint."
+    },
+    {
+      "source_path": "interfaces/DEMANDS_SCHEMA",
+      "text": "# interfaces/DEMANDS_SCHEMA\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes how human constraints become structured demands: must, must-not, priority, and durability.\n\n## ambiguity\n\nStop inference if two 'Must' demands are mutually exclusive and no precedence rule applies."
+    },
+    {
+      "source_path": "interfaces/DOC_RULES",
+      "text": "# interfaces/DOC_RULES\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes machine-readable documentation rules: canonical vs generated, boundaries, and drift handling.\n\n## ambiguity\n\nStop inference if a file's status as 'canonical' or 'generated' is unclear."
+    }
+  ],
+  "capabilities": [
+    "agent-helper",
+    "authentication",
+    "authorization",
+    "background-processing",
+    "control-plane",
+    "event-driven",
+    "external-integrations",
+    "governance-kernel",
+    "persistent-state",
+    "scheduled-jobs"
+  ],
+  "policy": {
+    "risk_tier": "medium",
+    "policy_hash": "4be692d786ecc3514b98ed3228e133501360531cdcb4ef77fe3b3a111c9e38cb",
+    "policy_version": "jit-capsule-policy-v1",
+    "policy_path": ".decapod/generated/policy/context_capsule_policy.json",
+    "repo_revision": "3ffcbd30ae88fd063786c4ec2de4d0470c977241"
+  },
+  "capsule_hash": "e2799579ba3e9a69349dc836d80afdf855839e8e9388d6dd83e106ac81e7dfca",
+  "repo_signal_fingerprint": "24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f",
+  "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
+  "spec_input_hash": "e3298089a143e0cb48eef29d8bf23a908b63377c924bc9c59a81c5645c226c37"
+}

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784133979Z",
-  "repo_signal_fingerprint": "4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4",
+  "generated_at": "1784134123Z",
+  "repo_signal_fingerprint": "81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "dc325c41efdab49c15ec49e72e8dfc3e5a183f76c2b90c83a0ebc26967779173",
+  "spec_input_hash": "4b98a04611533344d5c55f5503165322af4a5f0ea7990c76f4243ccbaea4b92c",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "d42a8b1b454cc01eba499aa2795c6f0642dae4b28206cef246811cb1fced51d3"
+      "content_hash": "84d395dcaa3397a13ca9d6858765fdf546ee5b8e680aeeb4c23c00c6fb34b7ec"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "123aa176d88a7b3937eceeb94d8908b797fe22ddee135b3db8752aab669a7cf1"
+      "content_hash": "5e0a070700bfeaef5f933fd7e5caaa47b0420c503398a8ea9c90dd103e6aacd5"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "6c40c0f87d452cb011ed8f2b4f485fb71dc3306375261bc26d707bd4f2162b50"
+      "content_hash": "06d76f163e9f4aa3a7e379367620e5bb729aa6554e0adb50a989fc5637810695"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "56ff57fc1abb0f879655491414d2e7441d93df09039588cedc530768009997b1"
+      "content_hash": "99f0fe570a3212d6ca70fe4aab4c30a51b268dac704a9dd3294f60f1b8e050a2"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "095a053f03194a477f05ee4f34af9624c824c831b119fc9807807e5637ecb0d7"
+      "content_hash": "15f3144c9183e8e41733d1e73d1611a7040242ad9fba63d540996b3d1c4d1a84"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "0ec0ffc5abba9fdfcfad1fb48f9b42c0a155243533da3097ed70e4fe15ac09be"
+      "content_hash": "70bf6cff1bd03b92377845b384922d5be5a1cb1fbb43df40a8a603ee893d66d8"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "47489eb3e3f75ef38db2c5686d62f0455c32e6911e56ec8d1ec7a125cb5f53cf"
+      "content_hash": "df9075c503fee2aa577293f05f5ad3f2fe9fae7f9aa99c379aac9227c891c70b"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "cbeed5dab15f31ade89a63f5cb09d1114d3afec4d0c095b0fe755a2d22b8b6fc"
+      "content_hash": "8a233404a2c0e4e6e8610830d9de599e3fc2f028099f36e76339252d997b0fb7"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784133554Z",
-  "repo_signal_fingerprint": "f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f",
+  "generated_at": "1784133845Z",
+  "repo_signal_fingerprint": "7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "5a7bd61ee41eb8b9161ddc94434b95edb9732c09caa3eca20fe2a3608293bb3e",
+  "spec_input_hash": "236496a7416306b302dff14cc9b37b1c3fdea857474153db30410974da19c337",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "cd808b75ce313da3fa487f83474dd15c08df1a9eba4a671ed9ecf8017df7ffc4"
+      "content_hash": "a4d500259d81ed5264056c783c1f5efaef40e026a2299db23f981c2e405fc717"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "fc803b6a5605a42ef27f314e08328d5fc5aeed38f0da0a542eb4bfe66d11fb82"
+      "content_hash": "016ea485118510ecd9c5af2f65c2751a4a4d3cd4c062cd2f21f577cb8a440338"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "32369ff58db78319b088763f110b44c519048cd294c57ea5f90b24fdc82bf093"
+      "content_hash": "1c89d228d5d8803774ac6e7b3374dfc740813df0e73ba7fe09c1e954d38a9fc9"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "574e5c20eb44e83f3fb84aa7ad541c75f3a5720bdd8fd8875f67b5268edaf057"
+      "content_hash": "fa4c1886d22522dcf64c72d42cbaedb4fe5a4906272e2d45c55b0c35def2ae55"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "d27452316c16c4dc9ec1857e90de9ea3ceb788f9374429fe0b6c3da1e7de4b8a"
+      "content_hash": "ea9d7de379d202dc35159428a9be01e7f0c3c12ab26a7a1057985b7d64b3d580"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "013895e005eb8a2f0b40279d8a7d0876dbdbfc55cd962dd1913ffef187c845b6"
+      "content_hash": "d84fff123aa67e61ac43a0253dbce72ae4280df91aa0801ff292c3e6615cfc54"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "55934e6fce368a1f66f33fb6c40e4c2385790482afbc044711a64a108367cff3"
+      "content_hash": "0299983369333ceb1f74456e53e58b4031dd2934de5da9cb1209b406f69b871f"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "11d1e91fca585e15011702a120d5894a558a532b71f7d049d42ba3d43856327e"
+      "content_hash": "e0e49106203273b0151a64568856a31d7d23f482e05d3d88469dd06d5c88de73"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1783988239Z",
-  "repo_signal_fingerprint": "cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed",
+  "generated_at": "1784132722Z",
+  "repo_signal_fingerprint": "24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "13a7ede9164caf385f2a28161ac4cff44252546a6c52ff4d26df6069355266b7",
+  "spec_input_hash": "e3298089a143e0cb48eef29d8bf23a908b63377c924bc9c59a81c5645c226c37",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "c8a2484a7defb903ff8beb34feef7052a2bc88e3a86443cb648a6254fda7f974"
+      "content_hash": "68e1b858e43e968bbf1ab5399f21a36cf0d63079a17921faa48ca2d0e347aafb"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "e7c3d55a03a894eb77400797bd0024e4cc77ec8e5efe06d34b7708a98dbea28e"
+      "content_hash": "ec21042259df4f4ed5e22d3466e0cd0cf468952c3ef059445fbf2eaf29f89ad2"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "c00446697923956070224493293c37f59381fd95bf84e392df82e0f8a59044e0"
+      "content_hash": "1255239af6139bf5670073e0fceb265b96bc619704c7c8d2d42706756d4397c2"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "20b109d8587498d96337794251344c3c748afc61e6372f517199567c5833e8f6"
+      "content_hash": "5c5c660d03bc4cfeb182f967d388931ed08e49f84f306673202dad834f3984d5"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "45508a51449c5f8a3869617b869a7e1eb826cfa4e40f057b93b982ee7e3f25ba"
+      "content_hash": "0bb5b38f550944ddec275711ae43a1f87165dbe4167d952fd3d9a4dfe902e240"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "16312a656cf9eb4a8320fde8ba9e9772614d4dbcd7342616a8594bc7b0ac5759"
+      "content_hash": "e3e002f17c23140dd0de60c0601c11f6a14fe0adad01c50c84f004b7bbf2f982"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "58fe0a532e02421c5199d187002683abf695a577533b2127bb04a9d77011a5c6"
+      "content_hash": "1aee2fa10e66b21474feb28d2f0d320b5f7879b11808aa35c5bcb74d7d6ce0b6"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "b886a8f4b515f020dbd7cfa253a3651bb6ae45b09e78b45814dc4c9bea86acb8"
+      "content_hash": "7d61ee6fc07854e8293d3f153a747866320f4582f02682f517854ee04f0c5bf7"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784133845Z",
-  "repo_signal_fingerprint": "7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0",
+  "generated_at": "1784133979Z",
+  "repo_signal_fingerprint": "4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "236496a7416306b302dff14cc9b37b1c3fdea857474153db30410974da19c337",
+  "spec_input_hash": "dc325c41efdab49c15ec49e72e8dfc3e5a183f76c2b90c83a0ebc26967779173",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "a4d500259d81ed5264056c783c1f5efaef40e026a2299db23f981c2e405fc717"
+      "content_hash": "d42a8b1b454cc01eba499aa2795c6f0642dae4b28206cef246811cb1fced51d3"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "016ea485118510ecd9c5af2f65c2751a4a4d3cd4c062cd2f21f577cb8a440338"
+      "content_hash": "123aa176d88a7b3937eceeb94d8908b797fe22ddee135b3db8752aab669a7cf1"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "1c89d228d5d8803774ac6e7b3374dfc740813df0e73ba7fe09c1e954d38a9fc9"
+      "content_hash": "6c40c0f87d452cb011ed8f2b4f485fb71dc3306375261bc26d707bd4f2162b50"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "fa4c1886d22522dcf64c72d42cbaedb4fe5a4906272e2d45c55b0c35def2ae55"
+      "content_hash": "56ff57fc1abb0f879655491414d2e7441d93df09039588cedc530768009997b1"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "ea9d7de379d202dc35159428a9be01e7f0c3c12ab26a7a1057985b7d64b3d580"
+      "content_hash": "095a053f03194a477f05ee4f34af9624c824c831b119fc9807807e5637ecb0d7"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "d84fff123aa67e61ac43a0253dbce72ae4280df91aa0801ff292c3e6615cfc54"
+      "content_hash": "0ec0ffc5abba9fdfcfad1fb48f9b42c0a155243533da3097ed70e4fe15ac09be"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "0299983369333ceb1f74456e53e58b4031dd2934de5da9cb1209b406f69b871f"
+      "content_hash": "47489eb3e3f75ef38db2c5686d62f0455c32e6911e56ec8d1ec7a125cb5f53cf"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "e0e49106203273b0151a64568856a31d7d23f482e05d3d88469dd06d5c88de73"
+      "content_hash": "cbeed5dab15f31ade89a63f5cb09d1114d3afec4d0c095b0fe755a2d22b8b6fc"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784132722Z",
-  "repo_signal_fingerprint": "24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f",
+  "generated_at": "1784133554Z",
+  "repo_signal_fingerprint": "f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "e3298089a143e0cb48eef29d8bf23a908b63377c924bc9c59a81c5645c226c37",
+  "spec_input_hash": "5a7bd61ee41eb8b9161ddc94434b95edb9732c09caa3eca20fe2a3608293bb3e",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "68e1b858e43e968bbf1ab5399f21a36cf0d63079a17921faa48ca2d0e347aafb"
+      "content_hash": "cd808b75ce313da3fa487f83474dd15c08df1a9eba4a671ed9ecf8017df7ffc4"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ec21042259df4f4ed5e22d3466e0cd0cf468952c3ef059445fbf2eaf29f89ad2"
+      "content_hash": "fc803b6a5605a42ef27f314e08328d5fc5aeed38f0da0a542eb4bfe66d11fb82"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "1255239af6139bf5670073e0fceb265b96bc619704c7c8d2d42706756d4397c2"
+      "content_hash": "32369ff58db78319b088763f110b44c519048cd294c57ea5f90b24fdc82bf093"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "5c5c660d03bc4cfeb182f967d388931ed08e49f84f306673202dad834f3984d5"
+      "content_hash": "574e5c20eb44e83f3fb84aa7ad541c75f3a5720bdd8fd8875f67b5268edaf057"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "0bb5b38f550944ddec275711ae43a1f87165dbe4167d952fd3d9a4dfe902e240"
+      "content_hash": "d27452316c16c4dc9ec1857e90de9ea3ceb788f9374429fe0b6c3da1e7de4b8a"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "e3e002f17c23140dd0de60c0601c11f6a14fe0adad01c50c84f004b7bbf2f982"
+      "content_hash": "013895e005eb8a2f0b40279d8a7d0876dbdbfc55cd962dd1913ffef187c845b6"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "1aee2fa10e66b21474feb28d2f0d320b5f7879b11808aa35c5bcb74d7d6ce0b6"
+      "content_hash": "55934e6fce368a1f66f33fb6c40e4c2385790482afbc044711a64a108367cff3"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "7d61ee6fc07854e8293d3f153a747866320f4582f02682f517854ee04f0c5bf7"
+      "content_hash": "11d1e91fca585e15011702a120d5894a558a532b71f7d049d42ba3d43856327e"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784134123Z",
-  "repo_signal_fingerprint": "81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475",
+  "generated_at": "1784134520Z",
+  "repo_signal_fingerprint": "8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "4b98a04611533344d5c55f5503165322af4a5f0ea7990c76f4243ccbaea4b92c",
+  "spec_input_hash": "20370d587333d198e55560a0e8b72baff43b82368eb2e25a1086b6c419001b4d",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "84d395dcaa3397a13ca9d6858765fdf546ee5b8e680aeeb4c23c00c6fb34b7ec"
+      "content_hash": "fa8e45caed2fb67678204f6638e1d51e9c1236cb2b266d59f625b6a0a3695b14"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "5e0a070700bfeaef5f933fd7e5caaa47b0420c503398a8ea9c90dd103e6aacd5"
+      "content_hash": "5912cb184f45e693dd14b197d6a18da26e95724dc3eee9ccaea60fd21ad154d4"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "06d76f163e9f4aa3a7e379367620e5bb729aa6554e0adb50a989fc5637810695"
+      "content_hash": "019ebaf8aeda53677d2588913385c74130a29a8193a5cf933ec30a13571cf0bc"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "99f0fe570a3212d6ca70fe4aab4c30a51b268dac704a9dd3294f60f1b8e050a2"
+      "content_hash": "6321feee08ba0ee113c17601347ed31b5297d650cc0f719366ad95d2910e311c"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "15f3144c9183e8e41733d1e73d1611a7040242ad9fba63d540996b3d1c4d1a84"
+      "content_hash": "3a06f125d80c1d28a64c943e122a0f376a807823f93afeac932c39729982e93c"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "70bf6cff1bd03b92377845b384922d5be5a1cb1fbb43df40a8a603ee893d66d8"
+      "content_hash": "e1b2252a7b91e7e3adcd9746ed4d4676a3db703c4f4e5b65ee1e3537ac9edece"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "df9075c503fee2aa577293f05f5ad3f2fe9fae7f9aa99c379aac9227c891c70b"
+      "content_hash": "20cf28685972126a693652f4b34b1b3acc6ed425a2fb1c0de77f283eab34c057"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "8a233404a2c0e4e6e8610830d9de599e3fc2f028099f36e76339252d997b0fb7"
+      "content_hash": "eb76ba132063d804d0c4f216056f1aec9db89fc6614c8aa55e9633fc0da0e16f"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `cec3aed0e7cab9de9386257b55adcd9125d40cb0ff54ecba21016513b0cb51ed`
+- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `24e551f34149fd7be7cde5ccffba95b1ae3a4922d670ffd1416073610521ce7f`
+- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `f79458e336b77b2add3c833809d0dbb3dc218919f999b78a874a04fc2af0c14f`
+- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7f0a1a15e78182f4dc6fee67b7afd55f1c750824ba79c1d80834c99c4ed117f0`
+- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `4ac074304b1455f84101df4f9e369b77f0750ed9345f16c4ce5fb37dd662cda4`
+- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81f6a0cfde3282deed8ed6fe6719eb66a110acdd01a07ba03a7db7fc32946475`
+- Repository signal fingerprint: `8b057da25526255b1de85954cf6d074ffc4bebda9af7aae10256d2a58529d603`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -18,7 +18,7 @@
     {
       "gate": "state_commit",
       "status": "pass",
-      "artifact_ref": "28247b5"
+      "artifact_ref": "5976132"
     },
     {
       "gate": "test:cargo-test-release-workflow-policy",

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -18,7 +18,7 @@
     {
       "gate": "state_commit",
       "status": "pass",
-      "artifact_ref": "c59c1c0"
+      "artifact_ref": "b2a9bea"
     },
     {
       "gate": "test:cargo-test-release-workflow-policy",

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -28,7 +28,7 @@
     {
       "gate": "validate_passes",
       "status": "pass",
-      "artifact_ref": "DECAPOD_CONTAINER=1 DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate --format json (193 passed, 0 failed)"
+      "artifact_ref": "DECAPOD_CONTAINER=1 decapod validate --format json (198 passed, 0 failed)"
     }
   ],
   "status": "VERIFIED"

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "bugs_01kxk92eec5zvxc2",
+  "intent_ref": "github:DecapodLabs/decapod#886",
+  "spec_refs": [
+    ".decapod/generated/specs/VALIDATION.md",
+    ".github/workflows/release.yml"
+  ],
+  "state_refs": [
+    ".decapod/generated/context/bugs_01kxk92eec5zvxc2.json",
+    "state://release-workflow/ghcr-public"
+  ],
+  "proof_plan": [
+    "state_commit",
+    "test:cargo-test-release-workflow-policy",
+    "validate_passes"
+  ],
+  "proof_results": [
+    {
+      "gate": "state_commit",
+      "status": "pass",
+      "artifact_ref": "3ffcbd3"
+    },
+    {
+      "gate": "test:cargo-test-release-workflow-policy",
+      "status": "pass",
+      "artifact_ref": "tests/release_workflow_policy.rs"
+    },
+    {
+      "gate": "validate_passes",
+      "status": "pass",
+      "artifact_ref": "DECAPOD_CONTAINER=1 DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate --format json (193 passed, 0 failed)"
+    }
+  ],
+  "status": "VERIFIED"
+}

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -18,7 +18,7 @@
     {
       "gate": "state_commit",
       "status": "pass",
-      "artifact_ref": "1652010"
+      "artifact_ref": "c59c1c0"
     },
     {
       "gate": "test:cargo-test-release-workflow-policy",

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -18,7 +18,7 @@
     {
       "gate": "state_commit",
       "status": "pass",
-      "artifact_ref": "5976132"
+      "artifact_ref": "1652010"
     },
     {
       "gate": "test:cargo-test-release-workflow-policy",

--- a/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
+++ b/.decapod/governance/workunits/bugs_01kxk92eec5zvxc2.json
@@ -18,7 +18,7 @@
     {
       "gate": "state_commit",
       "status": "pass",
-      "artifact_ref": "3ffcbd3"
+      "artifact_ref": "28247b5"
     },
     {
       "gate": "test:cargo-test-release-workflow-policy",

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -28,6 +28,6 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
-          git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
+          git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml
           decapod rpc --op specs.refresh
           decapod validate

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -28,4 +28,5 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
+          git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
           decapod validate

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/decapod
-          key: ${{ runner.os }}-decapod
+          key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
       - name: Install Decapod
         run: |
           if ! command -v decapod &> /dev/null; then
@@ -28,6 +28,4 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
-          git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml
-          decapod rpc --op specs.refresh
           decapod validate

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -29,4 +29,5 @@ jobs:
         run: |
           decapod init --proof --force
           git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
+          decapod rpc --op specs.refresh
           decapod validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,20 @@ jobs:
             DECAPOD_REVISION=${{ steps.commit.outputs.sha_short }}
             DECAPOD_BUILD_IMAGE=${{ matrix.build_image }}
             DECAPOD_RUNTIME_IMAGE=${{ matrix.runtime_image }}
+      - name: Verify anonymous GHCR pull
+        env:
+          IMAGE_TAG: ${{ github.ref_name }}${{ matrix.tag_suffix }}
+        run: |
+          set -euo pipefail
+          token="$(curl --fail-with-body --silent --show-error --location \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:decapodlabs/decapod:pull" \
+            | jq --raw-output '.token // empty')"
+          test -n "$token"
+          curl --fail-with-body --silent --show-error --location \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+            "https://ghcr.io/v2/decapodlabs/decapod/manifests/$IMAGE_TAG" \
+            >/dev/null
 
   # Build and packages all the platform-specific things
   build-local-artifacts:

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -618,7 +618,7 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
-          git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
+          git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml
           decapod rpc --op specs.refresh
           decapod validate
 "#

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -619,6 +619,7 @@ jobs:
         run: |
           decapod init --proof --force
           git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
+          decapod rpc --op specs.refresh
           decapod validate
 "#
     .to_string()

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -618,6 +618,7 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
+          git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml
           decapod validate
 "#
     .to_string()

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -607,7 +607,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/decapod
-          key: ${{ runner.os }}-decapod
+          key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
       - name: Install Decapod
         run: |
           if ! command -v decapod &> /dev/null; then
@@ -618,8 +618,6 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof --force
-          git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml
-          decapod rpc --op specs.refresh
           decapod validate
 "#
     .to_string()

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -617,7 +617,7 @@ jobs:
         env:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
-          decapod init --proof
+          decapod init --proof --force
           decapod validate
 "#
     .to_string()

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -1766,7 +1766,6 @@ pub fn scaffold_project_entrypoints(
             specs_files.push((spec.path, content));
         }
 
-        let existing_manifest = read_specs_manifest(&opts.target_dir)?;
         for (rel_path, mut content) in specs_files {
             // Epistemic Custody Preservation:
             // If we are regenerating INTENT.md and it already exists, try to preserve the Epistemic Custody Fields section.
@@ -1778,23 +1777,18 @@ pub fn scaffold_project_entrypoints(
             let dest = opts.target_dir.join(rel_path);
             let existing_content = fs::read_to_string(&dest).ok();
 
-            let mut is_customized = false;
             let mut final_content_hash = hash_text(&content);
-            if let Some(ref existing) = existing_manifest
-                && let Some(entry) = existing.files.iter().find(|f| f.path == rel_path)
-                && let Some(existing_str) = existing_content
-            {
-                let disk_hash = hash_text(&existing_str);
-                if disk_hash != entry.template_hash {
-                    is_customized = true;
-                    if !opts.force {
-                        final_content_hash = disk_hash;
-                    }
+            if let Some(existing_str) = existing_content {
+                // Living specs are project-owned contracts. `--force` may repair
+                // missing scaffold files, but must not replace authored content
+                // with a fresh scaffold; use the specs refresh path for a
+                // deliberate re-evaluation.
+                final_content_hash = hash_text(&existing_str);
+                if final_content_hash == hash_text(&content) {
+                    unchanged += 1;
+                } else {
+                    preserved += 1;
                 }
-            }
-
-            if is_customized && !opts.force {
-                preserved += 1;
             } else {
                 match write_file(opts, rel_path, &content)? {
                     FileAction::Created => created += 1,

--- a/tests/init_ci_scaffolding.rs
+++ b/tests/init_ci_scaffolding.rs
@@ -29,7 +29,7 @@ fn init_scaffolds_github_action_workflow() {
     let content = fs::read_to_string(workflow_path).expect("read workflow file");
     assert!(content.contains("name: Decapod Validate"));
     assert!(content.contains("decapod validate"));
-    assert!(content.contains("decapod init --proof"));
+    assert!(content.contains("decapod init --proof --force"));
     assert!(content.contains("DECAPOD_VALIDATE_SKIP_GIT_GATES: 1"));
     assert!(content.contains("on:"));
     assert!(content.contains("push:"));

--- a/tests/init_ci_scaffolding.rs
+++ b/tests/init_ci_scaffolding.rs
@@ -30,10 +30,10 @@ fn init_scaffolds_github_action_workflow() {
     assert!(content.contains("name: Decapod Validate"));
     assert!(content.contains("decapod validate"));
     assert!(content.contains("decapod init --proof --force"));
-    assert!(content.contains(
-        "git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml"
-    ));
-    assert!(content.contains("decapod rpc --op specs.refresh"));
+    assert!(
+        content
+            .contains("key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}")
+    );
     assert!(content.contains("DECAPOD_VALIDATE_SKIP_GIT_GATES: 1"));
     assert!(content.contains("on:"));
     assert!(content.contains("push:"));
@@ -62,6 +62,29 @@ fn init_force_updates_existing_workflow() {
     assert!(
         content.contains("name: Decapod Validate"),
         "workflow should be updated with --force"
+    );
+}
+
+#[test]
+fn init_force_preserves_existing_living_specs() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(tmp.path(), &["init", "--proof"]);
+    assert!(out.status.success(), "initial init should succeed");
+
+    let specs_path = tmp.path().join(".decapod/generated/specs/README.md");
+    let mut authored = fs::read_to_string(&specs_path).expect("read generated README");
+    authored.push_str("\nProject-authored contract.\n");
+    fs::write(&specs_path, &authored).expect("write authored README");
+
+    let out = run_decapod(tmp.path(), &["init", "--proof", "--force"]);
+    assert!(
+        out.status.success(),
+        "force init should preserve living specs: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(specs_path).expect("read preserved README"),
+        authored
     );
 }
 

--- a/tests/init_ci_scaffolding.rs
+++ b/tests/init_ci_scaffolding.rs
@@ -33,6 +33,7 @@ fn init_scaffolds_github_action_workflow() {
     assert!(content.contains(
         "git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml"
     ));
+    assert!(content.contains("decapod rpc --op specs.refresh"));
     assert!(content.contains("DECAPOD_VALIDATE_SKIP_GIT_GATES: 1"));
     assert!(content.contains("on:"));
     assert!(content.contains("push:"));

--- a/tests/init_ci_scaffolding.rs
+++ b/tests/init_ci_scaffolding.rs
@@ -30,6 +30,9 @@ fn init_scaffolds_github_action_workflow() {
     assert!(content.contains("name: Decapod Validate"));
     assert!(content.contains("decapod validate"));
     assert!(content.contains("decapod init --proof --force"));
+    assert!(content.contains(
+        "git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml"
+    ));
     assert!(content.contains("DECAPOD_VALIDATE_SKIP_GIT_GATES: 1"));
     assert!(content.contains("on:"));
     assert!(content.contains("push:"));

--- a/tests/init_ci_scaffolding.rs
+++ b/tests/init_ci_scaffolding.rs
@@ -31,7 +31,7 @@ fn init_scaffolds_github_action_workflow() {
     assert!(content.contains("decapod validate"));
     assert!(content.contains("decapod init --proof --force"));
     assert!(content.contains(
-        "git restore --source=HEAD -- .decapod/generated/specs .github/workflows/decapod-validate.yml"
+        "git restore --source=HEAD -- .decapod/config.toml .decapod/generated .github/workflows/decapod-validate.yml"
     ));
     assert!(content.contains("decapod rpc --op specs.refresh"));
     assert!(content.contains("DECAPOD_VALIDATE_SKIP_GIT_GATES: 1"));

--- a/tests/release_workflow_policy.rs
+++ b/tests/release_workflow_policy.rs
@@ -82,6 +82,32 @@ fn release_workflow_publishes_decapod_ghcr_image() {
 }
 
 #[test]
+fn release_workflow_verifies_anonymous_ghcr_pull() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow = fs::read_to_string(root.join(".github/workflows/release.yml"))
+        .expect("read release workflow");
+
+    assert!(
+        workflow.contains("name: Verify anonymous GHCR pull"),
+        "release workflow should verify the published image without caller credentials"
+    );
+    assert!(
+        workflow.contains(
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:decapodlabs/decapod:pull"
+        ),
+        "release workflow should request an anonymous pull token"
+    );
+    assert!(
+        workflow.contains("Authorization: Bearer $token"),
+        "release workflow should use the anonymous registry token for the manifest request"
+    );
+    assert!(
+        workflow.contains("https://ghcr.io/v2/decapodlabs/decapod/manifests/$IMAGE_TAG"),
+        "release workflow should fetch the exact variant tag that it just published"
+    );
+}
+
+#[test]
 fn release_workflow_can_resume_existing_github_release() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let workflow = fs::read_to_string(root.join(".github/workflows/release.yml"))


### PR DESCRIPTION
## Summary

- Add a release-time anonymous OCI manifest pull check for both GHCR image variants.
- Fail the release if the published image cannot be pulled without caller credentials.
- Keep `decapod init --proof --force` safe for existing living specs and invalidate the Decapod CI binary cache when the project version changes.
- Refresh generated spec attestation and align the generated workspace Dockerfile with v0.66.4.

## Issue correlation

Fixes #886
Related to #793
Related to #775

#886 is the current user-facing failure: the published workspace image is private and therefore requires credentials. The check requests the anonymous GHCR pull token and fetches the exact release variant tag after the push.

#793 established the GHCR base-image publication path. This PR adds the missing public-consumer proof to that path.

#775 established that generated workspace containers must contain a runnable Decapod binary. This PR verifies the release image's exact tag is anonymously pullable before it can be treated as the workspace base image.

The existing package must be changed to Public once in GitHub Package settings; the release workflow now fails closed if that setting is absent or regresses.

## Proof

- `cargo fmt --check`
- `cargo test --test release_workflow_policy` (5 passed)
- `cargo test --test init_ci_scaffolding` (4 passed)
- `cargo test --test init_config_behavior` (18 passed, 1 ignored)
- `git diff --check`
- `DECAPOD_CONTAINER=1 decapod validate --format json` (198 passed, 0 failed after the verified workunit trajectory)
