### PR TITLE
fix: enforce per-file release entrypoint fingerprints

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.69.1
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.70.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.69.1
+ARG DECAPOD_VERSION=0.70.0
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784256077Z",
-  "repo_signal_fingerprint": "058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1",
+  "generated_at": "1784263910Z",
+  "repo_signal_fingerprint": "a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,71 +17,82 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "6e958933af74996864b23def11bd21fe19c5be73f42bf09f382267d45ad5af65",
-  "spec_input_hash": "aafabd27e9ff99b02f3617ec16b18f62e1976e49d8fc1e871c424f8caca93154",
-  "decapod_release": "0.69.1",
-  "binary_hash": "fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659",
+  "spec_input_hash": "17fe432d6c3a89ee6be584b1a411a72a3bd3d46e1df88e31250cd74bc3dadc22",
+  "decapod_release": "0.70.0",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "fc0d508a743365fd08a2b1ceb335ba20ab08f1319aa1e9ef739144821dfdba24",
-      "content_hash": "fc0d508a743365fd08a2b1ceb335ba20ab08f1319aa1e9ef739144821dfdba24"
+      "template_hash": "fb7ac86311f3b038a2b97ef294f5de12beedbc5c52a10945ac17f6648eb653ea",
+      "content_hash": "fb7ac86311f3b038a2b97ef294f5de12beedbc5c52a10945ac17f6648eb653ea",
+      "fingerprint": "50c3a42ed545891ddd40a8aa8734534b69fe36c0f7ddc122ea828bfc429ea018"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "dc44b7e9cfe1da03b15b028fd33ff53cd8b4d072bd396b565a268bfa9cc9102d",
-      "content_hash": "dc44b7e9cfe1da03b15b028fd33ff53cd8b4d072bd396b565a268bfa9cc9102d"
+      "template_hash": "21cff947f822172bed45ca37ccfab6e680fea102e5ddf71d7014d0a2a64efae2",
+      "content_hash": "21cff947f822172bed45ca37ccfab6e680fea102e5ddf71d7014d0a2a64efae2",
+      "fingerprint": "07c8f158e69f0b23ba6e00de1ff6f36a8c6c32acae17bbfaa138cd8ccc6a6dd9"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "2578bfb2fc62e8fa07dcca2c74df8c0ee01213a9bf94077c9d309e156162c7ea",
-      "content_hash": "2578bfb2fc62e8fa07dcca2c74df8c0ee01213a9bf94077c9d309e156162c7ea"
+      "template_hash": "eed983c16effdc77741ac41a93110115245b7f0aedf47090a36572a5c993a803",
+      "content_hash": "eed983c16effdc77741ac41a93110115245b7f0aedf47090a36572a5c993a803",
+      "fingerprint": "fbffd0756dffda8498f55d5169142244bbff131714851675a5d22b8393676af6"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "82e6c9a8d33c37a5c59b2030e9a46515bd221e2ed4aa036f1eafd94a73fd564d",
-      "content_hash": "82e6c9a8d33c37a5c59b2030e9a46515bd221e2ed4aa036f1eafd94a73fd564d"
+      "template_hash": "68e95f7c061d22c7109f0c37ac43f51b050a9ac5de587af0df313977cabda961",
+      "content_hash": "68e95f7c061d22c7109f0c37ac43f51b050a9ac5de587af0df313977cabda961",
+      "fingerprint": "6c79c882f2814eeb3ac076cb683c079cb394ca9b434c103e7cfcf308b654c245"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "1f5be2fce531f50934b0ee1df3a9a0b31bde87b5f758f98d95577e9a885f1d28"
+      "content_hash": "b189e9e4a65459b07e8555bdafbe58e2c2a6bf45ce25d63ea4675c69232f3bf5",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "f01e43531f97a5c6f459c30c606ee855734e8bf859639d03044176dc818f2431"
+      "content_hash": "2d0e92a3319eae61964e4071aa3f0e7394340e37a465d1d5774cef2b61097cdb",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "1a05805f9f106e8aaa711377fee8c34e302324880067bb5128ce944dea3793ef"
+      "content_hash": "b68cd69d063efb5355c68ee9c90a8ca33df45d2831a392792b55e98de5f2c50c",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "1cd712d077ec81369108a9fbaeb23e94ed3316154b585d9b8804ce692af53998"
+      "content_hash": "055f1e5c5586c032652035af2193cf4125831c009e5b8fb4aa47020248644648",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "2779e85d72593f90b0f8f79fcbf4e382daf59b49610e821b9704cd0e26862c18",
-      "content_hash": "e696c6e5c5a2c3de1eebb014ca2ee8880cef7ca41567b0de47ccc72aaea29955"
+      "content_hash": "606a08adf4be64b55c56506eec39a807a2279e003b51c91c6801d778a6ca267a",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "ebf7f494efd5bb7c59bcdd9fe7ecbcafcd72976c555f596fa6031371b15ac766"
+      "content_hash": "2991e99f801df1d350a84fc009d70ed9cbca973c18e2b32a4243d3edf01f2a00",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "5e548be944c54a4cdf1d668c9518427f729556fee501f876ef55587910f1b163"
+      "content_hash": "fadf4f2b453eb921d44beab1c8ebd2a96531d4e4bf875fd09ea03e4be7ff6b62",
+      "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "4318b44609ad12a7a580e4218f1de2281d27ca0a6e6314956941dd6d9c7eb292"
+      "content_hash": "005a14096d79ebadb1155713fb22d01981581d4d994a09e431a44d87200dfe4d",
+      "fingerprint": ""
     }
   ]
 }

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -282,7 +282,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -308,7 +308,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -340,7 +340,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `058d5cfccbc4f6cdf7755991ede06d6efc3e6541f32160169b9e64dafcc6acb1`
+- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.69.1 -->
-<!-- decapod-binary-sha256: fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659 -->
+<!-- decapod-release: 0.70.0 -->
+<!-- decapod-fingerprint: 50c3a42ed545891ddd40a8aa8734534b69fe36c0f7ddc122ea828bfc429ea018 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,7 +32,7 @@ rust_library(
     # Keep Bazel's release identity aligned with Cargo.toml. rules_rust does
     # not synthesize Cargo's package environment variables automatically.
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.69.1",
+        "CARGO_PKG_VERSION": "0.70.0",
     },
     deps = [
         ":build_script",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.69.1 -->
-<!-- decapod-binary-sha256: fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659 -->
+<!-- decapod-release: 0.70.0 -->
+<!-- decapod-fingerprint: 07c8f158e69f0b23ba6e00de1ff6f36a8c6c32acae17bbfaa138cd8ccc6a6dd9 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.69.1 -->
-<!-- decapod-binary-sha256: fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659 -->
+<!-- decapod-release: 0.70.0 -->
+<!-- decapod-fingerprint: 6c79c882f2814eeb3ac076cb683c079cb394ca9b434c103e7cfcf308b654c245 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.69.1 -->
-<!-- decapod-binary-sha256: fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659 -->
+<!-- decapod-release: 0.70.0 -->
+<!-- decapod-fingerprint: fbffd0756dffda8498f55d5169142244bbff131714851675a5d22b8393676af6 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/entrypoint_integrity.rs
+++ b/src/core/entrypoint_integrity.rs
@@ -4,7 +4,7 @@
 //! are deliberately not derived from the files being validated or from the
 //! repository at runtime.
 
-use crate::core::assets;
+use crate::core::{assets, error};
 use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fs;
@@ -12,10 +12,10 @@ use std::path::Path;
 
 pub const ENTRYPOINT_FILES: [&str; 4] = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CODEX.md"];
 pub const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
-/// Release identity SHA compiled into the binary and copied into generated
-/// entrypoints. This is the SHA of the immutable release contract, not a
-/// runtime hash of a mutable repository file or self-declared marker.
-pub const BINARY_SHA256: &str = "fa91eefdc903310d8fb9a760f7ae44fb4225afc1b4f8fe121674a8a5b3b43659";
+const RELEASE_MARKER: &str = "<!-- decapod-release:";
+const FINGERPRINT_MARKER: &str = "<!-- decapod-fingerprint:";
+const LEGACY_BINARY_MARKER: &str = "<!-- decapod-binary-sha256:";
+const FINGERPRINT_PLACEHOLDER: &str = "<fingerprint>";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EntrypointExpectation {
@@ -23,25 +23,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.69.1 release manifest. Keep them immutable for the
+// These values are the v0.70.0 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "9210b4634ebc9d2dbc7e0fa56cc23277f74196d954d63dc931eed98bc015cb28",
+        fingerprint: "50c3a42ed545891ddd40a8aa8734534b69fe36c0f7ddc122ea828bfc429ea018",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "54881ae547640ac5c829fd36639a443c679e40c012d2e46a24e1a6a0ab577a2a",
+        fingerprint: "07c8f158e69f0b23ba6e00de1ff6f36a8c6c32acae17bbfaa138cd8ccc6a6dd9",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "b87541fe0f153f8dfb25f638f721e47e9d1fa586bff2ecc63fc8f874b7b81ad8",
+        fingerprint: "fbffd0756dffda8498f55d5169142244bbff131714851675a5d22b8393676af6",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "d49882f00ac748c6fbe8d1c80c73cb556916353433e64b99b34c0b36786538ca",
+        fingerprint: "6c79c882f2814eeb3ac076cb683c079cb394ca9b434c103e7cfcf308b654c245",
     },
 ];
 
