### PR TITLE
fix: enforce configured identity trust roots

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.3
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.4
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.71.3
+ARG DECAPOD_VERSION=0.71.4
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784332983Z",
-  "repo_signal_fingerprint": "312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c",
+  "generated_at": "1784574949Z",
+  "repo_signal_fingerprint": "ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "ee7922512e2ec185a23d240505728c19807a9042dae68c27f05709cfd418fd6c",
-  "decapod_release": "0.71.3",
+  "spec_input_hash": "58e0ebb9639a1998357a8ff5a17587ce33612c307e007598d20e4e3cd89e8cef",
+  "decapod_release": "0.71.4",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "5921fa9a7766ee7a284f47e3c91f63e325dc17ada5d3432cedf3996661d5377a",
-      "content_hash": "5921fa9a7766ee7a284f47e3c91f63e325dc17ada5d3432cedf3996661d5377a",
-      "fingerprint": "eea4cec5c809e46aa6dfe102aa47ce9277ee8cf93cbd3001d64c4433057f8296"
+      "template_hash": "e0e4c2a0cd1ef5dd02ac8e16b1fc66e93c5d5a750c16d6ac3a7882b67ac5b184",
+      "content_hash": "e0e4c2a0cd1ef5dd02ac8e16b1fc66e93c5d5a750c16d6ac3a7882b67ac5b184",
+      "fingerprint": "507605493cb1e301901956dcf3b122cc194b789905a1f8464a7531728484cbb3"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "b49e7fad739b8fc17ddf33d188e1af3507f38a46ed0253dadfdd11cfc3796d48",
-      "content_hash": "b49e7fad739b8fc17ddf33d188e1af3507f38a46ed0253dadfdd11cfc3796d48",
-      "fingerprint": "7a2d1f4dee91bb004d3a444e97df05d74141920cca926646d2afdca686ce0082"
+      "template_hash": "a58d8f485e12843d9008f75eec5c54a26e32c8574d862a372b7ab97fb7f79081",
+      "content_hash": "a58d8f485e12843d9008f75eec5c54a26e32c8574d862a372b7ab97fb7f79081",
+      "fingerprint": "c014aa086e94be4bce57c9215d34f7d6bb00f929062db577fd17e59127d1a121"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "71bbb3da52efd47c0dd03bb4313bb368d82a37ef617e2b85518ccd51e0f728ec",
-      "content_hash": "71bbb3da52efd47c0dd03bb4313bb368d82a37ef617e2b85518ccd51e0f728ec",
-      "fingerprint": "630e6a0f3f56877812bf83afc8db238ef47cc64c531f2477b0053997c056ed0d"
+      "template_hash": "699c4a6df0a64fde0d6542d57ebce9ba1b4f4c18acd73f91e2d34a4d36e1d5b9",
+      "content_hash": "699c4a6df0a64fde0d6542d57ebce9ba1b4f4c18acd73f91e2d34a4d36e1d5b9",
+      "fingerprint": "d5075ec14abf4d19dbc87f7ee54cb5b745bf3dc39c7a15b18c9590087c7e5967"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "88bb899a7146b66ce887387fc9112033ee4966d4c826f0e2faf8217b8c763319",
-      "content_hash": "88bb899a7146b66ce887387fc9112033ee4966d4c826f0e2faf8217b8c763319",
-      "fingerprint": "5de620d13e0d8869e9319619f1a9ca0297252c031527a56e7a79bba74b002c50"
+      "template_hash": "70f6a0d94dfe405f7164f05894bde363a6e28c745d7bc076c66474791c0ca6dd",
+      "content_hash": "70f6a0d94dfe405f7164f05894bde363a6e28c745d7bc076c66474791c0ca6dd",
+      "fingerprint": "23c4fb2e65f7263467ef8358c35e236cd48fb6e2eb14d2dc28cc6a7018b70c63"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "bfe02c569c6982f455422ddbbcdc47a67f6c73278ec5bb8f5f74f9961be33ea1",
+      "content_hash": "a189ce425ca590767f2eae32ec43f60c2d214c76dd67f5927fb462fbbd8048fc",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "cc39dd804dd22e28e28b7f501121911fd1ec7a580198d6aef603de6f7cf3eb74",
+      "content_hash": "83cba11ea108928621c3d446678f1b80666b9de564327e27b26eeec6b6524b4e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "7db30d4c0abe45e1f48d3d2bd5bf6bd4a13eac98805b0d9fd0941490abf85280",
+      "content_hash": "2b3e8391b48c5c34f9133cf5a116583fbc47c5da8875ecb1ef8269ab27619ff7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "24b70a629f4d2af1663d65c8a28629ea9fd498336cb4ae3086c74ef98b6ca993",
+      "content_hash": "234102c958074a3f6efa965edaf3e16daad4cd9a18d3f4cd1729b28384fbe51a",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "5413957df8396f165f9fb81d2fbdc7d123f6bcb4b81642a30c3ce4036f378700",
+      "content_hash": "059da2b3c27bdbdcfefb92647d8365f6a85a2c0a6517aab50d1f757bdd1bd35c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "41c1f581fd5e1e7915180d8b0a72db811b2dd0f1991aff6040f544dd5549c4ce",
+      "content_hash": "c7f3f16a9dfd3ae7365b8883d88e9bac6388fe072a6d40ee3d7ef24f89369b49",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "1cdbe9f1e8bf448046f744ff5d37346dba5acfbeb313584b2f733702aa035358",
+      "content_hash": "955744a2e4977e8ef7f9605fbdf5ea7c704dcdd83faf428adf0bcd96c1659081",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "a612cc6064574d04b8b327517e44889d9520153b2d3028493d98eae4a4602874",
+      "content_hash": "1c1bc78fa2fe4f32e133cf79b3f6ed13ecbaca50454c0226ed068b74dde4f7e6",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -4,6 +4,7 @@
 
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -399,7 +400,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -6,6 +6,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -290,7 +292,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -6,6 +6,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -316,7 +318,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -6,6 +6,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -348,7 +350,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `312a022991bd869fe00886e10dc0061e0ed3a7b34daa0b142d69833777baf09c`
+- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.3 -->
-<!-- decapod-fingerprint: eea4cec5c809e46aa6dfe102aa47ce9277ee8cf93cbd3001d64c4433057f8296 -->
+<!-- decapod-release: 0.71.4 -->
+<!-- decapod-fingerprint: 507605493cb1e301901956dcf3b122cc194b789905a1f8464a7531728484cbb3 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.3 -->
-<!-- decapod-fingerprint: 7a2d1f4dee91bb004d3a444e97df05d74141920cca926646d2afdca686ce0082 -->
+<!-- decapod-release: 0.71.4 -->
+<!-- decapod-fingerprint: c014aa086e94be4bce57c9215d34f7d6bb00f929062db577fd17e59127d1a121 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.3 -->
-<!-- decapod-fingerprint: 5de620d13e0d8869e9319619f1a9ca0297252c031527a56e7a79bba74b002c50 -->
+<!-- decapod-release: 0.71.4 -->
+<!-- decapod-fingerprint: 23c4fb2e65f7263467ef8358c35e236cd48fb6e2eb14d2dc28cc6a7018b70c63 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.3 -->
-<!-- decapod-fingerprint: 630e6a0f3f56877812bf83afc8db238ef47cc64c531f2477b0053997c056ed0d -->
+<!-- decapod-release: 0.71.4 -->
+<!-- decapod-fingerprint: d5075ec14abf4d19dbc87f7ee54cb5b745bf3dc39c7a15b18c9590087c7e5967 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3364,18 +3364,48 @@ struct IdentityVerificationPolicy {
     expected_scope: String,
     now_epoch_secs: u64,
     accepted_evidence_classes: Vec<IdentityEvidenceClass>,
+    trusted_authorities: Vec<String>,
+    trusted_verifiers: Vec<String>,
     require_authority: bool,
     require_verifier: bool,
 }
 
 impl IdentityVerificationPolicy {
     fn local_handshake(scope: &str, now_epoch_secs: u64) -> Self {
+        let mut policy = Self::configured(
+            scope,
+            now_epoch_secs,
+            vec![IdentityEvidenceClass::SelfDeclared],
+            Vec::new(),
+            Vec::new(),
+        );
+        policy.require_authority = false;
+        policy.require_verifier = false;
+        policy
+    }
+
+    /// Build a policy for an explicitly configured local trust boundary.
+    ///
+    /// Trust roots are represented by stable authority/verifier identifiers;
+    /// an assertion is not promoted merely because it supplies arbitrary
+    /// non-empty values for those fields. Cryptographic attestation remains a
+    /// separate transport concern, while this boundary makes the local
+    /// policy decision explicit and claim-specific.
+    fn configured(
+        scope: &str,
+        now_epoch_secs: u64,
+        accepted_evidence_classes: Vec<IdentityEvidenceClass>,
+        trusted_authorities: Vec<String>,
+        trusted_verifiers: Vec<String>,
+    ) -> Self {
         Self {
             expected_scope: scope.to_string(),
             now_epoch_secs,
-            accepted_evidence_classes: vec![IdentityEvidenceClass::SelfDeclared],
-            require_authority: false,
-            require_verifier: false,
+            accepted_evidence_classes,
+            trusted_authorities,
+            trusted_verifiers,
+            require_authority: true,
+            require_verifier: true,
         }
     }
 }
