### PR TITLE
test: add governed activation conformance fixture

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784188069Z",
-  "repo_signal_fingerprint": "60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6",
+  "generated_at": "1784190039Z",
+  "repo_signal_fingerprint": "4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,47 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "009555f8f641814a19980ebf930c7dfecede0048f2122c8b8d76abcda12489db",
+  "spec_input_hash": "d1bc9d320ceafa600fc0bfc77c014566e5a302df72fce33cce6d64a6b05064a4",
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "9304689aa88b42137cb32658b2906a5bc32c806e2414c17704532037977f441f"
+      "content_hash": "f2b2475f1415ba4489e6e96ba6efe2b9e54ffa9ef3a691f2f8ff40d61e914cb3"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "d175c4dcba6faebe14092e95bd03db93a56d19899ce04133b3ab235316644286"
+      "content_hash": "0e0c5aa9fdc16c8e528e71224b1f76cbfc4a427036ae5cd58ea9c91280d252b8"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "c8696fd893d56375b26b171f9b8f1d6b31bada171d22e738d785de3835b2a0fd"
+      "content_hash": "56b27a8262c13ab333dd6252ef7ddcb2e984c8cdd5c602e5873b9f372346bb59"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "1bf8dd79c71c5e1a3b05328416c00726d3545c55752c81f7dae461a0c5206d09"
+      "content_hash": "3d1a16628c276e32a21cc3f86c2bba89f4a02a191ae9dbc0c058c8375c12fb69"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "2b3d0d09ee82817d5b79871f4c16e305005079825d26583f8363bfc50ffefec2"
+      "content_hash": "b041bc6e4b31d1636721e3049c202cbe40151221157b7e42da9273a918def83f"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "25acb2eee0cd0d98f4043a3077882be65001aa22de78c54b2dde4cebe421e768"
+      "content_hash": "e50a164419d231f306956f9cd662a2f7457441750d0f96b78f46e1e51fe27d03"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "3e758230b816d26ac4ba1b87dd05086d73114896a0ff8f776f37c4eec921ddc5"
+      "content_hash": "8fdeaf810bc181ce57f0120dcfc78f0a2314db5e58e1d5bd64d5deaf05e37d9f"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "b15c77a6a1f8f6ae18cc97527128d2675658c03e57d60c15b660a06eb582971d"
+      "content_hash": "11d07d320eb0258f41aabba62dba296798e942a8c361c44096f9b98612815e67"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -337,7 +337,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `4dec04d4ceba8b9e2bb24a5431d08794bdaa0a759989e2e4eaa4cbbb1f838bfb`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/tests/activation_conformance.rs
+++ b/tests/activation_conformance.rs
@@ -1,0 +1,437 @@
+//! Clean-checkout activation contract for representative coding-agent hosts.
+//!
+//! This test does not emulate a model or vendor SDK. It exercises the same
+//! repository-native path a host must discover from an entrypoint, and emits a
+//! structured observation report when a contract boundary is missed.
+
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const AGENT_ID: &str = "activation-fixture-agent";
+const INTENT: &str =
+    "Update the fixture greeting while preserving the repository governance contract.";
+
+#[derive(Debug, Serialize)]
+struct Observation {
+    id: &'static str,
+    passed: bool,
+    evidence: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ActivationReport {
+    schema_version: &'static str,
+    fixture: &'static str,
+    intent: &'static str,
+    observations: Vec<Observation>,
+}
+
+fn run_decapod(dir: &Path, args: &[&str], password: Option<&str>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    command
+        .current_dir(dir)
+        .args(args)
+        .env("DECAPOD_AGENT_ID", AGENT_ID)
+        .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
+        .env("DECAPOD_VALIDATE_SKIP_TOOLING_GATES", "1")
+        .env("DECAPOD_VALIDATE_TIMEOUT_SECONDS", "30");
+    if let Some(password) = password {
+        command.env("DECAPOD_SESSION_PASSWORD", password);
+    }
+    command.output().expect("run decapod")
+}
+
+fn run_git(dir: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
+fn combined(output: &Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn require_success(output: &Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed:\n{}",
+        combined(output)
+    );
+}
+
+fn parse_json(output: &Output, operation: &str) -> Value {
+    require_success(output, operation);
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "{operation} did not return JSON: {error}\n{}",
+            combined(output)
+        )
+    })
+}
+
+fn session_password(output: &Output) -> String {
+    require_success(output, "session acquire");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("Password: ").map(str::trim))
+        .map(ToString::to_string)
+        .expect("session acquire should return a password")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let temp = TempDir::new().expect("create fixture repository");
+    let root = temp.path().to_path_buf();
+
+    require_success(&run_git(&root, &["init", "-b", "master"]), "git init");
+    require_success(
+        &run_git(
+            &root,
+            &["config", "user.name", "Decapod Activation Fixture"],
+        ),
+        "git config user.name",
+    );
+    require_success(
+        &run_git(&root, &["config", "user.email", "activation@decapod.local"]),
+        "git config user.email",
+    );
+    fs::write(
+        root.join("README.md"),
+        "# Activation fixture\n\nHello from Decapod.\n",
+    )
+    .expect("write fixture README");
+    fs::write(
+        root.join("activation-task.md"),
+        "# Activation task\n\nUpdate the fixture greeting while preserving the repository governance contract.\n",
+    )
+    .expect("write fixture task");
+    require_success(
+        &run_git(&root, &["add", "README.md", "activation-task.md"]),
+        "git add fixture",
+    );
+    require_success(
+        &run_git(&root, &["commit", "-m", "fixture task"]),
+        "git commit fixture",
+    );
+
+    require_success(
+        &run_decapod(&root, &["init", "--force"], None),
+        "decapod init",
+    );
+    require_success(&run_git(&root, &["add", "-A"]), "git add decapod substrate");
+    require_success(
+        &run_git(&root, &["commit", "-m", "initialize decapod governance"]),
+        "git commit decapod substrate",
+    );
+
+    let password = session_password(&run_decapod(&root, &["session", "acquire"], None));
+    (temp, root, password)
+}
+
+fn rpc(dir: &Path, password: &str, op: &str, params: Value) -> Value {
+    parse_json(
+        &run_decapod(
+            dir,
+            &["rpc", "--op", op, "--params", &params.to_string()],
+            Some(password),
+        ),
+        op,
+    )
+}
+
+#[test]
+fn clean_checkout_activation_path_is_bounded_and_proof_gated() {
+    let (_temp, root, password) = setup_repo();
+    let mut observations = Vec::new();
+
+    let entrypoints = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CODEX.md"];
+    let required_entrypoint_markers = [
+        "decapod docs ingest",
+        "decapod rpc --op context.resolve",
+        "decapod todo add",
+        "decapod workspace ensure",
+        "decapod validate",
+    ];
+    for entrypoint in entrypoints {
+        let content = fs::read_to_string(root.join(entrypoint)).expect("read generated entrypoint");
+        let missing = required_entrypoint_markers
+            .iter()
+            .filter(|marker| !content.contains(**marker))
+            .copied()
+            .collect::<Vec<_>>();
+        observations.push(Observation {
+            id: "entrypoint_discovery",
+            passed: missing.is_empty(),
+            evidence: format!("{entrypoint}: missing={missing:?}"),
+        });
+    }
+
+    let todo = parse_json(
+        &run_decapod(
+            &root,
+            &["todo", "add", INTENT, "--format", "json"],
+            Some(&password),
+        ),
+        "todo add",
+    );
+    let task_id = todo["id"].as_str().expect("todo id").to_string();
+    require_success(
+        &run_decapod(
+            &root,
+            &["todo", "claim", "--id", &task_id, "--format", "json"],
+            Some(&password),
+        ),
+        "todo claim",
+    );
+    observations.push(Observation {
+        id: "task_custody",
+        passed: true,
+        evidence: format!("claimed todo {task_id}"),
+    });
+
+    let orientation = parse_json(
+        &run_decapod(
+            &root,
+            &[
+                "infer",
+                "orientation",
+                "--intent",
+                INTENT,
+                "--task-id",
+                &task_id,
+            ],
+            Some(&password),
+        ),
+        "infer orientation",
+    );
+    let proof_required = orientation["proof_required"]
+        .as_array()
+        .expect("proof_required array");
+    observations.push(Observation {
+        id: "orientation_before_mutation",
+        passed: proof_required.iter().any(|item| {
+            item.as_str()
+                .map(|value| value.contains("decapod validate"))
+                .unwrap_or(false)
+        }),
+        evidence: format!("proof_required={proof_required:?}"),
+    });
+
+    let workspace = parse_json(
+        &run_decapod(
+            &root,
+            &[
+                "workspace",
+                "ensure",
+                "--branch",
+                &format!("agent/{AGENT_ID}/{task_id}"),
+            ],
+            Some(&password),
+        ),
+        "workspace ensure",
+    );
+    let workspace_path =
+        PathBuf::from(workspace["worktree_path"].as_str().expect("workspace path"));
+    observations.push(Observation {
+        id: "workspace_custody",
+        passed: workspace["status"] == "ok"
+            && workspace_path.starts_with(root.join(".decapod").join("workspaces")),
+        evidence: workspace_path.display().to_string(),
+    });
+
+    let init = rpc(
+        &workspace_path,
+        &password,
+        "agent.init",
+        serde_json::json!({}),
+    );
+    observations.push(Observation {
+        id: "agent_initialization",
+        passed: init["success"] == true,
+        evidence: init.to_string(),
+    });
+
+    let context = rpc(
+        &workspace_path,
+        &password,
+        "context.resolve",
+        serde_json::json!({}),
+    );
+    observations.push(Observation {
+        id: "context_resolution",
+        passed: context["success"] == true,
+        evidence: context.to_string(),
+    });
+
+    let workunit_init = run_decapod(
+        &workspace_path,
+        &[
+            "govern",
+            "workunit",
+            "init",
+            "--task-id",
+            &task_id,
+            "--intent-ref",
+            &format!("todo://{task_id}"),
+        ],
+        Some(&password),
+    );
+    require_success(&workunit_init, "workunit init");
+    require_success(
+        &run_decapod(
+            &workspace_path,
+            &[
+                "govern",
+                "workunit",
+                "set-proof-plan",
+                "--task-id",
+                &task_id,
+                "--gate",
+                "validate_passes",
+            ],
+            Some(&password),
+        ),
+        "workunit set-proof-plan",
+    );
+
+    for (to, operation) in [
+        ("executing", "workunit enter"),
+        ("claimed", "workunit claim"),
+    ] {
+        require_success(
+            &run_decapod(
+                &workspace_path,
+                &[
+                    "govern",
+                    "workunit",
+                    "transition",
+                    "--task-id",
+                    &task_id,
+                    "--to",
+                    to,
+                ],
+                Some(&password),
+            ),
+            operation,
+        );
+    }
+
+    let premature_verify = run_decapod(
+        &workspace_path,
+        &[
+            "govern",
+            "workunit",
+            "transition",
+            "--task-id",
+            &task_id,
+            "--to",
+            "verified",
+        ],
+        Some(&password),
+    );
+    let premature_output = combined(&premature_verify);
+    observations.push(Observation {
+        id: "proof_prerequisite_refusal",
+        passed: !premature_verify.status.success()
+            && (premature_output.contains("missing passing proof result")
+                || premature_output.contains("proof result")),
+        evidence: premature_output,
+    });
+
+    let capsule = rpc(
+        &workspace_path,
+        &password,
+        "context.capsule.query",
+        serde_json::json!({
+            "topic": "activation",
+            "scope": "interfaces",
+            "task_id": task_id,
+            "limit": 4,
+            "write": true
+        }),
+    );
+    observations.push(Observation {
+        id: "state_bound_context_capsule",
+        passed: capsule["success"] == true
+            && workspace_path
+                .join(".decapod/generated/context")
+                .join(format!("{task_id}.json"))
+                .exists(),
+        evidence: capsule.to_string(),
+    });
+
+    let validate = run_decapod(&workspace_path, &["validate"], Some(&password));
+    observations.push(Observation {
+        id: "normal_validation",
+        passed: validate.status.success(),
+        evidence: combined(&validate),
+    });
+    require_success(
+        &run_decapod(
+            &workspace_path,
+            &[
+                "govern",
+                "workunit",
+                "record-proof",
+                "--task-id",
+                &task_id,
+                "--gate",
+                "validate_passes",
+                "--status",
+                "pass",
+                "--artifact",
+                "decapod validate",
+            ],
+            Some(&password),
+        ),
+        "workunit record-proof",
+    );
+    require_success(
+        &run_decapod(
+            &workspace_path,
+            &[
+                "govern",
+                "workunit",
+                "transition",
+                "--task-id",
+                &task_id,
+                "--to",
+                "verified",
+            ],
+            Some(&password),
+        ),
+        "workunit verified transition",
+    );
+    observations.push(Observation {
+        id: "proof_backed_completion",
+        passed: true,
+        evidence: format!("workunit {task_id} reached VERIFIED after validate_passes"),
+    });
+
+    let report = ActivationReport {
+        schema_version: "1.0.0",
+        fixture: "activation-conformance-v1",
+        intent: INTENT,
+        observations,
+    };
+    let failed = report
+        .observations
+        .iter()
+        .filter(|item| !item.passed)
+        .count();
+    assert_eq!(
+        failed,
+        0,
+        "activation conformance report:\n{}",
+        serde_json::to_string_pretty(&report).expect("serialize report")
+    );
+}

