### PR TITLE
feat: record evidence-bearing handshake identities

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.5
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.6
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.5
+ARG DECAPOD_VERSION=0.66.6
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784139367Z",
-  "repo_signal_fingerprint": "7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69",
+  "generated_at": "1784142348Z",
+  "repo_signal_fingerprint": "9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "f920972ac687b036446ca6f29901f26aa9ace31cba52eb83d589a7edf0d5a37d",
+  "spec_input_hash": "195478afbd5da965a22e9af8ef9740995da2ae3e53d0fafce4fe7cad5c8185af",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "917f77e516579d7e171068e922a9c4f285f35dcdd452e9b0c0955dc88e746077"
+      "content_hash": "a26387f0e436fe57e5e0dcd3ae789c11f091b5e65cc1a78e844fa1e22ce7f841"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "335c491490fc4a88c12e8a8799210524d4c6adc843f93449b8c004b074a5e84b"
+      "content_hash": "42244fb1290d872046288b18e5297fd6d8c48d024d9ccdf0aa9455b03eb23b76"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "7175a0b6bff3106ffccb54741505ab4ce205241ea65d08f09a5d3e98849c51e7"
+      "content_hash": "fbbd0afe25befaff97d2d9d262403966c74d6066475b04fc858abc78ce0b9cc1"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "5f6f859857383ded52a4c284ecf3562e0ba400e38dfcbcce9c86c02f61e9f85f"
+      "content_hash": "8079dd13ab28feb6c40a316716fd4feadfdaf8ddd2fd04fe9d02b1af2f7a1cf8"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "019d29a87bc550c21f42abf6af4522f841b6a998958edc2c3bc46ad7b8e6efda"
+      "content_hash": "bbee5d3dcc432995b70ec12dc61e4f270dbab2481acbb2b4a1887430a8c07a93"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "bdbf7b4b00243daf78227b202b8d59a0ee57c9b5f530f7a325adea01af99e91d"
+      "content_hash": "d8641206e5c57079efd1c5c976296cf0b6bf74f6ed2b29474b15bbb787491354"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "24b312877a815e2455d89b9332d89f1361fe2e15a12389509f3ac65afb827af2"
+      "content_hash": "c66be5dc35570cab8ca81a07eb4f4d93cba7ccf7a5a4952cef85f52a825e752c"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "71d5da9421563415ea5fe3822f20ac76d6467114f87ee317e1c34e58ffc285f6"
+      "content_hash": "80ec629c9f0c057cf7ec0fdc5e0577b18b375ee09d4d50192af0513d4d757b44"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7fbdd7877e5efa44430affe88184d6e33f7f4b07e52c259e3ce83b75a95ffe69`
+- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/docs/agent/mcp.md
+++ b/docs/agent/mcp.md
@@ -8,4 +8,6 @@ MCP adapters remain a planned integration surface. An adapter may map MCP resour
 
 `decapod handshake` records local declarations, scope, proof declarations, document hashes, and a deterministic artifact hash. The hash makes the recorded data tamper-evident; it does not authenticate a model provider, harness, binary, human principal, or organization.
 
+Handshake records also expose identity-adjacent values as `identity_assertions`. Each assertion keeps the claim kind, subject type, asserted value, evidence class, scope, lifecycle fields, authority/verifier slots, verification method, and claim-specific result together. Environment-provided agent and provider values are recorded as `self-declared` with an `unverified` result; they are not promoted to authenticated identity without a configured trust root.
+
 The local session credential establishes repository-local custody and correlation for the current session. It must not be described as provider authentication.

--- a/docs/book/src/concepts/mcp.md
+++ b/docs/book/src/concepts/mcp.md
@@ -8,4 +8,6 @@ MCP support is an adapter boundary tracked separately from the current runtime. 
 
 `decapod handshake` records local declarations, scope, proof declarations, document hashes, and a deterministic artifact hash. That hash provides tamper-evident integrity for the recorded handshake data; it does not authenticate a model provider, harness, binary, human principal, or organization.
 
+The handshake’s `identity_assertions` preserve identity claims separately from verification. An assertion carries its claim kind, subject type, value, evidence class, scope, lifecycle, authority/verifier slots, method, and result. Environment-provided agent and provider values are `self-declared` and `unverified` unless a configured trust root establishes stronger evidence.
+
 The repository-local session credential establishes local custody and correlation for the current session. It is not external provider authentication. See [Identity and provenance](https://github.com/DecapodLabs/decapod/issues/876) and [the interoperability profile](https://github.com/DecapodLabs/decapod/issues/870) for the boundaries future adapters must preserve.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3254,12 +3254,112 @@ struct HandshakeArtifact {
     schema_version: String,
     request_id: String,
     agent_id: String,
+    identity_assertions: Vec<IdentityAssertion>,
     repo_version: String,
     scope: String,
     proofs: Vec<String>,
     declared_docs: Vec<String>,
     doc_hashes: serde_json::Value,
     artifact_hash: String,
+}
+
+/// Evidence-bearing identity claims recorded by the local handshake.
+///
+/// These fields deliberately model what was claimed separately from what a
+/// verifier accepted. A local environment declaration is useful for
+/// correlation, but it is not provider, principal, or organization
+/// authentication without an external trust root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct IdentityAssertion {
+    claim_kind: String,
+    subject_type: String,
+    asserted_value: String,
+    evidence_class: String,
+    authority: Option<String>,
+    verifier: Option<String>,
+    scope: String,
+    issued_at_epoch_secs: u64,
+    expires_at_epoch_secs: Option<u64>,
+    revocation: Option<String>,
+    verification_method: String,
+    verification_result: String,
+}
+
+fn build_identity_assertions(
+    agent_id: &str,
+    provider: Option<&str>,
+    scope: &str,
+    issued_at_epoch_secs: u64,
+) -> Vec<IdentityAssertion> {
+    let mut assertions = vec![IdentityAssertion {
+        claim_kind: "agent_id".to_string(),
+        subject_type: "agent".to_string(),
+        asserted_value: agent_id.to_string(),
+        evidence_class: "self-declared".to_string(),
+        authority: None,
+        verifier: None,
+        scope: scope.to_string(),
+        issued_at_epoch_secs,
+        expires_at_epoch_secs: None,
+        revocation: None,
+        verification_method: "environment declaration".to_string(),
+        verification_result: "unverified".to_string(),
+    }];
+
+    if let Some(provider) = provider.map(str::trim).filter(|value| !value.is_empty()) {
+        assertions.push(IdentityAssertion {
+            claim_kind: "agent_provider".to_string(),
+            subject_type: "model_provider".to_string(),
+            asserted_value: provider.to_string(),
+            evidence_class: "self-declared".to_string(),
+            authority: None,
+            verifier: None,
+            scope: scope.to_string(),
+            issued_at_epoch_secs,
+            expires_at_epoch_secs: None,
+            revocation: None,
+            verification_method: "environment declaration".to_string(),
+            verification_result: "unverified".to_string(),
+        });
+    }
+
+    assertions
+}
+
+#[cfg(test)]
+mod handshake_identity_tests {
+    use super::build_identity_assertions;
+
+    #[test]
+    fn records_agent_and_provider_as_separate_unverified_claims() {
+        let assertions =
+            build_identity_assertions("agent/codex", Some("example-provider"), "task-123", 42);
+
+        assert_eq!(assertions.len(), 2);
+        assert_eq!(assertions[0].claim_kind, "agent_id");
+        assert_eq!(assertions[0].subject_type, "agent");
+        assert_eq!(assertions[0].asserted_value, "agent/codex");
+        assert_eq!(assertions[1].claim_kind, "agent_provider");
+        assert_eq!(assertions[1].subject_type, "model_provider");
+        assert_eq!(assertions[1].asserted_value, "example-provider");
+
+        for assertion in assertions {
+            assert_eq!(assertion.evidence_class, "self-declared");
+            assert_eq!(assertion.verification_result, "unverified");
+            assert_eq!(assertion.scope, "task-123");
+            assert_eq!(assertion.issued_at_epoch_secs, 42);
+            assert!(assertion.authority.is_none());
+            assert!(assertion.verifier.is_none());
+        }
+    }
+
+    #[test]
+    fn omits_an_empty_provider_claim() {
+        let assertions = build_identity_assertions("agent/codex", Some("  "), "task-123", 42);
+
+        assert_eq!(assertions.len(), 1);
+        assert_eq!(assertions[0].claim_kind, "agent_id");
+    }
 }
 
 fn hash_bytes_hex(input: &[u8]) -> String {
@@ -3311,10 +3411,15 @@ fn build_handshake_artifact(
     }
 
     let request_id = crate::core::ulid::new_ulid();
+    let agent_id = current_agent_id();
+    let provider = std::env::var("DECAPOD_AGENT_PROVIDER").ok();
+    let identity_assertions =
+        build_identity_assertions(&agent_id, provider.as_deref(), scope, now_epoch_secs());
     let mut unsigned = serde_json::json!({
         "schema_version": "1.0.0",
         "request_id": request_id,
-        "agent_id": current_agent_id(),
+        "agent_id": agent_id,
+        "identity_assertions": identity_assertions,
         "repo_version": migration::DECAPOD_VERSION,
         "scope": scope,
         "proofs": proofs,


### PR DESCRIPTION
## Summary

Addresses #876 with a first local provenance slice: handshake records now keep identity claims separate from verification results.

- Adds explicit identity_assertions for agent and provider claims.
- Records claim kind, subject type, asserted value, evidence class, scope, lifecycle fields, authority and verifier slots, method, and result.
- Keeps environment-derived values self-declared and unverified; no provider, human, harness, binary, or organization authentication is implied.
- Preserves the existing top-level agent_id for compatibility.
- Updates agent and book documentation and refreshes living specs.

## Correlated issues

- #861: portable provenance can carry these evidence-bearing claims without importing authority; receiver-side trust policy and signatures remain future work.
- #870: establishes a versioned-profile-ready assertion shape without defining the full interoperability profile.
- #872, #873, #874: gives future MCP, A2A, and authenticated HTTP adapters a shared claim-versus-verification boundary; this PR does not add those transports.

## Proof

- cargo test --lib handshake_identity_tests -- --nocapture (2 passed)
- cargo test --test doc_alignment -- --nocapture (3 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check
- DECAPOD_CONTAINER=1 decapod validate --format json (198 passed, 0 failed)

The full library suite currently has one pre-existing base-branch failure in core::capabilities::tests::built_in_overlays_do_not_select_universal_service_levels; the new tests and changed surfaces pass.