### PR TITLE
Uplift interfaces doctrine and fix release version coverage

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.2
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.3
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.2
+ARG DECAPOD_VERSION=0.72.3
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784588083Z",
-  "repo_signal_fingerprint": "323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650",
+  "generated_at": "1784589559Z",
+  "repo_signal_fingerprint": "7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "ae253ee4a6fbc1f1e8798f7b07a10bf4540d0a82a630a534a9b7695a0d847970",
-  "decapod_release": "0.72.2",
+  "spec_input_hash": "a18e3a3cc6df87b4436399857350381a0fea6ef89c85453603b5272897d7fdf2",
+  "decapod_release": "0.72.3",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "8dbb4ec753e58e78ebcdb83f1dce420d35d48b87a236399ad2b2d709a71023a6",
-      "content_hash": "8dbb4ec753e58e78ebcdb83f1dce420d35d48b87a236399ad2b2d709a71023a6",
-      "fingerprint": "c9459a9b6cf0fa15ed425e0c254fab36a66841b6ce21cfc93b3ec5e2fd87143e"
+      "template_hash": "f3f81af19bfecc21db9fc5e8103759352507eb34422153c670cd41f136230e08",
+      "content_hash": "f3f81af19bfecc21db9fc5e8103759352507eb34422153c670cd41f136230e08",
+      "fingerprint": "49bdd734de1171b7034e5f1192bc9fc6393bbad7c8063ea7134f47a7c60de304"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "1f7c2197b151063152c981ecbed61492787898fdd72f358fb8c91a807e9cd401",
-      "content_hash": "1f7c2197b151063152c981ecbed61492787898fdd72f358fb8c91a807e9cd401",
-      "fingerprint": "4eede26b663c4154d7ed660d3199a583259526728eb2c2344df41c1efae9ae73"
+      "template_hash": "2fe4b28c2072305d12e270f5f64d8e1d85ab9920618b14c97a99168e8127f282",
+      "content_hash": "2fe4b28c2072305d12e270f5f64d8e1d85ab9920618b14c97a99168e8127f282",
+      "fingerprint": "1c2a9d799c4d1210ba15bbf42d6fc1cd439d5cc22600510c2f3c665aceda408f"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "304a68290af16622dcd9f519b0bba8cc1adb18f7a5254c0c9ca637355026be74",
-      "content_hash": "304a68290af16622dcd9f519b0bba8cc1adb18f7a5254c0c9ca637355026be74",
-      "fingerprint": "b0bea43d8ab64686336bf2d2abeaf328485540f857950edc9c416a01724e5e8c"
+      "template_hash": "717459b238dccebc178ea1acf24eb209173f8d1486f56cefe0ac0020c680974c",
+      "content_hash": "717459b238dccebc178ea1acf24eb209173f8d1486f56cefe0ac0020c680974c",
+      "fingerprint": "3b09fe10dd5db97e74133d2e766fc2181344610b687d879e3644358637d7bdf5"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "b28b6551b326ac0560f2f5253b94ea6a7edc4e72bb7089b1f512037275ce1526",
-      "content_hash": "b28b6551b326ac0560f2f5253b94ea6a7edc4e72bb7089b1f512037275ce1526",
-      "fingerprint": "be5ffc60785bb2f3f2b42f359f361bfa7eb42c014528a0156307a38d8e6eb8d1"
+      "template_hash": "7304acc679cd6333beb66a62b08dc20f60a433e08b125da04c52382d857d595a",
+      "content_hash": "7304acc679cd6333beb66a62b08dc20f60a433e08b125da04c52382d857d595a",
+      "fingerprint": "ffa0de115baedd9ab48b1d203affb2bbb26dbd0eae43e8cd88212fef82f6a877"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "7f594b4736e3e687ae5a5540ca13746e0632889d15c6f3096e74466c5e05353e",
+      "content_hash": "46ddcf4083c0c0db1742be221e93b287cbd14e16e5c22add21ddf6aa3888813c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "309b7b4a3a9a97aa1fdaa29a093978b9d8f9c359b0a8e0d5b0832e334e02b638",
+      "content_hash": "f672d3183fc304c95fd76e0fb1de6d12ca230ecdf10ef2efa6fbd8da9a8ecdbe",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "22a6fc3ecef1597c1868918257547f1be84ffee829cb9199e6f640028430ecd8",
+      "content_hash": "3fbfc754ded1e6e3a6cba042501eda7f4bedf5e2a05488e160a768f12c5e93dd",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "2a96d85cd26c6cf8c52b1615b58c16ed9eb23c3104bf52288cc4ab02e1ac324c",
+      "content_hash": "0043313dd1e9ec9eb666cac2e254640a5de0ccf4e9a27d45cbdd092f6cd67b6c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "924b82259bf507f30f966db5dc535bbff812a19e191784efd4e604e74cbec82f",
+      "content_hash": "683b2d99ac0b1bf49fa15ac338ebcba840c5fff89bd944826c53634526481215",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "e6a84721f264c5d92233e3f4d49feae224e09c698e6e5f88bc8f434d7a08da6d",
+      "content_hash": "109d1cddf3e03b592eff0bad6f39064bd41bb03b3ab81543269935b89063353b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "fa708d02155fba00dc2b92ec52d32df743efa5ad7741c77a7840a958c77fb8a8",
+      "content_hash": "d81fcb9c28fcab94817dc67b04444edc00803746282354d7bfb9c1277e069770",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "82b903b59b92b27544dd53c3fc128e59ae81d57d1a4c597eb07e76141877d4cb",
+      "content_hash": "5011928d8356bcc86f58f4cbceb958fd49fae2bbddf846272ed21553d2b8c06c",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 
 
 
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -404,7 +405,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -16,6 +16,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -300,7 +302,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -16,6 +16,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -326,7 +328,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -16,6 +16,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -358,7 +360,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `323734d1960f0fad39dc5c0d1fee338339ffeea25d982a03b80ac09b77d9f650`
+- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.2 -->
-<!-- decapod-fingerprint: c9459a9b6cf0fa15ed425e0c254fab36a66841b6ce21cfc93b3ec5e2fd87143e -->
+<!-- decapod-release: 0.72.3 -->
+<!-- decapod-fingerprint: 49bdd734de1171b7034e5f1192bc9fc6393bbad7c8063ea7134f47a7c60de304 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,6 +71,7 @@ rust_test(
     name = "core_tests",
     srcs = ["tests/core/core.rs"],
     edition = "2024",
+    rustc_env_files = [":cargo_pkg_env"],
     rustc_env = {
         "CARGO_BIN_EXE_decapod": "./$(rootpath //:decapod)",
     },
@@ -89,6 +90,7 @@ rust_test(
         name = path[6:-3],  # strip "tests/" and ".rs"
         srcs = [path],
         edition = "2024",
+        rustc_env_files = [":cargo_pkg_env"],
         rustc_env = {
             "CARGO_BIN_EXE_decapod": "./$(rootpath //:decapod)",
         },
@@ -114,6 +116,7 @@ rust_test(
         name = "plugins_" + path[14:-3] + "_tests",  # e.g., plugins_todo_tests
         srcs = [path],
         edition = "2024",
+        rustc_env_files = [":cargo_pkg_env"],
         rustc_env = {
             "CARGO_BIN_EXE_decapod": "./$(rootpath //:decapod)",
         },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.2 -->
-<!-- decapod-fingerprint: 4eede26b663c4154d7ed660d3199a583259526728eb2c2344df41c1efae9ae73 -->
+<!-- decapod-release: 0.72.3 -->
+<!-- decapod-fingerprint: 1c2a9d799c4d1210ba15bbf42d6fc1cd439d5cc22600510c2f3c665aceda408f -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.2 -->
-<!-- decapod-fingerprint: be5ffc60785bb2f3f2b42f359f361bfa7eb42c014528a0156307a38d8e6eb8d1 -->
+<!-- decapod-release: 0.72.3 -->
+<!-- decapod-fingerprint: ffa0de115baedd9ab48b1d203affb2bbb26dbd0eae43e8cd88212fef82f6a877 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.2 -->
-<!-- decapod-fingerprint: b0bea43d8ab64686336bf2d2abeaf328485540f857950edc9c416a01724e5e8c -->
+<!-- decapod-release: 0.72.3 -->
+<!-- decapod-fingerprint: 3b09fe10dd5db97e74133d2e766fc2181344610b687d879e3644358637d7bdf5 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -11783,6 +11783,117 @@
         "proceed_when": [
           "Proceed when the context pack is focused, authoritative, and completely addresses the task intent."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/AGENT_CONTEXT_PACK as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes retrieved snippets, task scope, authority ordering, bounded context, and agent pre-inference consumption.",
+        "Use the existing interfaces/AGENT_CONTEXT_PACK decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/AGENT_CONTEXT_PACK additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/AGENT_CONTEXT_PACK?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/AGENT_CONTEXT_PACK can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/AGENT_CONTEXT_PACK contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exactly which snippets of code and which constitution nodes are strictly required for the immediate task."
+        },
+        {
+          "choice": "Evolve interfaces/AGENT_CONTEXT_PACK additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/AGENT_CONTEXT_PACK change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/AGENT_CONTEXT_PACK's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/AGENT_CONTEXT_PACK."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/AGENT_CONTEXT_PACK contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/AGENT_CONTEXT_PACK's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/AGENT_CONTEXT_PACK mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/AGENT_CONTEXT_PACK change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/AGENT_CONTEXT_PACK's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/AGENT_CONTEXT_PACK."
+        ],
+        "proof": [
+          "Map interfaces/AGENT_CONTEXT_PACK to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/AGENT_CONTEXT_PACK node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Context packs must explicitly label the provenance and authority level of the retrieved information."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/AGENT_CONTEXT_PACK without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the context pack is focused, authoritative, and completely addresses the task intent."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/AGENT_CONTEXT_PACK compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query methodology/MEMORY for context compaction strategies."
+        ]
       }
     },
     "interfaces/ARCHITECTURE_FOUNDATIONS": {
@@ -11834,6 +11945,117 @@
         ],
         "proceed_when": [
           "Proceed when foundational vocabulary is used to define the problem and state boundaries."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/ARCHITECTURE_FOUNDATIONS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes foundational architecture vocabulary: boundary, state, interface, runtime, deployment, and data flow.",
+        "Use the existing interfaces/ARCHITECTURE_FOUNDATIONS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/ARCHITECTURE_FOUNDATIONS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/ARCHITECTURE_FOUNDATIONS?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/ARCHITECTURE_FOUNDATIONS can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/ARCHITECTURE_FOUNDATIONS contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Identify the primary constraint axis for the design: latency, throughput, consistency, or cost."
+        },
+        {
+          "choice": "Evolve interfaces/ARCHITECTURE_FOUNDATIONS additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/ARCHITECTURE_FOUNDATIONS change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/ARCHITECTURE_FOUNDATIONS's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/ARCHITECTURE_FOUNDATIONS."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/ARCHITECTURE_FOUNDATIONS contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/ARCHITECTURE_FOUNDATIONS's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/ARCHITECTURE_FOUNDATIONS mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/ARCHITECTURE_FOUNDATIONS change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/ARCHITECTURE_FOUNDATIONS's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/ARCHITECTURE_FOUNDATIONS."
+        ],
+        "proof": [
+          "Map interfaces/ARCHITECTURE_FOUNDATIONS to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/ARCHITECTURE_FOUNDATIONS node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: All architectural designs must explicitly name their data flow, boundaries, and failure modes."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/ARCHITECTURE_FOUNDATIONS without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when foundational vocabulary is used to define the problem and state boundaries."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/ARCHITECTURE_FOUNDATIONS compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query architecture/SYSTEMS_DESIGN for implementation patterns."
         ]
       }
     },
