### PR TITLE
docs: align living specs with v0.72.0 transport contracts

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784578975Z",
-  "repo_signal_fingerprint": "0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e",
+  "generated_at": "1784581280Z",
+  "repo_signal_fingerprint": "0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "ba9e72bd2cb55130823a0b99e811d494042960d3869993c20d0ed8c3d73655c8",
-  "decapod_release": "0.71.5",
+  "spec_input_hash": "c659166be837b8675a2c9c8f27d0b1ebe4650a795e52edbe367a8a44d815cfb1",
+  "decapod_release": "0.72.0",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "0b90953ee468d8a5e86253f4df860750b46aab6daefaa2013001e6367aa04965",
+      "template_hash": "0e8c90eca1426b7be85e3686e34eb7b60452219f0629b52b6104a1dcbbbee4f9",
       "content_hash": "0b90953ee468d8a5e86253f4df860750b46aab6daefaa2013001e6367aa04965",
-      "fingerprint": "d4cd76577c8c6a860f98303cb683188f07c1bd1f5e02b99c6a2d37c29d776694"
+      "fingerprint": "fb7e1501668431ecd5efbad24f7b785ff5a24eb0856953aae6bf4492a94478c6"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "5d92be1a16d325b13124cc441bcc6c18b741b5192bb05e508cb8b7160388112c",
+      "template_hash": "3d030192fb6bc64691812dd20f57fb49224075201fdfce8fad4cc6d628a874a4",
       "content_hash": "5d92be1a16d325b13124cc441bcc6c18b741b5192bb05e508cb8b7160388112c",
-      "fingerprint": "d2f5127b6e3987c7e0f0997d74f4d09434e657dbbf3915b1a1a3bf09ee1ead11"
+      "fingerprint": "e16c63a6b6e46075baebfc8fb252caad2dbf999e16ed31ffecc2f1790d829ccc"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "fe101ec414a3fd2413925105f873735ec901e5e2da1e10c88986a9a04593978d",
+      "template_hash": "a1b3b95816272a8bdc1cbf94141beb0c206140ea723977e0ef02360b2137f204",
       "content_hash": "fe101ec414a3fd2413925105f873735ec901e5e2da1e10c88986a9a04593978d",
-      "fingerprint": "c8a692999b60fd791cfc74fcbb6b1f27704b21bdbf95346241aa6b30f97e493b"
+      "fingerprint": "2b733a5ca40507974debaf2ffa5c7467bf9e60b1e88d67a52afd7bda7e76196c"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "4c3d60b93db058cdd73c19c16ec792b2e518bec9d760eadd97201134438b9173",
+      "template_hash": "b39b49355a645dcf61deaa8966f6ca35a980c35bb491ea0e6b9d14c87c7957b7",
       "content_hash": "4c3d60b93db058cdd73c19c16ec792b2e518bec9d760eadd97201134438b9173",
-      "fingerprint": "3962dcaab6ff96df2cdc1b18e058b410c1b676e6d9be8eb1c3fa12d353bd0f5b"
+      "fingerprint": "08101165f95b54ec9e4066e08460895b9c60cbb145d05a52fbda5076c9485745"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "94d26b3118961b261b5321b0534115816c60f72bd277f1f05403af97fa6c19f0",
+      "content_hash": "0ff91963f549999680588993268ae312fc82bea32bf76a3395c75170c56ab551",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "86dea78a3c0240c6a4c4d485ed5a5bd98d03476094d876ac891b80905ab769d2",
+      "content_hash": "6c251850853d94d01f9a77c3c5eb1ccd3fadabcf0e3392fc29512933128c7fa5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "3ac60db491419a0038ca7495f88ee07213978712eb37ad20273212cacdeab030",
+      "content_hash": "b5f6fd8cea996b9b5589e0e05b29d845753038af1b61475c1278bde550b30c23",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "434ab62b15db60c2d6ce6de5dcfcc5db63cfc9e8c5d25f520809442aa38a8cd7",
+      "content_hash": "069964dab5b54d75d57360fb154527e3d47fe2a5b00948bccf189f26ce68ab3d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "fa016a66ae538496892b56e6b45cec20671046fcf7d4d4bdae9a3a96ef48ed90",
+      "content_hash": "10980fcb9c16452beb96c2c26bbd0d8908aede495ee882048a2f98f1d0814340",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "b6005581c2775cee8844948990d8fd91345079212303ca69520915456c5ed8f1",
+      "content_hash": "6b2cb76f417e7d2125d61f128863e641f31542c047e5cfe793c37c6a4f49c2b0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "b2103afbb49ba019c65864df52b41f3584d099fa6d7bb8cc753e460d40a00fe0",
+      "content_hash": "83edf9dcbe8ec8f0c7f6e787ccd18cdc1522bbb047e2bd8ccf4c0e23ca7486c4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "6a2e1ce89de75c60c39688d255a588d1e9f53da249f0ec8b1edf2e5dc17bbbae",
+      "content_hash": "916806349d3fd3ec051e16532bacfe88045fde7fd194d24f599dedbaf9cbcf94",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -6,6 +6,11 @@
 
 
 