@@ -75,10 +75,8 @@ pub struct Finding {
     pub surface: String,
     pub running_release: String,
     pub declared_release: Option<String>,
-    pub expected_binary_sha256: String,
-    pub observed_binary_sha256: Option<String>,
-    pub expected_payload_fingerprint: String,
-    pub observed_payload_fingerprint: Option<String>,
+    pub expected_fingerprint: String,
+    pub observed_fingerprint: Option<String>,
     pub kind: FindingKind,
 }
 
@@ -94,27 +92,13 @@ impl fmt::Display for Finding {
         )?;
         writeln!(
             f,
-            "Expected binary SHA-256: {}",
-            self.expected_binary_sha256
+            "Expected entrypoint fingerprint: {}",
+            self.expected_fingerprint
         )?;
         writeln!(
             f,
-            "Observed binary SHA-256: {}",
-            self.observed_binary_sha256
-                .as_deref()
-                .unwrap_or("<missing>")
-        )?;
-        writeln!(
-            f,
-            "Expected payload fingerprint: {}",
-            self.expected_payload_fingerprint
-        )?;
-        writeln!(
-            f,
-            "Observed payload fingerprint: {}",
-            self.observed_payload_fingerprint
-                .as_deref()
-                .unwrap_or("<missing>")
+            "Observed entrypoint fingerprint: {}",
+            self.observed_fingerprint.as_deref().unwrap_or("<missing>")
         )?;
         writeln!(f, "Finding: {}", self.kind.code())?;
         write!(
@@ -141,12 +125,79 @@ pub fn fingerprint(payload: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+fn fingerprint_input(surface: &str, release: &str, payload: &str) -> String {
+    format!(
+        "decapod-entrypoint:{surface}\n<!-- decapod-release: {release} -->\n<!-- decapod-fingerprint: {FINGERPRINT_PLACEHOLDER} -->\n{payload}"
+    )
+}
+
+fn fingerprint_for_payload(surface: &str, release: &str, payload: &str) -> String {
+    fingerprint(&fingerprint_input(surface, release, payload))
+}
+
 pub fn render_entrypoint(surface: &str) -> Option<String> {
     let payload = canonical_template(surface)?;
-    let _ = expected_fingerprint(surface)?;
+    let expected = expected_fingerprint(surface)?;
     Some(format!(
-        "<!-- decapod-release: {RELEASE_VERSION} -->\n<!-- decapod-binary-sha256: {BINARY_SHA256} -->\n{payload}"
+        "<!-- decapod-release: {RELEASE_VERSION} -->\n<!-- decapod-fingerprint: {expected} -->\n{payload}"
     ))
+}
+
+/// Refresh release metadata when the generated payload is still canonical.
+///
+/// A current-format marker is migrated only when its value is internally valid
+/// for the release named by that marker. This keeps a hand-edited fingerprint
+/// from being silently repaired. The legacy binary marker is accepted only as
+/// a migration source for the pre-v0.70 entrypoint format.
+pub fn refresh_entrypoint_metadata(project_root: &Path) -> Result<usize, error::DecapodError> {
+    let mut updated = 0;
+    for surface in ENTRYPOINT_FILES {
+        let path = project_root.join(surface);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error::DecapodError::IoError(error)),
+        };
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+
+        let existing = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+        let mut lines = existing.splitn(3, '\n');
+        let Some(first) = lines.next() else {
+            continue;
+        };
+        let Some(second) = lines.next() else {
+            continue;
+        };
+        let Some(payload) = lines.next() else {
+            continue;
+        };
+        let Some(Ok(declared_release)) = marker_value(first, RELEASE_MARKER) else {
+            continue;
+        };
+        if canonical_template(surface).as_deref() != Some(payload) {
+            continue;
+        }
+
+        match marker_value(second, FINGERPRINT_MARKER) {
+            Some(Ok(declared_fingerprint))
+                if fingerprint_for_payload(surface, &declared_release, payload)
+                    == declared_fingerprint => {}
+            Some(_) => continue,
+            None if matches!(marker_value(second, LEGACY_BINARY_MARKER), Some(Ok(_))) => {}
+            None => continue,
+        }
+
+        let Some(rendered) = render_entrypoint(surface) else {
+            continue;
+        };
+        if existing != rendered {
+            fs::write(&path, rendered).map_err(error::DecapodError::IoError)?;
+            updated += 1;
+        }
+    }
+    Ok(updated)
 }
 
 fn marker_value(line: &str, prefix: &str) -> Option<Result<String, ()>> {
@@ -168,38 +219,34 @@ fn finding(
     surface: &str,
     kind: FindingKind,
     declared_release: Option<String>,
-    observed_binary_sha256: Option<String>,
-    observed_payload_fingerprint: Option<String>,
+    observed_fingerprint: Option<String>,
 ) -> Box<Finding> {
     Box::new(Finding {
         surface: surface.to_string(),
         running_release: RELEASE_VERSION.to_string(),
         declared_release,
-        expected_binary_sha256: BINARY_SHA256.to_string(),
-        observed_binary_sha256,
-        expected_payload_fingerprint: expected_fingerprint(surface)
+        expected_fingerprint: expected_fingerprint(surface)
             .unwrap_or("<unknown>")
             .to_string(),
-        observed_payload_fingerprint,
+        observed_fingerprint,
         kind,
     })
 }
 
 pub fn validate_entrypoint(project_root: &Path, surface: &str) -> Result<(), Box<Finding>> {
     let Some(expected) = expected_fingerprint(surface) else {
-        return Err(finding(surface, FindingKind::Missing, None, None, None));
+        return Err(finding(surface, FindingKind::Missing, None, None));
     };
     let path = project_root.join(surface);
     let metadata = match fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Err(finding(surface, FindingKind::Missing, None, None, None));
+            return Err(finding(surface, FindingKind::Missing, None, None));
         }
         Err(_) => {
             return Err(finding(
                 surface,
                 FindingKind::UnsupportedFileType,
-                None,
                 None,
                 None,
             ));
@@ -211,22 +258,21 @@ pub fn validate_entrypoint(project_root: &Path, surface: &str) -> Result<(), Box
             FindingKind::UnsupportedFileType,
             None,
             None,
-            None,
         ));
     }
 
     let bytes = fs::read(&path)
