### PR TITLE
fix: restore architect-grade compliance constitution guidance

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.2
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.3
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.71.2
+ARG DECAPOD_VERSION=0.71.3
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784331153Z",
-  "repo_signal_fingerprint": "45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f",
+  "generated_at": "1784332983Z",
+  "repo_signal_fingerprint": "312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "1cbda651f4263c3e0e9e283f042bd74d7737aa3a0c61c5402033a51af7218067",
-  "decapod_release": "0.71.2",
+  "spec_input_hash": "ee7922512e2ec185a23d240505728c19807a9042dae68c27f05709cfd418fd6c",
+  "decapod_release": "0.71.3",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "7cb05831112f917c91c7846670f53fae18e31dfeb67baff0dacd822ab6ea4e18",
-      "content_hash": "7cb05831112f917c91c7846670f53fae18e31dfeb67baff0dacd822ab6ea4e18",
-      "fingerprint": "12e124547f6ea6e678dcb053c69277d910718ffb93c7777e03ea6979c036a60a"
+      "template_hash": "5921fa9a7766ee7a284f47e3c91f63e325dc17ada5d3432cedf3996661d5377a",
+      "content_hash": "5921fa9a7766ee7a284f47e3c91f63e325dc17ada5d3432cedf3996661d5377a",
+      "fingerprint": "eea4cec5c809e46aa6dfe102aa47ce9277ee8cf93cbd3001d64c4433057f8296"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "62199133aa5fd3d773455d2867d52611557fb02836b563aa8f7acac6c109dd3f",
-      "content_hash": "62199133aa5fd3d773455d2867d52611557fb02836b563aa8f7acac6c109dd3f",
-      "fingerprint": "ae98bb5ead5fc859a4ca9fc0bc7d1c14b6fcb0339b83b815113d63d35a557105"
+      "template_hash": "b49e7fad739b8fc17ddf33d188e1af3507f38a46ed0253dadfdd11cfc3796d48",
+      "content_hash": "b49e7fad739b8fc17ddf33d188e1af3507f38a46ed0253dadfdd11cfc3796d48",
+      "fingerprint": "7a2d1f4dee91bb004d3a444e97df05d74141920cca926646d2afdca686ce0082"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "e7f313c9c13e1a5ee9464f55acaed7ff9419d39b10e2f0a530f9dc632146ab28",
-      "content_hash": "e7f313c9c13e1a5ee9464f55acaed7ff9419d39b10e2f0a530f9dc632146ab28",
-      "fingerprint": "4bbc1808dcf86f5c98ca590ae455f0975264d7022112a823904bb2279f451809"
+      "template_hash": "71bbb3da52efd47c0dd03bb4313bb368d82a37ef617e2b85518ccd51e0f728ec",
+      "content_hash": "71bbb3da52efd47c0dd03bb4313bb368d82a37ef617e2b85518ccd51e0f728ec",
+      "fingerprint": "630e6a0f3f56877812bf83afc8db238ef47cc64c531f2477b0053997c056ed0d"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "72949b9f20b75cf1d381df860f2d7b8873470b03c02e00954dbefd75d2fd48fd",
-      "content_hash": "72949b9f20b75cf1d381df860f2d7b8873470b03c02e00954dbefd75d2fd48fd",
-      "fingerprint": "259ebf3d3346c30ce66012e87bc5f74a8f24e5892b413677b1e0a5f0da5be8a4"
+      "template_hash": "88bb899a7146b66ce887387fc9112033ee4966d4c826f0e2faf8217b8c763319",
+      "content_hash": "88bb899a7146b66ce887387fc9112033ee4966d4c826f0e2faf8217b8c763319",
+      "fingerprint": "5de620d13e0d8869e9319619f1a9ca0297252c031527a56e7a79bba74b002c50"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "dff2291aff445606fc5d4ebd7c06e8fd0a2386eeb3b36af43e0dbaf56bce56a2",
+      "content_hash": "bfe02c569c6982f455422ddbbcdc47a67f6c73278ec5bb8f5f74f9961be33ea1",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "3bb0ca2cc6326c63e0c1219b77edbcc8541ccb9fe03de1930682462ca18b6f6a",
+      "content_hash": "cc39dd804dd22e28e28b7f501121911fd1ec7a580198d6aef603de6f7cf3eb74",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "e2845a1bb6e3bee362711c0f8b3c25e996970d0a63df5e5ded7cbed42879aa48",
+      "content_hash": "7db30d4c0abe45e1f48d3d2bd5bf6bd4a13eac98805b0d9fd0941490abf85280",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "54f3b38640da5c653d87297ffe32ade649017cfa8b490269a0c8e0dfb2171ede",
+      "content_hash": "24b70a629f4d2af1663d65c8a28629ea9fd498336cb4ae3086c74ef98b6ca993",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "81cafedfb1741f6a4c492bb8c37b39634a8a32f2d89826c3b2eb986c96ae6acc",
+      "content_hash": "5413957df8396f165f9fb81d2fbdc7d123f6bcb4b81642a30c3ce4036f378700",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "377353a2077bcfc74e4daafb038a823aa76460179b35307709fdf5e5b5984f50",
+      "content_hash": "41c1f581fd5e1e7915180d8b0a72db811b2dd0f1991aff6040f544dd5549c4ce",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "a34e87d92504f30a7e27b84605bb58fbef8b8aa3200eb70201e4ebdda128dfc0",
+      "content_hash": "1cdbe9f1e8bf448046f744ff5d37346dba5acfbeb313584b2f733702aa035358",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "28cbbd0d7cfa7fa8a8c68cad7fe4d7e15b854f8bb0e4c0733a135cec08e6d25f",
+      "content_hash": "a612cc6064574d04b8b327517e44889d9520153b2d3028493d98eae4a4602874",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -3,6 +3,7 @@
 
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -398,7 +399,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -4,6 +4,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -288,7 +290,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -4,6 +4,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -314,7 +316,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -4,6 +4,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -346,7 +348,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `45cb4e58ffc125779cf749b3b9f94e6ecc2de5902fbc99adb102c0cfb6ea804f`
+- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.2 -->
-<!-- decapod-fingerprint: 12e124547f6ea6e678dcb053c69277d910718ffb93c7777e03ea6979c036a60a -->
+<!-- decapod-release: 0.71.3 -->
+<!-- decapod-fingerprint: eea4cec5c809e46aa6dfe102aa47ce9277ee8cf93cbd3001d64c4433057f8296 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.2 -->
-<!-- decapod-fingerprint: ae98bb5ead5fc859a4ca9fc0bc7d1c14b6fcb0339b83b815113d63d35a557105 -->
+<!-- decapod-release: 0.71.3 -->
+<!-- decapod-fingerprint: 7a2d1f4dee91bb004d3a444e97df05d74141920cca926646d2afdca686ce0082 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.2 -->
-<!-- decapod-fingerprint: 259ebf3d3346c30ce66012e87bc5f74a8f24e5892b413677b1e0a5f0da5be8a4 -->
+<!-- decapod-release: 0.71.3 -->
+<!-- decapod-fingerprint: 5de620d13e0d8869e9319619f1a9ca0297252c031527a56e7a79bba74b002c50 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.2 -->
-<!-- decapod-fingerprint: 4bbc1808dcf86f5c98ca590ae455f0975264d7022112a823904bb2279f451809 -->
+<!-- decapod-release: 0.71.3 -->
+<!-- decapod-fingerprint: 630e6a0f3f56877812bf83afc8db238ef47cc64c531f2477b0053997c056ed0d -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -4012,8 +4012,8 @@
           "Use when handling regulated data (PII, PHI, PCI) or preparing for security audits."
         ],
         "concepts": [
-          "Workspace Isolation: Agents are prohibited from working on main or master or modifying the root repository's active branch. Isolated workspaces must be created via decapod workspace ensure.",
-          "Todo Claim Mandatory: Agents must create and claim a Decapod todo before running decapod workspace ensure, decapod workspace ensure --container, or executing any containerized task.",
+          "Isolation Boundaries: Define which regulated data may cross service, storage, and operational boundaries, and specify segregation or masking controls.",
+          "Control Ownership: Assign each compliance control an accountable owner, review cadence, and auditable evidence path.",
           "Data Classification: Categorize every field by sensitivity level and map it to required technical controls.",
           "Audit Evidence: Automatically collect and store execution logs as immutable evidence of control adherence.",
           "Subject Rights: Design for Data Subject Access Requests (DSAR) and the right-to-delete from the start."


### PR DESCRIPTION
## Summary

- Replace the two Decapod workflow/process concepts incorrectly embedded in `architecture/COMPLIANCE` with architect-grade compliance guidance on isolation boundaries and control ownership.
- Preserve the existing data classification, audit evidence, and subject-rights guidance.
- Refresh Decapod 0.71.3 generated release/spec artifacts required by validation.

## Relationship

- Follow-up to the identity-verification implementation in #921.
- Provides the constitution-text correction called out in #921's final test note.
- Related to #876; the external trust roots, signatures, and remote-attestation scope remains intentionally outside this local slice.

## Proof

- `cargo test --test constitution_scaffolding all_architecture_nodes_have_architect_grade_guidance -- --nocapture` — passed
- `cargo test --all-targets` — 161 library tests and all 16 constitution scaffolding tests passed; the run remains blocked only by the unrelated pre-existing `tests/core/core.rs::scaffold_specs_are_fresh_project_only` failure (`NotFound("config.toml not found")`)
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `decapod validate --format json` — 200 passed, 0 failed