@@ -11902,6 +12124,117 @@
         "proceed_when": [
           "Proceed when the claim is backed by a passing validation check and evidence is recorded."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/CLAIMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes claim type, evidence, verification status, stale claim risk, and mapping claims to proof.",
+        "Use the existing interfaces/CLAIMS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/CLAIMS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/CLAIMS?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/CLAIMS can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/CLAIMS contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Decide whether a claim is 'enforced' (automated check), 'partially_enforced', or 'not_enforced' (human review)."
+        },
+        {
+          "choice": "Evolve interfaces/CLAIMS additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/CLAIMS change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/CLAIMS's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/CLAIMS."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/CLAIMS contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/CLAIMS's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/CLAIMS mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/CLAIMS change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/CLAIMS's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/CLAIMS."
+        ],
+        "proof": [
+          "Map interfaces/CLAIMS to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/CLAIMS node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Every 'REAL' subsystem must map to at least one enforced claim with an executable proof surface."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/CLAIMS without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the claim is backed by a passing validation check and evidence is recorded."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/CLAIMS compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/TESTING for specific proof mechanisms."
+        ]
       }
     },
     "interfaces/CONTROL_PLANE": {
@@ -11968,6 +12301,117 @@
         "proceed_when": [
           "Proceed when the operation receipt is valid, no blockers remain, and liveness is verified."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/CONTROL_PLANE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes operation sequencing, receipts, allowed next operations, and mutation boundaries.",
+        "Use the existing interfaces/CONTROL_PLANE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/CONTROL_PLANE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/CONTROL_PLANE?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/CONTROL_PLANE can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/CONTROL_PLANE contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine the next allowed operation based on the receipt and liveness signals from the previous step."
+        },
+        {
+          "choice": "Evolve interfaces/CONTROL_PLANE additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/CONTROL_PLANE change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/CONTROL_PLANE's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/CONTROL_PLANE."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/CONTROL_PLANE contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/CONTROL_PLANE's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/CONTROL_PLANE mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/CONTROL_PLANE change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/CONTROL_PLANE's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/CONTROL_PLANE."
+        ],
+        "proof": [
+          "Map interfaces/CONTROL_PLANE to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/CONTROL_PLANE node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Agents must consult Decapod doctrine and retrieve context packs before hardening any plan or code."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/CONTROL_PLANE without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the operation receipt is valid, no blockers remain, and liveness is verified."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/CONTROL_PLANE compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query docs/CONTROL_PLANE_API for payload examples and error shapes."
+        ]
       }
     },
     "interfaces/DEMANDS_SCHEMA": {
@@ -12019,6 +12463,117 @@
         ],
         "proceed_when": [
           "Proceed when demands are structured, scoped, and conflicts are resolved per precedence."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/DEMANDS_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes how human constraints become structured demands: must, must-not, priority, and durability.",
+        "Use the existing interfaces/DEMANDS_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/DEMANDS_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/DEMANDS_SCHEMA?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/DEMANDS_SCHEMA can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/DEMANDS_SCHEMA contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine if a user's prompt should be encoded as a durable demand or an ephemeral preference."
+        },
+        {
+          "choice": "Evolve interfaces/DEMANDS_SCHEMA additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/DEMANDS_SCHEMA change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/DEMANDS_SCHEMA's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/DEMANDS_SCHEMA."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/DEMANDS_SCHEMA contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/DEMANDS_SCHEMA's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/DEMANDS_SCHEMA mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/DEMANDS_SCHEMA change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/DEMANDS_SCHEMA's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/DEMANDS_SCHEMA."
+        ],
+        "proof": [
+          "Map interfaces/DEMANDS_SCHEMA to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/DEMANDS_SCHEMA node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Structured demands must be linked to specific user intent or session IDs for auditability."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/DEMANDS_SCHEMA without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when demands are structured, scoped, and conflicts are resolved per precedence."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/DEMANDS_SCHEMA compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query specs/INTENT to link demands to outcome contracts."
         ]
       }
     },
