### PR TITLE
feat: complete identity provenance and authenticated transport

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.4
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.5
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.71.4
+ARG DECAPOD_VERSION=0.71.5
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784574949Z",
-  "repo_signal_fingerprint": "ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c",
+  "generated_at": "1784578975Z",
+  "repo_signal_fingerprint": "0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "58e0ebb9639a1998357a8ff5a17587ce33612c307e007598d20e4e3cd89e8cef",
-  "decapod_release": "0.71.4",
+  "spec_input_hash": "ba9e72bd2cb55130823a0b99e811d494042960d3869993c20d0ed8c3d73655c8",
+  "decapod_release": "0.71.5",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "e0e4c2a0cd1ef5dd02ac8e16b1fc66e93c5d5a750c16d6ac3a7882b67ac5b184",
-      "content_hash": "e0e4c2a0cd1ef5dd02ac8e16b1fc66e93c5d5a750c16d6ac3a7882b67ac5b184",
-      "fingerprint": "507605493cb1e301901956dcf3b122cc194b789905a1f8464a7531728484cbb3"
+      "template_hash": "0b90953ee468d8a5e86253f4df860750b46aab6daefaa2013001e6367aa04965",
+      "content_hash": "0b90953ee468d8a5e86253f4df860750b46aab6daefaa2013001e6367aa04965",
+      "fingerprint": "d4cd76577c8c6a860f98303cb683188f07c1bd1f5e02b99c6a2d37c29d776694"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "a58d8f485e12843d9008f75eec5c54a26e32c8574d862a372b7ab97fb7f79081",
-      "content_hash": "a58d8f485e12843d9008f75eec5c54a26e32c8574d862a372b7ab97fb7f79081",
-      "fingerprint": "c014aa086e94be4bce57c9215d34f7d6bb00f929062db577fd17e59127d1a121"
+      "template_hash": "5d92be1a16d325b13124cc441bcc6c18b741b5192bb05e508cb8b7160388112c",
+      "content_hash": "5d92be1a16d325b13124cc441bcc6c18b741b5192bb05e508cb8b7160388112c",
+      "fingerprint": "d2f5127b6e3987c7e0f0997d74f4d09434e657dbbf3915b1a1a3bf09ee1ead11"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "699c4a6df0a64fde0d6542d57ebce9ba1b4f4c18acd73f91e2d34a4d36e1d5b9",
-      "content_hash": "699c4a6df0a64fde0d6542d57ebce9ba1b4f4c18acd73f91e2d34a4d36e1d5b9",
-      "fingerprint": "d5075ec14abf4d19dbc87f7ee54cb5b745bf3dc39c7a15b18c9590087c7e5967"
+      "template_hash": "fe101ec414a3fd2413925105f873735ec901e5e2da1e10c88986a9a04593978d",
+      "content_hash": "fe101ec414a3fd2413925105f873735ec901e5e2da1e10c88986a9a04593978d",
+      "fingerprint": "c8a692999b60fd791cfc74fcbb6b1f27704b21bdbf95346241aa6b30f97e493b"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "70f6a0d94dfe405f7164f05894bde363a6e28c745d7bc076c66474791c0ca6dd",
-      "content_hash": "70f6a0d94dfe405f7164f05894bde363a6e28c745d7bc076c66474791c0ca6dd",
-      "fingerprint": "23c4fb2e65f7263467ef8358c35e236cd48fb6e2eb14d2dc28cc6a7018b70c63"
+      "template_hash": "4c3d60b93db058cdd73c19c16ec792b2e518bec9d760eadd97201134438b9173",
+      "content_hash": "4c3d60b93db058cdd73c19c16ec792b2e518bec9d760eadd97201134438b9173",
+      "fingerprint": "3962dcaab6ff96df2cdc1b18e058b410c1b676e6d9be8eb1c3fa12d353bd0f5b"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "a189ce425ca590767f2eae32ec43f60c2d214c76dd67f5927fb462fbbd8048fc",
+      "content_hash": "94d26b3118961b261b5321b0534115816c60f72bd277f1f05403af97fa6c19f0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "83cba11ea108928621c3d446678f1b80666b9de564327e27b26eeec6b6524b4e",
+      "content_hash": "86dea78a3c0240c6a4c4d485ed5a5bd98d03476094d876ac891b80905ab769d2",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "2b3e8391b48c5c34f9133cf5a116583fbc47c5da8875ecb1ef8269ab27619ff7",
+      "content_hash": "3ac60db491419a0038ca7495f88ee07213978712eb37ad20273212cacdeab030",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "234102c958074a3f6efa965edaf3e16daad4cd9a18d3f4cd1729b28384fbe51a",
+      "content_hash": "434ab62b15db60c2d6ce6de5dcfcc5db63cfc9e8c5d25f520809442aa38a8cd7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "059da2b3c27bdbdcfefb92647d8365f6a85a2c0a6517aab50d1f757bdd1bd35c",
+      "content_hash": "fa016a66ae538496892b56e6b45cec20671046fcf7d4d4bdae9a3a96ef48ed90",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "c7f3f16a9dfd3ae7365b8883d88e9bac6388fe072a6d40ee3d7ef24f89369b49",
+      "content_hash": "b6005581c2775cee8844948990d8fd91345079212303ca69520915456c5ed8f1",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "955744a2e4977e8ef7f9605fbdf5ea7c704dcdd83faf428adf0bcd96c1659081",
+      "content_hash": "b2103afbb49ba019c65864df52b41f3584d099fa6d7bb8cc753e460d40a00fe0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "1c1bc78fa2fe4f32e133cf79b3f6ed13ecbaca50454c0226ed068b74dde4f7e6",
+      "content_hash": "6a2e1ce89de75c60c39688d255a588d1e9f53da249f0ec8b1edf2e5dc17bbbae",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -5,6 +5,7 @@
 
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -400,7 +401,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -292,7 +294,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -318,7 +320,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -8,6 +8,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -350,7 +352,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ebbdb3294c324b315438af5b6a6e7ba9d587920493d514bb4e6ddb0e3b8db64c`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (89 files), `tests/` (4 files)
+- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.4 -->
-<!-- decapod-fingerprint: 507605493cb1e301901956dcf3b122cc194b789905a1f8464a7531728484cbb3 -->
+<!-- decapod-release: 0.71.5 -->
+<!-- decapod-fingerprint: d4cd76577c8c6a860f98303cb683188f07c1bd1f5e02b99c6a2d37c29d776694 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.4 -->
-<!-- decapod-fingerprint: c014aa086e94be4bce57c9215d34f7d6bb00f929062db577fd17e59127d1a121 -->
+<!-- decapod-release: 0.71.5 -->
+<!-- decapod-fingerprint: d2f5127b6e3987c7e0f0997d74f4d09434e657dbbf3915b1a1a3bf09ee1ead11 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.4 -->
-<!-- decapod-fingerprint: 23c4fb2e65f7263467ef8358c35e236cd48fb6e2eb14d2dc28cc6a7018b70c63 -->
+<!-- decapod-release: 0.71.5 -->
+<!-- decapod-fingerprint: 3962dcaab6ff96df2cdc1b18e058b410c1b676e6d9be8eb1c3fa12d353bd0f5b -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.71.4 -->
-<!-- decapod-fingerprint: d5075ec14abf4d19dbc87f7ee54cb5b745bf3dc39c7a15b18c9590087c7e5967 -->
+<!-- decapod-release: 0.71.5 -->
+<!-- decapod-fingerprint: c8a692999b60fd791cfc74fcbb6b1f27704b21bdbf95346241aa6b30f97e493b -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,21 @@ pub(crate) struct RpcCli {
     /// Read request from stdin instead of command line
     #[clap(long)]
     pub stdin: bool,
+    /// Serve the transport-neutral RPC profile over authenticated HTTP.
+    #[clap(long)]
+    pub http_server: bool,
+    /// HTTP bind address. Loopback is required unless --allow-remote is set.
+    #[clap(long, default_value = "127.0.0.1:7331")]
+    pub listen: String,
+    /// Bearer token for the optional HTTP transport. May also be supplied by DECAPOD_HTTP_TOKEN.
+    #[clap(long)]
+    pub auth_token: Option<String>,
+    /// Explicitly allow binding beyond loopback.
+    #[clap(long)]
+    pub allow_remote: bool,
+    /// Maximum HTTP request body size.
+    #[clap(long, default_value_t = 1_048_576)]
+    pub max_body_bytes: usize,
 }
 
 // ===== Grouped Command Structures =====

--- a/src/core/completion_evidence.rs
+++ b/src/core/completion_evidence.rs
@@ -111,7 +111,19 @@ pub struct PortableCompletionEvidence {
     pub capsule_artifact: FileDigest,
     #[serde(default)]
     pub proof_artifacts: Vec<FileDigest>,
+    /// Optional content custody for referenced artifacts. Digests alone are
+    /// evidence references; content is carried only when explicitly included.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifact_contents: Vec<PortableArtifactContent>,
     pub envelope_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PortableArtifactContent {
+    pub digest: FileDigest,
+    /// Hex encoding keeps the envelope JSON-only and avoids an implicit
+    /// binary format or unbounded path-based extraction on import.
+    pub content_hex: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -123,6 +135,8 @@ pub struct PortableCompletionEvidenceVerification {
     pub local_decision: String,
     pub checks: Vec<EvidenceCheck>,
     pub unresolved_claims: Vec<UnresolvedClaim>,
+    pub decision_path: String,
+    pub custody_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -184,12 +198,16 @@ impl PortableCompletionEvidence {
         let mut proof_artifacts = self.proof_artifacts.clone();
         proof_artifacts.sort();
         proof_artifacts.dedup();
+        let mut artifact_contents = self.artifact_contents.clone();
+        artifact_contents.sort();
+        artifact_contents.dedup();
         CanonicalPortableCompletionEvidence {
             schema_version: self.schema_version.clone(),
             source_repository: self.source_repository.clone(),
             record: self.record.clone(),
             capsule_artifact: self.capsule_artifact.clone(),
             proof_artifacts,
+            artifact_contents,
         }
     }
 
@@ -217,6 +235,8 @@ struct CanonicalPortableCompletionEvidence {
     record: CompletionEvidenceRecord,
     capsule_artifact: FileDigest,
     proof_artifacts: Vec<FileDigest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    artifact_contents: Vec<PortableArtifactContent>,
 }
 
 pub fn default_record_path(
@@ -271,6 +291,19 @@ pub fn export_record(
         .collect::<Vec<_>>();
     proof_artifacts.sort();
     proof_artifacts.dedup();
+    let mut artifact_contents = Vec::new();
+    let mut custody_digests = vec![capsule_artifact.clone()];
+    custody_digests.extend(proof_artifacts.iter().cloned());
+    custody_digests.sort();
+    custody_digests.dedup();
+    for digest in custody_digests {
+        let bytes = fs::read(safe_reference_path(project_root, &digest.path)?)
+            .map_err(error::DecapodError::IoError)?;
+        artifact_contents.push(PortableArtifactContent {
+            digest,
+            content_hex: hex_encode(&bytes),
+        });
+    }
 
     let envelope = PortableCompletionEvidence {
         schema_version: COMPLETION_EVIDENCE_SCHEMA_VERSION.to_string(),
@@ -282,6 +315,7 @@ pub fn export_record(
         record,
         capsule_artifact,
         proof_artifacts,
+        artifact_contents,
         envelope_hash: String::new(),
     }
     .with_recomputed_hash()
@@ -328,7 +362,14 @@ pub fn import_record(
     fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
     let bytes = fs::read(input_path).map_err(error::DecapodError::IoError)?;
     fs::write(&destination, bytes).map_err(error::DecapodError::IoError)?;
-    let report = verify_portable_evidence(project_root, task_id, &envelope, &destination)?;
+    let custody_paths = write_artifact_custody(project_root, &envelope)?;
+    let mut report = verify_portable_evidence(project_root, task_id, &envelope, &destination)?;
+    report.custody_paths = custody_paths;
+    report.decision_path = format!(
+        "{IMPORTED_COMPLETION_EVIDENCE_DIR}/{}.decision.json",
+        envelope.envelope_hash
+    );
+    write_receiver_decision(project_root, &envelope, &report)?;
     Ok((destination, report))
 }
 
@@ -435,6 +476,38 @@ fn validate_portable_evidence(
     for artifact in &envelope.proof_artifacts {
         validate_relative_evidence_path(&artifact.path)?;
     }
+    let expected_custody = expected_artifacts
+        .iter()
+        .chain(std::iter::once(&envelope.capsule_artifact))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut actual_custody = BTreeSet::new();
+    for content in &envelope.artifact_contents {
+        if !expected_custody.contains(&content.digest) {
+            return Err(error::DecapodError::ValidationError(
+                "PORTABLE_COMPLETION_EVIDENCE_INVALID: artifact custody contains an unreferenced digest".to_string(),
+            ));
+        }
+        let bytes = hex_decode(&content.content_hex).ok_or_else(|| {
+            error::DecapodError::ValidationError(
+                "PORTABLE_COMPLETION_EVIDENCE_INVALID: artifact custody is not valid hex"
+                    .to_string(),
+            )
+        })?;
+        if hash_bytes(&bytes) != content.digest.sha256 || bytes.len() as u64 != content.digest.size
+        {
+            return Err(error::DecapodError::ValidationError(
+                "PORTABLE_COMPLETION_EVIDENCE_TAMPERED: artifact custody digest mismatch"
+                    .to_string(),
+            ));
+        }
+        actual_custody.insert(content.digest.clone());
+    }
+    if !envelope.artifact_contents.is_empty() && actual_custody != expected_custody {
+        return Err(error::DecapodError::ValidationError(
+            "PORTABLE_COMPLETION_EVIDENCE_INVALID: artifact custody is incomplete".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -526,7 +599,67 @@ fn verify_portable_evidence(
         local_decision: local_decision.to_string(),
         checks,
         unresolved_claims: envelope.record.unresolved_claims.clone(),
+        decision_path: String::new(),
+        custody_paths: Vec::new(),
     })
+}
+
+fn write_artifact_custody(
+    project_root: &Path,
+    envelope: &PortableCompletionEvidence,
+) -> Result<Vec<String>, error::DecapodError> {
+    let base = project_root
+        .join(IMPORTED_COMPLETION_EVIDENCE_DIR)
+        .join(&envelope.envelope_hash)
+        .join("artifacts");
+    fs::create_dir_all(&base).map_err(error::DecapodError::IoError)?;
+    let mut paths = Vec::new();
+    for content in &envelope.artifact_contents {
+        let path = base.join(&content.digest.sha256["sha256:".len()..]);
+        let bytes = hex_decode(&content.content_hex).ok_or_else(|| {
+            error::DecapodError::ValidationError(
+                "portable completion evidence artifact custody is not valid hex".to_string(),
+            )
+        })?;
+        if path.exists() {
+            let existing = fs::read(&path).map_err(error::DecapodError::IoError)?;
+            if existing != bytes {
+                return Err(error::DecapodError::ValidationError(
+                    "portable completion evidence artifact custody is immutable".to_string(),
+                ));
+            }
+        } else {
+            fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+        }
+        paths.push(relative_path(project_root, &path)?);
+    }
+    Ok(paths)
+}
+
+fn write_receiver_decision(
+    project_root: &Path,
+    envelope: &PortableCompletionEvidence,
+    report: &PortableCompletionEvidenceVerification,
+) -> Result<(), error::DecapodError> {
+    let path = project_root
+        .join(IMPORTED_COMPLETION_EVIDENCE_DIR)
+        .join(format!("{}.decision.json", envelope.envelope_hash));
+    let bytes = serde_json::to_vec_pretty(report).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "portable completion evidence decision serialization failed: {e}"
+        ))
+    })?;
+    if path.exists() {
+        let existing = fs::read(&path).map_err(error::DecapodError::IoError)?;
+        if existing != bytes {
+            return Err(error::DecapodError::ValidationError(
+                "portable completion evidence receiver decision is immutable".to_string(),
+            ));
+        }
+    } else {
+        fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+    }
+    Ok(())
 }
 
 fn read_local_record(
@@ -1043,6 +1176,24 @@ fn hash_bytes(bytes: &[u8]) -> String {
     format!("sha256:{:x}", hasher.finalize())
 }
 
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn hex_decode(value: &str) -> Option<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..value.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&value[index..index + 2], 16).ok())
+        .collect()
+}
+
 fn digest_reference(
     project_root: &Path,
     reference: &str,
@@ -1363,6 +1514,7 @@ mod tests {
                 size: 1,
             },
             proof_artifacts: Vec::new(),
+            artifact_contents: Vec::new(),
             envelope_hash: String::new(),
         }
         .with_recomputed_hash()
@@ -1457,8 +1609,14 @@ mod tests {
         let envelope = export_record(root, "task-1", &record_path, &portable_path)
             .expect("export portable evidence");
         assert_eq!(envelope.record.evidence_hash, record.evidence_hash);
+        assert_eq!(envelope.artifact_contents.len(), 2);
         let imported = read_portable_evidence(&portable_path).expect("read portable evidence");
         assert_eq!(imported.envelope_hash, envelope.envelope_hash);
+        let (_, report) = import_record(root, "task-1", &portable_path).expect("import evidence");
+        assert_eq!(report.local_decision, "rejected");
+        assert!(report.decision_path.ends_with(".decision.json"));
+        assert_eq!(report.custody_paths.len(), 2);
+        assert!(root.join(&report.decision_path).is_file());
 
         fs::write(&proof_path, "altered\n").expect("alter proof");
         let report = verify_record(root, "task-1", &record_path).expect("verify altered record");

--- a/src/core/http_transport.rs
+++ b/src/core/http_transport.rs
@@ -1,0 +1,243 @@
+//! Small, opt-in HTTP adapter for the transport-neutral RPC profile.
+//!
+//! This module deliberately owns only HTTP framing, authentication, replay
+//! protection, and request limits. Semantic authority remains in the existing
+//! local RPC process invoked by the caller.
+
+#![allow(clippy::disallowed_types)]
+
+use std::collections::{HashMap, HashSet};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+const MAX_HEADER_BYTES: usize = 32 * 1024;
+const MAX_REPLAY_KEYS: usize = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub content_type: &'static str,
+}
+
+impl HttpResponse {
+    pub fn json(status: u16, body: Vec<u8>) -> Self {
+        Self {
+            status,
+            body,
+            content_type: "application/json",
+        }
+    }
+}
+
+pub fn serve<F>(
+    bind: &str,
+    auth_token: &str,
+    allow_remote: bool,
+    max_body_bytes: usize,
+    mut handler: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(&[u8]) -> HttpResponse,
+{
+    if auth_token.trim().is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "authenticated HTTP transport requires a non-empty bearer token",
+        ));
+    }
+    let listener = TcpListener::bind(bind)?;
+    let address = listener.local_addr()?;
+    if !allow_remote && !address.ip().is_loopback() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "remote HTTP binding requires --allow-remote",
+        ));
+    }
+    eprintln!("decapod HTTP RPC listening on {address}");
+
+    let mut replayed = HashSet::new();
+    let mut cached: HashMap<String, HttpResponse> = HashMap::new();
+    for stream in listener.incoming() {
+        let mut stream = stream?;
+        stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+        let request = match read_request(&mut stream, max_body_bytes) {
+            Ok(request) => request,
+            Err(response) => {
+                write_response(&mut stream, response)?;
+                continue;
+            }
+        };
+        let idempotency_key = request.headers.get("idempotency-key");
+        let request_id = request.headers.get("x-decapod-request-id");
+        let key = idempotency_key.or(request_id);
+        let Some(_key) = key.filter(|value| !value.trim().is_empty()) else {
+            write_response(
+                &mut stream,
+                HttpResponse::json(400, error_json("missing idempotency key")),
+            )?;
+            continue;
+        };
+        if request.headers.get("authorization") != Some(&format!("Bearer {auth_token}")) {
+            write_response(
+                &mut stream,
+                HttpResponse::json(401, error_json("unauthorized")),
+            )?;
+            continue;
+        }
+        if request.path != "/rpc/v1" || request.method != "POST" {
+            write_response(
+                &mut stream,
+                HttpResponse::json(404, error_json("use POST /rpc/v1")),
+            )?;
+            continue;
+        }
+        if let Some(response) = idempotency_key.and_then(|value| cached.get(value)) {
+            write_response(&mut stream, response.clone())?;
+            continue;
+        }
+        if let Some(request_id) = request_id
+            && !replayed.insert(request_id.to_string())
+        {
+            write_response(
+                &mut stream,
+                HttpResponse::json(409, error_json("replayed request")),
+            )?;
+            continue;
+        }
+        if replayed.len() > MAX_REPLAY_KEYS {
+            replayed.clear();
+            cached.clear();
+        }
+        let response = handler(&request.body);
+        if let Some(idempotency_key) = idempotency_key {
+            cached.insert(idempotency_key.to_string(), response.clone());
+        }
+        write_response(&mut stream, response)?;
+    }
+    Ok(())
+}
+
+struct HttpRequest {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+fn read_request(
+    stream: &mut TcpStream,
+    max_body_bytes: usize,
+) -> Result<HttpRequest, HttpResponse> {
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let header_end = loop {
+        let count = stream.read(&mut chunk).map_err(internal_error)?;
+        if count == 0 {
+            return Err(HttpResponse::json(
+                400,
+                error_json("incomplete HTTP request"),
+            ));
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+        if bytes.len() > MAX_HEADER_BYTES + max_body_bytes {
+            return Err(HttpResponse::json(413, error_json("request too large")));
+        }
+        if let Some(end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break end + 4;
+        }
+        if bytes.len() > MAX_HEADER_BYTES {
+            return Err(HttpResponse::json(
+                431,
+                error_json("HTTP headers too large"),
+            ));
+        }
+    };
+    let header = std::str::from_utf8(&bytes[..header_end])
+        .map_err(|_| HttpResponse::json(400, error_json("HTTP headers are not UTF-8")))?;
+    let mut lines = header.split("\r\n");
+    let request_line = lines.next().unwrap_or_default();
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default().to_string();
+    let path = request_parts.next().unwrap_or_default().to_string();
+    let version = request_parts.next();
+    if !matches!(version, Some("HTTP/1.1") | Some("HTTP/1.0")) {
+        return Err(HttpResponse::json(
+            400,
+            error_json("unsupported HTTP request line"),
+        ));
+    }
+    let mut headers = HashMap::new();
+    for line in lines.filter(|line| !line.is_empty()) {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(HttpResponse::json(400, error_json("malformed HTTP header")));
+        };
+        headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+    }
+    let length = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .ok_or_else(|| HttpResponse::json(400, error_json("content-length is required")))?;
+    if length > max_body_bytes {
+        return Err(HttpResponse::json(
+            413,
+            error_json("request body too large"),
+        ));
+    }
+    while bytes.len() - header_end < length {
+        let count = stream.read(&mut chunk).map_err(internal_error)?;
+        if count == 0 {
+            return Err(HttpResponse::json(400, error_json("incomplete HTTP body")));
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+    }
+    Ok(HttpRequest {
+        method,
+        path,
+        headers,
+        body: bytes[header_end..header_end + length].to_vec(),
+    })
+}
+
+fn write_response(stream: &mut TcpStream, response: HttpResponse) -> std::io::Result<()> {
+    let reason = match response.status {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        409 => "Conflict",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
+        _ => "Internal Server Error",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {} {reason}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response.status,
+        response.content_type,
+        response.body.len()
+    )?;
+    stream.write_all(&response.body)
+}
+
+fn error_json(message: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({"success": false, "error": message}))
+        .unwrap_or_else(|_| b"{\"success\":false}".to_vec())
+}
+
+fn internal_error(error: std::io::Error) -> HttpResponse {
+    HttpResponse::json(500, error_json(&error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    #[test]
+    fn requires_loopback_for_default_binding() {
+        let parsed: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(parsed.is_loopback());
+        assert!(!"192.0.2.1".parse::<IpAddr>().unwrap().is_loopback());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,6 +28,7 @@ pub mod external_action;
 pub mod flight_recorder;
 pub mod gatekeeper;
 pub mod group_broker;
+pub mod http_transport;
 pub mod interview;
 pub mod mentor;
 pub mod migration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3327,6 +3327,12 @@ struct IdentityAssertion {
     issued_at_epoch_secs: u64,
     expires_at_epoch_secs: Option<u64>,
     revocation: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    binding_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    signature: Option<String>,
     verification_method: String,
     verification_result: IdentityVerificationResult,
 }
@@ -3368,6 +3374,16 @@ struct IdentityVerificationPolicy {
     trusted_verifiers: Vec<String>,
     require_authority: bool,
     require_verifier: bool,
+    expected_binding_hash: Option<String>,
+    replayed_nonces: Vec<String>,
+    trusted_attestation_keys: Vec<TrustedAttestationKey>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrustedAttestationKey {
+    authority: String,
+    verifier: String,
+    key: String,
 }
 
 impl IdentityVerificationPolicy {
@@ -3381,6 +3397,9 @@ impl IdentityVerificationPolicy {
         );
         policy.require_authority = false;
         policy.require_verifier = false;
+        policy.expected_binding_hash = None;
+        policy.replayed_nonces = Vec::new();
+        policy.trusted_attestation_keys = Vec::new();
         policy
     }
 
@@ -3406,7 +3425,29 @@ impl IdentityVerificationPolicy {
             trusted_verifiers,
             require_authority: true,
             require_verifier: true,
+            expected_binding_hash: None,
+            replayed_nonces: Vec::new(),
+            trusted_attestation_keys: Vec::new(),
         }
+    }
+
+    #[allow(dead_code)]
+    fn with_attestation_key(
+        mut self,
+        authority: &str,
+        verifier: &str,
+        key: &str,
+        binding_hash: Option<&str>,
+        replayed_nonces: Vec<String>,
+    ) -> Self {
+        self.expected_binding_hash = binding_hash.map(str::to_string);
+        self.replayed_nonces = replayed_nonces;
+        self.trusted_attestation_keys.push(TrustedAttestationKey {
+            authority: authority.to_string(),
+            verifier: verifier.to_string(),
+            key: key.to_string(),
+        });
+        self
     }
 }
 
@@ -3479,7 +3520,79 @@ fn verify_identity_assertion(
         return IdentityVerificationResult::Indeterminate;
     }
 
+    if matches!(
+        assertion.evidence_class,
+        IdentityEvidenceClass::HarnessAttested
+            | IdentityEvidenceClass::RemotelyAuthenticated
+            | IdentityEvidenceClass::IndependentlyVerified
+    ) {
+        if let Some(expected_binding) = policy.expected_binding_hash.as_deref()
+            && assertion.binding_hash.as_deref() != Some(expected_binding)
+        {
+            return IdentityVerificationResult::Rejected;
+        }
+        let Some(nonce) = assertion
+            .nonce
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return IdentityVerificationResult::Indeterminate;
+        };
+        if policy
+            .replayed_nonces
+            .iter()
+            .any(|replayed| replayed == nonce)
+        {
+            return IdentityVerificationResult::Rejected;
+        }
+        let Some(signature) = assertion
+            .signature
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return IdentityVerificationResult::Indeterminate;
+        };
+        let Some(key) = policy.trusted_attestation_keys.iter().find(|trusted| {
+            assertion.authority.as_deref() == Some(trusted.authority.as_str())
+                && assertion.verifier.as_deref() == Some(trusted.verifier.as_str())
+        }) else {
+            return IdentityVerificationResult::Indeterminate;
+        };
+        let expected_signature = identity_attestation_digest(assertion, &key.key);
+        if signature != expected_signature {
+            return IdentityVerificationResult::Rejected;
+        }
+    }
+
     IdentityVerificationResult::Verified
+}
+
+fn identity_attestation_digest(assertion: &IdentityAssertion, key: &str) -> String {
+    let mut material = String::new();
+    material.push_str(key);
+    material.push('|');
+    material.push_str(&assertion.claim_kind);
+    material.push('|');
+    material.push_str(&assertion.subject_type);
+    material.push('|');
+    material.push_str(&assertion.asserted_value);
+    material.push('|');
+    material.push_str(&assertion.scope);
+    material.push('|');
+    material.push_str(&assertion.issued_at_epoch_secs.to_string());
+    material.push('|');
+    material.push_str(
+        assertion
+            .expires_at_epoch_secs
+            .map(|value| value.to_string())
+            .as_deref()
+            .unwrap_or(""),
+    );
+    material.push('|');
+    material.push_str(assertion.nonce.as_deref().unwrap_or(""));
+    material.push('|');
+    material.push_str(assertion.binding_hash.as_deref().unwrap_or(""));
+    format!("sha256:{}", hash_bytes_hex(material.as_bytes()))
 }
 
 fn build_identity_assertions(
@@ -3499,6 +3612,9 @@ fn build_identity_assertions(
         issued_at_epoch_secs,
         expires_at_epoch_secs: None,
         revocation: None,
+        nonce: None,
+        binding_hash: None,
+        signature: None,
         verification_method: "environment declaration".to_string(),
         verification_result: IdentityVerificationResult::Unverified,
     }];
@@ -3515,6 +3631,9 @@ fn build_identity_assertions(
             issued_at_epoch_secs,
             expires_at_epoch_secs: None,
             revocation: None,
+            nonce: None,
+            binding_hash: None,
+            signature: None,
             verification_method: "environment declaration".to_string(),
             verification_result: IdentityVerificationResult::Unverified,
         });
@@ -3527,7 +3646,7 @@ fn build_identity_assertions(
 mod handshake_identity_tests {
     use super::{
         IdentityEvidenceClass, IdentityVerificationPolicy, IdentityVerificationResult,
-        build_identity_assertions, verify_identity_assertion,
+        build_identity_assertions, identity_attestation_digest, verify_identity_assertion,
     };
 
     #[test]
@@ -3591,6 +3710,9 @@ mod handshake_identity_tests {
             trusted_verifiers: Vec::new(),
             require_authority: true,
             require_verifier: true,
+            expected_binding_hash: None,
+            replayed_nonces: Vec::new(),
+            trusted_attestation_keys: Vec::new(),
         };
 
         assert_eq!(
@@ -3640,6 +3762,9 @@ mod handshake_identity_tests {
             trusted_verifiers: Vec::new(),
             require_authority: false,
             require_verifier: false,
+            expected_binding_hash: None,
+            replayed_nonces: Vec::new(),
+            trusted_attestation_keys: Vec::new(),
         };
 
         assert_eq!(
@@ -3659,15 +3784,25 @@ mod handshake_identity_tests {
         assertion.evidence_class = IdentityEvidenceClass::RemotelyAuthenticated;
         assertion.authority = Some("provider-authority".to_string());
         assertion.verifier = Some("local-verifier-v1".to_string());
+        assertion.nonce = Some("nonce-1".to_string());
+        assertion.binding_hash = Some("sha256:binding".to_string());
         assertion.verification_method = "signed assertion".to_string();
 
-        let policy = IdentityVerificationPolicy::configured(
+        let mut policy = IdentityVerificationPolicy::configured(
             "task-123",
             42,
             vec![IdentityEvidenceClass::RemotelyAuthenticated],
             vec!["provider-authority".to_string()],
             vec!["local-verifier-v1".to_string()],
         );
+        policy = policy.with_attestation_key(
+            "provider-authority",
+            "local-verifier-v1",
+            "test-key",
+            Some("sha256:binding"),
+            Vec::new(),
+        );
+        assertion.signature = Some(identity_attestation_digest(&assertion, "test-key"));
         assert_eq!(
             verify_identity_assertion(&assertion, &policy),
             IdentityVerificationResult::Verified
@@ -3703,6 +3838,48 @@ mod handshake_identity_tests {
             Vec::new(),
             Vec::new(),
         );
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Rejected
+        );
+    }
+
+    #[test]
+    fn attestation_replay_and_forgery_fail_closed() {
+        let mut assertion =
+            build_identity_assertions("agent/codex", None, "task-123", 42).remove(0);
+        assertion.evidence_class = IdentityEvidenceClass::HarnessAttested;
+        assertion.authority = Some("harness-authority".to_string());
+        assertion.verifier = Some("repo-verifier".to_string());
+        assertion.nonce = Some("nonce-2".to_string());
+        assertion.binding_hash = Some("sha256:task-binding".to_string());
+        assertion.verification_method = "keyed attestation".to_string();
+        assertion.signature = Some(identity_attestation_digest(&assertion, "harness-key"));
+        let policy = IdentityVerificationPolicy::configured(
+            "task-123",
+            42,
+            vec![IdentityEvidenceClass::HarnessAttested],
+            vec!["harness-authority".to_string()],
+            vec!["repo-verifier".to_string()],
+        )
+        .with_attestation_key(
+            "harness-authority",
+            "repo-verifier",
+            "harness-key",
+            Some("sha256:task-binding"),
+            vec!["already-used".to_string()],
+        );
+        assert_eq!(
+            verify_identity_assertion(&assertion, &policy),
+            IdentityVerificationResult::Verified
+        );
+        let mut replay_policy = policy.clone();
+        replay_policy.replayed_nonces.push("nonce-2".to_string());
+        assert_eq!(
+            verify_identity_assertion(&assertion, &replay_policy),
+            IdentityVerificationResult::Rejected
+        );
+        assertion.asserted_value = "forged-agent".to_string();
         assert_eq!(
             verify_identity_assertion(&assertion, &policy),
             IdentityVerificationResult::Rejected
@@ -8686,6 +8863,27 @@ mod rpc_handlers {
 fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::DecapodError> {
     use crate::core::rpc::*;
 
+    if cli.http_server {
+        let token = cli
+            .auth_token
+            .or_else(|| std::env::var("DECAPOD_HTTP_TOKEN").ok())
+            .ok_or_else(|| {
+                error::DecapodError::ValidationError(
+                    "authenticated HTTP transport requires --auth-token or DECAPOD_HTTP_TOKEN"
+                        .to_string(),
+                )
+            })?;
+        let root = project_root.to_path_buf();
+        return core::http_transport::serve(
+            &cli.listen,
+            &token,
+            cli.allow_remote,
+            cli.max_body_bytes,
+            move |body| http_rpc_handler(&root, body),
+        )
+        .map_err(error::DecapodError::IoError);
+    }
+
     let request: RpcRequest = if cli.stdin {
         let mut buffer = String::new();
         std::io::stdin()
@@ -8816,6 +9014,54 @@ fn run_rpc_command(cli: RpcCli, project_root: &Path) -> Result<(), error::Decapo
 
     println!("{}", serde_json::to_string_pretty(&response).unwrap());
     Ok(())
+}
+
+/// Execute HTTP requests through the exact local stdin RPC path. This keeps
+/// semantic envelopes, session checks, mandates, and repository authority in
+/// one implementation while making HTTP an explicitly opt-in adapter.
+fn http_rpc_handler(project_root: &Path, body: &[u8]) -> core::http_transport::HttpResponse {
+    let output = match std::process::Command::new(
+        std::env::current_exe().unwrap_or_else(|_| PathBuf::from("decapod")),
+    )
+    .current_dir(project_root)
+    .args(["rpc", "--stdin"])
+    .stdin(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    {
+        Ok(mut child) => {
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(body);
+            }
+            child.wait_with_output()
+        }
+        Err(error) => Err(error),
+    };
+    match output {
+        Ok(output) if output.status.success() => {
+            core::http_transport::HttpResponse::json(200, output.stdout)
+        }
+        Ok(output) => {
+            let body = if output.stdout.is_empty() {
+                serde_json::json!({
+                    "success": false,
+                    "error": String::from_utf8_lossy(&output.stderr).trim()
+                })
+                .to_string()
+                .into_bytes()
+            } else {
+                output.stdout
+            };
+            core::http_transport::HttpResponse::json(400, body)
+        }
+        Err(error) => core::http_transport::HttpResponse::json(
+            500,
+            serde_json::json!({"success": false, "error": error.to_string()})
+                .to_string()
+                .into_bytes(),
+        ),
+    }
 }
 
 fn maybe_bind_capsule_to_workunit_state_ref(


### PR DESCRIPTION
## Summary

Completes the remaining implementation slices for #876, #861, and #874 on top of merged #925.

- #876: adds claim-specific attestation nonce/binding/signature verification, replay rejection, and fail-closed lifecycle checks while preserving local self-declared operation.
- #861: exports optional artifact contents with digest validation, stores immutable receiver custody, and persists a separate receiver decision record without importing source authority.
- #874: adds an opt-in authenticated HTTP RPC adapter with loopback-by-default binding, bearer authentication, body limits, idempotency keys, request replay rejection, and delegation to the existing local RPC path.

## Proof

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (165 library tests pass; broader integration run has one unrelated pre-existing scaffold failure: config.toml not found)
- container decapod validate: 199 gates pass; only inherited pre-existing proof-hook backlog remains for 11 older TODOs

The issues should be closed after this PR is merged and the issue-specific acceptance criteria are reviewed.