### PR TITLE
fix: derive Bazel package version from Cargo

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.1
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.2
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.1
+ARG DECAPOD_VERSION=0.72.2
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.71.5
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.71.5
+ARG DECAPOD_VERSION=0.72.1
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784586772Z",
-  "repo_signal_fingerprint": "81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f",
+  "generated_at": "1784588083Z",
+  "repo_signal_fingerprint": "323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "f6e2fc7c4903f8317f05ddf525acd47448912ea13b4bce488b2d113a868c34dd",
-  "decapod_release": "0.72.1",
+  "spec_input_hash": "ae253ee4a6fbc1f1e8798f7b07a10bf4540d0a82a630a534a9b7695a0d847970",
+  "decapod_release": "0.72.2",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "c10e4d99adcc03e681c40a15346b1fd68a0a72f04e732d45cd10ad9c659b809a",
-      "content_hash": "c10e4d99adcc03e681c40a15346b1fd68a0a72f04e732d45cd10ad9c659b809a",
-      "fingerprint": "b6695b01589924435f09ca6d57c584ea4084362b1c9e6a7b01819591ad6ab96f"
+      "template_hash": "8dbb4ec753e58e78ebcdb83f1dce420d35d48b87a236399ad2b2d709a71023a6",
+      "content_hash": "8dbb4ec753e58e78ebcdb83f1dce420d35d48b87a236399ad2b2d709a71023a6",
+      "fingerprint": "c9459a9b6cf0fa15ed425e0c254fab36a66841b6ce21cfc93b3ec5e2fd87143e"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "49239f7fdd75147b2701d0fcc60ce507f7f01ec6db5414a9478ba9a484409a50",
-      "content_hash": "49239f7fdd75147b2701d0fcc60ce507f7f01ec6db5414a9478ba9a484409a50",
-      "fingerprint": "af97344312ffaf315c5bb8c8195d567431fe2978853109f3806880f669583f61"
+      "template_hash": "1f7c2197b151063152c981ecbed61492787898fdd72f358fb8c91a807e9cd401",
+      "content_hash": "1f7c2197b151063152c981ecbed61492787898fdd72f358fb8c91a807e9cd401",
+      "fingerprint": "4eede26b663c4154d7ed660d3199a583259526728eb2c2344df41c1efae9ae73"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "7f64e2c67f670dd2b0f54c898d1470e6480584d63ca9a040457f8a146e5c5495",
-      "content_hash": "7f64e2c67f670dd2b0f54c898d1470e6480584d63ca9a040457f8a146e5c5495",
-      "fingerprint": "b565cae127f8b025cc6ed2e04124d1aef9dceaf11e5dd87d2413c67bf1d63fd2"
+      "template_hash": "304a68290af16622dcd9f519b0bba8cc1adb18f7a5254c0c9ca637355026be74",
+      "content_hash": "304a68290af16622dcd9f519b0bba8cc1adb18f7a5254c0c9ca637355026be74",
+      "fingerprint": "b0bea43d8ab64686336bf2d2abeaf328485540f857950edc9c416a01724e5e8c"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "3cb98ca147180d9edd36948e1b5cd64b82458258b22f98b8d402a2d90b928f96",
-      "content_hash": "3cb98ca147180d9edd36948e1b5cd64b82458258b22f98b8d402a2d90b928f96",
-      "fingerprint": "6a7671d910eaa2c64b6a57d732791f1737458bfcdead34658e5550405dc57080"
+      "template_hash": "b28b6551b326ac0560f2f5253b94ea6a7edc4e72bb7089b1f512037275ce1526",
+      "content_hash": "b28b6551b326ac0560f2f5253b94ea6a7edc4e72bb7089b1f512037275ce1526",
+      "fingerprint": "be5ffc60785bb2f3f2b42f359f361bfa7eb42c014528a0156307a38d8e6eb8d1"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "a4ee06b47eab55fb8db36a27f398932f38b57e9bd6292ad4db750a24635d84b0",
+      "content_hash": "7f594b4736e3e687ae5a5540ca13746e0632889d15c6f3096e74466c5e05353e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "f7ef048ab47a01c21ff4576e3dee477af15ae1ac1e5e19a489971de4e6cd8f56",
+      "content_hash": "309b7b4a3a9a97aa1fdaa29a093978b9d8f9c359b0a8e0d5b0832e334e02b638",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "fdb0cd13a3a67659c0cf9940ee21a432f3a94dea6ea163d4ae722c3a2f77ce0f",
+      "content_hash": "22a6fc3ecef1597c1868918257547f1be84ffee829cb9199e6f640028430ecd8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "b50e1ff7cb5731b79c6c7937747b3f8e9c5b3e311346974d8ba973be4ce790ab",
+      "content_hash": "2a96d85cd26c6cf8c52b1615b58c16ed9eb23c3104bf52288cc4ab02e1ac324c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "b223419691714cf86e21f61a5ba66e124f4dfd716f42da288c24de10760bf4b5",
+      "content_hash": "924b82259bf507f30f966db5dc535bbff812a19e191784efd4e604e74cbec82f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "8c73a03c1d9a306bc6b619ab6e7a013265fd867b96caf6f85dd7e4fd43ada92d",
+      "content_hash": "e6a84721f264c5d92233e3f4d49feae224e09c698e6e5f88bc8f434d7a08da6d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "7524906608a223947f4e15456ea569c1667f2e046e2a07129ca56523ca2adba9",
+      "content_hash": "fa708d02155fba00dc2b92ec52d32df743efa5ad7741c77a7840a958c77fb8a8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "491d04225a2019e31b8aa74b0ac6010a33d8a2f321d2e7752692cb32c9467f3d",
+      "content_hash": "82b903b59b92b27544dd53c3fc128e59ae81d57d1a4c597eb07e76141877d4cb",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -8,6 +8,7 @@
 
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -403,7 +404,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -14,6 +14,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -298,7 +300,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -14,6 +14,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -324,7 +326,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -14,6 +14,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -356,7 +358,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `81a546f1b00cf5510a2f1f2c5a96ab2830d77b37b08b541c3174c118293c186f`
+- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.1 -->
-<!-- decapod-fingerprint: b6695b01589924435f09ca6d57c584ea4084362b1c9e6a7b01819591ad6ab96f -->
+<!-- decapod-release: 0.72.2 -->
+<!-- decapod-fingerprint: c9459a9b6cf0fa15ed425e0c254fab36a66841b6ce21cfc93b3ec5e2fd87143e -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,17 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
-load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+load(
+    "@rules_rust//cargo:defs.bzl",
+    "cargo_build_script",
+    "cargo_toml_env_vars",
+)
 load("@crates//:defs.bzl", "all_crate_deps")
 
 package(default_visibility = ["//visibility:public"])