@@ -12073,6 +12628,117 @@
         "proceed_when": [
           "Proceed when documentation changes respect the canonical/generated boundary and authority."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/DOC_RULES as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes machine-readable documentation rules: canonical vs generated, boundaries, and drift handling.",
+        "Use the existing interfaces/DOC_RULES decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/DOC_RULES additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/DOC_RULES?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/DOC_RULES can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/DOC_RULES contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Decide whether to update a hand-written doc or regenerate a spec after a structural change."
+        },
+        {
+          "choice": "Evolve interfaces/DOC_RULES additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/DOC_RULES change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/DOC_RULES's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/DOC_RULES."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/DOC_RULES contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/DOC_RULES's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/DOC_RULES mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/DOC_RULES change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/DOC_RULES's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/DOC_RULES."
+        ],
+        "proof": [
+          "Map interfaces/DOC_RULES to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/DOC_RULES node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: All docs must cite their authority layer and freshness/proof expectations to prevent drift."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/DOC_RULES without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when documentation changes respect the canonical/generated boundary and authority."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/DOC_RULES compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query core/DOCS for routing to specific document nodes."
+        ]
       }
     },
     "interfaces/GLOSSARY": {
@@ -12125,6 +12791,117 @@
         "proceed_when": [
           "Proceed when the vernacular is successfully mapped to canonical system terms and IDs."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/GLOSSARY as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes vocabulary governance: canonical terms, aliases, ambiguity reduction, and retrieval support.",
+        "Use the existing interfaces/GLOSSARY decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/GLOSSARY additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/GLOSSARY?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/GLOSSARY can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/GLOSSARY contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine if a new term should be added to the glossary or mapped to an existing canonical ID."
+        },
+        {
+          "choice": "Evolve interfaces/GLOSSARY additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/GLOSSARY change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/GLOSSARY's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/GLOSSARY."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/GLOSSARY contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/GLOSSARY's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/GLOSSARY mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/GLOSSARY change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/GLOSSARY's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/GLOSSARY."
+        ],
+        "proof": [
+          "Map interfaces/GLOSSARY to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/GLOSSARY node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Glossary entries support retrieval and clarity but do not invent binding behavioral rules."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/GLOSSARY without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the vernacular is successfully mapped to canonical system terms and IDs."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/GLOSSARY compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query core/METADATA for taxonomy and classification retrieval."
+        ]
       }
     },
     "interfaces/INTERNALIZATION_SCHEMA": {
@@ -12176,6 +12953,117 @@
         ],
         "proceed_when": [
           "Proceed when the internalization lifecycle is verified and schema-compliant."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/INTERNALIZATION_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes the lifecycle of attaching, inspecting, and validating external knowledge into Decapod-governed state.",
+        "Use the existing interfaces/INTERNALIZATION_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/INTERNALIZATION_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/INTERNALIZATION_SCHEMA?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/INTERNALIZATION_SCHEMA can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/INTERNALIZATION_SCHEMA contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Decide if external knowledge should be internalized as durable state or ephemeral context."
+        },
+        {
+          "choice": "Evolve interfaces/INTERNALIZATION_SCHEMA additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/INTERNALIZATION_SCHEMA change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/INTERNALIZATION_SCHEMA's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/INTERNALIZATION_SCHEMA."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/INTERNALIZATION_SCHEMA contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/INTERNALIZATION_SCHEMA's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/INTERNALIZATION_SCHEMA mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/INTERNALIZATION_SCHEMA change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/INTERNALIZATION_SCHEMA's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/INTERNALIZATION_SCHEMA."
+        ],
+        "proof": [
+          "Map interfaces/INTERNALIZATION_SCHEMA to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/INTERNALIZATION_SCHEMA node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: All internalized data must have an owner and timestamp to manage decay and re-validation."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/INTERNALIZATION_SCHEMA without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the internalization lifecycle is verified and schema-compliant."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/INTERNALIZATION_SCHEMA compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/KNOWLEDGE_SCHEMA for internal object shapes."
         ]
       }
     },
