### PR TITLE
fix: make validation recovery and publication base-safe

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784154099Z",
-  "repo_signal_fingerprint": "3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f",
+  "generated_at": "1784156275Z",
+  "repo_signal_fingerprint": "bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "34e3eafff21bffcf638f7e1fd092b82c13e573e2727546ce11cecde8783dc6ff",
+  "spec_input_hash": "bbe8a9bcaf3c053faad3a9d550e2708a459235568296f778b0e3755748434070",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "aaf1a67631aa710d48e3fd74fb19ec973ee928569a9f0577573289defd4e792f"
+      "content_hash": "e598414c3d69982043ea3c2d40409b726e2e3a9e858b7d907dc5c10119db98af"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "5443d8431af933da3b00f08db24bfc02e917d9a663803d1e5f718716f49279c5"
+      "content_hash": "e479094a7359afa4f61e2a0fdbc6622be833ef812f52c81aa267ae80b7047877"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "2d19c8ef0f4041339360c3611df442b4201e43394c1c5598508fa60af2ced008"
+      "content_hash": "05ef95f5fc038135a8378e022888c4ef7083357c6be8d87331fdb921d5507828"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "0ef7514765f32a8fb98d6ec207d52454b53a05b2b96c3993f1c0e20a348bb496"
+      "content_hash": "24dce96678b9c92d3cd036ee6fe1578fa3f039f197dfba568a4a3077c7aab358"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "612a7c53633546c0fddceb2efe6404abd0e1be6a4cc1da281ad92b7c66d69a36"
+      "content_hash": "ad7455d37ebd47d840c5a6a8c6adfffbb77e87dbf4e1a963c2dba1a870b7edbe"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "ac616ff1e34148ca690755362e659276d57e8c42a08e1c40041d092ab84dce3f"
+      "content_hash": "2f6a556d06a8fa4e2781e4d0ab7a90a0bfdb5500eb037f19589c4b4690323313"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "24f8817f692f2d2433b37be82cc454a4f982ded78197a28f25046c2afe8e6946"
+      "content_hash": "9787d82b6fc81cf8af62ae1190a5729313effc3140a33ef42a2670df7f74a2bc"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "a7c25369a92a36a8096cb0e3f48ac55c189d2c72d96f15018a9624b083f43f17"
+      "content_hash": "ba2b5dedb8357a3e5c1ea20e5b31adf71534fb699370e4c69ea99526635440ba"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ae5b9e9e77b5a3f29469f2257f4008766aa165ca3488b6942cde7ba0e9b1d2f`
+- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -920,6 +920,9 @@ pub(crate) struct QaCli {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum QaCommand {
+    /// Inspect validation, proof, task, and workspace recovery state without mutating it.
+    Diagnose(crate::plugins::verify::DiagnoseCli),
+
     /// Verify previously completed work (proof replay + drift checks)
     Verify(verify::VerifyCli),
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -4940,7 +4940,7 @@ fn validate_tooling_gate(
                         fail(
                             &auto_remediable_validation_message(
                                 "cargo_fmt_failed",
-                                &format!(
+                                format!(
                                     "Rust code formatting failed - run `cargo fmt --all`.\nstderr:\n{}",
                                     String::from_utf8_lossy(&output.stderr).trim()
                                 ),
@@ -4955,7 +4955,7 @@ fn validate_tooling_gate(
                     fail(
                         &auto_remediable_validation_message(
                             "cargo_fmt_execution_failed",
-                            &format!("Failed to run cargo fmt: {e}"),
+                            format!("Failed to run cargo fmt: {e}"),
                             "Agent: switch to a complete Rust toolchain, then retry validation.",
                         ),
                         ctx,
@@ -4974,7 +4974,7 @@ fn validate_tooling_gate(
                         fail(
                             &auto_remediable_validation_message(
                                 "cargo_clippy_failed",
-                                &format!(
+                                format!(
                                     "Rust linting failed - run `cargo clippy --all-targets --all-features`.\nstderr:\n{}",
                                     String::from_utf8_lossy(&output.stderr).trim()
                                 ),
@@ -4989,7 +4989,7 @@ fn validate_tooling_gate(
                     fail(
                         &auto_remediable_validation_message(
                             "cargo_clippy_execution_failed",
-                            &format!("Failed to run cargo clippy: {e}"),
+                            format!("Failed to run cargo clippy: {e}"),
                             "Agent: switch to a complete Rust toolchain, then retry validation.",
                         ),
                         ctx,

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -78,9 +78,14 @@ fn is_container_workspaces_disabled(repo_root: &Path) -> bool {
     }
 }
 
-fn auto_remediable_validation_message(code: &str, message: &str, agent_action: &str) -> String {
+fn auto_remediable_validation_message(
+    code: &str,
+    message: impl AsRef<str>,
+    agent_action: &str,
+) -> String {
     format!(
-        "AUTOREMEDIABLE_VALIDATION_ERROR code={code} severity=transient auto_remediable=true audience=agent agent_action=\"{agent_action}\" user_note=\"Recoverable validation issue; the agent should take this action or report the concrete blocker.\"\n{message}"
+        "AUTOREMEDIABLE_VALIDATION_ERROR code={code} severity=transient auto_remediable=true audience=agent agent_action=\"{agent_action}\" user_note=\"Recoverable validation issue; the agent should take this action or report the concrete blocker.\"\n{message}",
+        message = message.as_ref()
     )
 }
 
@@ -3625,6 +3630,22 @@ fn validate_git_workspace_context(
 
     if is_isolated {
         pass("Running in isolated workspace (.decapod/workspaces/)", ctx);
+    } else if let Ok(status) = workspace::get_workspace_status(repo_root)
+        && status.git.in_worktree
+        && !status.git.is_main_repo
+    {
+        let path = status.git.worktree_path.as_deref().unwrap_or(repo_root);
+        fail(
+            &auto_remediable_validation_message(
+                "workspace_context_mismatch",
+                format!(
+                    "Git reports an isolated worktree at '{}' but it is not Decapod-owned under '.decapod/workspaces/'. The host worktree detector and validation context disagree about custody.",
+                    path.display()
+                ),
+                "Agent: run `decapod workspace status`; enter the Decapod-reported worktree or run `decapod workspace ensure`, then rerun validation.",
+            ),
+            ctx,
+        );
     } else {
         fail(
             "Not running in isolated git worktree - must use .decapod/workspaces/ to prevent disrupting the root repository",
@@ -6230,6 +6251,36 @@ mod tests {
             "unexpected validation failures: {:?}",
             ctx.fails.lock().unwrap()
         );
+    }
+
+    #[test]
+    fn external_worktree_reports_context_mismatch_instead_of_generic_failure() {
+        let (_tmp, main_root, _decapod_path) = decapod_worktree_fixture();
+        let external_path = main_root
+            .parent()
+            .expect("fixture parent")
+            .join("external-worktree");
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "external/agent",
+                external_path.to_str().unwrap(),
+            ])
+            .current_dir(&main_root)
+            .output()
+            .expect("external worktree should start");
+        assert!(output.status.success());
+
+        let ctx = ValidationContext::new();
+        validate_git_workspace_context(&ctx, &main_root, &external_path)
+            .expect("workspace context validation");
+        let failures = ctx.fails.lock().unwrap();
+        assert_eq!(ctx.fail_count.load(Ordering::Relaxed), 1);
+        assert!(failures.iter().any(|failure| {
+            failure.contains("workspace_context_mismatch") && failure.contains("not Decapod-owned")
+        }));
     }
 
     #[test]

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -73,6 +73,9 @@ pub struct WorkspaceConfig {
     pub use_container: bool,
     /// Base image for container (if use_container is true)
     pub base_image: Option<String>,
+    /// Repository base branch used when creating the worktree.
+    #[serde(default)]
+    pub base_branch: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -531,6 +534,7 @@ pub fn ensure_workspace(
             branch: Some(branch),
             use_container: cfg.use_container,
             base_image: cfg.base_image,
+            base_branch: cfg.base_branch,
         }
     } else {
         let ts = std::time::SystemTime::now()
@@ -546,6 +550,7 @@ pub fn ensure_workspace(
             )),
             use_container: false,
             base_image: None,
+            base_branch: None,
         }
     };
     let branch = config.branch.as_deref().ok_or_else(|| {
@@ -556,7 +561,12 @@ pub fn ensure_workspace(
     let worktree_path = if status.git.in_worktree {
         repo_root.to_path_buf()
     } else {
-        create_worktree(repo_root, branch, agent_id, &todo_scope)?
+        let base_branch = config
+            .base_branch
+            .as_deref()
+            .map(str::to_string)
+            .unwrap_or_else(|| resolve_base_branch(&main_repo, None));
+        create_worktree(repo_root, branch, agent_id, &todo_scope, &base_branch)?
     };
 
     // 2. Ensure container (if requested)
@@ -599,6 +609,7 @@ fn create_worktree(
     branch: &str,
     agent_id: &str,
     todo_scope: &str,
+    base_branch: &str,
 ) -> Result<PathBuf, DecapodError> {
     let main_repo = get_main_repo_root(repo_root)?;
     let workspaces_dir = main_repo.join(".decapod").join("workspaces");
@@ -616,17 +627,23 @@ fn create_worktree(
         return Ok(worktree_path);
     }
 
-    // git worktree add <path> -b <branch>
+    let start_point = base_ref_for_branch(&main_repo, base_branch);
+
+    // git worktree add <path> -b <branch> <base-ref>
+    let mut args = vec![
+        "-C".to_string(),
+        main_repo.to_string_lossy().to_string(),
+        "worktree".to_string(),
+        "add".to_string(),
+        "-b".to_string(),
+        branch.to_string(),
+        worktree_path.to_string_lossy().to_string(),
+    ];
+    if let Some(start_point) = &start_point {
+        args.push(start_point.clone());
+    }
     let output = Command::new("git")
-        .args([
-            "-C",
-            main_repo.to_str().unwrap_or("."),
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            worktree_path.to_str().unwrap_or("."),
-        ])
+        .args(&args)
         .output()
         .map_err(DecapodError::IoError)?;
 
@@ -822,6 +839,121 @@ fn is_branch_protected(branch: &str) -> bool {
         }
     }
     false
+}
+
+/// Resolve the repository base branch used by workspace and publication paths.
+pub fn resolve_base_branch(repo_root: &Path, explicit: Option<&str>) -> String {
+    explicit
+        .filter(|branch| !branch.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            crate::cli::DecapodProjectConfig::load(repo_root)
+                .ok()
+                .and_then(|config| config.repo.base_branch)
+                .filter(|branch| !branch.trim().is_empty())
+        })
+        .or_else(|| detect_base_branch(repo_root))
+        .unwrap_or_else(|| "master".to_string())
+}
+
+fn base_ref_for_branch(repo_root: &Path, branch: &str) -> Option<String> {
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    if git_ref_exists(repo_root, &remote_ref) {
+        return Some(format!("origin/{branch}"));
+    }
+    let local_ref = format!("refs/heads/{branch}");
+    git_ref_exists(repo_root, &local_ref).then(|| branch.to_string())
+}
+
+fn git_ref_exists(repo_root: &Path, git_ref: &str) -> bool {
+    Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            git_ref,
+        ])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Check whether the current branch can merge the selected base without conflicts.
+///
+/// This is read-only: `git merge-tree` computes the result without changing the
+/// worktree or index. A missing local base ref fails closed with setup guidance.
+pub fn check_merge_conflicts(repo_root: &Path, base_branch: &str) -> Result<(), DecapodError> {
+    let head_branch = current_branch(repo_root)?;
+    check_merge_conflicts_for_branch(repo_root, base_branch, &head_branch)
+}
+
+/// Check a named local branch against the configured base without checking it out.
+pub fn check_merge_conflicts_for_branch(
+    repo_root: &Path,
+    base_branch: &str,
+    head_branch: &str,
+) -> Result<(), DecapodError> {
+    let base_ref = base_ref_for_branch(repo_root, base_branch).ok_or_else(|| {
+        DecapodError::ValidationError(format!(
+            "AUTOREMEDIABLE_VALIDATION_ERROR code=PR_BASE_REF_MISSING severity=transient auto_remediable=true audience=agent agent_action=\"fetch the configured base branch, then rerun publication\" user_note=\"The configured PR base is not available in local Git metadata.\"\nCannot preflight merge conflicts: base branch '{base_branch}' is missing locally. Fetch origin/{base_branch} and retry."
+        ))
+    })?;
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "merge-tree",
+            "--write-tree",
+            &base_ref,
+            head_branch,
+        ])
+        .output()
+        .map_err(DecapodError::IoError)?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let details = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let details = details
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .take(20)
+        .collect::<Vec<_>>()
+        .join("\\n");
+    Err(DecapodError::ValidationError(format!(
+        "AUTOREMEDIABLE_VALIDATION_ERROR code=PR_MERGE_CONFLICT severity=blocking auto_remediable=true audience=agent agent_action=\"rebase or merge {base_branch} into the feature branch, resolve conflicts, rerun validation, and retry publication\" user_note=\"The feature branch cannot be safely proposed against the configured base branch.\"\nMerge conflict preflight failed for '{head_branch}' against '{base_ref}'.\n{details}"
+    )))
+}
+
+fn current_branch(repo_root: &Path) -> Result<String, DecapodError> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_root.to_str().unwrap_or("."),
+            "branch",
+            "--show-current",
+        ])
+        .output()
+        .map_err(DecapodError::IoError)?;
+    if !output.status.success() {
+        return Err(DecapodError::ValidationError(format!(
+            "failed determining current branch: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        return Err(DecapodError::ValidationError(
+            "Cannot preflight merge conflicts from a detached HEAD".to_string(),
+        ));
+    }
+    Ok(branch)
 }
 
 /// Detect the repository's base branch from local Git metadata.
@@ -1235,6 +1367,7 @@ pub fn publish_workspace(
     // worktrees can inherit a local-clone origin, which must never be
     // treated as publication to the upstream GitHub repository.
     let publish_remote = resolve_publish_remote(repo_root)?;
+    let base_branch = resolve_base_branch(repo_root, None);
 
     let dir = repo_root.to_str().unwrap_or(".");
 
@@ -1278,6 +1411,10 @@ pub fn publish_workspace(
         .trim()
         .to_string();
 
+    // Preflight against the same base that publication will use. This runs
+    // before any push or PR creation and never mutates the worktree.
+    check_merge_conflicts(repo_root, &base_branch)?;
+
     // 3. Push branch to the selected network remote.
     let push_output = Command::new("git")
         .args([
@@ -1316,6 +1453,8 @@ pub fn publish_workspace(
             pr_title,
             "--head",
             &status.git.current_branch,
+            "--base",
+            &base_branch,
         ];
         let repo_slug = github_repo_slug(&publish_remote.url);
         if let Some(slug) = repo_slug.as_deref() {
@@ -1776,6 +1915,71 @@ mod tests {
         );
 
         assert_eq!(detect_base_branch(tmp.path()).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn merge_preflight_detects_conflicts_against_configured_base() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(tmp.path(), &["config", "user.email", "test@test.com"]);
+        git(tmp.path(), &["config", "user.name", "Test"]);
+        std::fs::write(tmp.path().join("file.txt"), "base\n").expect("write base");
+        git(tmp.path(), &["add", "file.txt"]);
+        git(tmp.path(), &["commit", "-m", "initial"]);
+        git(tmp.path(), &["branch", "-M", "main"]);
+        git(tmp.path(), &["checkout", "-b", "feature"]);
+        std::fs::write(tmp.path().join("file.txt"), "feature\n").expect("write feature");
+        git(tmp.path(), &["commit", "-am", "feature"]);
+        git(tmp.path(), &["checkout", "main"]);
+        std::fs::write(tmp.path().join("file.txt"), "base-update\n").expect("write base update");
+        git(tmp.path(), &["commit", "-am", "base update"]);
+        git(tmp.path(), &["checkout", "feature"]);
+
+        let error = check_merge_conflicts(tmp.path(), "main").expect_err("conflict expected");
+        assert!(error.to_string().contains("PR_MERGE_CONFLICT"));
+        assert!(error.to_string().contains("rebase or merge main"));
+    }
+
+    #[test]
+    fn resolve_base_branch_prefers_explicit_value_then_repository_metadata() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(tmp.path(), &["config", "user.email", "test@test.com"]);
+        git(tmp.path(), &["config", "user.name", "Test"]);
+        std::fs::write(tmp.path().join("README.md"), "# project\n").expect("write readme");
+        git(tmp.path(), &["add", "README.md"]);
+        git(tmp.path(), &["commit", "-m", "initial"]);
+        git(tmp.path(), &["branch", "-M", "main"]);
+
+        assert_eq!(resolve_base_branch(tmp.path(), Some("release")), "release");
+        assert_eq!(resolve_base_branch(tmp.path(), None), "main");
+    }
+
+    #[test]
+    fn worktree_creation_starts_from_resolved_base_branch() {
+        let tmp = tempdir().expect("tempdir");
+        git(tmp.path(), &["init", "-q"]);
+        git(tmp.path(), &["config", "user.email", "test@test.com"]);
+        git(tmp.path(), &["config", "user.name", "Test"]);
+        std::fs::write(tmp.path().join("README.md"), "main\n").expect("write readme");
+        git(tmp.path(), &["add", "README.md"]);
+        git(tmp.path(), &["commit", "-m", "initial"]);
+        git(tmp.path(), &["branch", "-M", "main"]);
+        git(tmp.path(), &["checkout", "-b", "unrelated"]);
+        std::fs::write(tmp.path().join("README.md"), "unrelated\n").expect("write unrelated");
+        git(tmp.path(), &["commit", "-am", "unrelated"]);
+
+        let worktree = create_worktree(tmp.path(), "agent/test-base", "agent", "scope", "main")
+            .expect("worktree should be created from base");
+        let head = Command::new("git")
+            .args(["-C", worktree.to_str().unwrap(), "rev-parse", "HEAD"])
+            .output()
+            .expect("read worktree head");
+        let base = Command::new("git")
+            .args(["-C", tmp.path().to_str().unwrap(), "rev-parse", "main"])
+            .output()
+            .expect("read base head");
+        assert_eq!(head.stdout, base.stdout);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6349,6 +6349,9 @@ fn run_qa_command(
     workspace_root: &Path,
 ) -> Result<(), error::DecapodError> {
     match qa_cli.command {
+        QaCommand::Diagnose(diagnose_cli) => {
+            verify::run_diagnose_cli(project_store, workspace_root, diagnose_cli)?
+        }
         QaCommand::Verify(verify_cli) => {
             verify::run_verify_cli(project_store, workspace_root, verify_cli)?
         }
@@ -6615,6 +6618,7 @@ fn run_workspace_command(
                     } else {
                         None
                     },
+                    base_branch: None,
                 })
             } else {
                 None
@@ -6984,6 +6988,7 @@ mod rpc_handlers {
             branch: Some(b),
             use_container: false,
             base_image: None,
+            base_branch: None,
         });
 
         let status = workspace::ensure_workspace(ctx.project_root, config, &agent_id)?;

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -354,6 +354,14 @@ Agent must clear the disable marker through Decapod self-heal before retrying.",
         true
     };
 
+    if pr {
+        workspace::check_merge_conflicts_for_branch(
+            &repo,
+            &workspace.base_branch,
+            &workspace.branch,
+        )?;
+    }
+
     if push {
         push_branch_to_origin(&repo, &workspace.branch)?;
     }
@@ -423,17 +431,7 @@ Agent must clear the disable marker through Decapod self-heal before retrying.",
 }
 
 fn resolve_base_branch(repo_root: &Path, explicit: Option<&str>) -> String {
-    explicit
-        .filter(|branch| !branch.trim().is_empty())
-        .map(str::to_string)
-        .or_else(|| {
-            crate::cli::DecapodProjectConfig::load(repo_root)
-                .ok()
-                .and_then(|config| config.repo.base_branch)
-                .filter(|branch| !branch.trim().is_empty())
-        })
-        .or_else(|| workspace::detect_base_branch(repo_root))
-        .unwrap_or_else(|| "master".to_string())
+    workspace::resolve_base_branch(repo_root, explicit)
 }
 
 fn execute_container_with_timeout(

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -1314,10 +1314,10 @@ pub fn run_diagnose_cli(
                     task["proof"]["status"].as_str().unwrap_or("unknown"),
                     task["next_command"].as_str().unwrap_or("unknown")
                 );
-                if let Some(reason) = task["proof"]["notes"].as_str() {
-                    if !reason.is_empty() {
-                        println!("  proof note: {reason}");
-                    }
+                if let Some(reason) = task["proof"]["notes"].as_str()
+                    && !reason.is_empty()
+                {
+                    println!("  proof note: {reason}");
                 }
             }
         }

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -5,6 +5,7 @@ use crate::core::state_commit;
 use crate::core::store::Store;
 use crate::core::todo;
 use crate::core::validation_epoch::{ValidationEpochMetadata, active_validation_epoch};
+use crate::core::workspace;
 use crate::plugins::federation;
 use clap::{Parser, Subcommand};
 use fancy_regex::Regex;
@@ -26,6 +27,20 @@ pub struct VerifyCli {
     stale: bool,
     #[clap(subcommand)]
     command: Option<VerifyCommand>,
+}
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "diagnose",
+    about = "Inspect validation recovery state without mutation"
+)]
+pub struct DiagnoseCli {
+    /// Diagnose one TODO; without this flag, recent proof-bearing done TODOs are shown.
+    #[clap(long)]
+    pub todo: Option<String>,
+    /// Output machine-readable JSON.
+    #[clap(long)]
+    pub json: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -57,6 +72,7 @@ struct VerifyTarget {
     proof_plan: Option<String>,
     artifacts: Option<String>,
     last_verified_at: Option<String>,
+    last_verified_status: Option<String>,
     verification_policy_days: i64,
 }
 
@@ -149,13 +165,19 @@ fn epoch_secs(ts: &str) -> Option<i64> {
     ts.trim_end_matches('Z').parse::<i64>().ok()
 }
 
-fn validation_proof_reason(validate_ok: bool, hashes_match: bool) -> &'static str {
+fn validation_proof_reason(validate_ok: bool, hashes_match: bool, todo_id: &str) -> String {
     if !validate_ok && hashes_match {
-        "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked"
+        format!(
+            "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked. Next: fix the reported validation gate, then run `decapod qa verify todo {todo_id}`"
+        )
     } else if !validate_ok {
-        "decapod validate did not pass"
+        format!(
+            "decapod validate did not pass. Next: fix the reported validation gate, then run `decapod qa verify todo {todo_id}`"
+        )
     } else {
-        "validate output hash changed"
+        format!(
+            "validate output hash changed. Next: review the drift, then recapture with `decapod qa verify regen {todo_id}` if the change is intentional"
+        )
     }
 }
 
@@ -363,7 +385,7 @@ fn load_targets(
         let mut out = Vec::new();
         if let Some(id) = single_id {
             let mut stmt = conn.prepare(
-                "SELECT t.id, t.status, v.proof_plan, v.verification_artifacts, v.last_verified_at, COALESCE(v.verification_policy_days, 90)\n                 FROM tasks t\n                 LEFT JOIN task_verification v ON v.todo_id = t.id\n                 WHERE t.id = ?1",
+                "SELECT t.id, t.status, v.proof_plan, v.verification_artifacts, v.last_verified_at, v.last_verified_status, COALESCE(v.verification_policy_days, 90)\n                 FROM tasks t\n                 LEFT JOIN task_verification v ON v.todo_id = t.id\n                 WHERE t.id = ?1",
             )?;
             let rows = stmt.query_map(rusqlite::params![id], |row| {
                 Ok(VerifyTarget {
@@ -372,7 +394,8 @@ fn load_targets(
                     proof_plan: row.get(2)?,
                     artifacts: row.get(3)?,
                     last_verified_at: row.get(4)?,
-                    verification_policy_days: row.get(5)?,
+                    last_verified_status: row.get(5)?,
+                    verification_policy_days: row.get(6)?,
                 })
             })?;
 
@@ -381,7 +404,7 @@ fn load_targets(
             }
         } else {
             let mut stmt = conn.prepare(
-                "SELECT t.id, t.status, v.proof_plan, v.verification_artifacts, v.last_verified_at, COALESCE(v.verification_policy_days, 90)\n                 FROM tasks t\n                 LEFT JOIN task_verification v ON v.todo_id = t.id\n                 WHERE t.status = 'done'\n                   AND v.proof_plan IS NOT NULL\n                   AND v.proof_plan <> ''\n                 ORDER BY t.updated_at DESC",
+                "SELECT t.id, t.status, v.proof_plan, v.verification_artifacts, v.last_verified_at, v.last_verified_status, COALESCE(v.verification_policy_days, 90)\n                 FROM tasks t\n                 LEFT JOIN task_verification v ON v.todo_id = t.id\n                 WHERE t.status = 'done'\n                   AND v.proof_plan IS NOT NULL\n                   AND v.proof_plan <> ''\n                 ORDER BY t.updated_at DESC",
             )?;
             let rows = stmt.query_map([], |row| {
                 Ok(VerifyTarget {
@@ -390,7 +413,8 @@ fn load_targets(
                     proof_plan: row.get(2)?,
                     artifacts: row.get(3)?,
                     last_verified_at: row.get(4)?,
-                    verification_policy_days: row.get(5)?,
+                    last_verified_status: row.get(5)?,
+                    verification_policy_days: row.get(6)?,
                 })
             })?;
 
@@ -623,7 +647,11 @@ fn verify_target(
                 status: "fail".to_string(),
                 expected_output_hash: Some(expected),
                 actual_output_hash: Some(actual_hash),
-                reason: Some(validation_proof_reason(validate_ok, hashes_match).to_string()),
+                reason: Some(validation_proof_reason(
+                    validate_ok,
+                    hashes_match,
+                    &target.todo_id,
+                )),
             });
         } else {
             result.proofs.push(ProofCheckResult {
@@ -1177,6 +1205,202 @@ pub fn run_verify_cli(
     Ok(())
 }
 
+/// Emit a read-only recovery report for validation, proof, task, and workspace state.
+pub fn run_diagnose_cli(
+    store: &Store,
+    repo_root: &Path,
+    cli: DiagnoseCli,
+) -> Result<(), error::DecapodError> {
+    let main_root = workspace::get_main_repo_root(repo_root)?;
+    let workspace_status = workspace::get_workspace_status(repo_root)?;
+    let config = crate::cli::DecapodProjectConfig::load(&main_root).ok();
+    let expected_container = config
+        .as_ref()
+        .map(|config| config.repo.container_workspaces)
+        .unwrap_or(false);
+    let base_branch = workspace::resolve_base_branch(&main_root, None);
+
+    let tasks = if let Some(id) = cli.todo.as_deref() {
+        let task = todo::get_task(&store.root, id)?
+            .ok_or_else(|| error::DecapodError::NotFound(format!("TODO not found: {id}")))?;
+        vec![task]
+    } else {
+        todo::list_tasks(
+            &store.root,
+            Some("done".to_string()),
+            None,
+            None,
+            None,
+            None,
+        )?
+        .into_iter()
+        .filter(|task| !task.assigned_to.is_empty())
+        .take(12)
+        .collect()
+    };
+
+    let task_reports = tasks
+        .iter()
+        .map(|task| {
+            let target = load_targets(store, Some(&task.id))?.into_iter().next();
+            Ok(diagnose_task(
+                task,
+                target.as_ref(),
+                &workspace_status,
+                expected_container,
+                &base_branch,
+            ))
+        })
+        .collect::<Result<Vec<_>, error::DecapodError>>()?;
+
+    let report = serde_json::json!({
+        "read_only": true,
+        "repo_root": main_root.to_string_lossy().to_string(),
+        "workspace": {
+            "path": repo_root.to_string_lossy().to_string(),
+            "branch": workspace_status.git.current_branch.clone(),
+            "in_worktree": workspace_status.git.in_worktree,
+            "is_main_repo": workspace_status.git.is_main_repo,
+            "is_protected": workspace_status.git.is_protected,
+            "worktree_path": workspace_status.git.worktree_path.clone(),
+            "base_branch": base_branch.clone(),
+        },
+        "execution_context": {
+            "expected": if expected_container { "container workspace" } else { "isolated host worktree" },
+            "actual": if workspace_status.container.in_container { "container workspace" } else { "host process" },
+            "validation_executed": false,
+        },
+        "tasks": task_reports,
+        "next": if workspace_status.git.is_protected || !workspace_status.git.in_worktree {
+            "decapod workspace ensure"
+        } else if expected_container && !workspace_status.container.in_container {
+            "decapod workspace ensure --container"
+        } else {
+            "inspect the task-specific next_command"
+        },
+    });
+
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+    } else {
+        println!("Decapod QA diagnostic (read-only)");
+        println!("Repository: {}", main_root.display());
+        println!(
+            "Workspace: branch={} in_worktree={} main_repo={} protected={} path={}",
+            workspace_status.git.current_branch,
+            workspace_status.git.in_worktree,
+            workspace_status.git.is_main_repo,
+            workspace_status.git.is_protected,
+            repo_root.display()
+        );
+        println!(
+            "Execution context: expected={}, actual={}",
+            report["execution_context"]["expected"]
+                .as_str()
+                .unwrap_or("unknown"),
+            report["execution_context"]["actual"]
+                .as_str()
+                .unwrap_or("unknown")
+        );
+        if task_reports.is_empty() {
+            println!("Tasks: none selected (pass --todo <id> to inspect a specific task)");
+        } else {
+            for task in &task_reports {
+                println!(
+                    "Task {}: state={} claim={} proof={} next={}",
+                    task["todo_id"].as_str().unwrap_or("unknown"),
+                    task["state"].as_str().unwrap_or("unknown"),
+                    task["claim"].as_str().unwrap_or("unknown"),
+                    task["proof"]["status"].as_str().unwrap_or("unknown"),
+                    task["next_command"].as_str().unwrap_or("unknown")
+                );
+                if let Some(reason) = task["proof"]["notes"].as_str() {
+                    if !reason.is_empty() {
+                        println!("  proof note: {reason}");
+                    }
+                }
+            }
+        }
+        println!(
+            "Next: {}",
+            report["next"].as_str().unwrap_or("inspect task")
+        );
+    }
+    Ok(())
+}
+
+fn diagnose_task(
+    task: &todo::Task,
+    target: Option<&VerifyTarget>,
+    workspace_status: &workspace::WorkspaceStatus,
+    expected_container: bool,
+    base_branch: &str,
+) -> serde_json::Value {
+    let proof_status = target
+        .and_then(|target| target.last_verified_status.as_deref())
+        .unwrap_or("missing");
+    let proof_status = match proof_status {
+        "pass" => "pass",
+        "fail" => "blocked",
+        "missing" => "missing",
+        _ => "unknown",
+    };
+    let proof_notes = target
+        .and_then(|target| target.artifacts.as_deref())
+        .and_then(|raw| serde_json::from_str::<VerificationArtifacts>(raw).ok())
+        .and_then(|artifacts| {
+            artifacts
+                .proof_plan_results
+                .into_iter()
+                .find(|proof| proof.proof_gate == "validate_passes")
+        })
+        .map(|proof| {
+            format!(
+                "baseline_status={} expected_hash={}",
+                proof.status, proof.output_hash
+            )
+        })
+        .or_else(|| target.and_then(|target| target.last_verified_at.clone()))
+        .unwrap_or_else(|| "verification baseline is missing".to_string());
+
+    let branch_matches = workspace_status.git.current_branch.contains(&task.hash)
+        || workspace_status.git.current_branch.contains(&task.id);
+    let claim = if task.assigned_to.is_empty() {
+        "unclaimed"
+    } else {
+        "claimed"
+    };
+    let next_command = if workspace_status.git.is_protected || !workspace_status.git.in_worktree {
+        "decapod workspace ensure".to_string()
+    } else if expected_container && !workspace_status.container.in_container {
+        "decapod workspace ensure --container".to_string()
+    } else if !branch_matches {
+        format!("switch to the todo-scoped workspace for {}", task.id)
+    } else if proof_status == "missing" {
+        format!("decapod todo done --id {} --validated", task.id)
+    } else if proof_status == "blocked" || proof_status == "unknown" {
+        format!("decapod validate && decapod qa verify todo {}", task.id)
+    } else {
+        "decapod workspace publish".to_string()
+    };
+
+    serde_json::json!({
+        "todo_id": task.id,
+        "state": task.status,
+        "claim": claim,
+        "assigned_to": task.assigned_to,
+        "branch_matches_todo": branch_matches,
+        "expected_base_branch": base_branch,
+        "proof": {
+            "status": proof_status,
+            "last_verified_at": target.and_then(|target| target.last_verified_at.clone()),
+            "notes": proof_notes,
+            "validation_hash_current": "not executed by read-only diagnose",
+        },
+        "next_command": next_command,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::validation_proof_reason;
@@ -1184,24 +1408,24 @@ mod tests {
     #[test]
     fn stable_failed_validation_remains_blocked_with_explicit_reason() {
         assert_eq!(
-            validation_proof_reason(false, true),
-            "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked"
+            validation_proof_reason(false, true, "bugs_01test"),
+            "decapod validate did not pass; output hash is unchanged from the baseline, so verification remains blocked. Next: fix the reported validation gate, then run `decapod qa verify todo bugs_01test`"
         );
     }
 
     #[test]
     fn failed_validation_with_changed_output_reports_validation_failure() {
         assert_eq!(
-            validation_proof_reason(false, false),
-            "decapod validate did not pass"
+            validation_proof_reason(false, false, "bugs_01test"),
+            "decapod validate did not pass. Next: fix the reported validation gate, then run `decapod qa verify todo bugs_01test`"
         );
     }
 
     #[test]
     fn passing_validation_with_changed_output_reports_hash_drift() {
         assert_eq!(
-            validation_proof_reason(true, false),
-            "validate output hash changed"
+            validation_proof_reason(true, false, "bugs_01test"),
+            "validate output hash changed. Next: review the drift, then recapture with `decapod qa verify regen bugs_01test` if the change is intentional"
         );
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the five related validation, workspace, recovery, and publication issues:

- Fixes #773: resolve and persist the configured/detected base branch for normal worktree creation and publication, and pass it explicitly when creating the PR.
- Fixes #774: distinguish an external Git worktree from a Decapod-owned worktree so validation reports the actual custody mismatch and recovery command.
- Fixes #816: keep failed validation fail-closed while reporting the exact proof-recovery command, including the equal-hash case.
- Fixes #708: add read-only `decapod qa diagnose [--todo ID] [--json]` with workspace, task, proof, and next-action diagnostics.
- Fixes #736: run a read-only `git merge-tree` preflight against the selected base before any push or PR creation, including container publication.

The generated Decapod governance contracts were refreshed after the implementation.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --lib`
- `cargo check --bin decapod`
- `cargo clippy --lib -- -D warnings`
- `git diff --check`
- Built and exercised `decapod qa diagnose --json --todo code_01kxkxnmcphhqd5p`.

The focused Rust test build did not produce a test report on the local Rust/Nix host after dependency compilation; CI is the authoritative full test matrix.
