### PR TITLE
fix: restore capability and worktree validation contracts

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.71.0
+ARG DECAPOD_VERSION=0.71.1
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784278591Z",
-  "repo_signal_fingerprint": "1f2244e7c2c2d27faf3e8fc33add2c8039d1fddc8052dcf3f4dd86a5f9325173",
+  "generated_at": "1784307117Z",
+  "repo_signal_fingerprint": "9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "17fe432d6c3a89ee6be584b1a411a72a3bd3d46e1df88e31250cd74bc3dadc22",
+  "spec_input_hash": "6b30711fe4089b661324b56b0092736c90345be6d9e768d728374c22d77df905",
   "decapod_release": "0.71.1",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "b189e9e4a65459b07e8555bdafbe58e2c2a6bf45ce25d63ea4675c69232f3bf5",
+      "content_hash": "77040b9e3b4d5de2d930e300317cd7b3826c9682614fd4a46ed40df67c8c85aa",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "2d0e92a3319eae61964e4071aa3f0e7394340e37a465d1d5774cef2b61097cdb",
+      "content_hash": "ff134c6e977214ab9b01e4a1611053a735f0e6d54160b3bfaf24a82147494d54",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "b68cd69d063efb5355c68ee9c90a8ca33df45d2831a392792b55e98de5f2c50c",
+      "content_hash": "a007344d20496f7d1c4742730a7f3173186e5c5c9b9216e04e0a151fc544c0ee",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "055f1e5c5586c032652035af2193cf4125831c009e5b8fb4aa47020248644648",
+      "content_hash": "b8c1e51e94854b0dc862a82f5a2527670133b14ab1aad49284baa5bd109c8807",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "606a08adf4be64b55c56506eec39a807a2279e003b51c91c6801d778a6ca267a",
+      "content_hash": "1c2259a0e6cc8aec8ee27b6250613817b6cc3bbadeac80e554f770a431901bd6",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "2991e99f801df1d350a84fc009d70ed9cbca973c18e2b32a4243d3edf01f2a00",
+      "content_hash": "8b734fd2e35cf747cebaebd8cfe6bdabbd89fffbaab30b5de7d9cc211930961f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "fadf4f2b453eb921d44beab1c8ebd2a96531d4e4bf875fd09ea03e4be7ff6b62",
+      "content_hash": "097a2fa00d3ed0feab819db14f3781cd1200fbaa5f5c0d922df4c0331ff6b21c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "005a14096d79ebadb1155713fb22d01981581d4d994a09e431a44d87200dfe4d",
+      "content_hash": "819d15e03bb965705cf73e0579c5fce90557503d588db4307f33419b0cd25b77",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784275484Z",
-  "repo_signal_fingerprint": "494672e420bf8e369412a0f897d72dfee026729f5cfb69fc71827ea0a21ec068",
+  "generated_at": "1784278591Z",
+  "repo_signal_fingerprint": "1f2244e7c2c2d27faf3e8fc33add2c8039d1fddc8052dcf3f4dd86a5f9325173",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -18,31 +18,31 @@
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
   "spec_input_hash": "17fe432d6c3a89ee6be584b1a411a72a3bd3d46e1df88e31250cd74bc3dadc22",