@@ -12231,6 +13119,117 @@
         "proceed_when": [
           "Proceed when the knowledge object is fully structured and its authority/freshness is clear."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/KNOWLEDGE_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes knowledge object shape: source, provenance, authority, summary, and retrieval tags.",
+        "Use the existing interfaces/KNOWLEDGE_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/KNOWLEDGE_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/KNOWLEDGE_SCHEMA?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/KNOWLEDGE_SCHEMA can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/KNOWLEDGE_SCHEMA contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine which retrieval tags provide the highest signal for the intended consumer agent."
+        },
+        {
+          "choice": "Evolve interfaces/KNOWLEDGE_SCHEMA additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/KNOWLEDGE_SCHEMA change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/KNOWLEDGE_SCHEMA's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/KNOWLEDGE_SCHEMA."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/KNOWLEDGE_SCHEMA contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/KNOWLEDGE_SCHEMA's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/KNOWLEDGE_SCHEMA mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/KNOWLEDGE_SCHEMA change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/KNOWLEDGE_SCHEMA's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/KNOWLEDGE_SCHEMA."
+        ],
+        "proof": [
+          "Map interfaces/KNOWLEDGE_SCHEMA to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/KNOWLEDGE_SCHEMA node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Knowledge objects must pass strict schema validation before being added to the persistent store."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/KNOWLEDGE_SCHEMA without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the knowledge object is fully structured and its authority/freshness is clear."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/KNOWLEDGE_SCHEMA compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/KNOWLEDGE_STORE for persistence and indexing rules."
+        ]
       }
     },
     "interfaces/KNOWLEDGE_STORE": {
@@ -12285,6 +13284,117 @@
         "proceed_when": [
           "Proceed when store integrity is verified and retrieval paths are optimized for context signals."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/KNOWLEDGE_STORE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes persistent knowledge storage: indexing, update/delete semantics, and retrieval safety.",
+        "Use the existing interfaces/KNOWLEDGE_STORE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/KNOWLEDGE_STORE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/KNOWLEDGE_STORE?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/KNOWLEDGE_STORE can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/KNOWLEDGE_STORE contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine whether to purge a stale record or mark it as 'unverified' in the active index."
+        },
+        {
+          "choice": "Evolve interfaces/KNOWLEDGE_STORE additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/KNOWLEDGE_STORE change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/KNOWLEDGE_STORE's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/KNOWLEDGE_STORE."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/KNOWLEDGE_STORE contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/KNOWLEDGE_STORE's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/KNOWLEDGE_STORE mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/KNOWLEDGE_STORE change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/KNOWLEDGE_STORE's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/KNOWLEDGE_STORE."
+        ],
+        "proof": [
+          "Map interfaces/KNOWLEDGE_STORE to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/KNOWLEDGE_STORE node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: The knowledge store must enforce unique IDs and support deterministic, point-in-time retrieval."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/KNOWLEDGE_STORE without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when store integrity is verified and retrieval paths are optimized for context signals."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/KNOWLEDGE_STORE compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query architecture/KNOWLEDGE_BASE for technical implementation details."
+        ]
       }
     },
     "interfaces/LCM": {
@@ -12338,6 +13448,117 @@
         "proceed_when": [
           "Proceed when context is compacted without losing critical authority or proof signals."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/LCM as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes lossless context management: summary DAGs, deterministic compaction, and transfer boundaries.",
+        "Use the existing interfaces/LCM decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/LCM additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/LCM?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/LCM can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/LCM contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Decide which context branches are 'prunable' versus 'vital' for the current task sequence."
+        },
+        {
+          "choice": "Evolve interfaces/LCM additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/LCM change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/LCM's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/LCM."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/LCM contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/LCM's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/LCM mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/LCM change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/LCM's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/LCM."
+        ],
+        "proof": [
+          "Map interfaces/LCM to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/LCM node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Lossless context management must preserve governing anchors and the original proof evidence."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/LCM without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when context is compacted without losing critical authority or proof signals."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/LCM compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/AGENT_CONTEXT_PACK for session transfer boundaries."
+        ]
       }
     },
     "interfaces/MEMORY_INDEX": {
@@ -12389,6 +13610,117 @@
         ],
         "proceed_when": [
           "Proceed when memory retrieval is ranked by both semantic relevance and authority."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/MEMORY_INDEX as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes memory retrieval index: addressing, categorization, relevance, and search tiers.",
+        "Use the existing interfaces/MEMORY_INDEX decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/MEMORY_INDEX additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/MEMORY_INDEX?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/MEMORY_INDEX can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/MEMORY_INDEX contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine the appropriate tier (personal vs project) for indexing a new memory record."
+        },
+        {
+          "choice": "Evolve interfaces/MEMORY_INDEX additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/MEMORY_INDEX change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/MEMORY_INDEX's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/MEMORY_INDEX."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/MEMORY_INDEX contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/MEMORY_INDEX's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/MEMORY_INDEX mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/MEMORY_INDEX change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/MEMORY_INDEX's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/MEMORY_INDEX."
+        ],
+        "proof": [
+          "Map interfaces/MEMORY_INDEX to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/MEMORY_INDEX node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Index entries must be updated immediately after a linked memory record is modified."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/MEMORY_INDEX without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when memory retrieval is ranked by both semantic relevance and authority."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/MEMORY_INDEX compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/MEMORY_SCHEMA for record shapes and metadata requirements."
         ]
       }
     },
@@ -12442,6 +13774,117 @@
         "proceed_when": [
           "Proceed when the memory record matches the schema and its status is correctly labeled."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/MEMORY_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes durable memory record shape: subject, claim, provenance, scope, and status.",
+        "Use the existing interfaces/MEMORY_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/MEMORY_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/MEMORY_SCHEMA?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/MEMORY_SCHEMA can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/MEMORY_SCHEMA contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Decide if an existing record should be updated or if a new versioned record is required."
+        },
+        {
+          "choice": "Evolve interfaces/MEMORY_SCHEMA additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/MEMORY_SCHEMA change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/MEMORY_SCHEMA's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/MEMORY_SCHEMA."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/MEMORY_SCHEMA contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/MEMORY_SCHEMA's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/MEMORY_SCHEMA mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/MEMORY_SCHEMA change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/MEMORY_SCHEMA's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/MEMORY_SCHEMA."
+        ],
+        "proof": [
+          "Map interfaces/MEMORY_SCHEMA to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/MEMORY_SCHEMA node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Memory records must be schema-compliant and correctly scoped to prevent cross-repo pollution."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/MEMORY_SCHEMA without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the memory record matches the schema and its status is correctly labeled."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/MEMORY_SCHEMA compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query methodology/MEMORY for agent cognitive and distillation practices."
+        ]
       }
     },
     "interfaces/PLAN_GOVERNED_EXECUTION": {
@@ -12493,6 +13936,117 @@
         ],
         "proceed_when": [
           "Proceed when the plan is structured with explicit checkpoints and authorized mutations."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/PLAN_GOVERNED_EXECUTION as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes structured execution plans: steps, checkpoints, allowed mutations, and rollback.",
+        "Use the existing interfaces/PLAN_GOVERNED_EXECUTION decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/PLAN_GOVERNED_EXECUTION additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/PLAN_GOVERNED_EXECUTION?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/PLAN_GOVERNED_EXECUTION can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/PLAN_GOVERNED_EXECUTION contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine whether a failed checkpoint requires a full plan rollback or a surgical correction."
+        },
+        {
+          "choice": "Evolve interfaces/PLAN_GOVERNED_EXECUTION additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/PLAN_GOVERNED_EXECUTION change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/PLAN_GOVERNED_EXECUTION's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/PLAN_GOVERNED_EXECUTION."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/PLAN_GOVERNED_EXECUTION contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/PLAN_GOVERNED_EXECUTION's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/PLAN_GOVERNED_EXECUTION mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/PLAN_GOVERNED_EXECUTION change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/PLAN_GOVERNED_EXECUTION's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/PLAN_GOVERNED_EXECUTION."
+        ],
+        "proof": [
+          "Map interfaces/PLAN_GOVERNED_EXECUTION to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/PLAN_GOVERNED_EXECUTION node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Execution plans must be structured, versioned, and stored in the project-managed state."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/PLAN_GOVERNED_EXECUTION without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the plan is structured with explicit checkpoints and authorized mutations."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/PLAN_GOVERNED_EXECUTION compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/TODO_SCHEMA for linking plans to task IDs."
         ]
       }
     },
