### PR TITLE
Uplift data constitution doctrine for Issue #803

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.3
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.4
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.3
+ARG DECAPOD_VERSION=0.72.4
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784589559Z",
-  "repo_signal_fingerprint": "7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e",
+  "generated_at": "1784593122Z",
+  "repo_signal_fingerprint": "555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "a18e3a3cc6df87b4436399857350381a0fea6ef89c85453603b5272897d7fdf2",
-  "decapod_release": "0.72.3",
+  "spec_input_hash": "4a4157b6b6911269aa0c658b6f26e7ba86c355902ba87c3787385903759ba1ab",
+  "decapod_release": "0.72.4",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "f3f81af19bfecc21db9fc5e8103759352507eb34422153c670cd41f136230e08",
-      "content_hash": "f3f81af19bfecc21db9fc5e8103759352507eb34422153c670cd41f136230e08",
-      "fingerprint": "49bdd734de1171b7034e5f1192bc9fc6393bbad7c8063ea7134f47a7c60de304"
+      "template_hash": "fe9915ec53e060ff46223d77259145bf412ae30a26909c49730560c0721e11de",
+      "content_hash": "fe9915ec53e060ff46223d77259145bf412ae30a26909c49730560c0721e11de",
+      "fingerprint": "4b434caf0df8dda920d94a755e3307d065b85908a34346bd194779ee5861c553"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "2fe4b28c2072305d12e270f5f64d8e1d85ab9920618b14c97a99168e8127f282",
-      "content_hash": "2fe4b28c2072305d12e270f5f64d8e1d85ab9920618b14c97a99168e8127f282",
-      "fingerprint": "1c2a9d799c4d1210ba15bbf42d6fc1cd439d5cc22600510c2f3c665aceda408f"
+      "template_hash": "5dfcef4157bfcddce0660f0edd4a6613a56bf0e7ddb95248dae333af00370aac",
+      "content_hash": "5dfcef4157bfcddce0660f0edd4a6613a56bf0e7ddb95248dae333af00370aac",
+      "fingerprint": "66a67191355807bd94c13ca7e5ac747b7b587247a90123a8be3698ba8edad7d2"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "717459b238dccebc178ea1acf24eb209173f8d1486f56cefe0ac0020c680974c",
-      "content_hash": "717459b238dccebc178ea1acf24eb209173f8d1486f56cefe0ac0020c680974c",
-      "fingerprint": "3b09fe10dd5db97e74133d2e766fc2181344610b687d879e3644358637d7bdf5"
+      "template_hash": "cf2bcc87a26eb6b54f496e5b8d06116dbf771ba3d776220e37337f453a971e2b",
+      "content_hash": "cf2bcc87a26eb6b54f496e5b8d06116dbf771ba3d776220e37337f453a971e2b",
+      "fingerprint": "77f91824551875f8cf712ceaaaa25694b9f433981492be4f7cb6319094a1ec79"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "7304acc679cd6333beb66a62b08dc20f60a433e08b125da04c52382d857d595a",
-      "content_hash": "7304acc679cd6333beb66a62b08dc20f60a433e08b125da04c52382d857d595a",
-      "fingerprint": "ffa0de115baedd9ab48b1d203affb2bbb26dbd0eae43e8cd88212fef82f6a877"
+      "template_hash": "b93f89f0792d75cb43e5e66c9f398f288fa77991d4bc5c32f8333a0376b85763",
+      "content_hash": "b93f89f0792d75cb43e5e66c9f398f288fa77991d4bc5c32f8333a0376b85763",
+      "fingerprint": "481ec2e248b7e7d201a5379924dbbe2181005588b1d2a7c2df5b2495cab52abb"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "46ddcf4083c0c0db1742be221e93b287cbd14e16e5c22add21ddf6aa3888813c",
+      "content_hash": "cfc721bb25d89f2909f3d74cdd57a7738f47b3d3dc11740e68e60391d831736b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "f672d3183fc304c95fd76e0fb1de6d12ca230ecdf10ef2efa6fbd8da9a8ecdbe",
+      "content_hash": "cccdf4560de22fbcd24c99a3c25436b89d59d2f04d223534b1c793206cca1807",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "3fbfc754ded1e6e3a6cba042501eda7f4bedf5e2a05488e160a768f12c5e93dd",
+      "content_hash": "d93d07e7cab5cff88924716a729852dfcc9532df8101fb94aef3bf99b60ab08e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "0043313dd1e9ec9eb666cac2e254640a5de0ccf4e9a27d45cbdd092f6cd67b6c",
+      "content_hash": "02c20ee63d1c619b39821278d779591f85f94b8d564e4c3bf6dd709f70f9eea5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "683b2d99ac0b1bf49fa15ac338ebcba840c5fff89bd944826c53634526481215",
+      "content_hash": "4a7cb5b049368ec050d0e61368d1d911c6ea547f601ffa5be966e2be0ba4445d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "109d1cddf3e03b592eff0bad6f39064bd41bb03b3ab81543269935b89063353b",
+      "content_hash": "c03f03b1e2a8b29cd740fb6f7c17c6fa9c3e89fcc4d71c6dc2c20e0c2276ba41",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "d81fcb9c28fcab94817dc67b04444edc00803746282354d7bfb9c1277e069770",
+      "content_hash": "25fabcb3dd9e8a20309174a359d7ea8d8455419a352b02e057c273aba379f586",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "5011928d8356bcc86f58f4cbceb958fd49fae2bbddf846272ed21553d2b8c06c",
+      "content_hash": "79d2ea161cb45c4e314f43c3df57d135fb0659e1cc2236f0b6cdfc4c90d3ec70",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -10,6 +10,8 @@
 
 
 