--- a/tests/fixtures/activation_conformance/README.md
+++ b/tests/fixtures/activation_conformance/README.md
@@ -1,0 +1,28 @@
+# Decapod activation conformance fixture
+
+This fixture is the bounded, host-neutral task for Issue #880. A host must receive only the task intent below and operate in a clean checkout. The repository's generated entrypoint is the activation contract; the host must not be given a hand-translated Decapod command sequence.
+
+Task intent:
+
+Update the fixture greeting while preserving the repository governance contract.
+
+Required evidence for a host run:
+
+- the host discovered and followed its generated entrypoint;
+- governed context was resolved before mutation;
+- the task was claimed and work happened in a Decapod-managed workspace;
+- proof prerequisites blocked premature completion;
+- validation ran before completion;
+- the final workunit reached VERIFIED only after a passing proof result.
+
+The Rust integration test `activation_conformance` runs this same repository-native contract from a clean checkout and emits a JSON observation report on failure. External host runs should capture the equivalent observations using the schema in `result.schema.json` and attach the raw transcript or command receipts.
+
+Host procedure:
+
+1. Start from a clean checkout containing this fixture and the generated entrypoints.
+2. Give the host only the task intent above.
+3. Preserve the host transcript and the repository's Decapod state after the run.
+4. Record one result object for each required observation; a correct final file is not sufficient evidence.
+5. Repeat with equivalent clean checkouts for Claude Code, Codex, and Antigravity when those hosts are available.
+
+This fixture does not add a daemon, hidden context injection, vendor adapter, remote service, or new trust authority.