@@ -12549,6 +14103,117 @@
         "proceed_when": [
           "Proceed when the procedural conduct aligns with the 'Call Decapod Early' mandate and proof."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/PROCEDURAL_NORMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes agent procedural conduct: call Decapod early, ask when blocked, and preserve evidence.",
+        "Use the existing interfaces/PROCEDURAL_NORMS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/PROCEDURAL_NORMS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/PROCEDURAL_NORMS?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/PROCEDURAL_NORMS can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/PROCEDURAL_NORMS contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Choose between making a documented assumption versus stopping to ask the user for input."
+        },
+        {
+          "choice": "Evolve interfaces/PROCEDURAL_NORMS additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/PROCEDURAL_NORMS change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/PROCEDURAL_NORMS's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/PROCEDURAL_NORMS."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/PROCEDURAL_NORMS contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/PROCEDURAL_NORMS's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/PROCEDURAL_NORMS mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/PROCEDURAL_NORMS change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/PROCEDURAL_NORMS's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/PROCEDURAL_NORMS."
+        ],
+        "proof": [
+          "Map interfaces/PROCEDURAL_NORMS to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/PROCEDURAL_NORMS node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Agents must cite the constitution node or spec that authorized their procedural path."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/PROCEDURAL_NORMS without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the procedural conduct aligns with the 'Call Decapod Early' mandate and proof."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/PROCEDURAL_NORMS compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query core/EMERGENCY_PROTOCOL for risk-based stops and containment."
+        ]
       }
     },
     "interfaces/PROJECT_SPECS": {
@@ -12604,6 +14269,117 @@
         ],
         "proceed_when": [
           "Proceed when the spec is hydrated with repo-specific details and explicit proof targets."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/PROJECT_SPECS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes generated project specs: intent, acceptance criteria, boundaries, and spec drift.",
+        "Use the existing interfaces/PROJECT_SPECS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/PROJECT_SPECS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/PROJECT_SPECS?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/PROJECT_SPECS can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/PROJECT_SPECS contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine if a spec change requires a corresponding update to the architecture overview doc."
+        },
+        {
+          "choice": "Evolve interfaces/PROJECT_SPECS additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/PROJECT_SPECS change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/PROJECT_SPECS's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/PROJECT_SPECS."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/PROJECT_SPECS contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/PROJECT_SPECS's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/PROJECT_SPECS mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/PROJECT_SPECS change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/PROJECT_SPECS's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/PROJECT_SPECS."
+        ],
+        "proof": [
+          "Map interfaces/PROJECT_SPECS to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/PROJECT_SPECS node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Project specs must be updated and validated *before* the final implementation proceeds."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/PROJECT_SPECS without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the spec is hydrated with repo-specific details and explicit proof targets."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/PROJECT_SPECS compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query specs/INTENT for the parent authority contract."
         ]
       }
     },
@@ -12667,6 +14443,117 @@
         "proceed_when": [
           "Proceed when the change passes all automated risk policies and secures necessary approvals."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/RISK_POLICY_GATE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes risk classification, approval gates, blocked changes, policy outputs, and escalation.",
+        "Use the existing interfaces/RISK_POLICY_GATE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/RISK_POLICY_GATE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/RISK_POLICY_GATE?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/RISK_POLICY_GATE can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/RISK_POLICY_GATE contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine the severity of the proposed mutation and anticipate the required validation gates."
+        },
+        {
+          "choice": "Evolve interfaces/RISK_POLICY_GATE additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/RISK_POLICY_GATE change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/RISK_POLICY_GATE's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/RISK_POLICY_GATE."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/RISK_POLICY_GATE contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/RISK_POLICY_GATE's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/RISK_POLICY_GATE mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/RISK_POLICY_GATE change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/RISK_POLICY_GATE's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/RISK_POLICY_GATE."
+        ],
+        "proof": [
+          "Map interfaces/RISK_POLICY_GATE to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/RISK_POLICY_GATE node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Never bypass a risk policy gate. If a change is blocked, the agent must explain why and halt."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/RISK_POLICY_GATE without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the change passes all automated risk policies and secures necessary approvals."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/RISK_POLICY_GATE compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query architecture/COMPLIANCE for regulated boundaries."
+        ]
       }
     },
     "interfaces/STORE_MODEL": {
@@ -12729,6 +14616,117 @@
         "proceed_when": [
           "Proceed when the correct store is identified and mutation occurs exclusively via the CLI/RPC."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/STORE_MODEL as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes local repo state, user state, created artifacts, operational DB state, sync boundaries, and direct mutation risks.",
+        "Use the existing interfaces/STORE_MODEL decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/STORE_MODEL additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/STORE_MODEL?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/STORE_MODEL can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/STORE_MODEL contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine if a preference or configuration should be saved globally (repo) or locally (user)."
+        },
+        {
+          "choice": "Evolve interfaces/STORE_MODEL additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/STORE_MODEL change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/STORE_MODEL's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/STORE_MODEL."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/STORE_MODEL contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/STORE_MODEL's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/STORE_MODEL mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/STORE_MODEL change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/STORE_MODEL's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/STORE_MODEL."
+        ],
+        "proof": [
+          "Map interfaces/STORE_MODEL to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/STORE_MODEL node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Agents must never manually edit Decapod internal state stores or generated artifact directories."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/STORE_MODEL without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the correct store is identified and mutation occurs exclusively via the CLI/RPC."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/STORE_MODEL compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query core/INTERFACES to verify schema shapes."
+        ]
       }
     },
     "interfaces/TESTING": {
@@ -12786,6 +14784,117 @@
         ],
         "proceed_when": [
           "Proceed when the test command is known and the evidence capture path is configured."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/TESTING as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes testing interface: expected command, evidence capture, and validation status.",
+        "Use the existing interfaces/TESTING decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/TESTING additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/TESTING?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/TESTING can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/TESTING contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine whether a failing test is a regression or a symptom of an outdated project spec."
+        },
+        {
+          "choice": "Evolve interfaces/TESTING additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/TESTING change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/TESTING's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/TESTING."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/TESTING contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/TESTING's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/TESTING mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/TESTING change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/TESTING's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/TESTING."
+        ],
+        "proof": [
+          "Map interfaces/TESTING to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/TESTING node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Test evidence must be stored in the project's verification plan or the auditable session log."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/TESTING without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the test command is known and the evidence capture path is configured."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/TESTING compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query plugins/VERIFY for the invariant and proof check engine."
         ]
       }
     },
@@ -12848,6 +14957,117 @@
         "proceed_when": [
           "Proceed when the todo state accurately reflects reality and execution constraints are met."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/TODO_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes todo states, transitions, ownership, blockers, timestamps, evidence, and completion semantics.",
+        "Use the existing interfaces/TODO_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/TODO_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/TODO_SCHEMA?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/TODO_SCHEMA can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/TODO_SCHEMA contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Identify what concrete artifacts or test results are required to transition a task to 'Verified'."
+        },
+        {
+          "choice": "Evolve interfaces/TODO_SCHEMA additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/TODO_SCHEMA change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/TODO_SCHEMA's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/TODO_SCHEMA."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/TODO_SCHEMA contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/TODO_SCHEMA's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/TODO_SCHEMA mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/TODO_SCHEMA change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/TODO_SCHEMA's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/TODO_SCHEMA."
+        ],
+        "proof": [
+          "Map interfaces/TODO_SCHEMA to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/TODO_SCHEMA node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Agents must 'claim' a todo before modifying any repository files to ensure exclusive ownership."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/TODO_SCHEMA without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the todo state accurately reflects reality and execution constraints are met."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/TODO_SCHEMA compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/CONTROL_PLANE for operation sequencing."
+        ]
       }
     },
     "interfaces/jsonschema/internalization/InternalizationAttachResult.schema": {
@@ -12905,6 +15125,117 @@
         ],
         "proceed_when": [
           "Proceed when the payload structure guarantees validation success."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/jsonschema/internalization/InternalizationAttachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Use the existing interfaces/jsonschema/internalization/InternalizationAttachResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/jsonschema/internalization/InternalizationAttachResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/jsonschema/internalization/InternalizationAttachResult.schema?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/jsonschema/internalization/InternalizationAttachResult.schema can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationAttachResult.schema contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
+        },
+        {
+          "choice": "Evolve interfaces/jsonschema/internalization/InternalizationAttachResult.schema additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationAttachResult.schema change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/jsonschema/internalization/InternalizationAttachResult.schema's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/jsonschema/internalization/InternalizationAttachResult.schema."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/jsonschema/internalization/InternalizationAttachResult.schema contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/jsonschema/internalization/InternalizationAttachResult.schema's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/jsonschema/internalization/InternalizationAttachResult.schema mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/jsonschema/internalization/InternalizationAttachResult.schema change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/jsonschema/internalization/InternalizationAttachResult.schema's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/jsonschema/internalization/InternalizationAttachResult.schema."
+        ],
+        "proof": [
+          "Map interfaces/jsonschema/internalization/InternalizationAttachResult.schema to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/jsonschema/internalization/InternalizationAttachResult.schema node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Outputs must pass Ajv strict validation before being transmitted."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/jsonschema/internalization/InternalizationAttachResult.schema without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the payload structure guarantees validation success."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/jsonschema/internalization/InternalizationAttachResult.schema compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/INTERNALIZATION_SCHEMA for the broader lifecycle contract."
         ]
       }
     },
