### PR TITLE
feat: add portable completion evidence custody

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784184911Z",
-  "repo_signal_fingerprint": "acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba",
+  "generated_at": "1784188069Z",
+  "repo_signal_fingerprint": "60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "16532857a8bee20e2f211e240cb1d74b469fb5eb2c8a1fae693fd123964bed58",
+  "spec_input_hash": "009555f8f641814a19980ebf930c7dfecede0048f2122c8b8d76abcda12489db",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "43bbfa1ddc1f71b7fd3393f9073f211ef1836c43a84c4323269781c14c4e63d3"
+      "content_hash": "9304689aa88b42137cb32658b2906a5bc32c806e2414c17704532037977f441f"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "869f6ab96c5ee9f1204efaec8c518d63521df8be6d959b82dcee845ab6ea89df"
+      "content_hash": "d175c4dcba6faebe14092e95bd03db93a56d19899ce04133b3ab235316644286"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "48cb36ea4dc8397b8bee0edf4b4c6cf775b29423a49aae7fe5697349dcf712b5"
+      "content_hash": "c8696fd893d56375b26b171f9b8f1d6b31bada171d22e738d785de3835b2a0fd"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "badefcdbe9c7926c6f236e039ac664293b4ddecc2db43f5b240ed9089d205a35"
+      "content_hash": "1bf8dd79c71c5e1a3b05328416c00726d3545c55752c81f7dae461a0c5206d09"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "af10abe57acf59ba272e6c885556e0da72639c429b4dbb2cd24b3f7931b9d167"
+      "content_hash": "2b3d0d09ee82817d5b79871f4c16e305005079825d26583f8363bfc50ffefec2"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "2576c8468b270668fed4a42f31206fe1bb3223bcb3f56597338b15a5ec13f2f0"
+      "content_hash": "25acb2eee0cd0d98f4043a3077882be65001aa22de78c54b2dde4cebe421e768"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "74a945189a9cef48fc7a5d249801a5af4b430fd66474a9afe25b498ad9b6ba10"
+      "content_hash": "3e758230b816d26ac4ba1b87dd05086d73114896a0ff8f776f37c4eec921ddc5"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "5be0f00c7ab8580df39549f788f22d95b415631150a2a2e1e9ec3dbd9909fa5d"
+      "content_hash": "b15c77a6a1f8f6ae18cc97527128d2675658c03e57d60c15b660a06eb582971d"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -53,6 +53,7 @@ Generated interface specs include:
 | `decapod data knowledge add` | Add knowledge entry | `--id`, `--title`, `--text`, `--provenance` | KnowledgeEntry |
 | `decapod data knowledge search` | Search knowledge | `--query` | KnowledgeEntry[] |
 | `decapod qa verify` | Proof replay + drift check | — | VerificationReport |
+| `decapod qa verify completion <ID>` | Generate, verify, export, or import completion evidence | `--write`, `--path`, `--export`, `--import` | CompletionEvidenceVerification |
 | `decapod infer orientation` | Pre-inference context packet | `--intent`, `--task-id`, `--format` | OrientationPacket |
 | `decapod infer validate` | Post-inference verification | `--result`, `--intent`, `--format` | ValidationResult |
 | `decapod rpc --op <op>` | JSON-RPC interface | `--params`, `--stdin` | RpcResponse |
@@ -209,6 +210,8 @@ Response envelope (`RpcResponse`):
 | `.decapod/data/*.db` | Decapod CLI (single-writer per store) | Decapod CLI, validation (read-only) |
 | `.decapod/data/*.jsonl` | Decapod CLI (append-only) | Decapod CLI, flight-recorder, rebuild |
 | `.decapod/generated/context/*.json` | `capsule.query --write` | WorkUnit lineage, publish gate |
+| `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | `qa verify completion <ID> --write` | Completion verifier, promotion review |
+| `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | `qa verify completion <ID> --import` | Structural inspection and receiver-local decision |
 | `.decapod/generated/policy/context_capsule_policy.json` | `init` / scaffold | Capsule query resolution |
 | `.decapod/generated/specs/*.md` | `init --force` / `rpc specs.refresh` | Validation, agents |
 | `.decapod/generated/artifacts/provenance/*.json` | `workspace publish` / `validate` | Promotion, CI |
