### PR TITLE
feat: add reproducible completion evidence verification

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784156275Z",
-  "repo_signal_fingerprint": "bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11",
+  "generated_at": "1784184911Z",
+  "repo_signal_fingerprint": "acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "bbe8a9bcaf3c053faad3a9d550e2708a459235568296f778b0e3755748434070",
+  "spec_input_hash": "16532857a8bee20e2f211e240cb1d74b469fb5eb2c8a1fae693fd123964bed58",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "e598414c3d69982043ea3c2d40409b726e2e3a9e858b7d907dc5c10119db98af"
+      "content_hash": "43bbfa1ddc1f71b7fd3393f9073f211ef1836c43a84c4323269781c14c4e63d3"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "e479094a7359afa4f61e2a0fdbc6622be833ef812f52c81aa267ae80b7047877"
+      "content_hash": "869f6ab96c5ee9f1204efaec8c518d63521df8be6d959b82dcee845ab6ea89df"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "05ef95f5fc038135a8378e022888c4ef7083357c6be8d87331fdb921d5507828"
+      "content_hash": "48cb36ea4dc8397b8bee0edf4b4c6cf775b29423a49aae7fe5697349dcf712b5"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "24dce96678b9c92d3cd036ee6fe1578fa3f039f197dfba568a4a3077c7aab358"
+      "content_hash": "badefcdbe9c7926c6f236e039ac664293b4ddecc2db43f5b240ed9089d205a35"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "ad7455d37ebd47d840c5a6a8c6adfffbb77e87dbf4e1a963c2dba1a870b7edbe"
+      "content_hash": "af10abe57acf59ba272e6c885556e0da72639c429b4dbb2cd24b3f7931b9d167"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "2f6a556d06a8fa4e2781e4d0ab7a90a0bfdb5500eb037f19589c4b4690323313"
+      "content_hash": "2576c8468b270668fed4a42f31206fe1bb3223bcb3f56597338b15a5ec13f2f0"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "9787d82b6fc81cf8af62ae1190a5729313effc3140a33ef42a2670df7f74a2bc"
+      "content_hash": "74a945189a9cef48fc7a5d249801a5af4b430fd66474a9afe25b498ad9b6ba10"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "ba2b5dedb8357a3e5c1ea20e5b31adf71534fb699370e4c69ea99526635440ba"
+      "content_hash": "5be0f00c7ab8580df39549f788f22d95b415631150a2a2e1e9ec3dbd9909fa5d"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -398,7 +398,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -218,7 +218,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -334,7 +334,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `bb35b3633b3794d71c299f249969fe6247048865b46f0f73ccd74b0af04efc11`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (86 files), `tests/` (3 files)
+- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/core/completion_evidence.rs
+++ b/src/core/completion_evidence.rs
@@ -1,0 +1,1013 @@
+use crate::core::context_capsule::DeterministicContextCapsule;
+use crate::core::error;
+use crate::core::plan_governance;
+use crate::core::validation_epoch::active_validation_epoch;
+use crate::core::workunit::{self, WorkUnitStatus};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub const COMPLETION_EVIDENCE_SCHEMA_VERSION: &str = "1.0.0";
+pub const COMPLETION_EVIDENCE_DIR: &str =
+    ".decapod/generated/artifacts/provenance/completion_evidence";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CompletionProofEvidence {
+    pub gate: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<FileDigest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FileDigest {
+    pub path: String,
+    pub sha256: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WorkingTreeEntry {
+    pub path: String,
+    pub exists: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepositoryEvidence {
+    pub head_revision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_revision: Option<String>,
+    pub changed_paths: Vec<String>,
+    pub working_tree: Vec<WorkingTreeEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapsuleEvidence {
+    pub path: String,
+    pub capsule_hash: String,
+    pub policy_hash: String,
+    pub policy_version: String,
+    pub repo_revision: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationEpochEvidence {
+    pub epoch_id: String,
+    pub epoch_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnresolvedClaim {
+    pub kind: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompletionEvidenceRecord {
+    pub schema_version: String,
+    pub task_id: String,
+    pub workunit_hash: String,
+    pub intent_ref: String,
+    pub spec_refs: Vec<String>,
+    pub state_refs: Vec<String>,
+    pub proof_plan: Vec<String>,
+    pub proof_results: Vec<CompletionProofEvidence>,
+    pub capsule: CapsuleEvidence,
+    pub repository: RepositoryEvidence,
+    pub validation_epoch: ValidationEpochEvidence,
+    #[serde(default)]
+    pub unresolved_claims: Vec<UnresolvedClaim>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub evidence_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EvidenceCheck {
+    pub name: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompletionEvidenceVerification {
+    pub schema_version: String,
+    pub task_id: String,
+    pub status: String,
+    pub checks: Vec<EvidenceCheck>,
+    pub unresolved_claims: Vec<UnresolvedClaim>,
+}
+
+impl CompletionEvidenceRecord {
+    fn canonicalized(&self) -> Self {
+        let mut out = self.clone();
+        out.spec_refs.sort();
+        out.spec_refs.dedup();
+        out.state_refs.sort();
+        out.state_refs.dedup();
+        out.proof_plan.sort();
+        out.proof_plan.dedup();
+        out.proof_results.sort();
+        out.unresolved_claims.sort();
+        out.unresolved_claims.dedup();
+        out.repository.changed_paths.sort();
+        out.repository.changed_paths.dedup();
+        out.repository.working_tree.sort();
+        out.repository.working_tree.dedup();
+        out.evidence_hash.clear();
+        out
+    }
+
+    pub fn canonical_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.canonicalized())
+    }
+
+    pub fn computed_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let mut hasher = Sha256::new();
+        hasher.update(self.canonical_json_bytes()?);
+        Ok(format!("sha256:{:x}", hasher.finalize()))
+    }
+
+    pub fn with_recomputed_hash(&self) -> Result<Self, serde_json::Error> {
+        let mut out = self.clone();
+        out.evidence_hash = out.computed_hash_hex()?;
+        Ok(out)
+    }
+}
+
+pub fn default_record_path(
+    project_root: &Path,
+    task_id: &str,
+) -> Result<PathBuf, error::DecapodError> {
+    workunit::validate_task_id(task_id)?;
+    Ok(project_root
+        .join(COMPLETION_EVIDENCE_DIR)
+        .join(format!("{task_id}.json")))
+}
+
+pub fn build_record(
+    project_root: &Path,
+    task_id: &str,
+) -> Result<CompletionEvidenceRecord, error::DecapodError> {
+    let manifest = workunit::load_workunit(project_root, task_id)?;
+    if manifest.status != WorkUnitStatus::Verified {
+        return Err(error::DecapodError::ValidationError(format!(
+            "completion evidence requires VERIFIED workunit status for '{task_id}'"
+        )));
+    }
+    workunit::validate_verified_manifest(&manifest)?;
+    workunit::verify_capsule_policy_lineage_for_task(project_root, &manifest)?;
+
+    let capsule_path = project_root
+        .join(".decapod/generated/context")
+        .join(format!("{task_id}.json"));
+    let capsule = load_capsule(&capsule_path)?;
+    let capsule_hash = capsule.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence capsule hash could not be computed: {e}"
+        ))
+    })?;
+    if capsule.capsule_hash != capsule_hash {
+        return Err(error::DecapodError::ValidationError(format!(
+            "completion evidence capsule hash mismatch at {}",
+            capsule_path.display()
+        )));
+    }
+
+    let active_epoch = active_validation_epoch(project_root)?;
+    let captured_epoch = manifest.validation_epoch.as_ref().ok_or_else(|| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence requires a validation epoch in workunit '{task_id}'"
+        ))
+    })?;
+    if captured_epoch.epoch_id != active_epoch.epoch_id {
+        return Err(error::DecapodError::ValidationError(format!(
+            "completion evidence validation epoch is stale: captured {} but active {}",
+            captured_epoch.epoch_id, active_epoch.epoch_id
+        )));
+    }
+
+    let record_path = default_record_path(project_root, task_id)?;
+    let repository = repository_evidence(project_root, &record_path)?;
+    let proof_results = manifest
+        .proof_results
+        .iter()
+        .map(|result| {
+            let artifact = result
+                .artifact_ref
+                .as_deref()
+                .map(|reference| digest_reference(project_root, reference))
+                .transpose()?;
+            Ok(CompletionProofEvidence {
+                gate: result.gate.clone(),
+                status: result.status.clone(),
+                artifact_ref: result.artifact_ref.clone(),
+                artifact,
+            })
+        })
+        .collect::<Result<Vec<_>, error::DecapodError>>()?;
+
+    let (unresolved_claims, plan_hash) = unresolved_claims(project_root)?;
+    let record = CompletionEvidenceRecord {
+        schema_version: COMPLETION_EVIDENCE_SCHEMA_VERSION.to_string(),
+        task_id: manifest.task_id.clone(),
+        workunit_hash: manifest.canonical_hash_hex().map_err(|e| {
+            error::DecapodError::ValidationError(format!(
+                "completion evidence workunit hash failed: {e}"
+            ))
+        })?,
+        intent_ref: manifest.intent_ref,
+        spec_refs: manifest.spec_refs,
+        state_refs: manifest.state_refs,
+        proof_plan: manifest.proof_plan,
+        proof_results,
+        capsule: CapsuleEvidence {
+            path: relative_path(project_root, &capsule_path)?,
+            capsule_hash,
+            policy_hash: capsule.policy.policy_hash,
+            policy_version: capsule.policy.policy_version,
+            repo_revision: capsule.policy.repo_revision,
+        },
+        repository,
+        validation_epoch: ValidationEpochEvidence {
+            epoch_id: active_epoch.epoch_id.clone(),
+            epoch_hash: hash_json(&active_epoch)?,
+        },
+        unresolved_claims,
+        plan_hash,
+        evidence_hash: String::new(),
+    };
+    record.with_recomputed_hash().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence serialization failed: {e}"
+        ))
+    })
+}
+
+pub fn write_record(
+    project_root: &Path,
+    record: &CompletionEvidenceRecord,
+) -> Result<PathBuf, error::DecapodError> {
+    let path = default_record_path(project_root, &record.task_id)?;
+    let parent = path.parent().ok_or_else(|| {
+        error::DecapodError::ValidationError(
+            "completion evidence record has no parent directory".to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+    let bytes = serde_json::to_vec_pretty(record).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence record serialization failed: {e}"
+        ))
+    })?;
+    fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+    Ok(path)
+}
+
+pub fn verify_record(
+    project_root: &Path,
+    task_id: &str,
+    record_path: &Path,
+) -> Result<CompletionEvidenceVerification, error::DecapodError> {
+    let record_path = fs::canonicalize(record_path).map_err(error::DecapodError::IoError)?;
+    let project_root_canonical =
+        fs::canonicalize(project_root).map_err(error::DecapodError::IoError)?;
+    if !record_path.starts_with(&project_root_canonical) {
+        return Err(error::DecapodError::ValidationError(
+            "completion evidence record must be inside the repository".to_string(),
+        ));
+    }
+    let raw = fs::read_to_string(&record_path).map_err(error::DecapodError::IoError)?;
+    let record: CompletionEvidenceRecord = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence record is not valid JSON: {e}"
+        ))
+    })?;
+    if record.schema_version != COMPLETION_EVIDENCE_SCHEMA_VERSION {
+        return Ok(report(
+            &record,
+            "invalid",
+            vec![check(
+                "schema",
+                "fail",
+                Some(format!(
+                    "unsupported schema version {}",
+                    record.schema_version
+                )),
+            )],
+        ));
+    }
+    if record.task_id != task_id {
+        return Ok(report(
+            &record,
+            "invalid",
+            vec![check(
+                "task_binding",
+                "fail",
+                Some(format!(
+                    "record task_id is {}, requested {task_id}",
+                    record.task_id
+                )),
+            )],
+        ));
+    }
+
+    let mut checks = Vec::new();
+    let computed_hash = record.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence hash computation failed: {e}"
+        ))
+    })?;
+    let record_hash_ok = record.evidence_hash == computed_hash;
+    checks.push(check(
+        "record_integrity",
+        if record_hash_ok { "pass" } else { "fail" },
+        Some(format!(
+            "expected {}, computed {}",
+            record.evidence_hash, computed_hash
+        )),
+    ));
+    if !record_hash_ok {
+        return Ok(report(&record, "altered", checks));
+    }
+
+    let manifest = match workunit::load_workunit(project_root, task_id) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            checks.push(check("workunit", "fail", Some(error.to_string())));
+            return Ok(report(&record, "incomplete", checks));
+        }
+    };
+    let current_workunit_hash = manifest.canonical_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence workunit hash computation failed: {e}"
+        ))
+    })?;
+    let workunit_ok = current_workunit_hash == record.workunit_hash;
+    checks.push(check(
+        "workunit_binding",
+        if workunit_ok { "pass" } else { "fail" },
+        Some(format!(
+            "record {}, current {}",
+            record.workunit_hash, current_workunit_hash
+        )),
+    ));
+
+    let mut record_proofs: Vec<_> = record
+        .proof_results
+        .iter()
+        .map(|proof| {
+            (
+                proof.gate.clone(),
+                proof.status.clone(),
+                proof.artifact_ref.clone(),
+            )
+        })
+        .collect();
+    let mut current_proofs: Vec<_> = manifest
+        .proof_results
+        .iter()
+        .map(|proof| {
+            (
+                proof.gate.clone(),
+                proof.status.clone(),
+                proof.artifact_ref.clone(),
+            )
+        })
+        .collect();
+    record_proofs.sort();
+    current_proofs.sort();
+    let workunit_projection_ok = record.intent_ref == manifest.intent_ref
+        && canonical_strings(&record.spec_refs) == canonical_strings(&manifest.spec_refs)
+        && canonical_strings(&record.state_refs) == canonical_strings(&manifest.state_refs)
+        && canonical_strings(&record.proof_plan) == canonical_strings(&manifest.proof_plan)
+        && record_proofs == current_proofs;
+    checks.push(check(
+        "workunit_projection",
+        if workunit_projection_ok {
+            "pass"
+        } else {
+            "fail"
+        },
+        if workunit_projection_ok {
+            None
+        } else {
+            Some("record fields do not match the current workunit".to_string())
+        },
+    ));
+
+    let workunit_ready = workunit::validate_verified_manifest(&manifest).is_ok();
+    checks.push(check(
+        "proof_plan",
+        if workunit_ready { "pass" } else { "fail" },
+        if workunit_ready {
+            None
+        } else {
+            Some("workunit is not VERIFIED with passing proof results".to_string())
+        },
+    ));
+
+    let capsule_path = safe_reference_path(project_root, &record.capsule.path)?;
+    let capsule_result = load_capsule(&capsule_path).and_then(|capsule| {
+        let computed = capsule.computed_hash_hex().map_err(|e| {
+            error::DecapodError::ValidationError(format!("capsule hash failed: {e}"))
+        })?;
+        if computed != capsule.capsule_hash || computed != record.capsule.capsule_hash {
+            return Err(error::DecapodError::ValidationError(
+                "capsule hash does not match record".to_string(),
+            ));
+        }
+        if capsule.task_id.as_deref() != Some(task_id)
+            && capsule.workunit_id.as_deref() != Some(task_id)
+        {
+            return Err(error::DecapodError::ValidationError(
+                "capsule task/workunit binding mismatch".to_string(),
+            ));
+        }
+        if capsule.policy.policy_hash != record.capsule.policy_hash
+            || capsule.policy.policy_version != record.capsule.policy_version
+            || capsule.policy.repo_revision != record.capsule.repo_revision
+        {
+            return Err(error::DecapodError::ValidationError(
+                "capsule policy binding does not match record".to_string(),
+            ));
+        }
+        Ok(capsule)
+    });
+    let capsule_ok = capsule_result.is_ok();
+    checks.push(check(
+        "capsule_binding",
+        if capsule_ok { "pass" } else { "fail" },
+        capsule_result.err().map(|e| e.to_string()),
+    ));
+
+    let active_epoch = active_validation_epoch(project_root)?;
+    let current_epoch_hash = hash_json(&active_epoch)?;
+    let epoch_ok = record.validation_epoch.epoch_id == active_epoch.epoch_id
+        && record.validation_epoch.epoch_hash == current_epoch_hash;
+    checks.push(check(
+        "validation_epoch",
+        if epoch_ok { "pass" } else { "fail" },
+        Some(format!(
+            "record {} / {}, active {} / {}",
+            record.validation_epoch.epoch_id,
+            record.validation_epoch.epoch_hash,
+            active_epoch.epoch_id,
+            current_epoch_hash
+        )),
+    ));
+
+    let current_repository = repository_evidence(project_root, &record_path)?;
+    let repository_ok = current_repository == record.repository;
+    checks.push(check(
+        "repository_state",
+        if repository_ok { "pass" } else { "fail" },
+        if repository_ok {
+            None
+        } else {
+            Some("repository revision or changed surface differs from the record".to_string())
+        },
+    ));
+
+    let artifact_status = verify_proof_artifacts(project_root, &record.proof_results, &mut checks);
+    let plan_status = verify_plan(
+        project_root,
+        &record.plan_hash,
+        &record.unresolved_claims,
+        &mut checks,
+    )?;
+
+    let status =
+        if !workunit_ok || !workunit_projection_ok || !capsule_ok || artifact_status == "altered" {
+            "altered"
+        } else if !workunit_ready || artifact_status == "incomplete" || plan_status == "incomplete"
+        {
+            "incomplete"
+        } else if !epoch_ok {
+            "stale"
+        } else if !repository_ok || plan_status == "mismatch" {
+            "state_mismatch"
+        } else {
+            "current"
+        };
+    Ok(report(&record, status, checks))
+}
+
+fn verify_proof_artifacts(
+    project_root: &Path,
+    results: &[CompletionProofEvidence],
+    checks: &mut Vec<EvidenceCheck>,
+) -> &'static str {
+    let mut status = "pass";
+    for result in results {
+        let Some(reference) = result.artifact_ref.as_deref() else {
+            continue;
+        };
+        match digest_reference(project_root, reference) {
+            Ok(actual) if result.artifact.as_ref() == Some(&actual) => {
+                checks.push(check(&format!("proof_artifact:{reference}"), "pass", None))
+            }
+            Ok(actual) => {
+                status = "altered";
+                checks.push(check(
+                    &format!("proof_artifact:{reference}"),
+                    "fail",
+                    Some(format!(
+                        "record {:?}, current {:?}",
+                        result.artifact, actual
+                    )),
+                ));
+            }
+            Err(error) => {
+                if status != "altered" {
+                    status = "incomplete";
+                }
+                checks.push(check(
+                    &format!("proof_artifact:{reference}"),
+                    "fail",
+                    Some(error.to_string()),
+                ));
+            }
+        }
+    }
+    status
+}
+
+fn verify_plan(
+    project_root: &Path,
+    expected_hash: &Option<String>,
+    expected_claims: &[UnresolvedClaim],
+    checks: &mut Vec<EvidenceCheck>,
+) -> Result<&'static str, error::DecapodError> {
+    let Some(plan) = plan_governance::load_plan(project_root)? else {
+        if expected_hash.is_some() {
+            checks.push(check(
+                "governed_plan",
+                "fail",
+                Some("record references a missing governed plan".to_string()),
+            ));
+            return Ok("incomplete");
+        }
+        checks.push(check("governed_plan", "pass", None));
+        return Ok("pass");
+    };
+    let current_hash = hash_json(&plan)?;
+    let current_claims = claims_from_plan(&plan);
+    let hash_ok = expected_hash.as_deref() == Some(current_hash.as_str());
+    let claims_ok = expected_claims == current_claims;
+    checks.push(check(
+        "governed_plan",
+        if hash_ok && claims_ok { "pass" } else { "fail" },
+        Some(format!(
+            "record {:?}, current {current_hash}",
+            expected_hash
+        )),
+    ));
+    Ok(if hash_ok && claims_ok {
+        "pass"
+    } else {
+        "mismatch"
+    })
+}
+
+fn report(
+    record: &CompletionEvidenceRecord,
+    status: &str,
+    checks: Vec<EvidenceCheck>,
+) -> CompletionEvidenceVerification {
+    CompletionEvidenceVerification {
+        schema_version: record.schema_version.clone(),
+        task_id: record.task_id.clone(),
+        status: status.to_string(),
+        checks,
+        unresolved_claims: record.unresolved_claims.clone(),
+    }
+}
+
+fn check(name: &str, status: &str, detail: Option<String>) -> EvidenceCheck {
+    EvidenceCheck {
+        name: name.to_string(),
+        status: status.to_string(),
+        detail,
+    }
+}
+
+fn canonical_strings(values: &[String]) -> Vec<String> {
+    let mut values = values.to_vec();
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn load_capsule(path: &Path) -> Result<DeterministicContextCapsule, error::DecapodError> {
+    let raw = fs::read_to_string(path).map_err(error::DecapodError::IoError)?;
+    serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "invalid context capsule {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+fn hash_json<T: Serialize>(value: &T) -> Result<String, error::DecapodError> {
+    let bytes = serde_json::to_vec(value).map_err(|e| {
+        error::DecapodError::ValidationError(format!("completion evidence JSON hash failed: {e}"))
+    })?;
+    Ok(hash_bytes(&bytes))
+}
+
+fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn digest_reference(
+    project_root: &Path,
+    reference: &str,
+) -> Result<FileDigest, error::DecapodError> {
+    let path = safe_reference_path(project_root, reference)?;
+    let bytes = fs::read(&path).map_err(error::DecapodError::IoError)?;
+    let metadata = fs::metadata(&path).map_err(error::DecapodError::IoError)?;
+    Ok(FileDigest {
+        path: relative_path(project_root, &path)?,
+        sha256: hash_bytes(&bytes),
+        size: metadata.len(),
+    })
+}
+
+fn safe_reference_path(
+    project_root: &Path,
+    reference: &str,
+) -> Result<PathBuf, error::DecapodError> {
+    let root = fs::canonicalize(project_root).map_err(error::DecapodError::IoError)?;
+    let candidate = if Path::new(reference).is_absolute() {
+        PathBuf::from(reference)
+    } else {
+        project_root.join(reference)
+    };
+    let path = fs::canonicalize(&candidate).map_err(|_| {
+        error::DecapodError::NotFound(format!(
+            "completion evidence artifact not found: {reference}"
+        ))
+    })?;
+    if !path.starts_with(&root) {
+        return Err(error::DecapodError::ValidationError(format!(
+            "completion evidence artifact escapes repository root: {reference}"
+        )));
+    }
+    Ok(path)
+}
+
+fn relative_path(project_root: &Path, path: &Path) -> Result<String, error::DecapodError> {
+    let root = fs::canonicalize(project_root).map_err(error::DecapodError::IoError)?;
+    let path = fs::canonicalize(path).map_err(error::DecapodError::IoError)?;
+    path.strip_prefix(root)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .map_err(|_| {
+            error::DecapodError::ValidationError(format!(
+                "completion evidence path is outside repository: {}",
+                path.display()
+            ))
+        })
+}
+
+fn git_output(project_root: &Path, args: &[&str]) -> Result<String, error::DecapodError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .map_err(error::DecapodError::IoError)?;
+    if !output.status.success() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn optional_git_output(project_root: &Path, args: &[&str]) -> Option<String> {
+    git_output(project_root, args)
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+fn repository_evidence(
+    project_root: &Path,
+    record_path: &Path,
+) -> Result<RepositoryEvidence, error::DecapodError> {
+    let head_revision = git_output(project_root, &["rev-parse", "HEAD"])?;
+    let base_revision = optional_git_output(project_root, &["rev-parse", "HEAD^"]);
+    let mut changed_paths = BTreeSet::new();
+    if let Some(base) = base_revision.as_deref() {
+        let diff = git_output(
+            project_root,
+            &["diff", "--name-only", "--no-renames", base, &head_revision],
+        )?;
+        changed_paths.extend(
+            diff.lines()
+                .filter(|path| !path.is_empty())
+                .map(str::to_string),
+        );
+    } else {
+        let tree = git_output(
+            project_root,
+            &["ls-tree", "-r", "--name-only", &head_revision],
+        )?;
+        changed_paths.extend(
+            tree.lines()
+                .filter(|path| !path.is_empty())
+                .map(str::to_string),
+        );
+    }
+
+    let record_relative = relative_path(project_root, record_path).unwrap_or_default();
+    let status = git_output(
+        project_root,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )?;
+    let mut working_tree = Vec::new();
+    for line in status.lines().filter(|line| !line.is_empty()) {
+        let raw_path = line.get(3..).unwrap_or(line).trim();
+        let path = raw_path
+            .rsplit_once(" -> ")
+            .map(|(_, destination)| destination)
+            .unwrap_or(raw_path)
+            .trim_matches('"')
+            .replace('\\', "/");
+        if path == record_relative {
+            continue;
+        }
+        changed_paths.insert(path.clone());
+        let disk_path = project_root.join(&path);
+        if disk_path.is_file() {
+            let digest = digest_reference(project_root, &path)?;
+            working_tree.push(WorkingTreeEntry {
+                path,
+                exists: true,
+                sha256: Some(digest.sha256),
+                size: Some(digest.size),
+            });
+        } else {
+            working_tree.push(WorkingTreeEntry {
+                path,
+                exists: false,
+                sha256: None,
+                size: None,
+            });
+        }
+    }
+
+    Ok(RepositoryEvidence {
+        head_revision,
+        base_revision,
+        changed_paths: changed_paths.into_iter().collect(),
+        working_tree,
+    })
+}
+
+fn unresolved_claims(
+    project_root: &Path,
+) -> Result<(Vec<UnresolvedClaim>, Option<String>), error::DecapodError> {
+    let Some(plan) = plan_governance::load_plan(project_root)? else {
+        return Ok((Vec::new(), None));
+    };
+    let plan_hash = Some(hash_json(&plan)?);
+    Ok((claims_from_plan(&plan), plan_hash))
+}
+
+fn claims_from_plan(plan: &plan_governance::GovernedPlan) -> Vec<UnresolvedClaim> {
+    let mut claims = Vec::new();
+    for (kind, values) in [
+        ("unknown", &plan.unknowns),
+        ("human_question", &plan.human_questions),
+        ("contradiction", &plan.unresolved_contradictions),
+        ("deferred_question", &plan.deferred_questions),
+    ] {
+        claims.extend(values.iter().cloned().map(|text| UnresolvedClaim {
+            kind: kind.to_string(),
+            text,
+        }));
+    }
+    claims.sort();
+    claims.dedup();
+    claims
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::capsule_policy::CapsulePolicyBinding;
+    use crate::core::workunit::{WorkUnitManifest, WorkUnitProofResult};
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    fn fixture() -> CompletionEvidenceRecord {
+        CompletionEvidenceRecord {
+            schema_version: COMPLETION_EVIDENCE_SCHEMA_VERSION.to_string(),
+            task_id: "task-1".to_string(),
+            workunit_hash: "sha256:workunit".to_string(),
+            intent_ref: "INTENT.md".to_string(),
+            spec_refs: vec!["b".to_string(), "a".to_string(), "a".to_string()],
+            state_refs: vec!["state.json".to_string()],
+            proof_plan: vec!["b".to_string(), "a".to_string()],
+            proof_results: vec![CompletionProofEvidence {
+                gate: "a".to_string(),
+                status: "pass".to_string(),
+                artifact_ref: None,
+                artifact: None,
+            }],
+            capsule: CapsuleEvidence {
+                path: ".decapod/generated/context/task-1.json".to_string(),
+                capsule_hash: "sha256:capsule".to_string(),
+                policy_hash: "sha256:policy".to_string(),
+                policy_version: "1".to_string(),
+                repo_revision: "revision".to_string(),
+            },
+            repository: RepositoryEvidence {
+                head_revision: "head".to_string(),
+                base_revision: Some("base".to_string()),
+                changed_paths: vec!["b".to_string(), "a".to_string()],
+                working_tree: Vec::new(),
+            },
+            validation_epoch: ValidationEpochEvidence {
+                epoch_id: "epoch".to_string(),
+                epoch_hash: "sha256:epoch".to_string(),
+            },
+            unresolved_claims: vec![UnresolvedClaim {
+                kind: "unknown".to_string(),
+                text: "later".to_string(),
+            }],
+            plan_hash: None,
+            evidence_hash: String::new(),
+        }
+    }
+
+    #[test]
+    fn canonical_hash_is_stable_and_excludes_stored_hash() {
+        let record = fixture();
+        let hashed = record.with_recomputed_hash().expect("hash record");
+        assert_eq!(
+            record.computed_hash_hex().unwrap(),
+            hashed.computed_hash_hex().unwrap()
+        );
+        assert_eq!(hashed.evidence_hash, hashed.computed_hash_hex().unwrap());
+    }
+
+    #[test]
+    fn canonical_hash_ignores_order_of_repeated_fields() {
+        let record = fixture();
+        let mut reordered = record.clone();
+        reordered.spec_refs.reverse();
+        reordered.proof_plan.reverse();
+        reordered.repository.changed_paths.reverse();
+        assert_eq!(
+            record.computed_hash_hex().unwrap(),
+            reordered.computed_hash_hex().unwrap()
+        );
+    }
+
+    #[test]
+    fn proof_artifact_changes_are_reported_as_altered() {
+        let directory = tempdir().expect("temp directory");
+        let artifact_path = directory.path().join("proof.txt");
+        fs::write(&artifact_path, "original").expect("write artifact");
+        let digest = digest_reference(directory.path(), "proof.txt").expect("digest artifact");
+        let result = CompletionProofEvidence {
+            gate: "proof".to_string(),
+            status: "pass".to_string(),
+            artifact_ref: Some("proof.txt".to_string()),
+            artifact: Some(digest),
+        };
+        fs::write(&artifact_path, "altered").expect("alter artifact");
+        let mut checks = Vec::new();
+        assert_eq!(
+            verify_proof_artifacts(directory.path(), &[result], &mut checks),
+            "altered"
+        );
+        assert_eq!(checks[0].status, "fail");
+    }
+
+    #[test]
+    fn missing_proof_artifact_is_reported_as_incomplete() {
+        let directory = tempdir().expect("temp directory");
+        let result = CompletionProofEvidence {
+            gate: "proof".to_string(),
+            status: "pass".to_string(),
+            artifact_ref: Some("missing.txt".to_string()),
+            artifact: None,
+        };
+        let mut checks = Vec::new();
+        assert_eq!(
+            verify_proof_artifacts(directory.path(), &[result], &mut checks),
+            "incomplete"
+        );
+        assert_eq!(checks[0].status, "fail");
+    }
+
+    #[test]
+    fn artifact_reference_cannot_escape_repository_root() {
+        let directory = tempdir().expect("temp directory");
+        assert!(safe_reference_path(directory.path(), "../outside.txt").is_err());
+    }
+
+    #[test]
+    fn local_record_replays_and_detects_artifact_change() {
+        let directory = tempdir().expect("temp directory");
+        let root = directory.path();
+        git(root, &["init", "--initial-branch", "master"]);
+        git(root, &["config", "user.email", "test@example.com"]);
+        git(root, &["config", "user.name", "Test"]);
+        fs::write(root.join("README.md"), "fixture\n").expect("write fixture");
+        git(root, &["add", "README.md"]);
+        git(root, &["commit", "-m", "fixture"]);
+
+        let capsule_path = root.join(".decapod/generated/context/task-1.json");
+        fs::create_dir_all(capsule_path.parent().unwrap()).expect("capsule directory");
+        let capsule = DeterministicContextCapsule {
+            schema_version: "1.1.0".to_string(),
+            topic: "fixture".to_string(),
+            scope: "core".to_string(),
+            task_id: Some("task-1".to_string()),
+            workunit_id: None,
+            sources: Vec::new(),
+            snippets: Vec::new(),
+            capabilities: Vec::new(),
+            policy: CapsulePolicyBinding {
+                risk_tier: "low".to_string(),
+                policy_hash: "sha256:policy".to_string(),
+                policy_version: "1".to_string(),
+                policy_path: "policy.json".to_string(),
+                repo_revision: "HEAD".to_string(),
+            },
+            capsule_hash: String::new(),
+            repo_signal_fingerprint: String::new(),
+            config_input_hash: String::new(),
+            spec_input_hash: String::new(),
+        }
+        .with_recomputed_hash()
+        .expect("capsule hash");
+        fs::write(
+            &capsule_path,
+            serde_json::to_vec_pretty(&capsule).expect("capsule JSON"),
+        )
+        .expect("write capsule");
+
+        let proof_path = root.join("proof.txt");
+        fs::write(&proof_path, "proof\n").expect("write proof");
+        let epoch = active_validation_epoch(root).expect("validation epoch");
+        let manifest = WorkUnitManifest {
+            task_id: "task-1".to_string(),
+            intent_ref: "INTENT.md".to_string(),
+            spec_refs: vec!["ARCHITECTURE.md".to_string()],
+            state_refs: vec![".decapod/generated/context/task-1.json".to_string()],
+            proof_plan: vec!["proof".to_string()],
+            proof_results: vec![WorkUnitProofResult {
+                gate: "proof".to_string(),
+                status: "pass".to_string(),
+                artifact_ref: Some("proof.txt".to_string()),
+                evaluator_epoch: None,
+                validation_epoch: Some(epoch.clone()),
+            }],
+            validation_epoch: Some(epoch),
+            status: WorkUnitStatus::Verified,
+        };
+        workunit::write_workunit(root, &manifest).expect("write workunit");
+
+        let record = build_record(root, "task-1").expect("build record");
+        let record_path = write_record(root, &record).expect("write record");
+        let report = verify_record(root, "task-1", &record_path).expect("verify record");
+        assert_eq!(report.status, "current");
+
+        fs::write(&proof_path, "altered\n").expect("alter proof");
+        let report = verify_record(root, "task-1", &record_path).expect("verify altered record");
+        assert_eq!(report.status, "altered");
+    }
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod broker;
 pub mod capabilities;
 pub mod capsule_policy;
 pub mod cloud_backend;
+pub mod completion_evidence;
 pub mod constitution_cli;
 pub mod constitution_schema;
 pub mod container_runtime;

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -1,4 +1,5 @@
 use crate::core::broker::DbBroker;
+use crate::core::completion_evidence;
 use crate::core::error;
 use crate::core::external_action::{self, ExternalCapability};
 use crate::core::state_commit;
@@ -62,6 +63,17 @@ pub enum VerifyCommand {
     Prune {
         #[clap(value_name = "ID")]
         id: String,
+    },
+    /// Generate or independently verify a completion evidence record.
+    Completion {
+        #[clap(value_name = "ID")]
+        id: String,
+        /// Generate the record instead of verifying the existing record.
+        #[clap(long)]
+        write: bool,
+        /// Verify a specific record path instead of the default repository path.
+        #[clap(long)]
+        path: Option<PathBuf>,
     },
 }
 
@@ -1022,6 +1034,54 @@ pub fn run_verify_cli(
                     );
                 } else {
                     println!("{}", serde_json::json!({ "status": "ok", "todo_id": id }));
+                }
+                return Ok(());
+            }
+            VerifyCommand::Completion { id, write, path } => {
+                let record_path = path
+                    .clone()
+                    .unwrap_or(completion_evidence::default_record_path(repo_root, id)?);
+                if *write {
+                    let record = completion_evidence::build_record(repo_root, id)?;
+                    let written = completion_evidence::write_record(repo_root, &record)?;
+                    if cli.json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "status": "ok",
+                                "task_id": id,
+                                "record_path": written,
+                                "evidence_hash": record.evidence_hash,
+                            })
+                        );
+                    } else {
+                        println!(
+                            "completion evidence written: {} ({})",
+                            written.display(),
+                            record.evidence_hash
+                        );
+                    }
+                } else {
+                    let report = completion_evidence::verify_record(repo_root, id, &record_path)?;
+                    if cli.json {
+                        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+                    } else {
+                        println!("completion evidence {id} [{}]", report.status);
+                        for check in &report.checks {
+                            let detail = check
+                                .detail
+                                .as_deref()
+                                .map(|detail| format!(" ({detail})"))
+                                .unwrap_or_default();
+                            println!("- {}: {}{}", check.name, check.status, detail);
+                        }
+                    }
+                    if report.status != "current" {
+                        return Err(error::DecapodError::ValidationError(format!(
+                            "completion evidence verification status: {}",
+                            report.status
+                        )));
+                    }
                 }
                 return Ok(());
             }


### PR DESCRIPTION
Implements the first local-first slice prescribed in Issue #861.

- Adds a deterministic completion evidence record derived from existing workunit, context capsule, repository state, validation epoch, proof artifact, and governed-plan records.
- Extends qa verify with generation and independent verification.
- Detects altered records and artifacts, missing proof artifacts, mismatched workunit projections, changed repository state, stale validation epochs, unresolved plan changes, and repository-boundary violations.
- Keeps identity, ownership, signatures, cloud services, and authority transfer out of scope. Imported evidence and publication authority remain subject to the receiving repository's local gates.
- Uses Houseboat issues #851, #854, #856, #857, #858, and #860 as related context.

Closes #861