-        .map_err(|_| finding(surface, FindingKind::UnsupportedFileType, None, None, None))?;
+        .map_err(|_| finding(surface, FindingKind::UnsupportedFileType, None, None))?;
     let content = String::from_utf8(bytes)
-        .map_err(|_| finding(surface, FindingKind::PayloadModified, None, None, None))?;
+        .map_err(|_| finding(surface, FindingKind::PayloadModified, None, None))?;
     let mut lines = content.split_inclusive('\n');
     let first = lines.next().unwrap_or("");
     let second = lines.next().unwrap_or("");
     let payload_offset = first.len() + second.len();
     let payload = &content[payload_offset..];
 
-    let release = marker_value(first, "<!-- decapod-release:");
-    let declared_fingerprint = marker_value(second, "<!-- decapod-binary-sha256:");
+    let release = marker_value(first, RELEASE_MARKER);
+    let declared_fingerprint = marker_value(second, FINGERPRINT_MARKER);
     let malformed = release.as_ref().is_some_and(Result::is_err)
         || declared_fingerprint.as_ref().is_some_and(Result::is_err);
     let declared_release = release.and_then(Result::ok);
@@ -237,7 +283,6 @@ pub fn validate_entrypoint(project_root: &Path, surface: &str) -> Result<(), Box
             FindingKind::MetadataMalformed,
             declared_release,
             declared_fingerprint,