+
+
 <!-- decapod:capability-overlay:persistent-state:start -->
 
 
@@ -405,7 +407,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -191,7 +191,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -18,6 +18,10 @@
 
 
 
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -302,7 +306,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -18,6 +18,10 @@
 
 
 
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -328,7 +332,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -18,6 +18,10 @@
 
 
 
+
+
+
+
 <!-- decapod:capability-overlay:background-processing:start -->
 
 
@@ -360,7 +364,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `7d223262d165c11c6f14b1f3bac0bf9dc12efd7e348ec728850587e128c87c6e`
+- Repository signal fingerprint: `555c5e42edbc62d8edeffe6443a5c5a18c3b3fd640acd6387515a37d7a415a63`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.3 -->
-<!-- decapod-fingerprint: 49bdd734de1171b7034e5f1192bc9fc6393bbad7c8063ea7134f47a7c60de304 -->
+<!-- decapod-release: 0.72.4 -->
+<!-- decapod-fingerprint: 4b434caf0df8dda920d94a755e3307d065b85908a34346bd194779ee5861c553 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.3 -->
-<!-- decapod-fingerprint: 1c2a9d799c4d1210ba15bbf42d6fc1cd439d5cc22600510c2f3c665aceda408f -->
+<!-- decapod-release: 0.72.4 -->
+<!-- decapod-fingerprint: 66a67191355807bd94c13ca7e5ac747b7b587247a90123a8be3698ba8edad7d2 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.3 -->
-<!-- decapod-fingerprint: ffa0de115baedd9ab48b1d203affb2bbb26dbd0eae43e8cd88212fef82f6a877 -->
+<!-- decapod-release: 0.72.4 -->
+<!-- decapod-fingerprint: 481ec2e248b7e7d201a5379924dbbe2181005588b1d2a7c2df5b2495cab52abb -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.3 -->
-<!-- decapod-fingerprint: 3b09fe10dd5db97e74133d2e766fc2181344610b687d879e3644358637d7bdf5 -->
+<!-- decapod-release: 0.72.4 -->
+<!-- decapod-fingerprint: 77f91824551875f8cf712ceaaaa25694b9f433981492be4f7cb6319094a1ec79 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -3393,7 +3393,8 @@
         ],
         "referenced_by": [
           "data/DATABASE",
-          "core/ENGINEERING_EXCELLENCE"
+          "core/ENGINEERING_EXCELLENCE",
+          "core/DATA"
         ]
       },
       "sections": {
@@ -3428,6 +3429,121 @@
         ],
         "proceed_when": [
           "Proceed when invalidation logic is explicit and the fallback path to the database is tested."
+        ]
+      },
+      "architect_notes": [
+        "Treat data/CACHING as doctrine for ephemeral acceleration around a named source of truth; every cache decision must state freshness, invalidation ownership, and the safe miss path.",
+        "A cache is an availability and latency tradeoff, not a second database. Make stale tolerance and outage behavior explicit before generating a client, key scheme, or invalidation worker.",
+        "Architect-grade caching guidance connects key design, stampede control, observability, and recovery to the backing data contract and to a measurable proof surface."
+      ],
+      "init_questions": [
+        {
+          "id": "freshness_boundary",
+          "prompt": "What is the source of truth, and how stale may a returned value be for each user-visible operation?",
+          "why": "Freshness is a product and correctness constraint; without it, TTL and invalidation choices cannot be evaluated safely.",
+          "answers": [
+            "strongly consistent",
+            "bounded stale",
+            "best effort",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "outage_behavior",
+          "prompt": "What must happen when the cache is unavailable, empty, or under stampede pressure?",
+          "why": "The fallback path determines whether a cache outage becomes a database outage, a stale response, or a visible failure.",
+          "answers": [
+            "read backing store",
+            "serve stale",
+            "fail closed",
+            "shed load",
+            "run proof"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Cache-aside with explicit invalidation",
+          "use_when": "Reads dominate and the application can name the backing store and invalidation event.",
+          "avoid_when": "A write must be observed atomically by every cache consumer with no stale window.",
+          "implications": "Document key ownership, event ordering, miss behavior, TTL jitter, and the fallback proof in architecture and interface specs."
+        },
+        {
+          "choice": "Write-through cache",
+          "use_when": "The cache layer owns writes and can commit the source of truth under one tested contract.",
+          "avoid_when": "The cache provider cannot provide the required transaction, durability, or rollback semantics.",
+          "implications": "Treat the write path as a persistence interface and prove partial failure, retry, and recovery behavior against the source of truth."
+        },
+        {
+          "choice": "Explicit stale or fail-closed policy",
+          "use_when": "A cache outage or stale read changes safety, authorization, money, or user-visible correctness.",
+          "avoid_when": "The value is disposable and the caller already owns a bounded fallback policy.",
+          "implications": "Record the policy per operation rather than applying one global cache default, then test outage and stampede behavior."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "freshness versus latency",
+          "option_a": "Use short TTLs and active invalidation for fresher reads.",
+          "option_b": "Use longer TTLs and stale reads for lower backing-store load.",
+          "guidance": "Choose from the operation's stated stale tolerance and measure hit rate, freshness violations, and fallback load together."
+        },
+        {
+          "axis": "availability versus source-of-truth load",
+          "option_a": "Serve stale or coalesce misses during cache degradation.",
+          "option_b": "Fail or shed load to protect the backing store.",
+          "guidance": "Prefer the policy that preserves the highest-priority invariant, and make the degraded path observable and reversible."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture the backing source of truth, key namespace, freshness budget, invalidation owner, outage policy, and expected cache metrics.",
+          "Record the cache contract in project specs before generating a client, worker, migration, or deployment resource."
+        ],
+        "generate": [
+          "Generate the smallest cache adapter, key policy, invalidation hook, and fallback test needed by the selected operation.",
+          "Generate TTL jitter, request coalescing, circuit breaking, and hit/miss metrics only when the workload or proof plan requires them."
+        ],
+        "defer": [
+          "Defer a cache provider, multi-tier topology, write-behind queue, and global invalidation bus until source-of-truth and freshness requirements justify them.",
+          "Do not generate cache persistence or treat cached values as durable records without an explicit data/DATABASE decision."
+        ],
+        "proof": [
+          "Exercise cache hit, miss, invalidation, expiry, backing-store fallback, provider outage, and concurrent miss behavior.",
+          "Measure freshness, hit rate, latency, eviction, and fallback load for the chosen policy or record the unmeasured gap explicitly."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record which user or operator outcome permits caching, the acceptable stale window, and the non-goals that keep the cache from becoming a source of truth.",
+          "Preserve unanswered freshness and outage questions instead of turning a performance request into an implied consistency requirement."
+        ],
+        "architecture": [
+          "Record source-of-truth ownership, cache placement, invalidation flow, failure domains, resource bounds, and adjacent data/PIPELINES or architecture/PERFORMANCE decisions.",
+          "Link the architecture decision to data/CACHING so a later agent can revise freshness, eviction, or outage policy with context."
+        ],
+        "interfaces": [
+          "Record cache key formats, invalidation events, stale/error responses, and any public freshness headers or control-plane payloads as compatibility surfaces.",
+          "Keep cache internals behind an explicit adapter; do not expose provider-specific behavior as an accidental application contract."
+        ],
+        "proof": [
+          "Map the chosen cache policy to deterministic tests for miss fallback, invalidation, stampede protection, and outage behavior.",
+          "Validation evidence must identify the command, test, metric, or explicit deferral that proves cache behavior is bounded."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The node remains discoverable through data lookup terms and links to the database and pipeline doctrines.",
+          "Structured caching guidance survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can select a cache strategy, ask for freshness, or record an explicit outage-policy deferral from data/CACHING.",
+          "Runtime tests exercise the cache adapter and backing-store fallback without requiring a daemon to remain running."
+        ],
+        "release": [
+          "Release evidence names freshness, invalidation, provider, and recovery assumptions that remain unverified.",
+          "Generated specs are refreshed when cache behavior changes state ownership, interfaces, operations, or proof expectations."
         ]
       }
     },
@@ -6188,7 +6304,8 @@
           "data/CACHING",
           "data/DATABASE",
           "core/ENGINEERING_EXCELLENCE",
-          "docs/MIGRATIONS"
+          "docs/MIGRATIONS",
+          "core/DATA"
         ]
       },
       "sections": {
@@ -6223,6 +6340,121 @@
         ],
         "proceed_when": [
           "Proceed when data lineage is tracked and privacy boundaries are explicitly maintained."
+        ]
+      },
+      "architect_notes": [
+        "Treat data/PIPELINES as doctrine for moving owned data across bounded stages; every pipeline must name its source, sink, lineage, replay unit, and deletion obligations.",
+        "Batch and streaming are delivery choices under correctness, latency, cost, and recovery constraints. Idempotency and checkpoint ownership matter more than the orchestration brand.",
+        "Architect-grade pipeline guidance keeps operational and analytical workloads separate while making schema evolution, quality gates, privacy, retention, and replay inspectable."
+      ],
+      "init_questions": [
+        {
+          "id": "pipeline_owner",
+          "prompt": "Who owns each source, transformation, output contract, and decision to replay or delete pipeline data?",
+          "why": "Named ownership prevents orphaned stages, unsafe retries, and privacy or retention decisions from being inferred by tooling.",
+          "answers": [
+            "single team",
+            "multiple teams",
+            "external owner",
+            "ask human",
+            "record gap"
+          ]
+        },
+        {
+          "id": "delivery_semantics",
+          "prompt": "Does the consumer need periodic completeness, bounded latency, or both, and what duplicate or late-data behavior is acceptable?",
+          "why": "Delivery semantics determine batch or stream shape, checkpoints, deduplication, windows, and the proof needed for recovery.",
+          "answers": [
+            "batch completeness",
+            "low latency",
+            "hybrid",
+            "exactly once not proven",
+            "defer explicitly"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Idempotent batch pipeline",
+          "use_when": "The workload values complete periodic results and can tolerate bounded processing delay.",
+          "avoid_when": "The product requires reaction within a latency budget that batch windows cannot meet.",
+          "implications": "Define a replay partition, watermark, output replacement rule, quality gate, and retention behavior in specs and tests."
+        },
+        {
+          "choice": "Checkpointed streaming pipeline",
+          "use_when": "Consumers need low-latency events and the system can own offsets, late data, and replay boundaries.",
+          "avoid_when": "The source cannot provide stable ordering or the team cannot operate the failure and backfill path.",
+          "implications": "Specify event identity, checkpoint ownership, deduplication, windowing, dead-letter handling, and a bounded replay proof."
+        },
+        {
+          "choice": "Contract-first schema evolution",
+          "use_when": "Multiple producers or consumers share a pipeline boundary or analytical dataset.",
+          "avoid_when": "The data is private to one stage and can be migrated atomically with its sole consumer.",
+          "implications": "Define compatibility, versioning, validation, ownership, and deprecation windows before changing fields or semantics."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "latency versus completeness",
+          "option_a": "Stream early with explicit late-data correction.",
+          "option_b": "Batch after a completeness watermark.",
+          "guidance": "Choose the path that matches the consumer promise and make correction, replay, and incomplete-data states visible."
+        },
+        {
+          "axis": "flexibility versus governed schemas",
+          "option_a": "Accept schema-on-read variation for exploratory consumers.",
+          "option_b": "Enforce schema-on-write at shared ingestion boundaries.",
+          "guidance": "Use stronger contracts where downstream correctness, privacy, or replay depends on stable meaning; isolate exploration from operational interfaces."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture source and sink owners, data classification, lineage, delivery semantics, replay unit, quality checks, retention, and deletion policy.",
+          "Record whether the pipeline serves OLTP, OLAP, or a deliberate boundary between them before selecting storage or orchestration."
+        ],
+        "generate": [
+          "Generate an idempotent stage boundary, schema fixture, quality checks, lineage record, and replay command for the smallest supported flow.",
+          "Generate checkpoints, deduplication, late-data handling, or backfill tooling only when the selected delivery semantics require them."
+        ],
+        "defer": [
+          "Defer orchestration vendors, warehouse topology, streaming infrastructure, and broad data platforms until ownership, workload, and recovery facts are known.",
+          "Do not move PII into analytical storage or loosen schemas without an explicit privacy, retention, and compatibility decision."
+        ],
+        "proof": [
+          "Replay the same input twice and prove idempotent output, then exercise malformed, duplicate, late, partial, and deleted records.",
+          "Verify lineage, schema compatibility, quality failures, retention deletion, and recovery from a failed stage with deterministic evidence."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the user or operator outcome, freshness promise, analytical or operational purpose, data owner, and explicit non-goals for the pipeline.",
+          "Preserve unresolved privacy, retention, completeness, and replay questions rather than inventing a delivery guarantee."
+        ],
+        "architecture": [
+          "Record stage ownership, source and sink boundaries, OLTP/OLAP separation, checkpoint or batch partition ownership, and failure recovery topology.",
+          "Link schema evolution and lifecycle choices to data/DATABASE, data/DATA_ENGINEERING, and any architecture/EVENT_DRIVEN doctrine consulted."
+        ],
+        "interfaces": [
+          "Record event or batch schemas, versioning rules, quality failure contracts, lineage metadata, replay commands, and consumer compatibility promises.",
+          "Treat producer and consumer boundaries as explicit interfaces; do not hide transformations or deletion behavior inside orchestration configuration."
+        ],
+        "proof": [
+          "Map the pipeline to replay, idempotency, quality, privacy, schema-evolution, and retention tests or explicit deferred proof gates.",
+          "Validation evidence must identify the command, fixture, artifact, or review record that proves lineage and recovery claims."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The node remains discoverable through data lookup terms and cross-links to database, caching, and data-engineering doctrine.",
+          "Structured pipeline guidance survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can choose batch, streaming, or a contract-first boundary and name the resulting proof surface from data/PIPELINES.",
+          "Runtime proof replays a representative input and makes duplicate, late, malformed, and partial-data behavior observable."
+        ],
+        "release": [
+          "Release evidence names owner, lineage, privacy, retention, compatibility, and recovery assumptions that remain unverified.",
+          "Generated specs are refreshed when pipeline changes alter state ownership, data contracts, operations, security, or validation."
         ]
       }
     },
