### PR TITLE
fix: detect and honor repository base branch

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784147016Z",
-  "repo_signal_fingerprint": "84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6",
+  "generated_at": "1784148950Z",
+  "repo_signal_fingerprint": "7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "586a19933308a705cf890d22041d2aa6cc40e3f8afc0ad1258ce497c352fd705",
+  "spec_input_hash": "0cd719c2f9acc1833d26e30f82fd2f1df42637afebfffa48e2a4744ead3addbb",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "b881d0fc918dd747393efd2247e355ac0614520d2ac0ecfbcd1d4f9d2f3d2d33"
+      "content_hash": "a60433238e095447354539a031d9f41f7464e98f1771c9450345c3bc9b81b1b9"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "50c08e3fc5bd0bae55d1f37b1c939aa4d6f57c47f02f145453ab5953f5b8cc84"
+      "content_hash": "7dd57bd2c99e2bddc51be5f19287b5855ccb9ad4a69bcd21f8f1e551a5d25943"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "384694a5b26d8c5f2533e07a19e3f8da07035654e1bd475d66faea47983a6cb1"
+      "content_hash": "c9f01bbb9ec81c10cd15043609de8616240005f83ad15e76189fbc3c94278abf"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "ee1eaa0c1e0684dac369a63a605d04d0868c3f091b147d0ae3b9916be637baa2"
+      "content_hash": "523581958ef005821d190bf6d65263f9cbe1721f9e32730de4a95cf232c18653"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "660de406fa08d6f701d5b947540531eca78ba74a5a1762454c8d4849472f5ed9"
+      "content_hash": "5dd0e7e864a6dd189d126fb6979c86eeefcedbe014ba5a90deb7144b06f55241"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "2d5cc7bd894e849ff44970d0eff282581d4255c26b8af342c4651588a5d5b69e"
+      "content_hash": "b1907d126c55e8c0fe59be7aeb89941c3bc9f9f6d633ce620db259198054c51c"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "819a95ed68ff1aad90cdcb9a8361bee272848603befae3bfaf47457090e6f2dc"
+      "content_hash": "30ad34a8e622dd89df9c71cba1a2a1151672f26ea762f49dddaa97b891b98d39"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "681357420c7a4fb9a6fe01d41496d8fd5084ecd72220545c00ce00f9c4543474"
+      "content_hash": "3a92ce6cfae0dd21dd4dc2772c1b058d6348379cd9954d529cee4745d81a7934"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `84e40608e58f20cdb18803330562c40d52eec63d810f8115b60142fc815fd9e6`
+- Repository signal fingerprint: `7354a225b9c74d23c57b625a53ff9f4b5f0679474155f5a002c0f95ce5b45f35`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -375,6 +375,9 @@ pub struct RepoContext {
     pub product_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub done_criteria: Option<String>,
+    /// Repository base branch used for isolated workspaces and publication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub primary_languages: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -824,6 +824,57 @@ fn is_branch_protected(branch: &str) -> bool {
     false
 }
 