@@ -12964,6 +15295,117 @@
         "proceed_when": [
           "Proceed when the payload structure guarantees validation success."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/jsonschema/internalization/InternalizationCreateResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Use the existing interfaces/jsonschema/internalization/InternalizationCreateResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/jsonschema/internalization/InternalizationCreateResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/jsonschema/internalization/InternalizationCreateResult.schema?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/jsonschema/internalization/InternalizationCreateResult.schema can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationCreateResult.schema contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
+        },
+        {
+          "choice": "Evolve interfaces/jsonschema/internalization/InternalizationCreateResult.schema additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationCreateResult.schema change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/jsonschema/internalization/InternalizationCreateResult.schema's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/jsonschema/internalization/InternalizationCreateResult.schema."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/jsonschema/internalization/InternalizationCreateResult.schema contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/jsonschema/internalization/InternalizationCreateResult.schema's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/jsonschema/internalization/InternalizationCreateResult.schema mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/jsonschema/internalization/InternalizationCreateResult.schema change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/jsonschema/internalization/InternalizationCreateResult.schema's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/jsonschema/internalization/InternalizationCreateResult.schema."
+        ],
+        "proof": [
+          "Map interfaces/jsonschema/internalization/InternalizationCreateResult.schema to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/jsonschema/internalization/InternalizationCreateResult.schema node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Outputs must pass Ajv strict validation before being transmitted."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/jsonschema/internalization/InternalizationCreateResult.schema without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the payload structure guarantees validation success."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/jsonschema/internalization/InternalizationCreateResult.schema compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/INTERNALIZATION_SCHEMA for the broader lifecycle contract."
+        ]
       }
     },
     "interfaces/jsonschema/internalization/InternalizationDetachResult.schema": {
@@ -13021,6 +15463,117 @@
         ],
         "proceed_when": [
           "Proceed when the payload structure guarantees validation success."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/jsonschema/internalization/InternalizationDetachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Use the existing interfaces/jsonschema/internalization/InternalizationDetachResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/jsonschema/internalization/InternalizationDetachResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/jsonschema/internalization/InternalizationDetachResult.schema?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/jsonschema/internalization/InternalizationDetachResult.schema can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationDetachResult.schema contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
+        },
+        {
+          "choice": "Evolve interfaces/jsonschema/internalization/InternalizationDetachResult.schema additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationDetachResult.schema change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/jsonschema/internalization/InternalizationDetachResult.schema's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/jsonschema/internalization/InternalizationDetachResult.schema."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/jsonschema/internalization/InternalizationDetachResult.schema contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/jsonschema/internalization/InternalizationDetachResult.schema's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/jsonschema/internalization/InternalizationDetachResult.schema mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/jsonschema/internalization/InternalizationDetachResult.schema change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/jsonschema/internalization/InternalizationDetachResult.schema's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/jsonschema/internalization/InternalizationDetachResult.schema."
+        ],
+        "proof": [
+          "Map interfaces/jsonschema/internalization/InternalizationDetachResult.schema to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/jsonschema/internalization/InternalizationDetachResult.schema node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Outputs must pass Ajv strict validation before being transmitted."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/jsonschema/internalization/InternalizationDetachResult.schema without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the payload structure guarantees validation success."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/jsonschema/internalization/InternalizationDetachResult.schema compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/INTERNALIZATION_SCHEMA for the broader lifecycle contract."
         ]
       }
     },
@@ -13080,6 +15633,117 @@
         "proceed_when": [
           "Proceed when the payload structure guarantees validation success."
         ]