@@ -398,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -135,6 +135,8 @@ cargo vet             # Supply-chain auditing (manual)
 - **Major**: Manual review (breaking changes)
 
 ### Signed Artifact / Provenance Strategy
+
+Completion evidence export carries canonical records, source revision bindings, and artifact digests. Imported completion evidence is stored as untrusted evidence and must pass receiving-repository verification; it does not import authority, publication permission, provider trust, or agent permissions. Signatures remain optional and do not replace semantic validation.
 - `cargo dist` generates signed checksums (GPG)
 - `decapod release inventory` emits deterministic SBOM
 - Provenance manifests: `artifact_manifest.json`, `proof_manifest.json`
@@ -218,7 +220,7 @@ cargo vet             # Supply-chain auditing (manual)
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -133,6 +133,7 @@ flowchart LR
 | Session auth | `decapod session status` | Valid session token |
 | Specs manifest sync | `decapod validate` (specs gate) | `.manifest.json` fingerprints match |
 | Capsule policy lineage | `decapod govern capsule query --write` | Policy hash binds to HEAD |
+| Completion evidence integrity | `decapod qa verify completion <ID>` | Canonical record, artifact, epoch, and receiver-local checks |
 
 ### Warning Gates (Non-Blocking, SLA Tracked)
 | Gate | Trigger | Follow-up SLA |
@@ -148,6 +149,8 @@ flowchart LR
 | Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | Promotion |
 | Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
 | Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
+| Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
+| Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
 | Test logs | CI artifact store | Promotion |
 | Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
 | Changelog entry | `CHANGELOG.md` | Promotion |
@@ -334,7 +337,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `acdece1f7a55f5b8b2cfe935fc0c0dd6a8bd73fb264397e7d9402837a35002ba`
+- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/src/core/completion_evidence.rs
+++ b/src/core/completion_evidence.rs
@@ -13,6 +13,8 @@ use std::process::Command;
 pub const COMPLETION_EVIDENCE_SCHEMA_VERSION: &str = "1.0.0";
 pub const COMPLETION_EVIDENCE_DIR: &str =
     ".decapod/generated/artifacts/provenance/completion_evidence";