-            None,
         ));
     }
     if declared_release.is_none() || declared_fingerprint.is_none() {
@@ -246,40 +291,36 @@ pub fn validate_entrypoint(project_root: &Path, surface: &str) -> Result<(), Box
             FindingKind::MetadataMissing,
             declared_release,
             declared_fingerprint,
-            None,
         ));
     }
 
     let declared_release = declared_release.unwrap();
     let declared_fingerprint = declared_fingerprint.unwrap();
-    let observed_payload_fingerprint = fingerprint(payload);
+    let observed_fingerprint = fingerprint_for_payload(surface, &declared_release, payload);
     if declared_release != RELEASE_VERSION {
         return Err(finding(
             surface,
             FindingKind::ReleaseMismatch,
             Some(declared_release),
-            Some(declared_fingerprint),
-            Some(observed_payload_fingerprint),
+            Some(observed_fingerprint),
         ));
     }
-    if declared_fingerprint != BINARY_SHA256 {
+    if declared_fingerprint != expected {
         return Err(finding(
             surface,
             FindingKind::FingerprintMismatch,
             Some(declared_release),
-            Some(declared_fingerprint),
-            Some(observed_payload_fingerprint),
+            Some(observed_fingerprint),
         ));
     }
 
     let canonical = canonical_template(surface).unwrap_or_default();
-    if payload != canonical || observed_payload_fingerprint != expected {
+    if payload != canonical || observed_fingerprint != expected {
         return Err(finding(
             surface,
             FindingKind::PayloadModified,
             Some(declared_release),
-            Some(BINARY_SHA256.to_string()),
-            Some(observed_payload_fingerprint),
+            Some(observed_fingerprint),
         ));
     }
     Ok(())
@@ -295,7 +336,7 @@ mod tests {
         for surface in ENTRYPOINT_FILES {
             let payload = canonical_template(surface).expect("canonical entrypoint");
             assert_eq!(
-                fingerprint(&payload),
+                fingerprint_for_payload(surface, RELEASE_VERSION, &payload),
                 expected_fingerprint(surface).expect("compiled fingerprint"),
                 "compiled release manifest drifted from canonical {surface}"
             );
@@ -303,14 +344,13 @@ mod tests {
     }
 
     #[test]
-    fn release_manifest_matches_package_release() {
-        let mut release_contract = format!("decapod-release:{RELEASE_VERSION}\n");
+    fn release_manifest_is_filename_and_version_bound() {
         for entry in EXPECTED_ENTRYPOINTS {
-            release_contract.push_str(entry.surface);
-            release_contract.push(':');
-            release_contract.push_str(entry.fingerprint);
-            release_contract.push('\n');
+            let payload = canonical_template(entry.surface).expect("canonical entrypoint");
+            assert_eq!(
+                fingerprint_for_payload(entry.surface, RELEASE_VERSION, &payload),
+                entry.fingerprint
+            );
         }
-        assert_eq!(fingerprint(&release_contract), BINARY_SHA256);
     }
 }

--- a/src/core/project_specs.rs
+++ b/src/core/project_specs.rs
@@ -18,7 +18,7 @@ pub const LOCAL_PROJECT_SPECS_SEMANTICS: &str = ".decapod/generated/specs/SEMANT
 pub const LOCAL_PROJECT_SPECS_OPERATIONS: &str = ".decapod/generated/specs/OPERATIONS.md";
 pub const LOCAL_PROJECT_SPECS_SECURITY: &str = ".decapod/generated/specs/SECURITY.md";
 pub const LOCAL_PROJECT_SPECS_MANIFEST: &str = ".decapod/generated/specs/.manifest.json";
-pub const LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA: &str = "1.0.0";
+pub const LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA: &str = "1.1.0";
 pub const CAPABILITY_DEFINITION_VERSION: &str = "1.0.0";
 
 #[derive(Clone, Copy, Debug)]
@@ -157,6 +157,8 @@ pub struct ProjectSpecManifestEntry {
     pub path: String,
     pub template_hash: String,
     pub content_hash: String,
+    #[serde(default)]
+    pub fingerprint: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,9 +182,6 @@ pub struct ProjectSpecsManifest {
     /// Release identity of the Decapod binary that produced the projections.
     #[serde(default)]
     pub decapod_release: String,
-    /// Immutable release-contract SHA compiled into that Decapod binary.
-    #[serde(default)]
-    pub binary_hash: String,
     /// Generated agent entrypoints attested using the same template/content
     /// hash shape as the living spec files above.
     #[serde(default)]
@@ -377,6 +376,9 @@ pub fn entrypoint_manifest_entries(
             path: surface.to_string(),
             template_hash: hash_text(&rendered),
             content_hash,
+            fingerprint: crate::core::entrypoint_integrity::expected_fingerprint(surface)
+                .unwrap_or_default()
+                .to_string(),
         });
     }
     Ok(entries)
@@ -412,6 +414,7 @@ pub fn refresh_specs_manifest(
             path: spec.path.to_string(),
             template_hash,
             content_hash,
+            fingerprint: String::new(),
         });
     }
 
@@ -438,7 +441,6 @@ pub fn refresh_specs_manifest(
                 && manifest.config_input_hash == config_input_hash
                 && manifest.spec_input_hash == spec_input_hash
                 && manifest.decapod_release == crate::core::entrypoint_integrity::RELEASE_VERSION
-                && manifest.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256
                 && manifest.entrypoints == entrypoints
                 && manifest.files == manifest_entries
         })
@@ -454,7 +456,6 @@ pub fn refresh_specs_manifest(
         config_input_hash,
         spec_input_hash,
         decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
-        binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
         entrypoints,
         files: manifest_entries,
     };

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -833,7 +833,7 @@ Refresh output requirements:
 - Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set.
 
 ## Release-Bound Agent Entrypoint Integrity
-The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and compiled binary SHA-256; `.decapod/generated/specs/.manifest.json` records the same release identity plus `template_hash` and `content_hash` entries for `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `CODEX.md`. Default validation independently checks the compiled release contract, declared metadata, canonical payload, regular-file type, and manifest synchronization. Regeneration must be explicit through the installed Decapod release.
+The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and a deterministic filename/version-bound fingerprint; `.decapod/generated/specs/.manifest.json` records the same release identity plus per-entrypoint `fingerprint`, `template_hash`, and `content_hash` entries. Default validation recomputes each fingerprint from the actual file, compares it with the compiled expectation and declared marker, and preserves payload tamper failures. Regeneration is performed by validation only for intact canonical payloads.
 
 ## Validation Decision Tree
 ```mermaid
@@ -1275,6 +1275,7 @@ pub fn refresh_project_specs(
             path: spec.path.to_string(),
             template_hash,
             content_hash,
+            fingerprint: String::new(),
         });
     }
 
