### PR TITLE
fix: prevent local-clone workspace publication

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784136518Z",
-  "repo_signal_fingerprint": "61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426",
+  "generated_at": "1784138619Z",
+  "repo_signal_fingerprint": "e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "c6aab3ca7edc72e42dc08f3d67a2ef5daee4c18906003506af7115e16c055c46",
+  "spec_input_hash": "542aba2a4b24723e07eaae7805a0e85f0ad45736ec5d029e1ee44e3cd92091ea",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "4a02fef351d9f6a498b684fa4f859b0f0b4c8ea6a725127af13a1e12ed514895"
+      "content_hash": "9da1387d9c93122e3c8ee91d89a1c6a7a8d620d8b0599e4435bcb6ebd1ccaf52"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "c79f16e44d09cd79e70c2349ff8be3a4688e109c039451c2e359f33e40481a3a"
+      "content_hash": "fafdad02da1c20429d64812ad4bb25074ba6e20748de072d53dd2b3780acf47f"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "9ed1381cdcc41d10cac2d5b6fbd63cedf55f87e20525c044b2c9e2dca600cb7e"
+      "content_hash": "90b25178d5b2712e73452aa8c8703a8e36d78b27cefc627e1dd6e1a00a5c798e"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "59aad3d2061b85fbdda237428013f07d9197c3339a2756e12c6ca50cb5bb7dd2"
+      "content_hash": "c129de040a54918939a4b821ac72ad72ae3b0ee165c0a79bf86552f6515ed876"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "1861f844d9653a426302ada9b59ee181da8a6229779bca19ba2c96cc32ad88be"
+      "content_hash": "0e33b575aec125618bf47e7a3f74fc358bcb22a235517e5f21c9f31a33364dc9"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "727378b7c32207d0cbe7d05599989e21985f19edd83fa3303e8179d15d116b78"
+      "content_hash": "b79b5faf48548e404ac595984d17542d8a99e37af363b2cd914829ae257269e2"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "c7cecc7a359b29be3b9bfc3da8c24ea8a8eefc7977c9be6abdc39ef197dcd1ba"
+      "content_hash": "6c2a7256397f8f9237b0869a03d2093ce617bc2175659d36ceaf463dcbacce4d"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "d9b32c51ade4473e2dc55fb9d7b82e16f3f19729781718bae6038f6458e05a2a"
+      "content_hash": "b529d761263851cbc8ff3b18e7c3bd81dcd64979fc77e568471810b84b3332ff"
     }
   ]
 }

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784138619Z",
-  "repo_signal_fingerprint": "e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266",
+  "generated_at": "1784139367Z",
+  "repo_signal_fingerprint": "7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "542aba2a4b24723e07eaae7805a0e85f0ad45736ec5d029e1ee44e3cd92091ea",
+  "spec_input_hash": "f920972ac687b036446ca6f29901f26aa9ace31cba52eb83d589a7edf0d5a37d",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "9da1387d9c93122e3c8ee91d89a1c6a7a8d620d8b0599e4435bcb6ebd1ccaf52"
+      "content_hash": "917f77e516579d7e171068e922a9c4f285f35dcdd452e9b0c0955dc88e746077"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "fafdad02da1c20429d64812ad4bb25074ba6e20748de072d53dd2b3780acf47f"
+      "content_hash": "335c491490fc4a88c12e8a8799210524d4c6adc843f93449b8c004b074a5e84b"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "90b25178d5b2712e73452aa8c8703a8e36d78b27cefc627e1dd6e1a00a5c798e"
+      "content_hash": "7175a0b6bff3106ffccb54741505ab4ce205241ea65d08f09a5d3e98849c51e7"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "c129de040a54918939a4b821ac72ad72ae3b0ee165c0a79bf86552f6515ed876"
+      "content_hash": "5f6f859857383ded52a4c284ecf3562e0ba400e38dfcbcce9c86c02f61e9f85f"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "0e33b575aec125618bf47e7a3f74fc358bcb22a235517e5f21c9f31a33364dc9"
+      "content_hash": "019d29a87bc550c21f42abf6af4522f841b6a998958edc2c3bc46ad7b8e6efda"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "b79b5faf48548e404ac595984d17542d8a99e37af363b2cd914829ae257269e2"
+      "content_hash": "bdbf7b4b00243daf78227b202b8d59a0ee57c9b5f530f7a325adea01af99e91d"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "6c2a7256397f8f9237b0869a03d2093ce617bc2175659d36ceaf463dcbacce4d"
+      "content_hash": "24b312877a815e2455d89b9332d89f1361fe2e15a12389509f3ac65afb827af2"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "b529d761263851cbc8ff3b18e7c3bd81dcd64979fc77e568471810b84b3332ff"
+      "content_hash": "71d5da9421563415ea5fe3822f20ac76d6467114f87ee317e1c34e58ffc285f6"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
+- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `61d756c89fd73498853175acdead882e6c30e192dbdd75fe64029f7e199f1426`
+- Repository signal fingerprint: `e247eca10b4b2de2393c17bc0d74c5b288da68f0de70e179618989f45f493266`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1049,6 +1049,105 @@ pub struct PublishResult {
     pub pr_url: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublishRemote {
+    name: String,
+    url: String,
+}
+
+fn is_network_remote_url(url: &str) -> bool {
+    let trimmed = url.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('/')
+        || trimmed.starts_with("./")
+        || trimmed.starts_with("../")
+        || trimmed.starts_with("file://")
+    {
+        return false;
+    }
+
+    trimmed.contains("://") || trimmed.starts_with("git@")
+}
+
+fn github_repo_slug(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/').trim_end_matches(".git");
+    let path = if let Some(path) = trimmed.strip_prefix("git@github.com:") {
+        path
+    } else if let Some(path) = trimmed.strip_prefix("https://github.com/") {
+        path
+    } else if let Some(path) = trimmed.strip_prefix("http://github.com/") {
+        path
+    } else if let Some(path) = trimmed.strip_prefix("ssh://git@github.com/") {
+        path
+    } else {
+        return None;
+    };
+
+    let mut parts = path.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+fn resolve_publish_remote(repo_root: &Path) -> Result<PublishRemote, DecapodError> {
+    let dir = repo_root.to_str().unwrap_or(".");
+    let remotes = Command::new("git")
+        .args(["-C", dir, "remote"])
+        .output()
+        .map_err(DecapodError::IoError)?;
+    if !remotes.status.success() {
+        return Err(DecapodError::ValidationError(format!(
+            "Cannot inspect git remotes: {}",
+            String::from_utf8_lossy(&remotes.stderr).trim()
+        )));
+    }
+
+    let remote_names = String::from_utf8_lossy(&remotes.stdout);
+    let names: Vec<&str> = remote_names
+        .lines()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .collect();
+
+    let mut candidates = Vec::new();
+    for name in names {
+        let mut remote = Command::new("git")
+            .args(["-C", dir, "remote", "get-url", "--push", name])
+            .output()
+            .map_err(DecapodError::IoError)?;
+        if !remote.status.success() {
+            remote = Command::new("git")
+                .args(["-C", dir, "remote", "get-url", name])
+                .output()
+                .map_err(DecapodError::IoError)?;
+        }
+        if !remote.status.success() {
+            continue;
+        }
+        let url = String::from_utf8_lossy(&remote.stdout).trim().to_string();
+        if is_network_remote_url(&url) {
+            candidates.push(PublishRemote {
+                name: name.to_string(),
+                url,
+            });
+        }
+    }
+
+    candidates
+        .iter()
+        .find(|remote| remote.name == "origin")
+        .cloned()
+        .or_else(|| candidates.into_iter().next())
+        .ok_or_else(|| {
+            DecapodError::ValidationError(
+                "Cannot publish: no network-capable git remote is configured. The workspace may inherit a local-clone origin; add the upstream GitHub remote before retrying, for example: git remote add upstream git@github.com:OWNER/REPO.git. No commit was pushed.".to_string(),
+            )
+        })
+}
+
 /// Publish workspace changes: commit, push, and optionally create a PR
 pub fn publish_workspace(
     repo_root: &Path,
@@ -1082,6 +1181,11 @@ pub fn publish_workspace(
     }
     verify_workunit_gate_for_publish(repo_root, &status.git.current_branch)?;
     eval::verify_eval_gate_for_publish(&repo_root.join(".decapod").join("data"))?;
+
+    // Resolve the actual network remote before committing. Decapod-created
+    // worktrees can inherit a local-clone origin, which must never be
+    // treated as publication to the upstream GitHub repository.
+    let publish_remote = resolve_publish_remote(repo_root)?;
 
     let dir = repo_root.to_str().unwrap_or(".");
 
@@ -1125,14 +1229,14 @@ pub fn publish_workspace(
         .trim()
         .to_string();
 
-    // 3. Push branch to origin
+    // 3. Push branch to the selected network remote.
     let push_output = Command::new("git")
         .args([
             "-C",
             dir,
             "push",
             "-u",
-            "origin",
+            &publish_remote.name,
             &status.git.current_branch,
         ])
         .output()
@@ -1144,14 +1248,7 @@ pub fn publish_workspace(
         )));
     }
 
-    // Get remote URL
-    let remote_output = Command::new("git")
-        .args(["-C", dir, "remote", "get-url", "origin"])
-        .output()
-        .map_err(DecapodError::IoError)?;
-    let remote_url = String::from_utf8_lossy(&remote_output.stdout)
-        .trim()
-        .to_string();
+    let remote_url = publish_remote.url.clone();
 
     // 4. If gh CLI is available, create a PR
     let pr_url = if Command::new("gh")
@@ -1171,6 +1268,11 @@ pub fn publish_workspace(
             "--head",
             &status.git.current_branch,
         ];
+        let repo_slug = github_repo_slug(&publish_remote.url);
+        if let Some(slug) = repo_slug.as_deref() {
+            pr_args.push("--repo");
+            pr_args.push(slug);
+        }
         let desc;
         if let Some(ref d) = description {
             desc = d.clone();
@@ -1544,6 +1646,21 @@ pub fn prune_workspaces(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command should start");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn test_extract_task_ids_from_branch() {
@@ -1575,5 +1692,61 @@ mod tests {
             extract_task_ids_from_branch("agent/unknown/some-feature-branch"),
             Vec::<String>::new()
         );
+    }
+
+    #[test]
+    fn test_resolve_publish_remote_skips_local_clone_origin() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(
+            tmp.path(),
+            &["remote", "add", "origin", "/tmp/decapod-root-clone"],
+        );
+        git(
+            tmp.path(),
+            &[
+                "remote",
+                "add",
+                "upstream",
+                "git@github.com:DecapodLabs/decapod.git",
+            ],
+        );
+
+        let remote = resolve_publish_remote(tmp.path()).expect("network remote");
+        assert_eq!(
+            remote,
+            PublishRemote {
+                name: "upstream".to_string(),
+                url: "git@github.com:DecapodLabs/decapod.git".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_resolve_publish_remote_fails_closed_without_network_remote() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(
+            tmp.path(),
+            &["remote", "add", "origin", "/tmp/decapod-root-clone"],
+        );
+
+        let error = resolve_publish_remote(tmp.path()).expect_err("local remote must not publish");
+        let message = error.to_string();
+        assert!(message.contains("no network-capable git remote"));
+        assert!(message.contains("No commit was pushed"));
+    }
+
+    #[test]
+    fn test_github_repo_slug_supports_common_remote_forms() {
+        assert_eq!(
+            github_repo_slug("git@github.com:DecapodLabs/decapod.git"),
+            Some("DecapodLabs/decapod".to_string())
+        );
+        assert_eq!(
+            github_repo_slug("https://github.com/DecapodLabs/decapod.git"),
+            Some("DecapodLabs/decapod".to_string())
+        );
+        assert_eq!(github_repo_slug("/tmp/decapod-root-clone"), None);
     }
 }

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1077,10 +1077,8 @@ fn github_repo_slug(url: &str) -> Option<String> {
         path
     } else if let Some(path) = trimmed.strip_prefix("http://github.com/") {
         path
-    } else if let Some(path) = trimmed.strip_prefix("ssh://git@github.com/") {
-        path
     } else {
-        return None;
+        trimmed.strip_prefix("ssh://git@github.com/")?
     };
 
     let mut parts = path.split('/');


### PR DESCRIPTION
## Summary

- Fixes #758.
- Resolves a network-capable publication remote before committing or pushing.
- Skips a local-clone origin and selects an upstream network remote when one is configured.
- Fails closed with an actionable remediation when no network remote exists, so local pushes cannot be mistaken for GitHub publication.
- Passes the selected GitHub repository explicitly to gh pr create.
- Adds regression coverage for local-origin selection, fail-closed behavior, and GitHub remote parsing.

## Correlated issues

- #832 is the related custody-boundary issue; its root-claim/worktree-completion path was reproduced against current master and is already passing.
- #736 and #773 are adjacent PR workflow issues. This PR makes publication remote selection explicit; merge-conflict detection and persisted base-branch detection remain separate follow-ups.

## Proof

- cargo fmt --check
- cargo check --lib
- cargo test --lib core::workspace::tests -- --nocapture (4 passed)
- git diff --check
- DECAPOD_CONTAINER=1 decapod validate --format json (198 passed, 0 failed)