+
+
+
+
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -34,11 +39,25 @@ CLI governance runtime with dual-store architecture, git worktree isolation, and
 Decapod is a Rust CLI governance kernel for AI agents. It runs on-demand (daemonless), manages project-scoped state in SQLite with event sourcing, enforces workspace isolation via git worktrees and optional Docker containers, and provides deterministic context capsules for inference governance.
 
 **Architectural Principles:**
-- **Daemonless**: No background processes; invoked by agents on demand (INV-DAEMONLESS)
+- **Daemonless**: No background processes or detached services; an optional HTTP adapter is a foreground CLI mode whose listener and child request handling end with the invoking process (INV-DAEMONLESS)
 - **Dual-Store**: User (blank-slate) + Repo (dogfood backlog, event-sourced, deterministic rebuild)
 - **Workspace Isolation**: Git worktrees mandatory; containers optional but gated
 - **Deterministic**: Same inputs → identical outputs; event logs enable full rebuild
 - **Capability-Gated**: External actions (git, docker, fs) require declared capabilities
+
+### Optional HTTP Adapter Boundary
+
+`core/http_transport.rs` is a deliberately narrow, opt-in adapter around the existing transport-neutral RPC profile. `decapod rpc --http-server` owns the listener in the foreground and delegates each authenticated request to the existing local RPC semantics; it does not install a service, daemon, supervisor, or persistent background process. Loopback binding is the default, remote binding requires explicit `--allow-remote`, bearer authentication is mandatory, and request headers/body sizes are bounded.
+
+HTTP framing, authentication, request identity, idempotency caching, and replay rejection belong to the adapter. Session checks, authority, policy, and semantic mutation remain owned by the existing local RPC path. This keeps HTTP a replaceable transport rather than a second control plane.
+
+The Unix-domain `core/group_broker.rs` is not a competing agent API: it is an internal, short-lived mutation serializer for selected Todo/Decide/Knowledge operations. It routes the original CLI arguments and does not define alternate RPC semantics. Agents must use the CLI/RPC contract; HTTP and stdin/stdout converge on the same handler path.
+
+### Provenance and Evidence Boundaries
+
+Identity assertions retain claim kind, subject type, evidence class, scope, lifecycle fields, authority/verifier, and optional nonce/binding/signature material. Verification is recomputed under a receiver policy; serialized verification results do not grant authority. Self-declared claims remain unverified, while configured attestation keys can verify claim-specific remote or harness evidence and reject expired, revoked, out-of-scope, forged, or replayed claims.
+
+Portable completion evidence is an envelope containing canonical records, source revision bindings, artifact digests, and optional hex-encoded artifact contents. The receiving repository validates content against digest/size, stores immutable custody by envelope and digest, and persists a separate receiver decision. Source authority and publication permission never cross the import boundary.
 
 ## Capability Ownership
 
@@ -160,6 +179,9 @@ flowchart TD
 | `CapsulePolicyBinding` | `core/capsule_policy.rs` | Risk tiers, scope allowlists, repo-revision binding |
 | `ValidationContext` | `core/validate.rs` | Gate timing, pass/fail/warn counts, auto-remediable errors |
 | `RpcResponse` | `core/rpc.rs` | Standard envelope: receipt, capsule, allowed_ops, interlock |