@@ -6266,7 +6498,8 @@
           "core/ENGINEERING_EXCELLENCE",
           "docs/MIGRATIONS",
           "core/SCAFFOLDING",
-          "data/POSTGRESQL"
+          "data/POSTGRESQL",
+          "core/DATA"
         ]
       },
       "sections": {
@@ -6302,6 +6535,121 @@
         "proceed_when": [
           "Proceed when the migration is reversible and query performance impact is analyzed."
         ]
+      },
+      "architect_notes": [
+        "Treat data/DATABASE as the owner of durable state semantics: schema ownership, migration safety, constraints, transactions, query behavior, backup, restore, and data-loss risk.",
+        "A database change is a compatibility and recovery change even when the application diff is small. Name the migration owner, rollout order, rollback or roll-forward path, and retention boundary first.",
+        "Architect-grade database guidance turns consistency, performance, and recovery claims into inspectable schemas, migrations, queries, fixtures, and proof commands rather than ORM defaults."
+      ],
+      "init_questions": [
+        {
+          "id": "state_owner",
+          "prompt": "Which component owns this durable state, its schema, its migrations, and the invariant that must survive restart?",
+          "why": "A designated state owner prevents competing writers, accidental schema authority, and recovery steps that cannot be reconstructed.",
+          "answers": [
+            "this service",
+            "shared service",
+            "external owner",
+            "ask human",
+            "record gap"
+          ]
+        },
+        {
+          "id": "migration_recovery",
+          "prompt": "How will the change roll forward, recover from partial application, restore data, and retire old schema versions?",
+          "why": "Migration safety depends on operational recovery and compatibility windows, not only whether the new SQL parses.",
+          "answers": [
+            "expand contract",
+            "transactional",
+            "roll forward",
+            "restore backup",
+            "defer explicitly"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Expand-contract migration",
+          "use_when": "A live reader or writer must coexist with a changed schema or a large table needs a staged rollout.",
+          "avoid_when": "The store is disposable and can be recreated atomically with no compatibility or recovery obligation.",
+          "implications": "Add compatible columns or tables, dual-read or dual-write only when justified, backfill, switch ownership, and prove cleanup and rollback."
+        },
+        {
+          "choice": "Database-enforced invariant",
+          "use_when": "Uniqueness, referential integrity, valid ranges, or atomic state transitions must survive multiple callers.",
+          "avoid_when": "The rule is a transient presentation concern that cannot be represented durably in the store.",
+          "implications": "Use constraints and transactions as the durable contract, map violations to an explicit interface error, and test concurrent behavior."
+        },
+        {
+          "choice": "Evidence-led indexing",
+          "use_when": "A measured query path has a latency or workload requirement and the access pattern is stable enough to optimize.",
+          "avoid_when": "The index is speculative, duplicates an existing path, or its write and storage cost is unmeasured.",
+          "implications": "Record query evidence, migration cost, selectivity, rollback, and post-release monitoring before adding or removing an index."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "consistency versus availability",
+          "option_a": "Use stronger transactions and constraints for authoritative writes.",
+          "option_b": "Accept eventual reads or asynchronous repair for higher availability.",
+          "guidance": "Choose per invariant and operation; do not let an availability preference silently weaken a data-integrity contract."
+        },
+        {
+          "axis": "read performance versus write cost",
+          "option_a": "Add targeted indexes, denormalization, or read models.",
+          "option_b": "Keep the write schema lean and optimize queries or pagination first.",
+          "guidance": "Use query plans and workload evidence, then include index build, storage, write amplification, and rollback in the proof plan."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture state ownership, schema authority, invariants, transaction boundaries, consistency requirements, retention, backup, restore, and migration ownership.",
+          "Record the query or workload evidence that justifies indexes, pagination, denormalization, isolation, or replication choices."
+        ],
+        "generate": [
+          "Generate version-controlled migrations, constraints, seed fixtures, a repository boundary, and a deterministic migration or rollback proof command.",
+          "Generate query plans, pagination, concurrency tests, backup fixtures, or restore checks only where the selected risk requires them."
+        ],
+        "defer": [
+          "Defer sharding, replication topology, ORM replacement, vendor-specific extensions, and irreversible data movement until scale and recovery evidence justify them.",
+          "Do not call a destructive migration reversible when the old data shape or a tested restore path is not retained."
+        ],
+        "proof": [
+          "Apply migrations to a clean store and a representative prior snapshot, exercise rollback or roll-forward recovery, and verify constraints and data counts.",
+          "Measure representative query plans, pagination, concurrency, backup, restore, and retention behavior or record the bounded proof gap."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the durable state, user-visible correctness promise, retention or deletion requirement, and non-goals for the database change.",
+          "Preserve unresolved ownership, consistency, performance, backup, and recovery questions instead of inferring them from a model or migration tool."
+        ],
+        "architecture": [
+          "Record state ownership, storage boundary, transaction and consistency model, migration rollout, query workload, backup, restore, and retention posture.",
+          "Link concrete engine choices to data/POSTGRESQL or another engine doctrine, and link pipeline or cache consumers to data/PIPELINES and data/CACHING."
+        ],
+        "interfaces": [
+          "Record database schemas, migration versions, constraint errors, repository boundaries, pagination contracts, and compatibility windows that other components consume.",
+          "Keep generated ORM metadata subordinate to the version-controlled schema and migration contract."
+        ],
+        "proof": [
+          "Map the migration and persistence decision to schema, clean-apply, upgrade, recovery, query, concurrency, backup, and restore evidence.",
+          "Validation evidence must identify the command, fixture, database artifact, or explicit blocker supporting each data-loss and rollback claim."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The node remains discoverable through data lookup terms and cross-links to caching, pipelines, migrations, and the PostgreSQL doctrine.",
+          "Structured database guidance survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can select a migration, invariant, or indexing path and name its recovery proof from data/DATABASE.",
+          "Runtime proof applies the schema to a clean and prior state, then exercises the changed invariant and recovery path."
+        ],
+        "release": [
+          "Release evidence names state owner, migration compatibility, backup, restore, retention, and performance assumptions that remain unverified.",
+          "Generated specs are refreshed when database changes alter state ownership, interfaces, operations, security, semantics, or validation."
+        ]
       }
     },
     "data/POSTGRESQL": {
@@ -6335,7 +6683,8 @@
         "referenced_by": [
           "core/SCAFFOLDING",
           "core/ARCHITECTURE",
-          "data/DATABASE"
+          "data/DATABASE",
+          "core/DATA"
         ]
       },
       "sections": {
@@ -6349,6 +6698,10 @@
         ],
         "ambiguity": [
           "Stop if ownership of migrations, seed data, connection configuration, backup expectations, or local test database strategy is unknown."
+        ],
+        "decisions": [
+          "Choose migration-first, ORM-assisted, or SQL-first access only after naming schema ownership and the required proof path.",
+          "Choose pooling, isolation, indexing, and extension posture from workload evidence and recovery constraints rather than framework defaults."
         ],
         "standards": [
           "Generate reversible migrations when the migration tool supports them.",
@@ -21219,6 +21572,8 @@
           "data/DATABASE",
           "data/CACHING",
           "data/PIPELINES",
+          "data/POSTGRESQL",
+          "data/DATA_ENGINEERING",
           "architecture/DISTRIBUTED_SYSTEMS"
         ],
         "referenced_by": [
@@ -21236,6 +21591,8 @@
           "databases, tables, schema, queries -> data/DATABASE.",
           "redis, memcached, ephemeral state -> data/CACHING.",
           "ETL, streaming, data lineage -> data/PIPELINES.",
+          "PostgreSQL, SQL migrations, connection pools -> data/POSTGRESQL.",
+          "warehouses, lineage, quality, retention, analytical data -> data/DATA_ENGINEERING.",
           "partitions, consistency, consensus -> architecture/DISTRIBUTED_SYSTEMS."
         ],
         "apply": [
@@ -21401,7 +21758,8 @@
         ],
         "referenced_by": [
           "core/ENGINEERING_EXCELLENCE",
-          "data/PIPELINES"
+          "data/PIPELINES",
+          "core/DATA"
         ]
       },
       "sections": {
@@ -21434,6 +21792,121 @@
         ],
         "proceed_when": [
           "Proceed when the data lineage is tracked and quality checks are instrumented."
+        ]
+      },
+      "architect_notes": [
+        "Treat data/DATA_ENGINEERING as doctrine for governed analytical movement: lineage, quality, privacy, retention, ownership, and separation from operational workloads are first-class architecture decisions.",
+        "A pipeline is a recoverable data product, not merely a DAG. Its schema, quality gates, replay boundary, and deletion behavior must be inspectable by the next maintainer.",
+        "Architect-grade data-engineering guidance chooses the smallest reliable boundary and makes analytical correctness, privacy, and operational recovery measurable before platform expansion."
+      ],
+      "init_questions": [
+        {
+          "id": "data_product_owner",
+          "prompt": "Who is accountable for the meaning, quality, privacy classification, retention, and consumer contract of this data product?",
+          "why": "Data ownership is required to resolve schema changes, quality failures, deletion requests, and disagreements about correctness.",
+          "answers": [
+            "producer team",
+            "consumer team",
+            "shared steward",
+            "external owner",
+            "ask human"
+          ]
+        },
+        {
+          "id": "analytical_boundary",
+          "prompt": "Which data must remain operational, which may enter analytical storage, and what masking or tokenization is required?",
+          "why": "The OLTP and OLAP boundary controls privacy exposure, workload isolation, retention, and the shape of quality proof.",
+          "answers": [
+            "operational only",
+            "analytical copy",
+            "masked analytical copy",
+            "unknown classification",
+            "defer explicitly"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Governed analytical copy",
+          "use_when": "Consumers need analytical workloads without competing with the operational source of truth.",
+          "avoid_when": "The copy would duplicate sensitive data without an owner, retention policy, lineage, or consumer need.",
+          "implications": "Define transformation ownership, masking, freshness, quality thresholds, deletion propagation, and the source-to-report lineage."
+        },
+        {
+          "choice": "Quality gates at stage boundaries",
+          "use_when": "A malformed schema, null, range, uniqueness, or business-rule failure could corrupt downstream decisions.",
+          "avoid_when": "The stage is exploratory and its consumers explicitly accept unvalidated data.",
+          "implications": "Make failed records, quarantine, alerting, retry, and promotion behavior explicit; do not silently drop evidence."
+        },
+        {
+          "choice": "Replayable transformation contract",
+          "use_when": "Historical correction, backfill, audit, or recovery requires rebuilding outputs from retained inputs.",
+          "avoid_when": "Inputs are intentionally ephemeral and no downstream result is retained as authoritative.",
+          "implications": "Version transformation logic, retain the replay unit and lineage, and prove deterministic or explicitly reconciled output."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "analytical flexibility versus governance",
+          "option_a": "Permit schema-on-read exploration over isolated data.",
+          "option_b": "Enforce curated schema, quality, and ownership at publication.",
+          "guidance": "Keep experimentation away from trusted operational or published analytical contracts, then promote only reviewed meanings."
+        },
+        {
+          "axis": "retention value versus privacy and cost",
+          "option_a": "Retain inputs for audit, replay, and historical analysis.",
+          "option_b": "Delete or minimize data after the stated business and legal need.",
+          "guidance": "Choose a documented retention schedule with deletion propagation, access controls, storage cost, and recovery consequences."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture the data product owner, source, consumers, classification, lineage, freshness, quality thresholds, retention, deletion, and analytical/operational boundary.",
+          "Record the replay unit, transformation versioning, quarantine behavior, and escalation owner before generating platform-specific pipeline resources."
+        ],
+        "generate": [
+          "Generate a small transformation contract, lineage record, quality fixture, privacy test, retention check, and replay command for the first data product.",
+          "Generate separate analytical storage or orchestration resources only when workload isolation and ownership evidence require them."
+        ],
+        "defer": [
+          "Defer data lake, warehouse, streaming platform, catalog, and governance-vendor choices until the data product boundary and proof needs are known.",
+          "Do not copy PII or PHI into analytical environments, or retain raw inputs indefinitely, without an explicit classification and deletion decision."
+        ],
+        "proof": [
+          "Trace a representative record from source through transformations to a consumer, including lineage, quality failure, masking, and deletion behavior.",
+          "Replay retained inputs after a transformation change and verify outputs, ownership, freshness, and privacy evidence remain explainable."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the data product outcome, consumers, analytical or operational purpose, classification, retention requirement, and explicit non-goals.",
+          "Preserve unresolved owner, privacy, quality, lineage, and recovery questions instead of treating a data platform request as a complete requirement."
+        ],
+        "architecture": [
+          "Record source and analytical boundaries, workload isolation, transformation ownership, lineage, replay, retention, deletion, and quality-gate placement.",
+          "Link transactional source decisions to data/DATABASE and stage delivery decisions to data/PIPELINES so ownership does not split silently."
+        ],
+        "interfaces": [
+          "Record published schemas, lineage identifiers, quality failure contracts, masking guarantees, freshness promises, retention signals, and replay commands.",
+          "Keep data catalog or orchestration metadata from becoming an implicit source of truth; the durable contract belongs in versioned specs and schemas."
+        ],
+        "proof": [
+          "Map the data product to lineage, quality, privacy, retention, replay, and consumer-contract evidence before claiming it is production-ready.",
+          "Validation evidence must identify the fixture, transformation, command, report, or explicit blocker supporting each governance claim."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The node remains discoverable through data lookup terms and cross-links to pipeline and database doctrine.",
+          "Structured data-engineering guidance survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can select an analytical boundary, quality gate, or replay contract and name its proof surface from data/DATA_ENGINEERING.",
+          "Runtime proof traces a record through the pipeline and exercises a quality failure, masking, deletion, or replay path."
+        ],
+        "release": [
+          "Release evidence names ownership, classification, retention, lineage, freshness, and recovery assumptions that remain unverified.",
+          "Generated specs are refreshed when data-engineering changes alter state ownership, interfaces, operations, security, semantics, or validation."
         ]
       }
     },