+      },
+      "architect_notes": [
+        "Treat interfaces/jsonschema/internalization/InternalizationInspectResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Use the existing interfaces/jsonschema/internalization/InternalizationInspectResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/jsonschema/internalization/InternalizationInspectResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/jsonschema/internalization/InternalizationInspectResult.schema?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/jsonschema/internalization/InternalizationInspectResult.schema can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationInspectResult.schema contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
+        },
+        {
+          "choice": "Evolve interfaces/jsonschema/internalization/InternalizationInspectResult.schema additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationInspectResult.schema change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/jsonschema/internalization/InternalizationInspectResult.schema's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/jsonschema/internalization/InternalizationInspectResult.schema."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/jsonschema/internalization/InternalizationInspectResult.schema contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/jsonschema/internalization/InternalizationInspectResult.schema's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/jsonschema/internalization/InternalizationInspectResult.schema mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/jsonschema/internalization/InternalizationInspectResult.schema change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/jsonschema/internalization/InternalizationInspectResult.schema's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/jsonschema/internalization/InternalizationInspectResult.schema."
+        ],
+        "proof": [
+          "Map interfaces/jsonschema/internalization/InternalizationInspectResult.schema to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/jsonschema/internalization/InternalizationInspectResult.schema node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Outputs must pass Ajv strict validation before being transmitted."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/jsonschema/internalization/InternalizationInspectResult.schema without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the payload structure guarantees validation success."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/jsonschema/internalization/InternalizationInspectResult.schema compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/INTERNALIZATION_SCHEMA for the broader lifecycle contract."
+        ]
       }
     },
     "interfaces/jsonschema/internalization/InternalizationManifest.schema": {
@@ -13137,6 +15801,117 @@
         ],
         "proceed_when": [
           "Proceed when the payload structure guarantees validation success."
+        ]
+      },
+      "architect_notes": [
+        "Treat interfaces/jsonschema/internalization/InternalizationManifest.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Use the existing interfaces/jsonschema/internalization/InternalizationManifest.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
+        "Keep interfaces/jsonschema/internalization/InternalizationManifest.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
+      ],
+      "init_questions": [
+        {
+          "id": "contract_owners",
+          "prompt": "Which producer, consumer, and state owner must agree before changing interfaces/jsonschema/internalization/InternalizationManifest.schema?",
+          "why": "Naming ownership prevents implementation convenience from silently redefining a shared machine contract.",
+          "answers": [
+            "inspect schema",
+            "query consumer",
+            "ask human",
+            "record assumption",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "evolution_proof",
+          "prompt": "What compatibility and proof evidence will show that interfaces/jsonschema/internalization/InternalizationManifest.schema can evolve safely?",
+          "why": "An interface decision is incomplete until a consumer-visible compatibility check can falsify it.",
+          "answers": [
+            "schema test",
+            "contract test",
+            "runtime check",
+            "spec refresh",
+            "blocked note"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationManifest.schema contract",
+          "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
+          "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
+          "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
+        },
+        {
+          "choice": "Evolve interfaces/jsonschema/internalization/InternalizationManifest.schema additively",
+          "use_when": "A new capability is needed and it can be introduced through optional fields, versioned envelopes, or compatibility adapters.",
+          "avoid_when": "Avoid additive changes when consumers cannot distinguish the new form or when omission changes existing meaning.",
+          "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
+        },
+        {
+          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationManifest.schema change",
+          "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
+          "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
+          "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "compatibility versus expressiveness",
+          "option_a": "Preserve existing fields, defaults, omissions, and error meanings.",
+          "option_b": "Expose a richer contract that may require consumer migration.",
+          "guidance": "Prefer compatibility for existing consumers; choose expressiveness only when the new semantics are explicit, versioned, and proven."
+        },
+        {
+          "axis": "producer autonomy versus consumer safety",
+          "option_a": "Let the producer evolve its implementation behind the stable contract.",
+          "option_b": "Require shared schema and contract checks before the producer changes behavior.",
+          "guidance": "Prefer shared validation when the interface crosses process, agent, repository, or trust boundaries."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture interfaces/jsonschema/internalization/InternalizationManifest.schema's producer, consumer, state owner, lifecycle, compatibility rule, and first proof command before editing it.",
+          "Record the requested change, rejected alternatives, unresolved assumptions, and affected project specs for interfaces/jsonschema/internalization/InternalizationManifest.schema."
+        ],
+        "generate": [
+          "Generate only the schema, example, adapter, test, or spec note required to prove the selected interfaces/jsonschema/internalization/InternalizationManifest.schema contract decision.",
+          "Keep generated payloads deterministic and preserve existing fields, defaults, omissions, and error shapes unless migration is explicit."
+        ],
+        "defer": [
+          "Defer vendor, framework, deployment, or storage choices that do not belong to interfaces/jsonschema/internalization/InternalizationManifest.schema's contract boundary.",
+          "Defer breaking changes until affected consumers, compatibility windows, migration evidence, and rollback behavior are named."
+        ],
+        "proof": [
+          "Pair every interfaces/jsonschema/internalization/InternalizationManifest.schema mutation with schema validation, representative consumer coverage, and a recorded validation result.",
+          "If the proof surface cannot run, record the exact blocker and keep the interface claim unverified."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record how the interfaces/jsonschema/internalization/InternalizationManifest.schema change affects accepted scope, non-goals, assumptions, and consumer-visible behavior."
+        ],
+        "architecture": [
+          "Record interfaces/jsonschema/internalization/InternalizationManifest.schema's producer, consumer, state ownership, lifecycle, and runtime boundary when they change."
+        ],
+        "interfaces": [
+          "Record the schema, envelope, command, payload, omission rule, error shape, compatibility promise, and affected consumers for interfaces/jsonschema/internalization/InternalizationManifest.schema."
+        ],
+        "proof": [
+          "Map interfaces/jsonschema/internalization/InternalizationManifest.schema to deterministic schema, contract, runtime, and release evidence before claiming compatibility."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The interfaces/jsonschema/internalization/InternalizationManifest.schema node remains discoverable, preserves its structured doctrine fields, and validates against the constitution schema.",
+          "Static checks cover the contract rule: Outputs must pass Ajv strict validation before being transmitted."
+        ],
+        "runtime": [
+          "A representative producer and consumer can use interfaces/jsonschema/internalization/InternalizationManifest.schema without inventing payload shape or silently changing omission and error semantics.",
+          "Proceed when the node's current guidance is satisfied: Proceed when the payload structure guarantees validation success."
+        ],
+        "release": [
+          "Refresh living specs and record which interfaces/jsonschema/internalization/InternalizationManifest.schema compatibility claims are verified, assumed, deferred, or blocked.",
+          "Carry forward the next consultation when the boundary crosses another contract: Query interfaces/INTERNALIZATION_SCHEMA for the broader lifecycle contract."
         ]
       }
     },

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -15172,7 +15172,7 @@
           "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
         },
         {
-          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationAttachResult.schema change",
+          "choice": "Defer incompatible schema change",
           "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
           "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
           "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
@@ -15329,7 +15329,7 @@
       ],
       "decision_matrix": [
         {
-          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationCreateResult.schema contract",
+          "choice": "Preserve the existing schema contract",
           "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
           "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
           "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
@@ -15341,7 +15341,7 @@
           "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
         },
         {
-          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationCreateResult.schema change",
+          "choice": "Defer incompatible schema change",
           "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
           "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
           "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
@@ -15498,7 +15498,7 @@
       ],
       "decision_matrix": [
         {
-          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationDetachResult.schema contract",
+          "choice": "Preserve the existing schema contract",
           "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
           "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
           "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
@@ -15510,7 +15510,7 @@
           "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
         },
         {
-          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationDetachResult.schema change",
+          "choice": "Defer incompatible schema change",
           "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
           "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
           "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
@@ -15667,7 +15667,7 @@
       ],
       "decision_matrix": [
         {
-          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationInspectResult.schema contract",
+          "choice": "Preserve the existing schema contract",
           "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
           "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
           "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
@@ -15679,7 +15679,7 @@
           "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
         },
         {
-          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationInspectResult.schema change",
+          "choice": "Defer incompatible schema change",
           "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
           "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
           "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."
@@ -15836,7 +15836,7 @@
       ],
       "decision_matrix": [
         {
-          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationManifest.schema contract",
+          "choice": "Preserve the existing schema contract",
           "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
           "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
           "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."
@@ -15848,7 +15848,7 @@
           "implications": "Update the schema, examples, consumer checks, and living specs together, then prove old and new forms remain deterministic."
         },
         {
-          "choice": "Defer incompatible interfaces/jsonschema/internalization/InternalizationManifest.schema change",
+          "choice": "Defer incompatible schema change",
           "use_when": "The proposed change alters required fields, ownership, lifecycle, error semantics, or a durable consumer promise.",
           "avoid_when": "Avoid deferral when a reversible additive change and its proof path are already clear.",
           "implications": "Open a migration decision with affected consumers, compatibility window, rollback path, and approval requirement before mutating the contract."

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -15160,7 +15160,7 @@
       ],
       "decision_matrix": [
         {
-          "choice": "Preserve the existing interfaces/jsonschema/internalization/InternalizationAttachResult.schema contract",
+          "choice": "Preserve the existing AttachResult schema contract",
           "use_when": "The current producer, consumer, and validation evidence already satisfy the requested behavior.",
           "avoid_when": "Avoid preservation when the existing contract leaves ownership, required fields, or failure behavior ambiguous.",
           "implications": "Record the current contract and proof surface without changing payload shape; the relevant guidance is: Determine exact field population and formatting required by the schema constraints."

--- a/assets/constitution.schema.json
+++ b/assets/constitution.schema.json
@@ -6,10 +6,11 @@
     "schema_version": "section-doctrine-v1",
     "uplifted_namespaces": [
       "architecture",
-      "methodology"
+      "methodology",
+      "interfaces"
     ],
-    "migration_strategy": "architecture and methodology nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
-    "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain required doctrine fields"
+    "migration_strategy": "architecture, methodology, and interfaces nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
+    "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain additive doctrine fields"
   },
   "type": "object",
   "required": [
@@ -77,6 +78,29 @@
             "properties": {
               "category": {
                 "const": "methodology"
+              }
+            },
+            "required": [
+              "category"
+            ]
+          },
+          "then": {
+            "required": [
+              "architect_notes",
+              "init_questions",
+              "decision_matrix",
+              "tradeoffs",
+              "scaffolding",
+              "spec_impacts",
+              "proof"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "category": {
+                "const": "interfaces"
               }
             },
             "required": [

--- a/tests/constitution_scaffolding.rs
+++ b/tests/constitution_scaffolding.rs
@@ -68,6 +68,34 @@ const ARCHITECTURE_DOCTRINE_FIELDS: &[&str] = &[
     "proof",
 ];
 
+const INTERFACE_NODES: &[&str] = &[
+    "interfaces/AGENT_CONTEXT_PACK",
+    "interfaces/ARCHITECTURE_FOUNDATIONS",
+    "interfaces/CLAIMS",
+    "interfaces/CONTROL_PLANE",
+    "interfaces/DEMANDS_SCHEMA",
+    "interfaces/DOC_RULES",
+    "interfaces/GLOSSARY",
+    "interfaces/INTERNALIZATION_SCHEMA",
+    "interfaces/KNOWLEDGE_SCHEMA",
+    "interfaces/KNOWLEDGE_STORE",
+    "interfaces/LCM",
+    "interfaces/MEMORY_INDEX",
+    "interfaces/MEMORY_SCHEMA",
+    "interfaces/PLAN_GOVERNED_EXECUTION",
+    "interfaces/PROCEDURAL_NORMS",
+    "interfaces/PROJECT_SPECS",
+    "interfaces/RISK_POLICY_GATE",
+    "interfaces/STORE_MODEL",
+    "interfaces/TESTING",
+    "interfaces/TODO_SCHEMA",
+    "interfaces/jsonschema/internalization/InternalizationAttachResult.schema",
+    "interfaces/jsonschema/internalization/InternalizationCreateResult.schema",
+    "interfaces/jsonschema/internalization/InternalizationDetachResult.schema",
+    "interfaces/jsonschema/internalization/InternalizationInspectResult.schema",
+    "interfaces/jsonschema/internalization/InternalizationManifest.schema",
+];
+
 const METHODOLOGY_NODES: &[&str] = &[
     "methodology/ARCHITECTURE",
     "methodology/CI_CD",
@@ -410,6 +438,66 @@ fn all_architecture_nodes_have_architect_grade_guidance() {
 }
 
 #[test]
+fn all_interface_nodes_have_architect_grade_contract_doctrine() {
+    let constitution = load_constitution_asset();
+    let nodes = constitution["nodes"].as_object().expect("nodes object");
+    let lookup = constitution["lookup"].as_object().expect("lookup object");
+
+    let actual_interface_count = nodes
+        .values()
+        .filter(|node| node["category"].as_str() == Some("interfaces"))
+        .count();
+    assert_eq!(
+        actual_interface_count,
+        INTERFACE_NODES.len(),
+        "INTERFACE_NODES test list must cover every interfaces/* node"
+    );
+
+    for node_id in INTERFACE_NODES {
+        let node = nodes
+            .get(*node_id)
+            .unwrap_or_else(|| panic!("missing interface node {node_id}"));
+        assert_eq!(
+            node["category"].as_str(),
+            Some("interfaces"),
+            "{node_id} must remain in the interfaces namespace"
+        );
+        assert_architect_grade_fields(node_id, node);
+        assert_non_empty_array(
+            &node["links"]["references"],
+            &format!("{node_id}.links.references"),
+        );
+
+        let sections = node["sections"].as_object().expect("sections object");
+        for section in [
+            "match",
+            "ambiguity",
+            "decisions",
+            "standards",
+            "failure_modes",
+            "proceed_when",
+        ] {
+            assert!(
+                sections
+                    .get(section)
+                    .and_then(|items| items.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                "{node_id}.{section} must preserve contract guidance"
+            );
+        }
+
+        assert!(
+            lookup.values().any(|entries| {
+                entries.as_array().is_some_and(|entries| {
+                    entries.iter().any(|entry| entry.as_str() == Some(node_id))
+                })
+            }),
+            "{node_id} must remain reachable through at least one lookup term"
+        );
+    }
+}
+
+#[test]
 fn all_methodology_nodes_have_architect_grade_delivery_doctrine() {
     let constitution = load_constitution_asset();
     let nodes = constitution["nodes"].as_object().expect("nodes object");
@@ -490,8 +578,8 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
     assert!(
         schema["x-doctrine_model"]["migration_strategy"]
             .as_str()
-            .is_some_and(|strategy| strategy.contains("architecture and methodology nodes")),
-        "schema must document in-place uplifted namespace migration"
+            .is_some_and(|strategy| strategy.contains("interfaces nodes")),
+        "schema must document in-place interfaces namespace migration"
     );
 
     let node_schema = &schema["definitions"]["node"];
@@ -511,6 +599,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         .iter()
         .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("methodology"))
         .expect("node schema must declare methodology doctrine conditional");
+    let interface_rule = rules
+        .iter()
+        .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("interfaces"))
+        .expect("node schema must declare interfaces doctrine conditional");
 
     let required = architecture_rule["then"]["required"]
         .as_array()
@@ -529,6 +621,16 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         assert!(
             required.iter().any(|value| value.as_str() == Some(field)),
             "methodology schema must require {field}"
+        );
+    }
+
+    let required = interface_rule["then"]["required"]
+        .as_array()
+        .expect("interfaces doctrine required fields");
+    for field in ARCHITECTURE_DOCTRINE_FIELDS {
+        assert!(
+            required.iter().any(|value| value.as_str() == Some(field)),
+            "interfaces schema must require {field}"
         );
     }
 
@@ -931,6 +1033,25 @@ fn embedded_constitution_preserves_architecture_architect_grade_fields() {
             }),
             "{node_id} must preserve doctrine decision guidance in embedded output"
         );
+    }
+}
+
+#[test]
+fn embedded_constitution_preserves_interface_contract_doctrine() {
+    for node_id in INTERFACE_NODES {
+        let output = Command::new(resolve_decapod_bin())
+            .args(["constitution", "get", node_id])
+            .output()
+            .expect("run decapod constitution get");
+        assert!(
+            output.status.success(),
+            "constitution get {node_id} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let node: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("constitution get json");
+        assert_architect_grade_fields(node_id, &node);
     }
 }
 

--- a/tests/gatling.rs
+++ b/tests/gatling.rs
@@ -200,10 +200,10 @@ fn t004_version_command_works() {
 
     let (success, output) = run(&dir, &["system", "version"]);
     assert!(success, "version command should succeed, got:\n{output}");
-    // Output contains the version number (e.g., "0.12.1")
+    let expected = format!("v{}", env!("CARGO_PKG_VERSION"));
     assert!(
-        output.contains(env!("CARGO_PKG_VERSION")),
-        "expected version string in output:\n{output}"
+        output.lines().any(|line| line.trim() == expected),
+        "expected exact version line {expected:?} in output:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Resolve #805 with a conservative, additive uplift of all 25 constitution interfaces/* nodes.
- Require architect-grade doctrine fields and preserve the existing interface sections, references, and embedded lookup contract.
- Fix the post-release Bazel regression from run 29785945131: all Rust test targets now receive Cargo.toml package metadata, and gatling requires the exact v<package-version> output.
- Refresh v0.72.3 entrypoint fingerprints, Dockerfile metadata, and living-spec attestations.

## Proof

- cargo test --test gatling -- --test-threads=4: 48 passed, 1 ignored.
- cargo test --test constitution_scaffolding: 18 passed.
- jq, cargo fmt --check, and git diff --check pass.
- Container validation: 199 gates pass; the remaining failure is two unrelated historical done TODOs whose validate_passes proofs are themselves stale/failing.

Closes #805.