+pub const IMPORTED_COMPLETION_EVIDENCE_DIR: &str =
+    ".decapod/generated/artifacts/provenance/completion_evidence/imports";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CompletionProofEvidence {
@@ -92,6 +94,37 @@ pub struct CompletionEvidenceRecord {
     pub evidence_hash: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceRepositoryBinding {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_id: Option<String>,
+    pub head_revision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PortableCompletionEvidence {
+    pub schema_version: String,
+    pub source_repository: SourceRepositoryBinding,
+    pub record: CompletionEvidenceRecord,
+    pub capsule_artifact: FileDigest,
+    #[serde(default)]
+    pub proof_artifacts: Vec<FileDigest>,
+    pub envelope_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PortableCompletionEvidenceVerification {
+    pub schema_version: String,
+    pub task_id: String,
+    pub envelope_hash: String,
+    pub structural_status: String,
+    pub local_decision: String,
+    pub checks: Vec<EvidenceCheck>,
+    pub unresolved_claims: Vec<UnresolvedClaim>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EvidenceCheck {
     pub name: String,
@@ -146,6 +179,46 @@ impl CompletionEvidenceRecord {
     }
 }
 
+impl PortableCompletionEvidence {
+    fn canonicalized(&self) -> CanonicalPortableCompletionEvidence {
+        let mut proof_artifacts = self.proof_artifacts.clone();
+        proof_artifacts.sort();
+        proof_artifacts.dedup();
+        CanonicalPortableCompletionEvidence {
+            schema_version: self.schema_version.clone(),
+            source_repository: self.source_repository.clone(),
+            record: self.record.clone(),
+            capsule_artifact: self.capsule_artifact.clone(),
+            proof_artifacts,
+        }
+    }
+
+    pub fn canonical_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.canonicalized())
+    }
+
+    pub fn computed_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let mut hasher = Sha256::new();
+        hasher.update(self.canonical_json_bytes()?);
+        Ok(format!("sha256:{:x}", hasher.finalize()))
+    }
+
+    pub fn with_recomputed_hash(&self) -> Result<Self, serde_json::Error> {
+        let mut out = self.clone();
+        out.envelope_hash = out.computed_hash_hex()?;
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CanonicalPortableCompletionEvidence {
+    schema_version: String,
+    source_repository: SourceRepositoryBinding,
+    record: CompletionEvidenceRecord,
+    capsule_artifact: FileDigest,
+    proof_artifacts: Vec<FileDigest>,
+}
+
 pub fn default_record_path(
     project_root: &Path,
     task_id: &str,
@@ -154,6 +227,334 @@ pub fn default_record_path(
     Ok(project_root
         .join(COMPLETION_EVIDENCE_DIR)
         .join(format!("{task_id}.json")))
+}
+
+pub fn imported_record_path(
+    project_root: &Path,
+    envelope_hash: &str,
+) -> Result<PathBuf, error::DecapodError> {
+    if !envelope_hash.starts_with("sha256:")
+        || envelope_hash.len() != "sha256:".len() + 64
+        || !envelope_hash["sha256:".len()..]
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return Err(error::DecapodError::ValidationError(
+            "portable completion evidence has an invalid envelope hash".to_string(),
+        ));
+    }
+    Ok(project_root
+        .join(IMPORTED_COMPLETION_EVIDENCE_DIR)
+        .join(format!("{envelope_hash}.json")))
+}
+
+pub fn export_record(
+    project_root: &Path,
+    task_id: &str,
+    record_path: &Path,
+    output_path: &Path,
+) -> Result<PortableCompletionEvidence, error::DecapodError> {
+    let record = read_local_record(project_root, task_id, record_path)?;
+    let report = verify_record(project_root, task_id, record_path)?;
+    if report.status != "current" {
+        return Err(error::DecapodError::ValidationError(format!(
+            "cannot export completion evidence with verification status {}",
+            report.status
+        )));
+    }
+
+    let capsule_artifact = digest_reference(project_root, &record.capsule.path)?;
+    let mut proof_artifacts = record
+        .proof_results
+        .iter()
+        .filter_map(|proof| proof.artifact.clone())
+        .collect::<Vec<_>>();
+    proof_artifacts.sort();
+    proof_artifacts.dedup();
+
+    let envelope = PortableCompletionEvidence {
+        schema_version: COMPLETION_EVIDENCE_SCHEMA_VERSION.to_string(),
+        source_repository: SourceRepositoryBinding {
+            repository_id: source_repository_id(project_root),
+            head_revision: record.repository.head_revision.clone(),
+            base_revision: record.repository.base_revision.clone(),
+        },
+        record,
+        capsule_artifact,
+        proof_artifacts,
+        envelope_hash: String::new(),
+    }
+    .with_recomputed_hash()
+    .map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "portable completion evidence serialization failed: {e}"
+        ))
+    })?;
+    validate_portable_evidence(&envelope)?;
+
+    let parent = output_path.parent().ok_or_else(|| {
+        error::DecapodError::ValidationError(
+            "portable completion evidence export has no parent directory".to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+    let bytes = serde_json::to_vec_pretty(&envelope).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "portable completion evidence serialization failed: {e}"
+        ))
+    })?;
+    fs::write(output_path, bytes).map_err(error::DecapodError::IoError)?;
+    Ok(envelope)
+}
+
+pub fn import_record(
+    project_root: &Path,
+    task_id: &str,
+    input_path: &Path,
+) -> Result<(PathBuf, PortableCompletionEvidenceVerification), error::DecapodError> {
+    let envelope = read_portable_evidence(input_path)?;
+    if envelope.record.task_id != task_id {
+        return Err(error::DecapodError::ValidationError(format!(
+            "portable completion evidence task binding is {}, requested {task_id}",
+            envelope.record.task_id
+        )));
+    }
+    let destination = imported_record_path(project_root, &envelope.envelope_hash)?;
+    let parent = destination.parent().ok_or_else(|| {
+        error::DecapodError::ValidationError(
+            "portable completion evidence import has no destination directory".to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+    let bytes = fs::read(input_path).map_err(error::DecapodError::IoError)?;
+    fs::write(&destination, bytes).map_err(error::DecapodError::IoError)?;
+    let report = verify_portable_evidence(project_root, task_id, &envelope, &destination)?;
+    Ok((destination, report))
+}
+
+pub fn read_portable_evidence(
+    input_path: &Path,
+) -> Result<PortableCompletionEvidence, error::DecapodError> {
+    let raw = fs::read_to_string(input_path).map_err(error::DecapodError::IoError)?;
+    let envelope = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "portable completion evidence is not valid JSON: {e}"
+        ))
+    })?;
+    validate_portable_evidence(&envelope)?;
+    Ok(envelope)
+}
+
+fn validate_portable_evidence(
+    envelope: &PortableCompletionEvidence,
+) -> Result<(), error::DecapodError> {
+    if envelope.schema_version != COMPLETION_EVIDENCE_SCHEMA_VERSION {
+        return Err(error::DecapodError::ValidationError(format!(
+            "PORTABLE_COMPLETION_EVIDENCE_INCOMPATIBLE: schema_version {} is not supported",
+            envelope.schema_version
+        )));
+    }
+    let expected_envelope_hash = envelope.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: envelope hash: {e}"
+        ))
+    })?;
+    if envelope.envelope_hash != expected_envelope_hash {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_TAMPERED: envelope_hash does not match canonical contents"
+                .to_string(),
+        ));
+    }
+    let expected_record_hash = envelope.record.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: record hash: {e}"
+        ))
+    })?;
+    if envelope.record.evidence_hash != expected_record_hash {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_TAMPERED: evidence_hash does not match canonical record"
+                .to_string(),
+        ));
+    }
+    if envelope.source_repository.head_revision != envelope.record.repository.head_revision
+        || envelope.source_repository.base_revision != envelope.record.repository.base_revision
+    {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: source repository binding does not match record"
+                .to_string(),
+        ));
+    }
+
+    validate_relative_evidence_path(&envelope.record.capsule.path)?;
+    if envelope.capsule_artifact.path != envelope.record.capsule.path {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: capsule artifact does not match record"
+                .to_string(),
+        ));
+    }
+    for path in &envelope.record.repository.changed_paths {
+        validate_relative_evidence_path(path)?;
+    }
+    for entry in &envelope.record.repository.working_tree {
+        validate_relative_evidence_path(&entry.path)?;
+    }
+
+    let mut expected_artifacts = Vec::new();
+    for proof in &envelope.record.proof_results {
+        match (&proof.artifact_ref, &proof.artifact) {
+            (None, None) => {}
+            (Some(reference), Some(artifact)) => {
+                validate_relative_evidence_path(reference)?;
+                if artifact.path != *reference {
+                    return Err(error::DecapodError::ValidationError(format!(
+                        "PORTABLE_COMPLETION_EVIDENCE_INVALID: proof artifact path {} does not match reference {reference}",
+                        artifact.path
+                    )));
+                }
+                expected_artifacts.push(artifact.clone());
+            }
+            _ => {
+                return Err(error::DecapodError::ValidationError(
+                    "PORTABLE_COMPLETION_EVIDENCE_INVALID: proof artifact reference and digest must be paired"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    expected_artifacts.sort();
+    expected_artifacts.dedup();
+    let mut actual_artifacts = envelope.proof_artifacts.clone();
+    actual_artifacts.sort();
+    actual_artifacts.dedup();
+    if expected_artifacts != actual_artifacts {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: proof artifact custody manifest does not match record"
+                .to_string(),
+        ));
+    }
+    for artifact in &envelope.proof_artifacts {
+        validate_relative_evidence_path(&artifact.path)?;
+    }
+    Ok(())
+}
+
+fn validate_relative_evidence_path(path: &str) -> Result<(), error::DecapodError> {
+    let candidate = Path::new(path);
+    if path.is_empty()
+        || candidate.is_absolute()
+        || candidate
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(error::DecapodError::ValidationError(format!(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: path is not repository-relative: {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn source_repository_id(project_root: &Path) -> Option<String> {
+    let remote = optional_git_output(project_root, &["remote", "get-url", "origin"])?;
+    sanitized_source_repository_id(&remote)
+}
+
+fn sanitized_source_repository_id(remote: &str) -> Option<String> {
+    let remote = remote.trim();
+    if remote.is_empty() {
+        return None;
+    }
+    if let Some((host, path)) = remote
+        .strip_prefix("git@")
+        .and_then(|value| value.split_once(':'))
+    {
+        return Some(format!("ssh://{host}/{path}"));
+    }
+    if let Some((scheme, remainder)) = remote.split_once("://") {
+        let without_credentials = remainder
+            .rsplit_once('@')
+            .map(|(_, value)| value)
+            .unwrap_or(remainder);
+        return Some(format!("{scheme}://{without_credentials}"));
+    }
+    Some(remote.to_string())
+}
+
+fn verify_portable_evidence(
+    project_root: &Path,
+    task_id: &str,
+    envelope: &PortableCompletionEvidence,
+    imported_path: &Path,
+) -> Result<PortableCompletionEvidenceVerification, error::DecapodError> {
+    let mut checks = vec![check("envelope_integrity", "pass", None)];
+    let workunit_path = workunit::workunit_path(project_root, task_id)?;
+    let (structural_status, local_decision) = if !workunit_path.exists() {
+        checks.push(check(
+            "local_policy",
+            "fail",
+            Some("receiving repository has no matching local workunit".to_string()),
+        ));
+        ("structurally_valid", "rejected")
+    } else {
+        let local_report =
+            verify_record_value(project_root, task_id, &envelope.record, imported_path)?;
+        for local_check in local_report.checks {
+            checks.push(check(
+                &format!("local:{}", local_check.name),
+                &local_check.status,
+                local_check.detail,
+            ));
+        }
+        if local_report.status == "current" {
+            ("structurally_valid", "accepted")
+        } else {
+            checks.push(check(
+                "local_policy",
+                "fail",
+                Some(format!(
+                    "receiving repository verification status: {}",
+                    local_report.status
+                )),
+            ));
+            ("structurally_valid", "rejected")
+        }
+    };
+    Ok(PortableCompletionEvidenceVerification {
+        schema_version: envelope.schema_version.clone(),
+        task_id: task_id.to_string(),
+        envelope_hash: envelope.envelope_hash.clone(),
+        structural_status: structural_status.to_string(),
+        local_decision: local_decision.to_string(),
+        checks,
+        unresolved_claims: envelope.record.unresolved_claims.clone(),
+    })
+}
+
+fn read_local_record(
+    project_root: &Path,
+    task_id: &str,
+    record_path: &Path,
+) -> Result<CompletionEvidenceRecord, error::DecapodError> {
+    let record_path = fs::canonicalize(record_path).map_err(error::DecapodError::IoError)?;
+    let project_root_canonical =
+        fs::canonicalize(project_root).map_err(error::DecapodError::IoError)?;
+    if !record_path.starts_with(&project_root_canonical) {
+        return Err(error::DecapodError::ValidationError(
+            "completion evidence record must be inside the repository".to_string(),
+        ));
+    }
+    let raw = fs::read_to_string(&record_path).map_err(error::DecapodError::IoError)?;
+    let record: CompletionEvidenceRecord = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "completion evidence record is not valid JSON: {e}"
+        ))
+    })?;
+    if record.task_id != task_id {
+        return Err(error::DecapodError::ValidationError(format!(
+            "completion evidence record task binding is {}, requested {task_id}",
+            record.task_id
+        )));
+    }
+    Ok(record)
 }
 
 pub fn build_record(
@@ -294,9 +695,18 @@ pub fn verify_record(
             "completion evidence record is not valid JSON: {e}"
         ))
     })?;
+    verify_record_value(project_root, task_id, &record, &record_path)
+}
+
+fn verify_record_value(
+    project_root: &Path,
+    task_id: &str,
+    record: &CompletionEvidenceRecord,
+    record_path: &Path,
+) -> Result<CompletionEvidenceVerification, error::DecapodError> {
     if record.schema_version != COMPLETION_EVIDENCE_SCHEMA_VERSION {
         return Ok(report(
-            &record,
+            record,
             "invalid",
             vec![check(
                 "schema",
@@ -310,7 +720,7 @@ pub fn verify_record(
     }
     if record.task_id != task_id {
         return Ok(report(
-            &record,
+            record,
             "invalid",
             vec![check(
                 "task_binding",
@@ -339,14 +749,14 @@ pub fn verify_record(
         )),
     ));
     if !record_hash_ok {
-        return Ok(report(&record, "altered", checks));
+        return Ok(report(record, "altered", checks));
     }
 
     let manifest = match workunit::load_workunit(project_root, task_id) {
         Ok(manifest) => manifest,
         Err(error) => {
             checks.push(check("workunit", "fail", Some(error.to_string())));
-            return Ok(report(&record, "incomplete", checks));
+            return Ok(report(record, "incomplete", checks));
         }
     };
     let current_workunit_hash = manifest.canonical_hash_hex().map_err(|e| {
@@ -468,7 +878,7 @@ pub fn verify_record(
         )),
     ));
 
-    let current_repository = repository_evidence(project_root, &record_path)?;
+    let current_repository = repository_evidence(project_root, record_path)?;
     let repository_ok = current_repository == record.repository;
     checks.push(check(
         "repository_state",
@@ -501,7 +911,7 @@ pub fn verify_record(
         } else {
             "current"
         };
-    Ok(report(&record, status, checks))
+    Ok(report(record, status, checks))
 }
 
 fn verify_proof_artifacts(
@@ -925,6 +1335,57 @@ mod tests {
     }
 
     #[test]
+    fn portable_source_repository_id_does_not_carry_remote_credentials() {
+        assert_eq!(
+            sanitized_source_repository_id("https://token:secret@github.com/org/repo.git"),
+            Some("https://github.com/org/repo.git".to_string())
+        );
+        assert_eq!(
+            sanitized_source_repository_id("git@github.com:org/repo.git"),
+            Some("ssh://github.com/org/repo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn portable_envelope_is_tamper_evident_and_fails_closed_without_local_binding() {
+        let record = fixture().with_recomputed_hash().expect("record hash");
+        let envelope = PortableCompletionEvidence {
+            schema_version: COMPLETION_EVIDENCE_SCHEMA_VERSION.to_string(),
+            source_repository: SourceRepositoryBinding {
+                repository_id: Some("https://example.invalid/source".to_string()),
+                head_revision: record.repository.head_revision.clone(),
+                base_revision: record.repository.base_revision.clone(),
+            },
+            record,
+            capsule_artifact: FileDigest {
+                path: ".decapod/generated/context/task-1.json".to_string(),
+                sha256: "sha256:capsule".to_string(),
+                size: 1,
+            },
+            proof_artifacts: Vec::new(),
+            envelope_hash: String::new(),
+        }
+        .with_recomputed_hash()
+        .expect("envelope hash");
+        validate_portable_evidence(&envelope).expect("valid envelope");
+
+        let directory = tempdir().expect("temp directory");
+        let report = verify_portable_evidence(
+            directory.path(),
+            "task-1",
+            &envelope,
+            &directory.path().join("import.json"),
+        )
+        .expect("portable report");
+        assert_eq!(report.structural_status, "structurally_valid");
+        assert_eq!(report.local_decision, "rejected");
+
+        let mut tampered = envelope;
+        tampered.source_repository.repository_id = Some("tampered".to_string());
+        assert!(validate_portable_evidence(&tampered).is_err());
+    }
+
+    #[test]
     fn local_record_replays_and_detects_artifact_change() {
         let directory = tempdir().expect("temp directory");
         let root = directory.path();
@@ -991,6 +1452,13 @@ mod tests {
         let record_path = write_record(root, &record).expect("write record");
         let report = verify_record(root, "task-1", &record_path).expect("verify record");
         assert_eq!(report.status, "current");
+
+        let portable_path = root.parent().unwrap().join("completion-evidence.json");
+        let envelope = export_record(root, "task-1", &record_path, &portable_path)
+            .expect("export portable evidence");
+        assert_eq!(envelope.record.evidence_hash, record.evidence_hash);
+        let imported = read_portable_evidence(&portable_path).expect("read portable evidence");
+        assert_eq!(imported.envelope_hash, envelope.envelope_hash);
 
         fs::write(&proof_path, "altered\n").expect("alter proof");
         let report = verify_record(root, "task-1", &record_path).expect("verify altered record");

--- a/src/plugins/verify.rs
+++ b/src/plugins/verify.rs
@@ -74,6 +74,12 @@ pub enum VerifyCommand {
         /// Verify a specific record path instead of the default repository path.
         #[clap(long)]
         path: Option<PathBuf>,
+        /// Export the current local record as portable evidence to this path.
+        #[clap(long)]
+        export: Option<PathBuf>,
+        /// Import portable evidence from this path into receiving-repository custody.
+        #[clap(long)]
+        import: Option<PathBuf>,
     },
 }
 
@@ -1037,7 +1043,88 @@ pub fn run_verify_cli(
                 }
                 return Ok(());
             }
-            VerifyCommand::Completion { id, write, path } => {
+            VerifyCommand::Completion {
+                id,
+                write,
+                path,
+                export,
+                import,
+            } => {
+                if *write && (export.is_some() || import.is_some()) {
+                    return Err(error::DecapodError::ValidationError(
+                        "completion evidence --write cannot be combined with --export or --import"
+                            .to_string(),
+                    ));
+                }
+                if export.is_some() && import.is_some() {
+                    return Err(error::DecapodError::ValidationError(
+                        "completion evidence --export cannot be combined with --import".to_string(),
+                    ));
+                }
+                if import.is_some() && path.is_some() {
+                    return Err(error::DecapodError::ValidationError(
+                        "completion evidence --import cannot be combined with --path".to_string(),
+                    ));
+                }
+                if let Some(output_path) = export {
+                    let record_path = path
+                        .clone()
+                        .unwrap_or(completion_evidence::default_record_path(repo_root, id)?);
+                    let envelope = completion_evidence::export_record(
+                        repo_root,
+                        id,
+                        &record_path,
+                        output_path,
+                    )?;
+                    if cli.json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "status": "ok",
+                                "task_id": id,
+                                "export_path": output_path,
+                                "envelope_hash": envelope.envelope_hash,
+                                "evidence_hash": envelope.record.evidence_hash,
+                            })
+                        );
+                    } else {
+                        println!(
+                            "portable completion evidence exported: {} ({})",
+                            output_path.display(),
+                            envelope.envelope_hash
+                        );
+                    }
+                    return Ok(());
+                }
+                if let Some(input_path) = import {
+                    let (stored_path, report) =
+                        completion_evidence::import_record(repo_root, id, input_path)?;
+                    if cli.json {
+                        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+                    } else {
+                        println!(
+                            "portable completion evidence imported: {} [{} / {}]",
+                            stored_path.display(),
+                            report.structural_status,
+                            report.local_decision
+                        );
+                        for check in &report.checks {
+                            let detail = check
+                                .detail
+                                .as_deref()
+                                .map(|detail| format!(" ({detail})"))
+                                .unwrap_or_default();
+                            println!("- {}: {}{}", check.name, check.status, detail);
+                        }
+                    }
+                    if report.local_decision != "accepted" {
+                        return Err(error::DecapodError::ValidationError(format!(
+                            "portable completion evidence local decision: {}",
+                            report.local_decision
+                        )));
+                    }
+                    return Ok(());
+                }
                 let record_path = path
                     .clone()
                     .unwrap_or(completion_evidence::default_record_path(repo_root, id)?);


### PR DESCRIPTION
Implements the portable evidence follow-up for Issue #861.

- Adds an evidence-only portable envelope around the existing completion record.
- Binds the envelope to the source repository revisions and preserves capsule and proof-artifact digests.
- Sanitizes optional remote metadata so credentials cannot enter exported evidence.
- Adds `decapod qa verify completion <ID> --export PATH` and `--import PATH`.
- Stores imported envelopes under receiving-repository custody without copying source authority, workunits, capsules, or artifact contents.
- Recomputes envelope and record integrity, validates repository-relative references, and records a receiver-local accepted or rejected decision.
- A receiver without the matching local workunit rejects the evidence; a matching local state must pass the existing completion verifier.
- Keeps signatures, remote transport, and publication authority transfer out of scope.

Related to #904. Issue #861 remains open for any later trust-boundary mechanism that is justified by a concrete use case.