+| `HttpTransport` | `core/http_transport.rs` | Foreground authenticated HTTP framing, limits, idempotency, and replay protection |
+| `IdentityAssertion` | `src/lib.rs` | Claim-specific identity evidence and receiver-side verification |
+| `PortableCompletionEvidence` | `core/completion_evidence.rs` | Portable artifact custody and receiver-local completion decision |
 | `AssuranceEngine` | `core/assurance.rs` | Interlock resolution, advisory, attestation |
 | `FlightRecorder` | `core/flight_recorder.rs` | Timeline from broker/todo/federation/proof event logs |
 
@@ -401,7 +423,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -18,7 +18,7 @@
 
 <!-- decapod:declared-capabilities:end -->
 ## Product Outcome
-Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work.
+Decapod is the daemonless, local-first governance kernel behind AI coding agents. Agents call it on demand to converge on human intent, shape context before inference, enforce boundaries, and deliver proof-backed completion across concurrent multi-agent work. An optional authenticated HTTP adapter may expose the same RPC profile only while its foreground CLI process is running; it is not a background daemon or service deployment.
 
 ## What This Project Is
 Decapod is a Rust CLI project that implements a governance runtime for AI agents. It provides:
@@ -44,6 +44,9 @@ Decapod is a Rust CLI project that implements a governance runtime for AI agents
 
 **Agent Interface:**
 - JSON-RPC over stdin/stdout with standard envelope (receipt, context_capsule, allowed_next_ops, blocked_by, interlock, advisory, attestation)
+- Optional authenticated HTTP transport for the same RPC semantics, with loopback-by-default binding, explicit remote opt-in, bounded requests, and replay/idempotency controls
+- Identity evidence that separates self-declared claims from locally observed or trusted attested claims
+- Portable completion evidence that carries referenced artifact bytes for receiver-side custody and decision-making without importing source authority
 - Capabilities discovery via `decapod capabilities` / `decapod rpc --op agent.init`
 - Constitution graph queries (`constitution get`, `constitution links`) with embedded methodology docs
 
@@ -93,13 +96,13 @@ flowchart LR
 ## Non-Goals (Falsifiable)
 | Non-goal | How to falsify |
 |----------|----------------|
-| Background daemon / server mode | Any PR adds long-running process or port listener |
+| Background daemon / server mode | Any PR adds a background process, detached listener, or always-on service; a foreground `decapod rpc --http-server` invocation is allowed only while the invoking process remains active |
 | Cloud-managed state (beyond experimental opt-in) | Cloud sync mutates local `.decapod/data` without explicit user action |
 | Replacing agent reasoning | Any PR adds LLM calling or prompt engineering beyond context shaping |
 | General-purpose task queue | Any PR adds job scheduling unrelated to governance primitives |
 
 ## Constraints
-- **Technical**: Daemonless (INV-DAEMONLESS), SQLite WAL mode, git worktree isolation, container runtime optional but gated
+- **Technical**: Daemonless (INV-DAEMONLESS), SQLite WAL mode, git worktree isolation, container runtime optional but gated, and any HTTP listener must be foreground, opt-in, bounded, and process-lifetime scoped
 - **Operational**: Agents must claim todo before work, session token required, elevated permissions for container commands
 - **Security**: No secrets in config.toml, .decapod/ CLI-only access (jail rule), capability-gated external actions
 
@@ -177,6 +180,9 @@ flowchart LR
 - [x] Inference governance (orientation/validate/budget)
 - [x] Validation harness with auto-remediable errors
 - [x] JSON-RPC interface with standard envelope
+- [x] Optional foreground authenticated HTTP adapter for the transport-neutral RPC profile
+- [x] Claim-specific identity evidence with attestation binding, nonce replay checks, and lifecycle rejection
+- [x] Portable completion evidence with immutable receiver custody and a separate receiver decision
 - [x] Embedded constitution graph with links navigation
 - [ ] Cross-repo federation (experimental)
 - [ ] Cloud sync (experimental opt-in only)
@@ -191,7 +197,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -4,7 +4,7 @@
 - Prefer explicit schemas over implicit behavior.
 - Every mutating interface defines idempotency semantics.
 - Every failure path maps to a typed, documented error code with auto-remediation guidance.