--- a/tests/fixtures/activation_conformance/activation-task.md
+++ b/tests/fixtures/activation_conformance/activation-task.md
@@ -1,0 +1,3 @@
+# Activation task
+
+Update the fixture greeting while preserving the repository governance contract.

--- a/tests/fixtures/activation_conformance/result.schema.json
+++ b/tests/fixtures/activation_conformance/result.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Decapod activation conformance result",
+  "type": "object",
+  "required": ["schema_version", "fixture", "intent", "host", "observations"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "fixture": {"const": "activation-conformance-v1"},
+    "intent": {"type": "string", "minLength": 1},
+    "host": {"type": "string", "minLength": 1},
+    "observations": {
+      "type": "array",
+      "minItems": 7,
+      "items": {
+        "type": "object",
+        "required": ["id", "passed", "evidence"],
+        "properties": {
+          "id": {
+            "enum": [
+              "entrypoint_discovery",
+              "task_custody",
+              "orientation_before_mutation",
+              "workspace_custody",
+              "agent_initialization",
+              "context_resolution",
+              "proof_prerequisite_refusal",
+              "state_bound_context_capsule",
+              "normal_validation",
+              "proof_backed_completion"
+            ]
+          },
+          "passed": {"type": "boolean"},
+          "evidence": {"type": "string", "minLength": 1}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds a clean-checkout activation conformance test for the repository-native agent path.
- Exercises generated entrypoint discovery, intent orientation, todo custody, isolated workspace entry, agent initialization, context resolution, state-bound context capsule creation, proof prerequisite refusal, validation, and proof-gated workunit completion.
- Adds a reusable fixture task, host-run procedure, and JSON result schema for equivalent Claude Code, Codex, and Antigravity runs.
- Refreshes generated spec attestations for the added test surface.

## Issue correlation

Refs #880
Relates to #684

This PR deliberately does not add a daemon, hidden context injection, vendor adapter, remote service, or new authority model. It makes the current repo-native activation contract executable and repeatable. The external three-host matrix remains a follow-up that can use the fixture and result schema when those hosts are available.

## Proof

- `cargo test --test activation_conformance -- --nocapture`
- `cargo test --test workunit_cli`
- `cargo test --test context_capsule_rpc`
- `cargo test --test entrypoint_correctness`
- `cargo clippy --all-targets --all-features -- -D warnings`

The focused and related suites pass. `tests/projection_consistency.rs::capability_survives_config_context_spec_deterministically` remains a pre-existing failure on this branch. `decapod validate` also remains blocked by the repository's required container proof and pre-existing claimed-but-unverified TODOs; those are unrelated to this fixture.