+/// Detect the repository's base branch from local Git metadata.
+///
+/// `origin/HEAD` is the strongest local signal because it is set from the
+/// remote's advertised default branch. A protected checked-out branch and
+/// existing local main/master refs provide deterministic offline fallbacks.
+pub fn detect_base_branch(repo_root: &Path) -> Option<String> {
+    let symbolic_head = Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| clean_branch_name(String::from_utf8_lossy(&output.stdout).trim()).to_string())
+        .filter(|branch| !branch.is_empty());
+    if symbolic_head.is_some() {
+        return symbolic_head;
+    }
+
+    let current_branch = get_current_branch(repo_root).ok();
+    if let Some(branch) = current_branch.filter(|branch| is_branch_protected(branch)) {
+        return Some(branch);
+    }
+
+    for branch in ["main", "master"] {
+        let reference = format!("refs/heads/{branch}");
+        let exists = Command::new("git")
+            .args([
+                "-C",
+                repo_root.to_str().unwrap_or("."),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                &reference,
+            ])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        if exists {
+            return Some(branch.to_string());
+        }
+    }
+
+    None
+}
+
 fn clean_branch_name(name: &str) -> &str {
     let mut s = name.trim();
     if s.starts_with('*') {
@@ -1690,6 +1741,41 @@ mod tests {
             extract_task_ids_from_branch("agent/unknown/some-feature-branch"),
             Vec::<String>::new()
         );
+    }
+
+    #[test]
+    fn detects_remote_default_base_branch() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(tmp.path(), &["config", "user.email", "test@test.com"]);
+        git(tmp.path(), &["config", "user.name", "Test"]);
+        std::fs::write(tmp.path().join("README.md"), "# project\n").expect("write readme");
+        git(tmp.path(), &["add", "README.md"]);
+        git(tmp.path(), &["commit", "-m", "initial"]);
+        git(tmp.path(), &["branch", "-M", "main"]);
+        git(
+            tmp.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/project.git",
+            ],
+        );
+        git(
+            tmp.path(),
+            &["update-ref", "refs/remotes/origin/main", "HEAD"],
+        );
+        git(
+            tmp.path(),
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+            ],
+        );
+
+        assert_eq!(detect_base_branch(tmp.path()).as_deref(), Some("main"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ fn infer_repo_context(target_dir: &Path) -> Result<RepoContext, error::DecapodEr
             .file_name()
             .and_then(|s| s.to_str())
             .map(|s| s.to_string()),
+        base_branch: workspace::detect_base_branch(target_dir),
         ..RepoContext::default()
     };
 
@@ -1955,10 +1956,15 @@ pub fn run() -> Result<(), error::DecapodError> {
             } else {
                 resolve_existing_init_dir(&current_dir)?
             };
+            let configured_base_branch = load_project_config_if_present(&init_target)?
+                .and_then(|config| config.repo.base_branch);
             let mut init_with = init_with;
             init_with.dir = Some(init_target.clone());
             init_with.project_dir = None;
             let mut repo_ctx = infer_repo_context(&init_target)?;
+            if configured_base_branch.is_some() {
+                repo_ctx.base_branch = configured_base_branch;
+            }
             apply_repo_context_env_overrides(&mut repo_ctx);
             apply_repo_context_cli_overrides(&mut repo_ctx, &init_with);
             if repo_ctx.mode == crate::cli::BackendType::Cloud

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -2,6 +2,7 @@ use crate::core::container_runtime;
 use crate::core::error;
 use crate::core::store::Store;
 use crate::core::time;
+use crate::core::workspace;
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::json;
@@ -44,8 +45,8 @@ pub enum ContainerCommand {
         push: bool,
         #[clap(long, default_value_t = false)]
         pr: bool,
-        #[clap(long, default_value = "master")]
-        pr_base: String,
+        #[clap(long)]
+        pr_base: Option<String>,
         #[clap(long)]
         pr_title: Option<String>,
         #[clap(long)]
@@ -167,7 +168,7 @@ pub fn run_container_cli(store: &Store, cli: ContainerCli) -> Result<(), error::
             task_id.as_deref(),
             push,
             pr,
-            &pr_base,
+            pr_base.as_deref(),
             pr_title.as_deref(),
             pr_body.as_deref(),
             image_profile,
@@ -221,7 +222,7 @@ pub fn run_container_for_claim(
         Some(task_id),
         push,
         pr,
-        "master",
+        None,
         pr_title.as_deref(),
         pr_body.as_deref(),
         ImageProfile::DebianSlim,
@@ -249,7 +250,7 @@ fn run_container(
     task_id: Option<&str>,
     push: bool,
     pr: bool,
-    pr_base: &str,
+    pr_base: Option<&str>,
     pr_title: Option<&str>,
     pr_body: Option<&str>,
     image_profile: ImageProfile,
@@ -293,7 +294,8 @@ Agent must clear the disable marker through Decapod self-heal before retrying.",
     let branch_name = branch
         .map(|s| s.to_string())
         .unwrap_or_else(|| default_branch_name(agent, task_id));
-    let workspace = prepare_workspace_clone(&repo, &branch_name, pr_base)?;
+    let base_branch = resolve_base_branch(&repo, pr_base);
+    let workspace = prepare_workspace_clone(&repo, &branch_name, &base_branch)?;
 
     let spec = build_docker_spec(
         &docker,
@@ -418,6 +420,20 @@ Agent must clear the disable marker through Decapod self-heal before retrying.",
     }
 
     Ok(RunSummary { value: summary })
+}
+
+fn resolve_base_branch(repo_root: &Path, explicit: Option<&str>) -> String {
+    explicit
+        .filter(|branch| !branch.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            crate::cli::DecapodProjectConfig::load(repo_root)
+                .ok()
+                .and_then(|config| config.repo.base_branch)
+                .filter(|branch| !branch.trim().is_empty())
+        })
+        .or_else(|| workspace::detect_base_branch(repo_root))
+        .unwrap_or_else(|| "master".to_string())
 }
 
 fn execute_container_with_timeout(
@@ -1652,6 +1668,20 @@ mod tests {
     fn default_branch_name_includes_agent_and_task() {
         let branch = default_branch_name("Agent_One", Some("R_ABC-123"));
         assert_eq!(branch, "agent/agent-one/r-abc-123");
+    }
+
+    #[test]
+    fn configured_base_branch_is_used_when_cli_override_is_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".decapod")).expect("config dir");
+        std::fs::write(
+            tmp.path().join(".decapod/config.toml"),
+            "schema_version = \"1.0.0\"\n\n[init]\nspecs = true\nci = true\ndiagram_style = \"ascii\"\nentrypoints = []\n\n[repo]\nbase_branch = \"main\"\n",
+        )
+        .expect("write config");
+
+        assert_eq!(resolve_base_branch(tmp.path(), None), "main");
+        assert_eq!(resolve_base_branch(tmp.path(), Some("release")), "release");
     }
 
     #[test]

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -10,6 +10,66 @@ fn run_decapod(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
         .expect("run decapod")
 }
 
+fn run_git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn init_persists_remote_default_base_branch() {
+    let tmp = tempdir().expect("tempdir");
+    run_git(tmp.path(), &["init", "-q"]);
+    run_git(tmp.path(), &["config", "user.email", "test@test.com"]);
+    run_git(tmp.path(), &["config", "user.name", "Test"]);
+    fs::write(tmp.path().join("README.md"), "# project\n").expect("write readme");
+    run_git(tmp.path(), &["add", "README.md"]);
+    run_git(tmp.path(), &["commit", "-m", "initial"]);
+    run_git(tmp.path(), &["branch", "-M", "main"]);
+    run_git(
+        tmp.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:example/project.git",
+        ],
+    );
+    run_git(
+        tmp.path(),
+        &["update-ref", "refs/remotes/origin/main", "HEAD"],
+    );
+    run_git(
+        tmp.path(),
+        &[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+        ],
+    );
+
+    let out = run_decapod(tmp.path(), &["init", "with", "--force"]);
+    assert!(
+        out.status.success(),
+        "decapod init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let config =
+        fs::read_to_string(tmp.path().join(".decapod/config.toml")).expect("read config.toml");
+    assert!(
+        config.contains("base_branch = \"main\""),
+        "init should persist the remote default branch: {config}"
+    );
+}
+
 #[test]
 fn init_with_backend_cloud_saves_to_config() {
     let tmp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

Addresses #773 and advances the pre-PR safety concern in #736.

Decapod now detects the repository base branch from local Git metadata, preferring `origin/HEAD`, then a protected checked-out branch, then local `main` or `master` refs. Fresh `decapod init` persists the result as `repo.base_branch` while refreshes preserve an existing user-edited value.

Container execution now uses the configured or detected base branch for workspace cloning and PR creation. An explicit `--pr-base` remains the highest-precedence override. The claim-triggered container path no longer hardcodes `master`.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted base-branch detection, container resolution, and init persistence tests pass
- full `cargo test --lib`: 138 passed; one pre-existing unrelated capabilities assertion fails in `core::capabilities::tests::built_in_overlays_do_not_select_universal_service_levels`
- generated specs refreshed via `decapod rpc --op specs.refresh`

The fallback remains `master` only when no local branch metadata is available, preserving compatibility for repositories that have not been initialized or fetched.