### PR TITLE
fix: explain stable validation proof failures

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.6
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.7
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.6
+ARG DECAPOD_VERSION=0.66.7
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784142348Z",
-  "repo_signal_fingerprint": "9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5",
+  "generated_at": "1784147016Z",
+  "repo_signal_fingerprint": "84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "195478afbd5da965a22e9af8ef9740995da2ae3e53d0fafce4fe7cad5c8185af",
+  "spec_input_hash": "586a19933308a705cf890d22041d2aa6cc40e3f8afc0ad1258ce497c352fd705",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "a26387f0e436fe57e5e0dcd3ae789c11f091b5e65cc1a78e844fa1e22ce7f841"
+      "content_hash": "b881d0fc918dd747393efd2247e355ac0614520d2ac0ecfbcd1d4f9d2f3d2d33"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "42244fb1290d872046288b18e5297fd6d8c48d024d9ccdf0aa9455b03eb23b76"
+      "content_hash": "50c08e3fc5bd0bae55d1f37b1c939aa4d6f57c47f02f145453ab5953f5b8cc84"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "fbbd0afe25befaff97d2d9d262403966c74d6066475b04fc858abc78ce0b9cc1"
+      "content_hash": "384694a5b26d8c5f2533e07a19e3f8da07035654e1bd475d66faea47983a6cb1"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "8079dd13ab28feb6c40a316716fd4feadfdaf8ddd2fd04fe9d02b1af2f7a1cf8"
+      "content_hash": "ee1eaa0c1e0684dac369a63a605d04d0868c3f091b147d0ae3b9916be637baa2"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "bbee5d3dcc432995b70ec12dc61e4f270dbab2481acbb2b4a1887430a8c07a93"
+      "content_hash": "660de406fa08d6f701d5b947540531eca78ba74a5a1762454c8d4849472f5ed9"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "d8641206e5c57079efd1c5c976296cf0b6bf74f6ed2b29474b15bbb787491354"
+      "content_hash": "2d5cc7bd894e849ff44970d0eff282581d4255c26b8af342c4651588a5d5b69e"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "c66be5dc35570cab8ca81a07eb4f4d93cba7ccf7a5a4952cef85f52a825e752c"
+      "content_hash": "819a95ed68ff1aad90cdcb9a8361bee272848603befae3bfaf47457090e6f2dc"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "80ec629c9f0c057cf7ec0fdc5e0577b18b375ee09d4d50192af0513d4d757b44"
+      "content_hash": "681357420c7a4fb9a6fe01d41496d8fd5084ecd72220545c00ce00f9c4543474"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9c2efd005952fba51a85a3e776db87799a8550024d3d7e2512a10da9c065d3b5`
+- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -149,6 +149,16 @@ fn epoch_secs(ts: &str) -> Option<i64> {
     ts.trim_end_matches('Z').parse::<i64>().ok()
 }
 
+fn validation_proof_reason(validate_ok: bool, hashes_match: bool) -> &'static str {
+    if !validate_ok && hashes_match {
+        "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked"
+    } else if !validate_ok {
+        "decapod validate did not pass"
+    } else {
+        "validate output hash changed"
+    }
+}
+
 fn normalize_validate_output(raw: &str) -> String {
     let ansi = Regex::new(r"\x1B\[[0-9;]*[A-Za-z]").expect("valid ANSI regex");
     let elapsed_re = Regex::new(r" elapsed=\S+").expect("valid elapsed regex");
@@ -604,24 +614,16 @@ fn verify_target(
         let (validate_ok, actual_hash) =
             run_validate_and_hash(store_root, repo_root, Some(&target.todo_id))?;
         let expected = expected_hash.unwrap_or_default();
+        let hashes_match = actual_hash == expected;
 
-        if !validate_ok {
+        if !validate_ok || !hashes_match {
             result.status = "fail".to_string();
             result.proofs.push(ProofCheckResult {
                 gate: "validate_passes".to_string(),
                 status: "fail".to_string(),
                 expected_output_hash: Some(expected),
                 actual_output_hash: Some(actual_hash),
-                reason: Some("decapod validate did not pass".to_string()),
-            });
-        } else if actual_hash != expected {
-            result.status = "fail".to_string();
-            result.proofs.push(ProofCheckResult {
-                gate: "validate_passes".to_string(),
-                status: "fail".to_string(),
-                expected_output_hash: Some(expected),
-                actual_output_hash: Some(actual_hash),
-                reason: Some("validate output hash changed".to_string()),
+                reason: Some(validation_proof_reason(validate_ok, hashes_match).to_string()),
             });
         } else {
             result.proofs.push(ProofCheckResult {
@@ -1128,6 +1130,9 @@ pub fn run_verify_cli(
                         p.expected_output_hash.as_deref().unwrap_or("n/a"),
                         p.actual_output_hash.as_deref().unwrap_or("n/a")
                     );
+                    if let Some(reason) = &p.reason {
+                        println!("    reason: {reason}");
+                    }
                 }
             }
             for a in &r.artifacts {
@@ -1170,4 +1175,33 @@ pub fn run_verify_cli(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validation_proof_reason;
+
+    #[test]
+    fn stable_failed_validation_remains_blocked_with_explicit_reason() {
+        assert_eq!(
+            validation_proof_reason(false, true),
+            "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked"
+        );
+    }
+
+    #[test]
+    fn failed_validation_with_changed_output_reports_validation_failure() {
+        assert_eq!(
+            validation_proof_reason(false, false),
+            "decapod validate did not pass"
+        );
+    }
+
+    #[test]
+    fn passing_validation_with_changed_output_reports_hash_drift() {
+        assert_eq!(
+            validation_proof_reason(true, false),
+            "validate output hash changed"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Addresses #816.

`qa verify` currently reports identical expected and actual validation hashes without explaining that `decapod validate` itself failed. This patch keeps that proof blocked, but makes the distinction explicit:

- failed validation with unchanged output says the baseline is stable but verification remains blocked;
- failed validation with changed output says validation did not pass;
- passing validation with changed output continues to report hash drift;
- text reports now print the proof reason.

This advances the recovery diagnostics requested by #708. It is related to the custody and context boundaries in #832 and #774, but does not change their root or worktree detection logic.

## Verification

Repository CI is green, including `validate`, Clippy, format, contract conformance, daemonless, chaos replay, RPC, and all selective test suites.

Local focused proof:

- `cargo fmt --check`
- `cargo test --lib plugins::verify::tests -- --nocapture` — 3 passed
- `cargo clippy --all-targets --all-features -- -D warnings`

The implementation deliberately does not treat equal hashes as proof of a passing validation, because that could promote a stable failed baseline. Local Decapod validation remains blocked only by worktree proof-state replay and a pre-existing unrelated claimed-but-unverified TODO; the clean CI validation gate passes.