### PR TITLE
feat: bind generated entrypoints to binary release identity

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.66.7
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.69.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.66.7
+ARG DECAPOD_VERSION=0.69.0
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784188069Z",
-  "repo_signal_fingerprint": "60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6",
+  "generated_at": "1784235828Z",
+  "repo_signal_fingerprint": "ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,47 +17,71 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "009555f8f641814a19980ebf930c7dfecede0048f2122c8b8d76abcda12489db",
+  "spec_input_hash": "4e3bf896d32594f977779fd4a94d8b52f27cab4594f5d5493ec6c3f427d1a50e",
+  "decapod_release": "0.69.0",
+  "binary_hash": "cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1",
+  "entrypoints": [
+    {
+      "path": "AGENTS.md",
+      "template_hash": "b86741e502a5aa9abc7c22d56a1693a67f5303eb6d9ef18bdd29d27a903c956d",
+      "content_hash": "b86741e502a5aa9abc7c22d56a1693a67f5303eb6d9ef18bdd29d27a903c956d"
+    },
+    {
+      "path": "CLAUDE.md",
+      "template_hash": "a2d3e3645c4ebb19cd64a8659c4cf52c2dc37b42ba597156a66c17f6945d06c3",
+      "content_hash": "a2d3e3645c4ebb19cd64a8659c4cf52c2dc37b42ba597156a66c17f6945d06c3"
+    },
+    {
+      "path": "GEMINI.md",
+      "template_hash": "1fae67e6b127dde088c60e3daf7f63a3ad9e0f1c73d6b0c001b750297654c009",
+      "content_hash": "1fae67e6b127dde088c60e3daf7f63a3ad9e0f1c73d6b0c001b750297654c009"
+    },
+    {
+      "path": "CODEX.md",
+      "template_hash": "91637b3798c0521a8bc7ab16d632f5200c624ebc5b9d7613a8049c8502503a21",
+      "content_hash": "91637b3798c0521a8bc7ab16d632f5200c624ebc5b9d7613a8049c8502503a21"
+    }
+  ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "9304689aa88b42137cb32658b2906a5bc32c806e2414c17704532037977f441f"
+      "content_hash": "970f8edeecd43587725852c2f4d881f5622e85eb8980a7078e850a0f5af2ee8a"
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "d175c4dcba6faebe14092e95bd03db93a56d19899ce04133b3ab235316644286"
+      "content_hash": "0c0f190b5e9af19483c79b2c09f433dcc2e8c79055d547a7b1ac9c13f8c0d08f"
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "c8696fd893d56375b26b171f9b8f1d6b31bada171d22e738d785de3835b2a0fd"
+      "content_hash": "7edec86ad9dafd3b355d314cdefeb8c82813484faaac7b17c419aa69a4369442"
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "1bf8dd79c71c5e1a3b05328416c00726d3545c55752c81f7dae461a0c5206d09"
+      "content_hash": "c5ea02754c65be22c4bcc0dd41dace74db4394707c82f46e8543c873d723bd15"
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
-      "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "2b3d0d09ee82817d5b79871f4c16e305005079825d26583f8363bfc50ffefec2"
+      "template_hash": "9829f6c335abb79627f67e6d5ffe5bf5c2e10355d19a65bfd61da8cf05421b0f",
+      "content_hash": "47515ab0df8368ea5c9c429f9361c0c0ee4cc7558528e86683bf03b05eba09af"
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "25acb2eee0cd0d98f4043a3077882be65001aa22de78c54b2dde4cebe421e768"
+      "content_hash": "56a0f7a96f4faeed98ffa2317770678b78dd92c3d8f513ae5ca6198f8608012b"
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "3e758230b816d26ac4ba1b87dd05086d73114896a0ff8f776f37c4eec921ddc5"
+      "content_hash": "1b5ae0fb3726dfa004c36baa518b1c950e5e4ebdc618da3170e8df81274d8e53"
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "b15c77a6a1f8f6ae18cc97527128d2675658c03e57d60c15b660a06eb582971d"
+      "content_hash": "1611de2442c7093bb4881029e0b19118210c17555b012cf0a91c9cb6949956ef"
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -73,6 +73,9 @@ Decapod keeps generated specs synchronized at governance pressure points. When r
 - Update `.decapod/generated/specs/.manifest.json` after writing files
 - Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set
 
+## Release-Bound Agent Entrypoint Integrity
+The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and compiled binary SHA-256; `.decapod/generated/specs/.manifest.json` records the same release identity plus `template_hash` and `content_hash` entries for `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `CODEX.md`. Default validation independently checks the compiled release contract, declared metadata, canonical payload, regular-file type, and manifest synchronization. Regeneration must be explicit through the installed Decapod release.
+
 ## Validation Decision Tree
 ```mermaid
 flowchart TD
@@ -337,7 +340,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `60000086784e970e6cf2b51749f783020d828a76a6dab39d546738e31f2f43f6`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (87 files), `tests/` (3 files)
+- Repository signal fingerprint: `ee705240a2b8b7f7ba71ed6f25a99b74784e333253bd1fec62bba569e97ce216`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (3 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- decapod-release: 0.69.0 -->
+<!-- decapod-binary-sha256: cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,6 +29,11 @@ rust_library(
     compile_data = glob(["src/**/*.sql"]),
     edition = "2024",
     crate_name = "decapod",
+    # Keep Bazel's release identity aligned with Cargo.toml. rules_rust does
+    # not synthesize Cargo's package environment variables automatically.
+    rustc_env = {
+        "CARGO_PKG_VERSION": "0.69.1",
+    },
     deps = [
         ":build_script",
     ] + all_crate_deps(normal = True),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+<!-- decapod-release: 0.69.0 -->
+<!-- decapod-binary-sha256: cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,3 +1,5 @@
+<!-- decapod-release: 0.69.0 -->
+<!-- decapod-binary-sha256: cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,5 @@
+<!-- decapod-release: 0.69.0 -->
+<!-- decapod-binary-sha256: cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -420,6 +420,16 @@ fn template_named_agent(file_stem: &str) -> String {
     )
 }
 
+pub fn canonical_template(name: &str) -> Option<String> {
+    match name {
+        "AGENTS.md" => Some(template_agents()),
+        "CLAUDE.md" => Some(template_named_agent("CLAUDE")),
+        "GEMINI.md" => Some(template_named_agent("GEMINI")),
+        "CODEX.md" => Some(template_named_agent("CODEX")),
+        _ => None,
+    }
+}
+
 fn template_readme() -> String {
     r#"# .decapod - Decapod Control Plane
 
@@ -576,10 +586,9 @@ over the embedded JSON constitution.
 
 pub fn get_template(name: &str) -> Option<String> {
     match name {
-        "AGENTS.md" => Some(template_agents()),
-        "CLAUDE.md" => Some(template_named_agent("CLAUDE")),
-        "GEMINI.md" => Some(template_named_agent("GEMINI")),
-        "CODEX.md" => Some(template_named_agent("CODEX")),
+        "AGENTS.md" | "CLAUDE.md" | "GEMINI.md" | "CODEX.md" => {
+            crate::core::entrypoint_integrity::render_entrypoint(name)
+        }
         "README.md" => Some(template_readme()),
         "OVERRIDE.md" => Some(template_override()),
         "decapod-validate.yml" => Some(template_github_action()),

--- a/src/core/entrypoint_integrity.rs
+++ b/src/core/entrypoint_integrity.rs
@@ -1,0 +1,316 @@
+//! Release-bound integrity for the generated agent entrypoints.
+//!
+//! The expected fingerprints in this module are release artifact data. They
+//! are deliberately not derived from the files being validated or from the
+//! repository at runtime.
+
+use crate::core::assets;
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+pub const ENTRYPOINT_FILES: [&str; 4] = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CODEX.md"];
+pub const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Release identity SHA compiled into the binary and copied into generated
+/// entrypoints. This is the SHA of the immutable release contract, not a
+/// runtime hash of a mutable repository file or self-declared marker.
+pub const BINARY_SHA256: &str = "cfe683de117811b28c68ca65200434257e01507167e109082e0e3d8695b589d1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntrypointExpectation {
+    pub surface: &'static str,
+    pub fingerprint: &'static str,
+}
+
+// These values are the v0.69.0 release manifest. Keep them immutable for the
+// lifetime of that release; a later release must update them deliberately and
+// regenerate the four root entrypoints through Decapod.
+pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
+    EntrypointExpectation {
+        surface: "AGENTS.md",
+        fingerprint: "9210b4634ebc9d2dbc7e0fa56cc23277f74196d954d63dc931eed98bc015cb28",
+    },
+    EntrypointExpectation {
+        surface: "CLAUDE.md",
+        fingerprint: "54881ae547640ac5c829fd36639a443c679e40c012d2e46a24e1a6a0ab577a2a",
+    },
+    EntrypointExpectation {
+        surface: "GEMINI.md",
+        fingerprint: "b87541fe0f153f8dfb25f638f721e47e9d1fa586bff2ecc63fc8f874b7b81ad8",
+    },
+    EntrypointExpectation {
+        surface: "CODEX.md",
+        fingerprint: "d49882f00ac748c6fbe8d1c80c73cb556916353433e64b99b34c0b36786538ca",
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingKind {
+    Missing,
+    MetadataMissing,
+    MetadataMalformed,
+    ReleaseMismatch,
+    FingerprintMismatch,
+    PayloadModified,
+    UnsupportedFileType,
+}
+
+impl FindingKind {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::Missing => "entrypoint_missing",
+            Self::MetadataMissing => "entrypoint_metadata_missing",
+            Self::MetadataMalformed => "entrypoint_metadata_malformed",
+            Self::ReleaseMismatch => "entrypoint_release_mismatch",
+            Self::FingerprintMismatch => "entrypoint_fingerprint_mismatch",
+            Self::PayloadModified => "entrypoint_payload_modified",
+            Self::UnsupportedFileType => "entrypoint_unsupported_file_type",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub surface: String,
+    pub running_release: String,
+    pub declared_release: Option<String>,
+    pub expected_binary_sha256: String,
+    pub observed_binary_sha256: Option<String>,
+    pub expected_payload_fingerprint: String,
+    pub observed_payload_fingerprint: Option<String>,
+    pub kind: FindingKind,
+}
+
+impl fmt::Display for Finding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Governed agent entrypoint integrity failure")?;
+        writeln!(f, "Surface: {}", self.surface)?;
+        writeln!(f, "Running Decapod release: {}", self.running_release)?;
+        writeln!(
+            f,
+            "Declared Decapod release: {}",
+            self.declared_release.as_deref().unwrap_or("<missing>")
+        )?;
+        writeln!(
+            f,
+            "Expected binary SHA-256: {}",
+            self.expected_binary_sha256
+        )?;
+        writeln!(
+            f,
+            "Observed binary SHA-256: {}",
+            self.observed_binary_sha256
+                .as_deref()
+                .unwrap_or("<missing>")
+        )?;
+        writeln!(
+            f,
+            "Expected payload fingerprint: {}",
+            self.expected_payload_fingerprint
+        )?;
+        writeln!(
+            f,
+            "Observed payload fingerprint: {}",
+            self.observed_payload_fingerprint
+                .as_deref()
+                .unwrap_or("<missing>")
+        )?;
+        writeln!(f, "Finding: {}", self.kind.code())?;
+        write!(
+            f,
+            "Remediation: regenerate the governed entrypoints using the installed Decapod release"
+        )
+    }
+}
+
+pub fn canonical_template(surface: &str) -> Option<String> {
+    assets::canonical_template(surface)
+}
+
+pub fn expected_fingerprint(surface: &str) -> Option<&'static str> {
+    EXPECTED_ENTRYPOINTS
+        .iter()
+        .find(|entry| entry.surface == surface)
+        .map(|entry| entry.fingerprint)
+}
+
+pub fn fingerprint(payload: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(payload.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn render_entrypoint(surface: &str) -> Option<String> {
+    let payload = canonical_template(surface)?;
+    let _ = expected_fingerprint(surface)?;
+    Some(format!(
+        "<!-- decapod-release: {RELEASE_VERSION} -->\n<!-- decapod-binary-sha256: {BINARY_SHA256} -->\n{payload}"
+    ))
+}
+
+fn marker_value(line: &str, prefix: &str) -> Option<Result<String, ()>> {
+    let line = line.trim_end_matches(['\r', '\n']).trim();
+    if !line.starts_with(prefix) {
+        return None;
+    }
+    Some(
+        line.strip_prefix(prefix)
+            .and_then(|value| value.strip_suffix("-->"))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .ok_or(()),
+    )
+}
+
+fn finding(
+    surface: &str,
+    kind: FindingKind,
+    declared_release: Option<String>,
+    observed_binary_sha256: Option<String>,
+    observed_payload_fingerprint: Option<String>,
+) -> Box<Finding> {
+    Box::new(Finding {
+        surface: surface.to_string(),
+        running_release: RELEASE_VERSION.to_string(),
+        declared_release,
+        expected_binary_sha256: BINARY_SHA256.to_string(),
+        observed_binary_sha256,
+        expected_payload_fingerprint: expected_fingerprint(surface)
+            .unwrap_or("<unknown>")
+            .to_string(),
+        observed_payload_fingerprint,
+        kind,
+    })
+}
+
+pub fn validate_entrypoint(project_root: &Path, surface: &str) -> Result<(), Box<Finding>> {
+    let Some(expected) = expected_fingerprint(surface) else {
+        return Err(finding(surface, FindingKind::Missing, None, None, None));
+    };
+    let path = project_root.join(surface);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(finding(surface, FindingKind::Missing, None, None, None));
+        }
+        Err(_) => {
+            return Err(finding(
+                surface,
+                FindingKind::UnsupportedFileType,
+                None,
+                None,
+                None,
+            ));
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return Err(finding(
+            surface,
+            FindingKind::UnsupportedFileType,
+            None,
+            None,
+            None,
+        ));
+    }
+
+    let bytes = fs::read(&path)
+        .map_err(|_| finding(surface, FindingKind::UnsupportedFileType, None, None, None))?;
+    let content = String::from_utf8(bytes)
+        .map_err(|_| finding(surface, FindingKind::PayloadModified, None, None, None))?;
+    let mut lines = content.split_inclusive('\n');
+    let first = lines.next().unwrap_or("");
+    let second = lines.next().unwrap_or("");
+    let payload_offset = first.len() + second.len();
+    let payload = &content[payload_offset..];
+
+    let release = marker_value(first, "<!-- decapod-release:");
+    let declared_fingerprint = marker_value(second, "<!-- decapod-binary-sha256:");
+    let malformed = release.as_ref().is_some_and(Result::is_err)
+        || declared_fingerprint.as_ref().is_some_and(Result::is_err);
+    let declared_release = release.and_then(Result::ok);
+    let declared_fingerprint = declared_fingerprint.and_then(Result::ok);
+    if malformed {
+        return Err(finding(
+            surface,
+            FindingKind::MetadataMalformed,
+            declared_release,
+            declared_fingerprint,
+            None,
+        ));
+    }
+    if declared_release.is_none() || declared_fingerprint.is_none() {
+        return Err(finding(
+            surface,
+            FindingKind::MetadataMissing,
+            declared_release,
+            declared_fingerprint,
+            None,
+        ));
+    }
+
+    let declared_release = declared_release.unwrap();
+    let declared_fingerprint = declared_fingerprint.unwrap();
+    let observed_payload_fingerprint = fingerprint(payload);
+    if declared_release != RELEASE_VERSION {
+        return Err(finding(
+            surface,
+            FindingKind::ReleaseMismatch,
+            Some(declared_release),
+            Some(declared_fingerprint),
+            Some(observed_payload_fingerprint),
+        ));
+    }
+    if declared_fingerprint != BINARY_SHA256 {
+        return Err(finding(
+            surface,
+            FindingKind::FingerprintMismatch,
+            Some(declared_release),
+            Some(declared_fingerprint),
+            Some(observed_payload_fingerprint),
+        ));
+    }
+
+    let canonical = canonical_template(surface).unwrap_or_default();
+    if payload != canonical || observed_payload_fingerprint != expected {
+        return Err(finding(
+            surface,
+            FindingKind::PayloadModified,
+            Some(declared_release),
+            Some(BINARY_SHA256.to_string()),
+            Some(observed_payload_fingerprint),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiled_manifest_matches_canonical_templates() {
+        assert_eq!(EXPECTED_ENTRYPOINTS.len(), ENTRYPOINT_FILES.len());
+        for surface in ENTRYPOINT_FILES {
+            let payload = canonical_template(surface).expect("canonical entrypoint");
+            assert_eq!(
+                fingerprint(&payload),
+                expected_fingerprint(surface).expect("compiled fingerprint"),
+                "compiled release manifest drifted from canonical {surface}"
+            );
+        }
+    }
+
+    #[test]
+    fn release_manifest_matches_package_release() {
+        let mut release_contract = format!("decapod-release:{RELEASE_VERSION}\n");
+        for entry in EXPECTED_ENTRYPOINTS {
+            release_contract.push_str(entry.surface);
+            release_contract.push(':');
+            release_contract.push_str(entry.fingerprint);
+            release_contract.push('\n');
+        }
+        assert_eq!(fingerprint(&release_contract), BINARY_SHA256);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -21,6 +21,7 @@ pub mod coplayer;
 pub mod db;
 pub mod docs;
 pub mod docs_cli;
+pub mod entrypoint_integrity;
 pub mod error;
 pub mod external_action;
 pub mod flight_recorder;

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -177,6 +177,16 @@ pub struct ProjectSpecsManifest {
     /// Hash of the ordered living-spec inputs, excluding this manifest.
     #[serde(default)]
     pub spec_input_hash: String,
+    /// Release identity of the Decapod binary that produced the projections.
+    #[serde(default)]
+    pub decapod_release: String,
+    /// Immutable release-contract SHA compiled into that Decapod binary.
+    #[serde(default)]
+    pub binary_hash: String,
+    /// Generated agent entrypoints attested using the same template/content
+    /// hash shape as the living spec files above.
+    #[serde(default)]
+    pub entrypoints: Vec<ProjectSpecManifestEntry>,
     pub files: Vec<ProjectSpecManifestEntry>,
 }
 
@@ -349,6 +359,29 @@ pub fn read_specs_manifest(
     Ok(Some(manifest))
 }
 
+pub fn entrypoint_manifest_entries(
+    project_root: &Path,
+) -> Result<Vec<ProjectSpecManifestEntry>, error::DecapodError> {
+    let mut entries = Vec::new();
+    for surface in crate::core::entrypoint_integrity::ENTRYPOINT_FILES {
+        let Some(rendered) = crate::core::entrypoint_integrity::render_entrypoint(surface) else {
+            continue;
+        };
+        let path = project_root.join(surface);
+        let content_hash = if path.is_file() {
+            hash_text(&fs::read_to_string(&path).map_err(error::DecapodError::IoError)?)
+        } else {
+            String::new()
+        };
+        entries.push(ProjectSpecManifestEntry {
+            path: surface.to_string(),
+            template_hash: hash_text(&rendered),
+            content_hash,
+        });
+    }
+    Ok(entries)
+}
+
 pub fn refresh_specs_manifest(
     project_root: &Path,
     declared_capabilities: &[String],
@@ -393,6 +426,7 @@ pub fn refresh_specs_manifest(
     let repo_signal_fingerprint = repo_signal_fingerprint(project_root)?;
     let config_input_hash = config_input_hash(project_root)?;
     let spec_input_hash = spec_input_hash(project_root)?;
+    let entrypoints = entrypoint_manifest_entries(project_root)?;
     let generated_at = existing
         .as_ref()
         .filter(|manifest| {
@@ -403,6 +437,9 @@ pub fn refresh_specs_manifest(
                 && manifest.capability_definition_version == CAPABILITY_DEFINITION_VERSION
                 && manifest.config_input_hash == config_input_hash
                 && manifest.spec_input_hash == spec_input_hash
+                && manifest.decapod_release == crate::core::entrypoint_integrity::RELEASE_VERSION
+                && manifest.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256
+                && manifest.entrypoints == entrypoints
                 && manifest.files == manifest_entries
         })
         .map(|manifest| manifest.generated_at.clone())
@@ -416,6 +453,9 @@ pub fn refresh_specs_manifest(
         capability_definition_version: CAPABILITY_DEFINITION_VERSION.to_string(),
         config_input_hash,
         spec_input_hash,
+        decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
+        binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
+        entrypoints,
         files: manifest_entries,
     };
 

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -14,7 +14,8 @@ use crate::core::project_specs::{
     LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA, LOCAL_PROJECT_SPECS_OPERATIONS,
     LOCAL_PROJECT_SPECS_README, LOCAL_PROJECT_SPECS_SECURITY, LOCAL_PROJECT_SPECS_SEMANTICS,
     LOCAL_PROJECT_SPECS_VALIDATION, ProjectSpecManifestEntry, ProjectSpecsManifest,
-    config_input_hash, hash_text, read_specs_manifest, repo_signal_fingerprint, spec_input_hash,
+    config_input_hash, entrypoint_manifest_entries, hash_text, read_specs_manifest,
+    repo_signal_fingerprint, spec_input_hash,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -831,6 +832,9 @@ Refresh output requirements:
 - Update `.decapod/generated/specs/.manifest.json` after writing files.
 - Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set.
 
+## Release-Bound Agent Entrypoint Integrity
+The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and compiled binary SHA-256; `.decapod/generated/specs/.manifest.json` records the same release identity plus `template_hash` and `content_hash` entries for `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `CODEX.md`. Default validation independently checks the compiled release contract, declared metadata, canonical payload, regular-file type, and manifest synchronization. Regeneration must be explicit through the installed Decapod release.
+
 ## Validation Decision Tree
 ```mermaid
 flowchart TD
@@ -1243,6 +1247,7 @@ pub fn refresh_project_specs(
 
     let existing_manifest = read_specs_manifest(project_root)?;
     let current_repo_fingerprint = repo_signal_fingerprint(project_root)?;
+    let entrypoints = entrypoint_manifest_entries(project_root)?;
     let mut manifest_entries = Vec::new();
     let mut file_writes: Vec<(PathBuf, String)> = Vec::new();
     for spec in LOCAL_PROJECT_SPECS {
@@ -1282,6 +1287,10 @@ pub fn refresh_project_specs(
                 existing.schema_version == LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA
                     && existing.template_version == PROJECT_SPEC_TEMPLATE_VERSION
                     && existing.repo_signal_fingerprint == current_repo_fingerprint
+                    && existing.decapod_release
+                        == crate::core::entrypoint_integrity::RELEASE_VERSION
+                    && existing.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256
+                    && existing.entrypoints == entrypoints
                     && existing.files == manifest_entries
                     && file_writes.is_empty()
             })
@@ -1294,6 +1303,9 @@ pub fn refresh_project_specs(
         capability_definition_version: CAPABILITY_DEFINITION_VERSION.to_string(),
         config_input_hash: config_input_hash(project_root)?,
         spec_input_hash: spec_input_hash(project_root)?,
+        decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
+        binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
+        entrypoints,
         files: manifest_entries,
     };
 
@@ -1301,6 +1313,9 @@ pub fn refresh_project_specs(
         && existing.schema_version == manifest.schema_version
         && existing.template_version == manifest.template_version
         && existing.repo_signal_fingerprint == manifest.repo_signal_fingerprint
+        && existing.decapod_release == manifest.decapod_release
+        && existing.binary_hash == manifest.binary_hash
+        && existing.entrypoints == manifest.entrypoints
         && existing.files == manifest.files
         && file_writes.is_empty()
     {
@@ -1822,6 +1837,9 @@ pub fn scaffold_project_entrypoints(
                 } else {
                     String::new()
                 },
+                decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
+                binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
+                entrypoints: entrypoint_manifest_entries(&opts.target_dir)?,
                 files: manifest_entries,
             };
             let manifest_path = opts.target_dir.join(LOCAL_PROJECT_SPECS_MANIFEST);

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -624,6 +624,14 @@ fn validate_entrypoint_invariants(
 ) -> Result<(), error::DecapodError> {
     info("Four Invariants Gate");
 
+    for surface in crate::core::entrypoint_integrity::ENTRYPOINT_FILES {
+        if let Err(finding) =
+            crate::core::entrypoint_integrity::validate_entrypoint(working_root, surface)
+        {
+            fail(&finding.to_string(), ctx);
+        }
+    }
+
     // Check AGENTS.md for the four invariants
     let agents_path = working_root.join("AGENTS.md");
     if !agents_path.is_file() {
@@ -1474,6 +1482,46 @@ fn validate_project_specs_docs(
                     manifest.template_version,
                     crate::core::scaffold::PROJECT_SPEC_TEMPLATE_VERSION
                 ),
+                ctx,
+            );
+        }
+
+        if manifest.decapod_release == crate::core::entrypoint_integrity::RELEASE_VERSION {
+            pass(
+                "Project specs manifest records the running Decapod release",
+                ctx,
+            );
+        } else {
+            fail(
+                &format!(
+                    "STALE_ENTRYPOINT_RELEASE: specs manifest records Decapod release '{}' while the running binary is '{}'. Regenerate the governed entrypoints and refresh specs.",
+                    manifest.decapod_release,
+                    crate::core::entrypoint_integrity::RELEASE_VERSION
+                ),
+                ctx,
+            );
+        }
+        if manifest.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256 {
+            pass(
+                "Project specs manifest records the compiled Decapod binary SHA-256",
+                ctx,
+            );
+        } else {
+            fail(
+                "STALE_ENTRYPOINT_BINARY: specs manifest binary_hash does not match the compiled Decapod release contract. Regenerate the governed entrypoints and refresh specs.",
+                ctx,
+            );
+        }
+        let expected_entrypoints =
+            crate::core::project_specs::entrypoint_manifest_entries(repo_root)?;
+        if manifest.entrypoints == expected_entrypoints {
+            pass(
+                "Generated agent entrypoint hashes match the specs manifest",
+                ctx,
+            );
+        } else {
+            fail(
+                "OUT_OF_SYNC_ENTRYPOINTS: Generated agent entrypoint hashes differ from .decapod/generated/specs/.manifest.json. Regenerate the governed entrypoints and refresh specs.",
                 ctx,
             );
         }

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -4,6 +4,7 @@
 //! and that `decapod validate` enforces invariants and detects tampering.
 
 use decapod::core::assets;
+use decapod::core::entrypoint_integrity;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Output};
@@ -427,7 +428,7 @@ fn test_validate_fails_on_missing_invariant() {
     fs::write(&agents_path, tampered).expect("Failed to write tampered AGENTS.md");
 
     // Run decapod validate (should fail)
-    let (success, output) = run_decapod(&temp_path, &["validate"]);
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
     assert!(
         !success,
         "decapod validate should fail after tampering. Output:\n{output}"
@@ -436,7 +437,7 @@ fn test_validate_fails_on_missing_invariant() {
     // Check that it detected the missing invariant
     assert!(
         output.contains("Invariant missing: Router pointer to core/DECAPOD"),
-        "Validation should detect missing router invariant"
+        "Validation should detect missing router invariant. Output:\n{output}"
     );
 }
 
@@ -457,7 +458,7 @@ fn test_validate_fails_on_bloated_entrypoint() {
     fs::write(&claude_path, bloated).expect("Failed to write bloated CLAUDE.md");
 
     // Run decapod validate (should fail)
-    let (success, output) = run_decapod(&temp_path, &["validate"]);
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
     assert!(
         !success,
         "decapod validate should fail on bloated entrypoint. Output:\n{output}"
@@ -466,7 +467,7 @@ fn test_validate_fails_on_bloated_entrypoint() {
     // Check that it detected the line limit violation
     assert!(
         output.contains("CLAUDE.md exceeds line limit"),
-        "Validation should detect bloated entrypoint"
+        "Validation should detect bloated entrypoint. Output:\n{output}"
     );
 }
 
@@ -534,6 +535,190 @@ fn test_root_entrypoints_match_scaffold_generators() {
 }
 
 #[test]
+fn test_entrypoints_record_binary_release_and_specs_manifest_attestation() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, output) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed: {output}");
+
+    for surface in entrypoint_integrity::ENTRYPOINT_FILES {
+        let content = fs::read_to_string(temp_path.join(surface)).expect("read entrypoint");
+        assert!(content.contains("<!-- decapod-release: 0.69.0 -->"));
+        assert!(content.contains(&format!(
+            "<!-- decapod-binary-sha256: {} -->",
+            entrypoint_integrity::BINARY_SHA256
+        )));
+    }
+
+    let manifest_body =
+        fs::read_to_string(temp_path.join(".decapod/generated/specs/.manifest.json"))
+            .expect("read specs manifest");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&manifest_body).expect("parse specs manifest");
+    assert_eq!(manifest["decapod_release"], "0.69.0");
+    assert_eq!(manifest["binary_hash"], entrypoint_integrity::BINARY_SHA256);
+    assert_eq!(manifest["entrypoints"].as_array().unwrap().len(), 4);
+    for surface in entrypoint_integrity::ENTRYPOINT_FILES {
+        assert!(
+            manifest["entrypoints"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["path"] == surface)
+        );
+    }
+}
+
+#[test]
+fn test_validate_reports_payload_modified_entrypoint() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("AGENTS.md");
+    let mut content = fs::read_to_string(&path).expect("read AGENTS.md");
+    content.push_str("\nuser payload tamper\n");
+    fs::write(path, content).expect("tamper AGENTS.md");
+
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(!success, "tampered entrypoint must fail validation");
+    assert!(
+        output.contains("Finding: entrypoint_payload_modified"),
+        "expected typed payload finding. Output:\n{output}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_rewritten_binary_sha_and_old_release() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("CLAUDE.md");
+    let content = fs::read_to_string(&path).expect("read CLAUDE.md");
+    let rewritten = content.replace(entrypoint_integrity::BINARY_SHA256, &"0".repeat(64));
+    fs::write(&path, rewritten).expect("rewrite binary sha");
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(!success, "rewritten binary sha must fail validation");
+    assert!(
+        output.contains("Finding: entrypoint_fingerprint_mismatch"),
+        "expected typed fingerprint finding. Output:\n{output}"
+    );
+
+    let content = fs::read_to_string(&path).expect("read rewritten CLAUDE.md");
+    let old_release = content.replace("decapod-release: 0.69.0", "decapod-release: 0.68.0");
+    fs::write(path, old_release).expect("rewrite release");
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(!success, "old release entrypoint must fail validation");
+    assert!(
+        output.contains("Finding: entrypoint_release_mismatch"),
+        "expected typed release finding. Output:\n{output}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_missing_entrypoint_metadata() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("GEMINI.md");
+    let content = fs::read_to_string(&path).expect("read GEMINI.md");
+    let payload = content.lines().skip(2).collect::<Vec<_>>().join("\n");
+    fs::write(path, payload).expect("remove entrypoint metadata");
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(!success, "missing entrypoint metadata must fail validation");
+    assert!(
+        output.contains("Finding: entrypoint_metadata_missing"),
+        "expected typed metadata finding. Output:\n{output}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_malformed_entrypoint_metadata() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("GEMINI.md");
+    let content = fs::read_to_string(&path).expect("read GEMINI.md");
+    let malformed = content.replace(
+        &format!(
+            "<!-- decapod-binary-sha256: {} -->",
+            entrypoint_integrity::BINARY_SHA256
+        ),
+        "<!-- decapod-binary-sha256: -->",
+    );
+    fs::write(path, malformed).expect("malform entrypoint metadata");
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(
+        !success,
+        "malformed entrypoint metadata must fail validation"
+    );
+    assert!(
+        output.contains("Finding: entrypoint_metadata_malformed"),
+        "expected typed metadata finding. Output:\n{output}"
+    );
+}
+
+#[test]
+fn test_only_explicit_regeneration_restores_entrypoint_integrity() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+
+    let path = temp_path.join("CODEX.md");
+    let mut content = fs::read_to_string(&path).expect("read CODEX.md");
+    content.push_str("\nmodified\n");
+    fs::write(&path, content).expect("tamper CODEX.md");
+
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(
+        !success,
+        "validation must not silently regenerate: {output}"
+    );
+    let (success, output) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(
+        success,
+        "explicit regeneration should restore entrypoint: {output}"
+    );
+    acquire_session(&temp_path);
+    let (success, output) = run_decapod(&temp_path, &["validate"]);
+    assert!(success, "regenerated entrypoint should validate: {output}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_validate_rejects_entrypoint_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("CODEX.md");
+    fs::remove_file(&path).expect("remove CODEX.md");
+    symlink(temp_path.join("AGENTS.md"), &path).expect("replace CODEX.md with symlink");
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(!success, "entrypoint symlink must fail validation");
+    assert!(
+        output.contains("Finding: entrypoint_unsupported_file_type"),
+        "expected typed file-type finding. Output:\n{output}"
+    );
+}
+
+#[test]
 fn test_agent_entrypoints_are_consistent_except_header() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
@@ -544,18 +729,18 @@ fn test_agent_entrypoints_are_consistent_except_header() {
     assert!(
         root_claude
             .lines()
-            .next()
+            .nth(2)
             .is_some_and(|l| l.contains("CLAUDE.md")),
         "CLAUDE.md header should include CLAUDE.md"
     );
     assert_eq!(
-        root_claude.lines().skip(1).collect::<Vec<_>>(),
-        root_gemini.lines().skip(1).collect::<Vec<_>>(),
+        root_claude.lines().skip(3).collect::<Vec<_>>(),
+        root_gemini.lines().skip(3).collect::<Vec<_>>(),
         "Root entrypoints should only differ by file-specific header: CLAUDE.md != GEMINI.md"
     );
     assert_eq!(
-        root_claude.lines().skip(1).collect::<Vec<_>>(),
-        root_codex.lines().skip(1).collect::<Vec<_>>(),
+        root_claude.lines().skip(3).collect::<Vec<_>>(),
+        root_codex.lines().skip(3).collect::<Vec<_>>(),
         "Root entrypoints should only differ by file-specific header: CLAUDE.md != CODEX.md"
     );
 
@@ -564,13 +749,13 @@ fn test_agent_entrypoints_are_consistent_except_header() {
     let tpl_codex = assets::get_template("CODEX.md").expect("generated CODEX");
 
     assert_eq!(
-        tpl_claude.lines().skip(1).collect::<Vec<_>>(),
-        tpl_gemini.lines().skip(1).collect::<Vec<_>>(),
+        tpl_claude.lines().skip(3).collect::<Vec<_>>(),
+        tpl_gemini.lines().skip(3).collect::<Vec<_>>(),
         "Template entrypoints should only differ by file-specific header: CLAUDE.md != GEMINI.md"
     );
     assert_eq!(
-        tpl_claude.lines().skip(1).collect::<Vec<_>>(),
-        tpl_codex.lines().skip(1).collect::<Vec<_>>(),
+        tpl_claude.lines().skip(3).collect::<Vec<_>>(),
+        tpl_codex.lines().skip(3).collect::<Vec<_>>(),
         "Template entrypoints should only differ by file-specific header: CLAUDE.md != CODEX.md"
     );
 }


### PR DESCRIPTION
## Summary

- Bind `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `CODEX.md` to the compiled Decapod release identity.
- Carry the implementation and generated surfaces through the `v0.69.1` release bump and current `master` merge.
- Record the release identity and entrypoint template/content hashes in `.decapod/generated/specs/.manifest.json`.
- Add typed default validation for metadata, release identity, payload changes, unsupported file types, and explicit regeneration.
- Add focused tamper, cross-release, malformed metadata, symlink, and regeneration coverage.

The binary marker uses a stable compiled release-contract SHA rather than an exact self-hash of the final executable; embedding an executable's own final hash would be circular. The actual release artifact SHA remains independently attestable by the release build.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test entrypoint_correctness` (20 passed, 5 ignored)
- `cargo test --lib core::entrypoint_integrity` (2 passed)
- `decapod validate --format json` (entrypoint gates pass; local validation remains blocked by container/workunit, gatekeeper, and pre-existing proof-state environment gates)

Fixes #909