--- a/assets/constitution.schema.json
+++ b/assets/constitution.schema.json
@@ -7,9 +7,10 @@
     "uplifted_namespaces": [
       "architecture",
       "methodology",
-      "interfaces"
+      "interfaces",
+      "data"
     ],
-    "migration_strategy": "architecture, methodology, and interfaces nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
+    "migration_strategy": "architecture, methodology, interfaces nodes, and data nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
     "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain additive doctrine fields"
   },
   "type": "object",
@@ -101,6 +102,29 @@
             "properties": {
               "category": {
                 "const": "interfaces"
+              }
+            },
+            "required": [
+              "category"
+            ]
+          },
+          "then": {
+            "required": [
+              "architect_notes",
+              "init_questions",
+              "decision_matrix",
+              "tradeoffs",
+              "scaffolding",
+              "spec_impacts",
+              "proof"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "category": {
+                "const": "data"
               }
             },
             "required": [

--- a/tests/constitution_scaffolding.rs
+++ b/tests/constitution_scaffolding.rs
@@ -96,6 +96,14 @@ const INTERFACE_NODES: &[&str] = &[
     "interfaces/jsonschema/internalization/InternalizationManifest.schema",
 ];
 
+const DATA_NODES: &[&str] = &[
+    "data/CACHING",
+    "data/DATABASE",
+    "data/DATA_ENGINEERING",
+    "data/PIPELINES",
+    "data/POSTGRESQL",
+];
+
 const METHODOLOGY_NODES: &[&str] = &[
     "methodology/ARCHITECTURE",
     "methodology/CI_CD",
@@ -498,6 +506,82 @@ fn all_interface_nodes_have_architect_grade_contract_doctrine() {
 }
 
 #[test]
+fn all_data_nodes_have_architect_grade_persistence_and_pipeline_doctrine() {
+    let constitution = load_constitution_asset();
+    let nodes = constitution["nodes"].as_object().expect("nodes object");
+    let lookup = constitution["lookup"].as_object().expect("lookup object");
+
+    let actual_data_count = nodes
+        .values()
+        .filter(|node| node["category"].as_str() == Some("data"))
+        .count();
+    assert_eq!(
+        actual_data_count,
+        DATA_NODES.len(),
+        "DATA_NODES test list must cover every data/* node"
+    );
+
+    let core_refs = nodes["core/DATA"]["links"]["references"]
+        .as_array()
+        .expect("core data references");
+
+    for node_id in DATA_NODES {
+        let node = nodes
+            .get(*node_id)
+            .unwrap_or_else(|| panic!("missing data node {node_id}"));
+        assert_eq!(
+            node["category"].as_str(),
+            Some("data"),
+            "{node_id} must remain in the data namespace"
+        );
+        assert_architect_grade_fields(node_id, node);
+        assert_non_empty_array(
+            &node["links"]["references"],
+            &format!("{node_id}.links.references"),
+        );
+        assert!(
+            node["links"]["referenced_by"]
+                .as_array()
+                .is_some_and(|refs| refs.iter().any(|value| value.as_str() == Some("core/DATA"))),
+            "{node_id} must be reachable from core/DATA"
+        );
+        assert!(
+            core_refs
+                .iter()
+                .any(|value| value.as_str() == Some(node_id)),
+            "core/DATA must route to {node_id}"
+        );
+
+        let sections = node["sections"].as_object().expect("sections object");
+        for section in [
+            "match",
+            "ambiguity",
+            "decisions",
+            "standards",
+            "failure_modes",
+            "proceed_when",
+        ] {
+            assert!(
+                sections
+                    .get(section)
+                    .and_then(|items| items.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                "{node_id}.{section} must preserve data guidance"
+            );
+        }
+
+        assert!(
+            lookup.values().any(|entries| {
+                entries.as_array().is_some_and(|entries| {
+                    entries.iter().any(|entry| entry.as_str() == Some(node_id))
+                })
+            }),
+            "{node_id} must remain reachable through at least one lookup term"
+        );
+    }
+}
+
+#[test]
 fn all_methodology_nodes_have_architect_grade_delivery_doctrine() {
     let constitution = load_constitution_asset();
     let nodes = constitution["nodes"].as_object().expect("nodes object");
@@ -578,8 +662,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
     assert!(
         schema["x-doctrine_model"]["migration_strategy"]
             .as_str()
-            .is_some_and(|strategy| strategy.contains("interfaces nodes")),
-        "schema must document in-place interfaces namespace migration"
+            .is_some_and(|strategy| {
+                strategy.contains("interfaces nodes") && strategy.contains("data nodes")
+            }),
+        "schema must document in-place interfaces and data namespace migration"
     );
 
     let node_schema = &schema["definitions"]["node"];
@@ -603,6 +689,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         .iter()
         .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("interfaces"))
         .expect("node schema must declare interfaces doctrine conditional");
+    let data_rule = rules
+        .iter()
+        .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("data"))
+        .expect("node schema must declare data doctrine conditional");
 
     let required = architecture_rule["then"]["required"]
         .as_array()
@@ -631,6 +721,16 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         assert!(
             required.iter().any(|value| value.as_str() == Some(field)),
             "interfaces schema must require {field}"
+        );
+    }
+
+    let required = data_rule["then"]["required"]
+        .as_array()
+        .expect("data doctrine required fields");
+    for field in ARCHITECTURE_DOCTRINE_FIELDS {
+        assert!(
+            required.iter().any(|value| value.as_str() == Some(field)),
+            "data schema must require {field}"
         );
     }
 
@@ -1052,6 +1152,31 @@ fn embedded_constitution_preserves_interface_contract_doctrine() {
         let node: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("constitution get json");
         assert_architect_grade_fields(node_id, &node);
+    }
+}
+
+#[test]
+fn embedded_constitution_preserves_data_doctrine() {
+    for node_id in DATA_NODES {
+        let output = Command::new(resolve_decapod_bin())
+            .args(["constitution", "get", node_id])
+            .output()
+            .expect("run decapod constitution get");
+        assert!(
+            output.status.success(),
+            "constitution get {node_id} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let node: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("constitution get json");
+        assert_architect_grade_fields(node_id, &node);
+        assert!(
+            node["links"]["references"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty()),
+            "{node_id} must preserve data cross-links in embedded output"
+        );
     }
 }
 

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -51,6 +51,12 @@ fn assets_docs_and_templates_resolve() {
 fn scaffold_specs_are_fresh_project_only() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
+    fs::create_dir_all(root.join(".decapod")).expect("create project config dir");
+    fs::write(
+        root.join(".decapod/config.toml"),
+        "schema_version = \"1.0.0\"\n\n[init]\nspecs = true\ndiagram_style = \"mermaid\"\nentrypoints = []\n\n[repo]\nproduct_name = \"fixture\"\n",
+    )
+    .expect("write project config");
     fs::create_dir_all(root.join(".decapod/generated/specs")).expect("create specs dir");
 
     let initial_seed = SpecsSeed {


### PR DESCRIPTION
## Summary

- Uplift data/CACHING, data/DATABASE, data/PIPELINES, and data/DATA_ENGINEERING with architect-grade persistence and pipeline doctrine.
- Include data/POSTGRESQL in the enforced data namespace and route all five nodes from core/DATA.
- Extend schema, embedded-output, lookup, cross-link, and doctrine regression coverage.
- Refresh governed generated specs and release-bound fingerprints.
- Fix the specs-refresh test fixture so it supplies the required project config.

## Verification

- cargo test --test constitution_scaffolding
- cargo fmt --all -- --check
- Container decapod validate --format json: 200 gates passed.
- cargo test --all-targets reaches unrelated pre-existing projection-consistency failures outside this PR.

Closes #803