@@ -1289,7 +1290,6 @@ pub fn refresh_project_specs(
                     && existing.repo_signal_fingerprint == current_repo_fingerprint
                     && existing.decapod_release
                         == crate::core::entrypoint_integrity::RELEASE_VERSION
-                    && existing.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256
                     && existing.entrypoints == entrypoints
                     && existing.files == manifest_entries
                     && file_writes.is_empty()
@@ -1304,7 +1304,6 @@ pub fn refresh_project_specs(
         config_input_hash: config_input_hash(project_root)?,
         spec_input_hash: spec_input_hash(project_root)?,
         decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
-        binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
         entrypoints,
         files: manifest_entries,
     };
@@ -1314,7 +1313,6 @@ pub fn refresh_project_specs(
         && existing.template_version == manifest.template_version
         && existing.repo_signal_fingerprint == manifest.repo_signal_fingerprint
         && existing.decapod_release == manifest.decapod_release
-        && existing.binary_hash == manifest.binary_hash
         && existing.entrypoints == manifest.entrypoints
         && existing.files == manifest.files
         && file_writes.is_empty()
@@ -1816,6 +1814,7 @@ pub fn scaffold_project_entrypoints(
                 path: rel_path.to_string(),
                 template_hash,
                 content_hash: final_content_hash,
+                fingerprint: String::new(),
             });
         }
 