@@ -3417,11 +3447,33 @@ fn verify_identity_assertion(
     {
         return IdentityVerificationResult::Rejected;
     }
-    if policy.require_authority && assertion.authority.is_none() {
-        return IdentityVerificationResult::Indeterminate;
+    if policy.require_authority {
+        match assertion.authority.as_deref().map(str::trim) {
+            None | Some("") => return IdentityVerificationResult::Indeterminate,
+            Some(authority)
+                if !policy
+                    .trusted_authorities
+                    .iter()
+                    .any(|trusted| trusted.trim() == authority) =>
+            {
+                return IdentityVerificationResult::Rejected;
+            }
+            Some(_) => {}
+        }
     }
-    if policy.require_verifier && assertion.verifier.is_none() {
-        return IdentityVerificationResult::Indeterminate;
+    if policy.require_verifier {
+        match assertion.verifier.as_deref().map(str::trim) {
+            None | Some("") => return IdentityVerificationResult::Indeterminate,
+            Some(verifier)
+                if !policy
+                    .trusted_verifiers
+                    .iter()
+                    .any(|trusted| trusted.trim() == verifier) =>
+            {
+                return IdentityVerificationResult::Rejected;
+            }
+            Some(_) => {}
+        }
     }
     if assertion.verification_method.trim().is_empty() {
         return IdentityVerificationResult::Indeterminate;
@@ -3535,6 +3587,8 @@ mod handshake_identity_tests {
             expected_scope: "task-123".to_string(),
             now_epoch_secs: 42,
             accepted_evidence_classes: vec![IdentityEvidenceClass::RemotelyAuthenticated],
+            trusted_authorities: Vec::new(),
+            trusted_verifiers: Vec::new(),
             require_authority: true,
             require_verifier: true,
         };
@@ -3582,6 +3636,8 @@ mod handshake_identity_tests {
             expected_scope: "task-123".to_string(),
             now_epoch_secs: 42,
             accepted_evidence_classes: vec![IdentityEvidenceClass::LocallyObserved],
+            trusted_authorities: Vec::new(),
+            trusted_verifiers: Vec::new(),
             require_authority: false,
             require_verifier: false,
         };
@@ -3593,6 +3649,63 @@ mod handshake_identity_tests {
         assert_eq!(
             verify_identity_assertion(&assertions[1], &policy),
             IdentityVerificationResult::Unverified
+        );
+    }
+
+    #[test]
+    fn configured_policy_requires_matching_trust_authority_and_verifier() {
+        let mut assertion =
+            build_identity_assertions("agent/codex", None, "task-123", 42).remove(0);
+        assertion.evidence_class = IdentityEvidenceClass::RemotelyAuthenticated;
+        assertion.authority = Some("provider-authority".to_string());
+        assertion.verifier = Some("local-verifier-v1".to_string());
+        assertion.verification_method = "signed assertion".to_string();
+
+        let policy = IdentityVerificationPolicy::configured(
+            "task-123",
+            42,
+            vec![IdentityEvidenceClass::RemotelyAuthenticated],
+            vec!["provider-authority".to_string()],
+            vec!["local-verifier-v1".to_string()],
+        );
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Verified
+        );
+
+        assertion.authority = Some("attacker-controlled-authority".to_string());
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Rejected
+        );
+
+        assertion.authority = Some("provider-authority".to_string());
+        assertion.verifier = Some("unknown-verifier".to_string());
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Rejected
+        );
+    }
+
+    #[test]
+    fn configured_policy_does_not_promote_missing_trust_configuration() {
+        let mut assertion =
+            build_identity_assertions("agent/codex", None, "task-123", 42).remove(0);
+        assertion.evidence_class = IdentityEvidenceClass::HarnessAttested;
+        assertion.authority = Some("provider-authority".to_string());
+        assertion.verifier = Some("local-verifier-v1".to_string());
+        assertion.verification_method = "attested harness record".to_string();
+
+        let policy = IdentityVerificationPolicy::configured(
+            "task-123",
+            42,
+            vec![IdentityEvidenceClass::HarnessAttested],
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Rejected
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes the local policy gap in #876 where an accepted evidence class plus arbitrary non-empty authority and verifier fields could be promoted as verified.

- Adds explicit trusted-authority and trusted-verifier allowlists to the claim-specific identity policy.
- Rejects unknown authority or verifier identifiers and refuses promotion when trust configuration is absent.
- Preserves self-declared agent/provider claims as unverified and keeps lifecycle, scope, and method checks intact.
- Refreshes release-bound generated metadata required by Decapod 0.71.4 validation.

## Related issues

- #876: separates claimed actors from verified identity; this PR hardens the configured local verifier boundary.
- #861: preserves the evidence-versus-authority separation needed for receiver-side provenance decisions.
- #874: keeps transport availability separate from authentication and does not add a listener or remote trust path.

## Proof

- cargo fmt --all -- --check
- cargo test --lib handshake_identity_tests (8 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- Container decapod validate --format json: 199 gates passed; one unrelated pre-existing proof-hook failure remains for ten claimed-but-unverified completed todos.