+
+cargo_toml_env_vars(
+    name = "cargo_pkg_env",
+    src = "Cargo.toml",
+)
 
 cargo_build_script(
     name = "build_script",
@@ -29,11 +38,9 @@ rust_library(
     compile_data = glob(["src/**/*.sql"]),
     edition = "2024",
     crate_name = "decapod",
-    # Keep Bazel's release identity aligned with Cargo.toml. rules_rust does
-    # not synthesize Cargo's package environment variables automatically.
-    rustc_env = {
-        "CARGO_PKG_VERSION": "0.72.0",
-    },
+    # Keep Bazel's release identity aligned with Cargo.toml instead of
+    # duplicating the package version in this BUILD file.
+    rustc_env_files = [":cargo_pkg_env"],
     deps = [
         ":build_script",
     ] + all_crate_deps(normal = True),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.1 -->
-<!-- decapod-fingerprint: af97344312ffaf315c5bb8c8195d567431fe2978853109f3806880f669583f61 -->
+<!-- decapod-release: 0.72.2 -->
+<!-- decapod-fingerprint: 4eede26b663c4154d7ed660d3199a583259526728eb2c2344df41c1efae9ae73 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.1 -->
-<!-- decapod-fingerprint: 6a7671d910eaa2c64b6a57d732791f1737458bfcdead34658e5550405dc57080 -->
+<!-- decapod-release: 0.72.2 -->
+<!-- decapod-fingerprint: be5ffc60785bb2f3f2b42f359f361bfa7eb42c014528a0156307a38d8e6eb8d1 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.1 -->
-<!-- decapod-fingerprint: b565cae127f8b025cc6ed2e04124d1aef9dceaf11e5dd87d2413c67bf1d63fd2 -->
+<!-- decapod-release: 0.72.2 -->
+<!-- decapod-fingerprint: b0bea43d8ab64686336bf2d2abeaf328485540f857950edc9c416a01724e5e8c -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.


### PR DESCRIPTION
## Summary

Fixes the merge CI failure in job https://github.com/DecapodLabs/decapod/actions/runs/29779745145/job/88478206266.

The failure was caused by BUILD.bazel hardcoding CARGO_PKG_VERSION=0.72.0 after Cargo.toml advanced to 0.72.1. Bazel therefore built a binary that reported the previous release, and t004_version_command_works failed.

This dedicated PR:
- derives Bazel Cargo package environment values from Cargo.toml via rules_rust cargo_toml_env_vars/rustc_env_files;
- removes the duplicated hardcoded release version;
- refreshes the v0.72.1 release/fingerprint metadata in the four agent entrypoints, generated Dockerfile, and generated specs attestations;
- preserves the existing version test as the regression proof.

## Verification

- cargo test --test gatling t004_version_command_works -- --exact --nocapture
- cargo fmt --all -- --check
- git diff --check
- PR CI: Bazel build, validation, contract conformance, RPC, daemonless, and test suites pass