-  "decapod_release": "0.71.0",
+  "decapod_release": "0.71.1",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "84c5bdcb2a22123015fa8d50069e46480482054512c6beb4935f85f905e668ab",
-      "content_hash": "84c5bdcb2a22123015fa8d50069e46480482054512c6beb4935f85f905e668ab",
-      "fingerprint": "5c6882d8a51f2e813c593d4556b5b1b79ecdbef5b01f46b25b36431f5ec136df"
+      "template_hash": "570e710ea83d871eb5cc98eac5e91b952d873104ced22d522fe28eed30633555",
+      "content_hash": "570e710ea83d871eb5cc98eac5e91b952d873104ced22d522fe28eed30633555",
+      "fingerprint": "9690a85584326deda839209a9ffb414555a5b0bfbe0060832490d6fa4f6e5f64"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "595449b689fccf4467dceb4eb033c1635d1cf6cf23ea6e206f386572e111f25c",
-      "content_hash": "595449b689fccf4467dceb4eb033c1635d1cf6cf23ea6e206f386572e111f25c",
-      "fingerprint": "967de5978b2b8965f88a587e30dcd4d5357dc7e6ff5e3c91b0e6c4f1030c0d70"
+      "template_hash": "4f8a48999b59201f2259923a6454b31a3a742a4c596e7b242d0904af110feff8",
+      "content_hash": "4f8a48999b59201f2259923a6454b31a3a742a4c596e7b242d0904af110feff8",
+      "fingerprint": "317be132fde7331f829619c1ecdd1be1b87a87fd03ab9922deb3547f01ca7023"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "b0af4c17f85ec4929ade9d27c2631a890f812d5feb1eae55f38db6c92809fd1e",
-      "content_hash": "b0af4c17f85ec4929ade9d27c2631a890f812d5feb1eae55f38db6c92809fd1e",
-      "fingerprint": "beb7679068364d39c7026f05efcede0e5cb1fdc6959fa7473a80b9760571c1fb"
+      "template_hash": "f20d41b52de7507a23adc27335711d5b0cffd5d08ba41b8754e9c4e3a7b9528a",
+      "content_hash": "f20d41b52de7507a23adc27335711d5b0cffd5d08ba41b8754e9c4e3a7b9528a",
+      "fingerprint": "14e8af4076b495de19ce8b0b6ea56ba604d8903f15e0a44bb3e2414f5b7c2733"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "95653a6f44bf6ca45e1d2a4fd55d4350a225401a1b5a920e459798d87366a249",
-      "content_hash": "95653a6f44bf6ca45e1d2a4fd55d4350a225401a1b5a920e459798d87366a249",
-      "fingerprint": "7d7539475a1bf3637c37aa5febba566b824342c587469b63294e66d70cd06ba9"
+      "template_hash": "2f942d64e9344b958c0088273032bff3b5fd939331eacab1b8ea3791d0a7ead0",
+      "content_hash": "2f942d64e9344b958c0088273032bff3b5fd939331eacab1b8ea3791d0a7ead0",
+      "fingerprint": "332e0389236df58d42470e51127bf5a32ed01acd90ee1f8283c9dc32724fbee7"
     }
   ],
   "files": [

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -1,6 +1,7 @@
 # Architecture
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -21,6 +22,7 @@
 - Portability or swappable implementations are project decisions, not universal requirements
 - Migration and rollback treatment MUST match the selected storage technology
 <!-- decapod:capability-overlay:persistent-state:end -->
+
 ## Direction
 CLI governance runtime with dual-store architecture, git worktree isolation, and deterministic context management.
 
@@ -395,7 +397,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,7 +1,27 @@
 # Operations
 
 
+
 <!-- decapod:capability-overlay:background-processing:start -->
+
+
+## Background Processing Operations Overlay
+
+### Queue Visibility
+- Queue depth, processing rate, and latency MUST be monitored
+- Dead letter queue MUST be visible and alerted
+- Worker health and processing rate metrics required
+
+### Shutdown Behavior
+- Graceful shutdown: stop accepting new work, finish current job
+- Drain behavior and timeout MUST be selected for the deployment
+- Termination and requeue behavior MUST be selected and proven for the deployment
+
+### Worker Health
+- Worker liveness and readiness probes
+- Queue depth alerts for backpressure detection
+- Processing latency percentiles (p50, p95, p99)
+<!-- decapod:capability-overlay:background-processing:end -->
 
 
 
@@ -22,23 +42,7 @@
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-## Background Processing Operations Overlay
 
-### Queue Visibility
-- Queue depth, processing rate, and latency MUST be monitored
-- Dead letter queue MUST be visible and alerted
-- Worker health and processing rate metrics required
-
-### Shutdown Behavior
-- Graceful shutdown: stop accepting new work, finish current job
-- Drain behavior and timeout MUST be selected for the deployment
-- Termination and requeue behavior MUST be selected and proven for the deployment
-
-### Worker Health
-- Worker liveness and readiness probes
-- Queue depth alerts for backpressure detection
-- Processing latency percentiles (p50, p95, p99)
-<!-- decapod:capability-overlay:background-processing:end -->
 ## Capability Operations
 
 Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.
@@ -282,7 +286,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,7 +1,27 @@
 # Semantics
 
 
+
 <!-- decapod:capability-overlay:background-processing:start -->
+
+
+## Background Processing Semantics Overlay
+
+### Retry Semantics
+- Retry and backoff behavior MUST be selected and documented for each work class
+- Poison-work handling MUST be selected and documented for each work class
+- Retry MUST preserve the declared side-effect and idempotency semantics
+
+### Idempotency
+- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
+- Deduplication or compensation mechanisms are project decisions and require proof
+- Duplicate execution MUST follow the job's declared duplicate-handling semantics
+
+### Poison Message Handling
+- Messages failing after max retries go to dead letter queue
+- DLQ MUST be monitored and alerted
+- Manual replay capability for DLQ messages
+<!-- decapod:capability-overlay:background-processing:end -->
 
 
 
@@ -25,23 +45,7 @@
 - Recovery objectives MUST be selected for the project and recorded as proof obligations
 - Recovery test cadence MUST be selected for the project and recorded as a proof obligation
 <!-- decapod:capability-overlay:persistent-state:end -->
-## Background Processing Semantics Overlay
 
-### Retry Semantics
-- Retry and backoff behavior MUST be selected and documented for each work class
-- Poison-work handling MUST be selected and documented for each work class
-- Retry MUST preserve the declared side-effect and idempotency semantics
-
-### Idempotency
-- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
-- Deduplication or compensation mechanisms are project decisions and require proof
-- Duplicate execution MUST follow the job's declared duplicate-handling semantics
-
-### Poison Message Handling
-- Messages failing after max retries go to dead letter queue
-- DLQ MUST be monitored and alerted
-- Manual replay capability for DLQ messages
-<!-- decapod:capability-overlay:background-processing:end -->
 ## State Machines
 
 ### Workspace State
@@ -308,7 +312,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -1,7 +1,27 @@
 # Validation
 
 
+
 <!-- decapod:capability-overlay:background-processing:start -->
+
+
+## Background Processing Validation Overlay
+
+### Duplicate Delivery Tests
+- Same message delivered multiple times MUST produce same result
+- Idempotency key verification
+- Verify the declared delivery guarantee; do not claim exactly-once behavior without proof
+
+### Retry Tests
+- Configured retry/backoff policy verified
+- Configured retry bound or unbounded policy verified
+- Poison-work handling verified when the project declares it
+
+### Shutdown Tests
+- Graceful drain on signal
+- In-flight job completion or safe requeue
+- No data loss on forced termination
+<!-- decapod:capability-overlay:background-processing:end -->
 
 
 
@@ -25,23 +45,7 @@
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-## Background Processing Validation Overlay
 
-### Duplicate Delivery Tests
-- Same message delivered multiple times MUST produce same result
-- Idempotency key verification
-- Verify the declared delivery guarantee; do not claim exactly-once behavior without proof
-
-### Retry Tests
-- Configured retry/backoff policy verified
-- Configured retry bound or unbounded policy verified
-- Poison-work handling verified when the project declares it
-
-### Shutdown Tests
-- Graceful drain on signal
-- In-flight job completion or safe requeue
-- No data loss on forced termination
-<!-- decapod:capability-overlay:background-processing:end -->
 ## Capability Proof Requirements
 
 When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.
@@ -340,7 +344,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a59bf96a4543d961d4c233bbfb3c7e42f2fc89460789a585994e4dc2746dc483`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (88 files), `tests/` (4 files)
+- Repository signal fingerprint: `9a83eefe7c495c9b0878ccd652cd141a1b5cbd094e9f2f04e5a0ce535080cea7`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -19,10 +19,7 @@ jobs:
           path: ~/.cargo/bin/decapod
           key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
       - name: Install Decapod
-        run: |
-          if ! command -v decapod &> /dev/null; then
-            cargo install decapod
-          fi
+        run: cargo install --path . --locked --force
       - name: Decapod Validate
         env:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.0 -->
-<!-- decapod-fingerprint: 5c6882d8a51f2e813c593d4556b5b1b79ecdbef5b01f46b25b36431f5ec136df -->
+<!-- decapod-release: 0.71.1 -->
+<!-- decapod-fingerprint: 9690a85584326deda839209a9ffb414555a5b0bfbe0060832490d6fa4f6e5f64 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,7 +32,7 @@ rust_library(
     # Keep Bazel's release identity aligned with Cargo.toml. rules_rust does
     # not synthesize Cargo's package environment variables automatically.
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.71.0",
+        "CARGO_PKG_VERSION": "0.71.1",
     },
     deps = [
         ":build_script",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.0 -->
-<!-- decapod-fingerprint: 967de5978b2b8965f88a587e30dcd4d5357dc7e6ff5e3c91b0e6c4f1030c0d70 -->
+<!-- decapod-release: 0.71.1 -->
+<!-- decapod-fingerprint: 317be132fde7331f829619c1ecdd1be1b87a87fd03ab9922deb3547f01ca7023 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.0 -->
-<!-- decapod-fingerprint: 7d7539475a1bf3637c37aa5febba566b824342c587469b63294e66d70cd06ba9 -->
+<!-- decapod-release: 0.71.1 -->
+<!-- decapod-fingerprint: 332e0389236df58d42470e51127bf5a32ed01acd90ee1f8283c9dc32724fbee7 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.0 -->
-<!-- decapod-fingerprint: beb7679068364d39c7026f05efcede0e5cb1fdc6959fa7473a80b9760571c1fb -->
+<!-- decapod-release: 0.71.1 -->
+<!-- decapod-fingerprint: 14e8af4076b495de19ce8b0b6ea56ba604d8903f15e0a44bb3e2414f5b7c2733 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/capabilities.rs
+++ b/src/core/capabilities.rs
@@ -945,14 +945,35 @@ fn apply_overlay(content: String, capability_id: &str, spec_path: &str) -> Strin
         let overlay = normalize_overlay_language(overlay);
         let overlay = format!("{start_marker}\n{overlay}\n{end_marker}");
         // Insert overlay before the first major section after the title
-        if let Some(pos) = content.find("\n## ") {
+        if let Some(pos) = first_unmarked_section_start(&content) {
             let mut result = content[..pos].to_string();
-            result.push_str(&format!("\n\n{}", overlay));
+            result.push_str(&format!("\n\n{}\n\n", overlay));
             result.push_str(&content[pos..]);
             return result;
         }
     }
     content
+}
+
+fn first_unmarked_section_start(content: &str) -> Option<usize> {
+    let mut offset = 0;
+    let mut inside_overlay = false;
+
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.starts_with("<!-- decapod:capability-overlay:")
+            && trimmed.ends_with(":start -->")
+        {
+            inside_overlay = true;
+        } else if !inside_overlay && trimmed.starts_with("## ") {
+            return Some(offset);
+        } else if inside_overlay && trimmed.ends_with(":end -->") {
+            inside_overlay = false;
+        }
+        offset += line.len();
+    }
+
+    None
 }
 
 /// Built-in packs transfer obligations without silently choosing local architecture,
@@ -1413,6 +1434,9 @@ mod tests {
             assert!(!content.contains(forbidden), "overlay contains {forbidden}");
         }
         assert!(content.contains("Migration Proof Command"));
-        assert!(content.contains("project decision"));
+        assert!(content.contains("Public API Validation Overlay"));
+        assert!(content.contains("Persistent State Validation Overlay"));
+        assert!(content.contains("Background Processing Validation Overlay"));
+        assert!(content.contains("Verify the declared delivery guarantee"));
     }
 }

--- a/src/core/entrypoint_integrity.rs
+++ b/src/core/entrypoint_integrity.rs
@@ -23,25 +23,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.71.0 release manifest. Keep them immutable for the
+// These values are the v0.71.1 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "5c6882d8a51f2e813c593d4556b5b1b79ecdbef5b01f46b25b36431f5ec136df",
+        fingerprint: "9690a85584326deda839209a9ffb414555a5b0bfbe0060832490d6fa4f6e5f64",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "967de5978b2b8965f88a587e30dcd4d5357dc7e6ff5e3c91b0e6c4f1030c0d70",
+        fingerprint: "317be132fde7331f829619c1ecdd1be1b87a87fd03ab9922deb3547f01ca7023",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "beb7679068364d39c7026f05efcede0e5cb1fdc6959fa7473a80b9760571c1fb",
+        fingerprint: "14e8af4076b495de19ce8b0b6ea56ba604d8903f15e0a44bb3e2414f5b7c2733",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "7d7539475a1bf3637c37aa5febba566b824342c587469b63294e66d70cd06ba9",
+        fingerprint: "332e0389236df58d42470e51127bf5a32ed01acd90ee1f8283c9dc32724fbee7",
     },
 ];
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -3669,7 +3669,6 @@ fn validate_git_workspace_context(
         pass("Running in isolated workspace (.decapod/workspaces/)", ctx);
     } else if let Ok(status) = workspace::get_workspace_status(repo_root)
         && status.git.in_worktree
-        && !status.git.is_main_repo
     {
         let path = status.git.worktree_path.as_deref().unwrap_or(repo_root);
         fail(

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -543,7 +543,10 @@ fn test_entrypoints_record_release_fingerprints_and_specs_manifest_attestation()
 
     for surface in entrypoint_integrity::ENTRYPOINT_FILES {
         let content = fs::read_to_string(temp_path.join(surface)).expect("read entrypoint");
-        assert!(content.contains("<!-- decapod-release: 0.70.0 -->"));
+        assert!(content.contains(&format!(
+            "<!-- decapod-release: {} -->",
+            entrypoint_integrity::RELEASE_VERSION
+        )));
         assert!(content.contains(&format!(
             "<!-- decapod-fingerprint: {} -->",
             entrypoint_integrity::expected_fingerprint(surface).expect("compiled fingerprint")
@@ -555,7 +558,10 @@ fn test_entrypoints_record_release_fingerprints_and_specs_manifest_attestation()
             .expect("read specs manifest");
     let manifest: serde_json::Value =
         serde_json::from_str(&manifest_body).expect("parse specs manifest");
-    assert_eq!(manifest["decapod_release"], "0.70.0");
+    assert_eq!(
+        manifest["decapod_release"],
+        entrypoint_integrity::RELEASE_VERSION
+    );
     assert!(
         !manifest
             .as_object()
@@ -599,6 +605,29 @@ fn test_validate_reports_payload_modified_entrypoint() {
 }
 
 #[test]
+fn test_validate_rejects_changes_to_every_root_markdown_entrypoint() {
+    for surface in entrypoint_integrity::ENTRYPOINT_FILES {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let temp_path = temp_dir.path().to_path_buf();
+        let (success, output) = run_decapod(&temp_path, &["init", "--force"]);
+        assert!(success, "decapod init should succeed: {output}");
+        acquire_session(&temp_path);
+
+        let path = temp_path.join(surface);
+        let mut content = fs::read_to_string(&path).expect("read entrypoint");
+        content.push_str("\nroot entrypoint payload tamper\n");
+        fs::write(&path, content).expect("tamper entrypoint");
+
+        let (success, output) = run_decapod(&temp_path, &["validate", "--format", "json"]);
+        assert!(!success, "changed {surface} must fail validation: {output}");
+        assert!(
+            output.contains("Finding: entrypoint_payload_modified"),
+            "changed {surface} must fail because its release/version-bound hash no longer matches: {output}"
+        );
+    }
+}
+
+#[test]
 fn test_validate_migrates_valid_legacy_entrypoint_metadata() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();
@@ -630,7 +659,10 @@ fn test_validate_migrates_valid_legacy_entrypoint_metadata() {
     assert!(output.contains("heal_release_bound_entrypoints"));
 
     let content = fs::read_to_string(&path).expect("read rewritten CLAUDE.md");
-    assert!(content.contains("<!-- decapod-release: 0.70.0 -->"));
+    assert!(content.contains(&format!(
+        "<!-- decapod-release: {} -->",
+        entrypoint_integrity::RELEASE_VERSION
+    )));
     assert!(content.contains(&format!(
         "<!-- decapod-fingerprint: {} -->",
         entrypoint_integrity::expected_fingerprint("CLAUDE.md").expect("compiled fingerprint")


### PR DESCRIPTION
## Summary

- Fix capability overlay insertion so multiple marked overlays remain intact and ordered instead of being inserted inside one another.
- Update the capability regression test to assert all validation overlays and the normalized delivery-guarantee wording.
- Fix external Git worktree validation to report the Decapod ownership mismatch for real worktrees outside `.decapod/workspaces/`.

## Verification

- `cargo test --lib core::capabilities::tests::built_in_overlays_do_not_select_universal_service_levels`
- `cargo test --lib core::validate::tests::external_worktree_reports_context_mismatch_instead_of_generic_failure`
- `cargo test --all-targets --quiet` — 157 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings`

Fixes #916
Depends on #915