@@ -1838,7 +1837,6 @@ pub fn scaffold_project_entrypoints(
                     String::new()
                 },
                 decapod_release: crate::core::entrypoint_integrity::RELEASE_VERSION.to_string(),
-                binary_hash: crate::core::entrypoint_integrity::BINARY_SHA256.to_string(),
                 entrypoints: entrypoint_manifest_entries(&opts.target_dir)?,
                 files: manifest_entries,
             };

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1501,17 +1501,6 @@ fn validate_project_specs_docs(
                 ctx,
             );
         }
-        if manifest.binary_hash == crate::core::entrypoint_integrity::BINARY_SHA256 {
-            pass(
-                "Project specs manifest records the compiled Decapod binary SHA-256",
-                ctx,
-            );
-        } else {
-            fail(
-                "STALE_ENTRYPOINT_BINARY: specs manifest binary_hash does not match the compiled Decapod release contract. Regenerate the governed entrypoints and refresh specs.",
-                ctx,
-            );
-        }
         let expected_entrypoints =
             crate::core::project_specs::entrypoint_manifest_entries(repo_root)?;
         if manifest.entrypoints == expected_entrypoints {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4618,6 +4618,59 @@ fn heal_validation_scaffold(
     }))
 }
 
+fn heal_release_bound_entrypoints(
+    project_root: &Path,
+) -> Result<Option<ValidationHealAction>, error::DecapodError> {
+    let updated = core::entrypoint_integrity::refresh_entrypoint_metadata(project_root)?;
+    let all_entrypoints_valid =
+        core::entrypoint_integrity::ENTRYPOINT_FILES
+            .iter()
+            .all(|surface| {
+                core::entrypoint_integrity::validate_entrypoint(project_root, surface).is_ok()
+            });
+    if !all_entrypoints_valid {
+        return if updated == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(ValidationHealAction {
+                action: "heal_release_bound_entrypoints".to_string(),
+                outcome: "refreshed".to_string(),
+                detail: format!(
+                    "Refreshed {updated} valid legacy release-bound entrypoint metadata file(s); validation remains blocked by another entrypoint integrity finding."
+                ),
+            }))
+        };
+    }
+
+    let expected_entries = core::project_specs::entrypoint_manifest_entries(project_root)?;
+    let manifest_needs_refresh = match core::project_specs::read_specs_manifest(project_root)? {
+        None => project_root
+            .join(core::project_specs::LOCAL_PROJECT_SPECS_DIR)
+            .is_dir(),
+        Some(manifest) => {
+            manifest.schema_version != core::project_specs::LOCAL_PROJECT_SPECS_MANIFEST_SCHEMA
+                || manifest.decapod_release != core::entrypoint_integrity::RELEASE_VERSION
+                || manifest.entrypoints != expected_entries
+        }
+    };
+    if updated == 0 && !manifest_needs_refresh {
+        return Ok(None);
+    }
+
+    let config = crate::cli::DecapodProjectConfig::load(project_root).unwrap_or_default();
+    let _ =
+        core::project_specs::refresh_specs_from_codebase(project_root, &config.repo.capabilities)?;
+
+    Ok(Some(ValidationHealAction {
+        action: "heal_release_bound_entrypoints".to_string(),
+        outcome: "refreshed".to_string(),
+        detail: format!(
+            "Refreshed {updated} release-bound entrypoint metadata file(s) and the generated specs manifest for Decapod {}.",
+            core::entrypoint_integrity::RELEASE_VERSION
+        ),
+    }))
+}
+
 fn heal_override_checksum(
     project_root: &Path,
 ) -> Result<Option<ValidationHealAction>, error::DecapodError> {
@@ -4930,6 +4983,9 @@ fn run_validate_command(
         heal_actions.push(action);
     }
     if let Some(action) = heal_validation_scaffold(workspace_root)? {
+        heal_actions.push(action);
+    }
+    if let Some(action) = heal_release_bound_entrypoints(workspace_root)? {
         heal_actions.push(action);
     }
     if let Some(action) = heal_agents_contract(workspace_root)? {

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -535,7 +535,7 @@ fn test_root_entrypoints_match_scaffold_generators() {
 }
 
 #[test]
-fn test_entrypoints_record_binary_release_and_specs_manifest_attestation() {
+fn test_entrypoints_record_release_fingerprints_and_specs_manifest_attestation() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();
     let (success, output) = run_decapod(&temp_path, &["init", "--force"]);
@@ -543,10 +543,10 @@ fn test_entrypoints_record_binary_release_and_specs_manifest_attestation() {
 
     for surface in entrypoint_integrity::ENTRYPOINT_FILES {
         let content = fs::read_to_string(temp_path.join(surface)).expect("read entrypoint");
-        assert!(content.contains("<!-- decapod-release: 0.69.1 -->"));
+        assert!(content.contains("<!-- decapod-release: 0.70.0 -->"));
         assert!(content.contains(&format!(
-            "<!-- decapod-binary-sha256: {} -->",
-            entrypoint_integrity::BINARY_SHA256
+            "<!-- decapod-fingerprint: {} -->",
+            entrypoint_integrity::expected_fingerprint(surface).expect("compiled fingerprint")
         )));
     }
 
@@ -555,16 +555,24 @@ fn test_entrypoints_record_binary_release_and_specs_manifest_attestation() {
             .expect("read specs manifest");
     let manifest: serde_json::Value =
         serde_json::from_str(&manifest_body).expect("parse specs manifest");
-    assert_eq!(manifest["decapod_release"], "0.69.1");
-    assert_eq!(manifest["binary_hash"], entrypoint_integrity::BINARY_SHA256);
+    assert_eq!(manifest["decapod_release"], "0.70.0");
+    assert!(
+        !manifest
+            .as_object()
+            .expect("manifest object")
+            .contains_key("binary_hash")
+    );
     assert_eq!(manifest["entrypoints"].as_array().unwrap().len(), 4);
     for surface in entrypoint_integrity::ENTRYPOINT_FILES {
-        assert!(
-            manifest["entrypoints"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|entry| entry["path"] == surface)
+        let entry = manifest["entrypoints"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["path"] == surface)
+            .expect("entrypoint manifest entry");
+        assert_eq!(
+            entry["fingerprint"],
+            entrypoint_integrity::expected_fingerprint(surface).expect("compiled fingerprint")
         );
     }
 }
@@ -591,7 +599,7 @@ fn test_validate_reports_payload_modified_entrypoint() {
 }
 
 #[test]
-fn test_validate_rejects_rewritten_binary_sha_and_old_release() {
+fn test_validate_migrates_valid_legacy_entrypoint_metadata() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();
     let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
@@ -600,24 +608,64 @@ fn test_validate_rejects_rewritten_binary_sha_and_old_release() {
 
     let path = temp_path.join("CLAUDE.md");
     let content = fs::read_to_string(&path).expect("read CLAUDE.md");
-    let rewritten = content.replace(entrypoint_integrity::BINARY_SHA256, &"0".repeat(64));
+    let rewritten = content
+        .replace(
+            &format!(
+                "<!-- decapod-release: {} -->",
+                entrypoint_integrity::RELEASE_VERSION
+            ),
+            "<!-- decapod-release: 0.69.1 -->",
+        )
+        .replace(
+            &format!(
+                "<!-- decapod-fingerprint: {} -->",
+                entrypoint_integrity::expected_fingerprint("CLAUDE.md")
+                    .expect("compiled fingerprint")
+            ),
+            "<!-- decapod-binary-sha256: legacy-release-contract -->",
+        );
     fs::write(&path, rewritten).expect("rewrite binary sha");
     let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
-    assert!(!success, "rewritten binary sha must fail validation");
+    assert!(success, "validate should refresh legacy metadata: {output}");
+    assert!(output.contains("heal_release_bound_entrypoints"));
+
+    let content = fs::read_to_string(&path).expect("read rewritten CLAUDE.md");
+    assert!(content.contains("<!-- decapod-release: 0.70.0 -->"));
+    assert!(content.contains(&format!(
+        "<!-- decapod-fingerprint: {} -->",
+        entrypoint_integrity::expected_fingerprint("CLAUDE.md").expect("compiled fingerprint")
+    )));
+}
+
+#[test]
+fn test_validate_rejects_tweaked_entrypoint_fingerprint() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_path_buf();
+    let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
+    assert!(success, "decapod init should succeed");
+    acquire_session(&temp_path);
+
+    let path = temp_path.join("CLAUDE.md");
+    let content = fs::read_to_string(&path).expect("read CLAUDE.md");
+    let expected =
+        entrypoint_integrity::expected_fingerprint("CLAUDE.md").expect("compiled fingerprint");
+    let rewritten = content.replace(
+        &format!("<!-- decapod-fingerprint: {expected} -->"),
+        "<!-- decapod-fingerprint: 0000000000000000000000000000000000000000000000000000000000000000 -->",
+    );
+    fs::write(&path, rewritten).expect("rewrite fingerprint");
+
+    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+    assert!(
+        !success,
+        "validate must reject a tweaked fingerprint: {output}"
+    );
     assert!(
         output.contains("Finding: entrypoint_fingerprint_mismatch"),
         "expected typed fingerprint finding. Output:\n{output}"
     );
-
-    let content = fs::read_to_string(&path).expect("read rewritten CLAUDE.md");
-    let old_release = content.replace("decapod-release: 0.69.1", "decapod-release: 0.68.0");
-    fs::write(path, old_release).expect("rewrite release");
-    let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
-    assert!(!success, "old release entrypoint must fail validation");
-    assert!(
-        output.contains("Finding: entrypoint_release_mismatch"),
-        "expected typed release finding. Output:\n{output}"
-    );
+    let content = fs::read_to_string(path).expect("read tweaked CLAUDE.md");
+    assert!(content.contains("decapod-fingerprint: 000000000000"));
 }
 
 #[test]
@@ -652,10 +700,10 @@ fn test_validate_rejects_malformed_entrypoint_metadata() {
     let content = fs::read_to_string(&path).expect("read GEMINI.md");
     let malformed = content.replace(
         &format!(
-            "<!-- decapod-binary-sha256: {} -->",
-            entrypoint_integrity::BINARY_SHA256
+            "<!-- decapod-fingerprint: {} -->",
+            entrypoint_integrity::expected_fingerprint("GEMINI.md").expect("compiled fingerprint")
         ),
-        "<!-- decapod-binary-sha256: -->",
+        "<!-- decapod-fingerprint: -->",
     );
     fs::write(path, malformed).expect("malform entrypoint metadata");
     let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
@@ -670,7 +718,7 @@ fn test_validate_rejects_malformed_entrypoint_metadata() {
 }
 
 #[test]
-fn test_only_explicit_regeneration_restores_entrypoint_integrity() {
+fn test_validate_does_not_overwrite_payload_tamper() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();
     let (success, _) = run_decapod(&temp_path, &["init", "--force"]);
@@ -684,7 +732,7 @@ fn test_only_explicit_regeneration_restores_entrypoint_integrity() {
     let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
     assert!(
         !success,
-        "validation must not silently regenerate: {output}"
+        "validation must fail without overwriting payload tamper: {output}"
     );
     let (success, output) = run_decapod(&temp_path, &["init", "--force"]);
     assert!(


### PR DESCRIPTION
## Summary

- Replace the release-wide entrypoint binary hash with deterministic fingerprints bound to filename, Decapod release, and canonical file payload.
- Make decapod validate migrate valid legacy metadata and refresh the generated specs manifest for the running release.
- Reject payload changes and edited current fingerprints, even when the marker itself is syntactically valid.
- Regenerate the v0.70.0 entrypoint markers and generated specs manifest.

Relates to #909.

## Verification

- Focused entrypoint unit tests: 2 passed.
- Entrypoint integration tests: 21 passed, 5 ignored.
- Clippy with all targets/features and warnings denied: passed.
- Full test run: 151 passed; 2 unrelated pre-existing failures in capability overlays and external-worktree validation.