-- Daemonless: all interfaces are synchronous CLI or JSON-RPC over stdin/stdout.
+- Daemonless: interfaces are synchronous CLI or JSON-RPC over stdin/stdout; the optional HTTP adapter is foreground-only and process-lifetime scoped.
 - Capability-gated: external actions (git, docker, cargo, etc.) require declared capability.
 - CLI-only access to `.decapod/` (jail rule enforced in entrypoint docs).
 
@@ -57,6 +57,7 @@ Generated interface specs include:
 | `decapod infer orientation` | Pre-inference context packet | `--intent`, `--task-id`, `--format` | OrientationPacket |
 | `decapod infer validate` | Post-inference verification | `--result`, `--intent`, `--format` | ValidationResult |
 | `decapod rpc --op <op>` | JSON-RPC interface | `--params`, `--stdin` | RpcResponse |
+| `decapod rpc --http-server` | Foreground authenticated HTTP adapter for the same RPC profile | `--listen`, `--auth-token`, `--allow-remote`, `--max-body-bytes` | HTTP JSON response |
 
 ### JSON-RPC Operations (Agent-Native)
 
@@ -87,6 +88,22 @@ Response envelope (`RpcResponse`):
   "error": null
 }
 ```
+
+#### Optional Authenticated HTTP Transport
+
+The HTTP adapter is opt-in and must be run as the foreground `decapod rpc --http-server` command. It does not create a daemon, detach, install a service, or expose a second semantic control plane. Its default bind is `127.0.0.1:7331`; binding a non-loopback address requires `--allow-remote`. A non-empty bearer token is required from `--auth-token` or `DECAPOD_HTTP_TOKEN`.
+
+Requests use `POST /rpc/v1`, require `Content-Length`, and are limited to `--max-body-bytes` (default 1 MiB) with a 32 KiB header limit and a ten-second read timeout. Every request must include `Idempotency-Key` or `X-Decapod-Request-Id`. An idempotency key replays the cached response; a duplicate request ID is rejected with `409`. Authentication, framing, and replay checks happen before the body is delegated to the existing local RPC process, which remains the authority for session, policy, and mutation semantics.
+
+The Unix-domain group broker is an internal mutation-serialization mechanism, not a second agent-facing RPC API. It may route selected CLI mutations through a short-lived coordination leader, but it preserves the original arguments and semantic handler. Agents should select the CLI/RPC contract; HTTP and stdin/stdout are transport choices for that one implementation.
+
+#### Identity Assertion Contract
+
+Handshake identity assertions distinguish `self-declared`, `locally-observed`, `harness-attested`, `remotely-authenticated`, and `independently-verified` evidence classes. Assertions carry claim-specific scope and lifecycle fields plus optional `nonce`, `binding_hash`, and `signature` values. Receiver policy recomputes the result and may require configured authority/verifier identifiers and a matching keyed attestation digest. Nonce replay, invalid binding, forgery, expiry, revocation, and scope mismatch fail closed; a serialized `verification_result` is never trusted as proof.
+
+#### Portable Completion Evidence Contract
+
+`PortableCompletionEvidence` may include `artifact_contents` entries containing a digest, declared size, and hex-encoded bytes for each referenced capsule/proof artifact. A receiver validates the envelope and artifact bytes, stores immutable custody under the envelope hash and artifact digest, and writes a separate receiver decision report. Re-importing different bytes or a different decision for the same immutable path is rejected. Import never promotes source authority, publication permission, provider trust, or agent permissions.
 
 #### RPC Operation Catalog
 
@@ -161,7 +178,7 @@ Response envelope (`RpcResponse`):
 - **Shell completions**: Generated via clap (bash, zsh, fish, powershell)
 
 ### JSON-RPC Surface
-- **Transport**: stdin/stdout (newline-delimited JSON)
+- **Transport**: stdin/stdout (newline-delimited JSON), or the opt-in foreground HTTP adapter at `POST /rpc/v1`
 - **Session**: `DECAPOD_SESSION_PASSWORD` env var + `session.acquire` RPC
 - **Capabilities**: `decapod capabilities` / `rpc --op agent.init`
 
@@ -212,6 +229,8 @@ Response envelope (`RpcResponse`):
 | `.decapod/generated/context/*.json` | `capsule.query --write` | WorkUnit lineage, publish gate |
 | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | `qa verify completion <ID> --write` | Completion verifier, promotion review |
 | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | `qa verify completion <ID> --import` | Structural inspection and receiver-local decision |
+| `.decapod/generated/artifacts/provenance/completion_evidence/imports/<envelope>/artifacts/<digest>` | `qa verify completion <ID> --import` | Immutable receiver-side artifact custody |
+| `.decapod/generated/artifacts/provenance/completion_evidence/imports/<envelope>.decision.json` | `qa verify completion <ID> --import` | Separate receiver verification decision |
 | `.decapod/generated/policy/context_capsule_policy.json` | `init` / scaffold | Capsule query resolution |
 | `.decapod/generated/specs/*.md` | `init --force` / `rpc specs.refresh` | Validation, agents |
 | `.decapod/generated/artifacts/provenance/*.json` | `workspace publish` / `validate` | Promotion, CI |
@@ -274,7 +293,7 @@ AUTOREMEDIABLE_VALIDATION_ERROR code=WORKSPACE_TODO_CLAIM_CONFLICT severity=tran
 - **Version strategy**: Semantic versioning for binary (`Cargo.toml` version), schema_version in config.toml (1.0.0), POLICY_SCHEMA_VERSION for capsule policy
 - **Backward-compatibility**: 
   - CLI: New flags additive; breaking changes require major version
-  - RPC: Operation names stable; new ops additive; params/results extensible
+  - RPC: Operation names stable; new ops additive; params/results extensible. HTTP is an additive transport adapter and must preserve the stdin/stdout RPC semantics.
   - Schemas: Additive migrations only (TODO_SCHEMA_VERSION tracks)
   - Config: `schema_version` gate in validate
 - **Deprecation window**: 2 minor versions for CLI flags; RPC ops never removed
@@ -401,7 +420,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -10,6 +10,16 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -69,6 +79,18 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - Prebuilt binaries via `cargo-dist` (GitHub Releases): linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64
 - Runs entirely in user's repository context
 - State stored in `.decapod/` within each repository
+
+### Optional Foreground HTTP RPC
+
+HTTP is permitted only as an explicitly launched, process-lifetime-scoped adapter:
+
+```bash
+decapod rpc --http-server --listen 127.0.0.1:7331 --auth-token "$DECAPOD_HTTP_TOKEN"
+```
+
+This command remains attached to the invoking terminal and exits with that process; it is not a daemon, service, supervisor, or deployment target. Keep the default loopback bind unless remote exposure is deliberately approved with `--allow-remote`. Operators must provide a non-empty bearer token, retain the request size limit, and treat `Idempotency-Key`/`X-Decapod-Request-Id` as request-correlation controls rather than durable task state.
+
+The adapter is operationally replaceable: stdin/stdout remains the canonical local transport, and session, authorization, validation, proof, and mutation semantics continue to execute through the existing local RPC path.
 
 **Runtime Requirements:**
 - Git 2.30+ (worktree support)
@@ -294,7 +316,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -33,6 +33,7 @@ flowchart LR
 3. **Decapod ↔ Container**: Capability-gated (`ContainerExec`), elevated perms required
 4. **Decapod ↔ Cargo**: Capability-gated (`ProofExec`), runs in workspace
 5. **Decapod ↔ Stores**: CLI-only access (jail rule), brokered mutations
+6. **HTTP client ↔ foreground adapter**: Bearer token, loopback default, explicit remote opt-in, bounded requests, and request replay controls; the adapter delegates authority to the existing local RPC path
 
 ## STRIDE Table
 
@@ -58,6 +59,15 @@ flowchart LR
 - **Identity Source**: Git author/committer + SSH keys for remote
 - **Token Lifetime**: N/A (direct CLI invocation)
 - **Elevation**: `sudo`/`doas` required for `workspace ensure --container`
+
+### Identity Evidence
+- Self-declared environment values are recorded for correlation and remain `unverified`.
+- Locally observed, harness-attested, remotely authenticated, and independently verified claims are evaluated against claim-specific receiver policy; accepting an evidence class alone is insufficient.
+- Configured attestation requires scope, authority, verifier, binding hash, nonce, and keyed digest checks. Replayed nonces, forged digests, expired claims, revoked claims, and lifecycle/scope violations are rejected or remain indeterminate rather than being promoted.
+- The local session credential provides repository-local custody and correlation. It is not provider authentication and does not substitute for an attestation trust root.
+
+### Optional HTTP Authentication
+The HTTP transport is a foreground adapter, not a daemon or service. It requires a non-empty bearer token, binds to loopback by default, requires explicit `--allow-remote` for non-loopback addresses, caps headers/body size, and requires an idempotency key or request ID. Authentication and replay controls protect the adapter; semantic authorization remains in the existing session/policy/RPC path.
 
 ## Authorization
 
@@ -103,7 +113,7 @@ flowchart LR
 ### Encryption in Transit
 - Git: SSH/HTTPS (delegated to git CLI)
 - Container: Local Docker socket (no network)
-- RPC: stdin/stdout (local process boundary)
+- RPC: stdin/stdout (local process boundary); optional HTTP uses bearer-authenticated `POST /rpc/v1` and remains process-lifetime scoped
 
 ### Redaction in Logs
 - `DECAPOD_SESSION_PASSWORD` never logged
@@ -136,7 +146,7 @@ cargo vet             # Supply-chain auditing (manual)
 
 ### Signed Artifact / Provenance Strategy
 
-Completion evidence export carries canonical records, source revision bindings, and artifact digests. Imported completion evidence is stored as untrusted evidence and must pass receiving-repository verification; it does not import authority, publication permission, provider trust, or agent permissions. Signatures remain optional and do not replace semantic validation.
+Completion evidence export carries canonical records, source revision bindings, artifact digests, and optional artifact bytes. Imported completion evidence is stored as untrusted evidence and must pass receiving-repository verification; the receiver validates digest/size, stores immutable artifact custody, and persists a separate receiver decision. It does not import authority, publication permission, provider trust, or agent permissions. Attestation material is optional and does not replace semantic validation.
 - `cargo dist` generates signed checksums (GPG)
 - `decapod release inventory` emits deterministic SBOM
 - Provenance manifests: `artifact_manifest.json`, `proof_manifest.json`
@@ -201,6 +211,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 - [ ] Capsule policy `repo_revision` matches HEAD
 - [ ] WorkUnit manifests `VERIFIED` with proof artifacts attached
 - [ ] Provenance manifests present for `workspace publish`
+- [ ] Any HTTP deployment remains an explicitly launched foreground process with loopback binding unless remote exposure is deliberately approved
 
 ## Strongest Security Primitives
 1. **Capability-Gated External Actions**: Every `git`, `docker`, `cargo` call requires declared capability, logged with actor + operation
@@ -220,7 +231,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -10,6 +10,16 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -295,6 +305,18 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 3. **Specs Sync**: Template drift = fail (or `--refresh-specs` to acknowledge)
 4. **Config Schema**: `schema_version=1.0.0` required; forbidden keys rejected
 
+## Transport Semantics
+
+The canonical RPC semantics are transport-neutral. Newline-delimited JSON over stdin/stdout remains the default local interface. `decapod rpc --http-server` is an additive, opt-in foreground adapter for `POST /rpc/v1`; it applies bearer authentication, loopback-by-default binding, explicit remote opt-in, bounded headers/body, and request identity before delegating the same RPC request to local semantic handling. It must not detach, supervise, or survive the invoking process.
+
+An `Idempotency-Key` identifies a replayable request whose response may be cached. `X-Decapod-Request-Id` identifies a one-time request and duplicate use returns a replay conflict. The cache/replay window is bounded in memory and does not become durable governance state.
+
+## Identity and Evidence Semantics
+
+Claim evidence and verification outcome are separate values. Self-declared claims are retained but never promoted by serialization or by a permissive policy. Configured attestation can verify a claim-specific keyed digest over the claim fields, nonce, and binding hash; receiver policy also checks authority/verifier, scope, expiry, revocation, accepted evidence class, and nonce freshness.
+
+Portable completion evidence is structurally valid only when its canonical envelope and optional artifact contents agree. Receiver-local verification determines acceptance, while immutable custody and the receiver decision are stored separately from the imported envelope. Imported source claims do not become local authority.
+
 ## Idempotency Contracts
 
 | Operation | Idempotency Key | Duplicate Behavior |
@@ -309,18 +331,20 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 | `session acquire` | `agent_id` (from password) | Returns existing token |
 | `data knowledge add` | `id` (ULID) | Fails if ID exists |
 | `broker mutation` | `op+entity+id` | Append-only event log |
+| `HTTP idempotency` | `Idempotency-Key` | Cached response for duplicate idempotent requests |
+| `HTTP request replay` | `X-Decapod-Request-Id` | Duplicate request rejected with `409` |
 
 ## Language Note
 - Primary language: Rust (edition 2024, rust-version 1.96.1)
 - Schema definitions: Rust structs + serde + SQL DDL in `schemas.rs`
 - CLI: Clap 4 derive
-- RPC: JSON over stdin/stdout (no HTTP)
+- RPC: JSON over stdin/stdout by default, with an optional authenticated foreground HTTP adapter
 - Event logs: JSONL (one JSON object per line)
 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -10,6 +10,16 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -149,6 +159,9 @@ flowchart LR
 | Specs manifest sync | `decapod validate` (specs gate) | `.manifest.json` fingerprints match |
 | Capsule policy lineage | `decapod govern capsule query --write` | Policy hash binds to HEAD |
 | Completion evidence integrity | `decapod qa verify completion <ID>` | Canonical record, artifact, epoch, and receiver-local checks |
+| Identity evidence lifecycle | `cargo test --lib handshake_identity_tests` | Claim-specific scope, authority, attestation, replay, expiry, and revocation checks |
+| Portable evidence custody | `cargo test --lib core::completion_evidence::tests` | Artifact bytes, digest/size validation, immutable custody, and receiver decision persistence |
+| Foreground HTTP transport | `cargo test --lib core::http_transport::tests` plus `cargo clippy --all-targets --all-features -- -D warnings` | Loopback boundary, bounded framing, and daemonless adapter policy |
 
 ### Warning Gates (Non-Blocking, SLA Tracked)
 | Gate | Trigger | Follow-up SLA |
@@ -166,6 +179,8 @@ flowchart LR
 | Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
 | Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
 | Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
+| Imported artifact custody | `.decapod/generated/artifacts/provenance/completion_evidence/imports/<envelope>/artifacts/<digest>` | Receiver-owned immutable bytes |
+| Receiver decision | `.decapod/generated/artifacts/provenance/completion_evidence/imports/<envelope>.decision.json` | Separate local acceptance/rejection record |
 | Test logs | CI artifact store | Promotion |
 | Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
 | Changelog entry | `CHANGELOG.md` | Promotion |
@@ -352,7 +367,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0d6f25a6103a993ee229b04303812ff06bdca868c1b5418c57815d4319a89f2e`
+- Repository signal fingerprint: `0b393ee74774752475148c2c5fbe524af975456d0d31d5083429de309e8ffefc`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,7 +32,7 @@ rust_library(
     # Keep Bazel's release identity aligned with Cargo.toml. rules_rust does
     # not synthesize Cargo's package environment variables automatically.
     rustc_env = {
-        "CARGO_PKG_VERSION": "0.71.1",
+        "CARGO_PKG_VERSION": "0.72.0",
     },
     deps = [
         ":build_script",


### PR DESCRIPTION
## Summary

Follow-up to merged PR #927.

- Update the living intent, architecture, interface, security, semantics, operations, and validation specs for:
  - the single canonical RPC semantic path
  - the opt-in foreground-only authenticated HTTP adapter
  - identity evidence and attestation lifecycle checks
  - portable completion-evidence artifact custody and receiver decisions
- Explicitly document that the Unix group broker is internal mutation serialization, not a competing agent API.
- Fix the stale Bazel CARGO_PKG_VERSION value (0.71.1 -> 0.72.0) that caused t004_version_command_works to fail in the release gatling job.

## Verification

- decapod rpc --op specs.refresh
- cargo test --lib core::project_specs::tests
- cargo test --test gatling t004_version_command_works -- --exact --nocapture
- cargo fmt --all -- --check
- git diff --check

The HTTP contract remains daemonless: foreground process lifetime, loopback by default, explicit remote opt-in, bounded requests, and delegation to the existing local RPC semantics.