### PR TITLE
Uplift metadata constitution doctrine for Issue #806

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.4
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.6
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.4
+ARG DECAPOD_VERSION=0.72.6
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784595539Z",
-  "repo_signal_fingerprint": "28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419",
+  "generated_at": "1784596843Z",
+  "repo_signal_fingerprint": "2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "7d891a53a3c2692cde9c5cc75f96f394f38554e014997f2dd21f359bf0be89f9",
-  "decapod_release": "0.72.5",
+  "spec_input_hash": "a15db84c0b4cea38d9dbce4f95667515f7e8a64543eaf0c8c16530d20acdd1a8",
+  "decapod_release": "0.72.6",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "e9baf976580a19b9639b5912bb45bcbea3190d9a3a68bd29ba06ddc2706d2c53",
-      "content_hash": "e9baf976580a19b9639b5912bb45bcbea3190d9a3a68bd29ba06ddc2706d2c53",
-      "fingerprint": "75a3dc2f04c658e0b4397950731c6fdadfc3c78080980619337afccb50e579c0"
+      "template_hash": "129f9b1afcb95a391f72cc3fa3900ef743167c5012075d799a7827ee77336174",
+      "content_hash": "129f9b1afcb95a391f72cc3fa3900ef743167c5012075d799a7827ee77336174",
+      "fingerprint": "e9897afcd2e4eb609f8843c25bfc67b5a004afaa6d16b0c5e5ac3c0e722722f5"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "a8c970a79160feeaab44ebba6a106c955f5c5922399f057fb3d20fe00301e4d1",
-      "content_hash": "a8c970a79160feeaab44ebba6a106c955f5c5922399f057fb3d20fe00301e4d1",
-      "fingerprint": "50e8e5fc7d98ed0b108cbaf8b41a6d848a3e8249424715d9ef116c1476b9a833"
+      "template_hash": "e54945ebebd4eeb139a3cfd567f04cd9af88f3227ff62d2e36001bb8422d9f1e",
+      "content_hash": "e54945ebebd4eeb139a3cfd567f04cd9af88f3227ff62d2e36001bb8422d9f1e",
+      "fingerprint": "8ed76b172fd2aac1c95366eb177ff9cbc02a02e5c9d0f05a8f97feab0d3ae509"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "6147436b3edd8658c458ea166171b95678717bd8cf502215b21c617106d0eecd",
-      "content_hash": "6147436b3edd8658c458ea166171b95678717bd8cf502215b21c617106d0eecd",
-      "fingerprint": "202dd8b6d0e1496f8fb5f8791fbe033c1a7dbf0757227c477730a23292dd0c05"
+      "template_hash": "b427cbb127fa5d1b095465c9b237517ae086b006e9c20a246a537db6f6ac72ed",
+      "content_hash": "b427cbb127fa5d1b095465c9b237517ae086b006e9c20a246a537db6f6ac72ed",
+      "fingerprint": "fb8760c0f8fac013c6f4d628f4a63ae77c88e9330361976010184ed9824e0c5b"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "070c3d78f4dd8d5bf14ea6ce6ee9d048372432bfa036b13a1c558cfda87402ef",
-      "content_hash": "070c3d78f4dd8d5bf14ea6ce6ee9d048372432bfa036b13a1c558cfda87402ef",
-      "fingerprint": "4d5172c41d6bfea1b46c2762b680f0ca0d1e6facc938815045dfc9af9bc0f9a0"
+      "template_hash": "90e639174a5444cde8669f0c635b62d329543cdb5ed4a4a905da9d4b91513f45",
+      "content_hash": "90e639174a5444cde8669f0c635b62d329543cdb5ed4a4a905da9d4b91513f45",
+      "fingerprint": "0f509c04ae38d89d1c8f05a264fdad03b973800eb9d9bf24ccc57bc450e73105"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "eafd8d9f59b34ebaaffc55d6e51b46eb5dbf7f00271d4c3cf222d19edffca0dc",
+      "content_hash": "61fc0dd7036a0adaa46d6addeeec5425784875b620bca2722c00fb851f15e077",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "2280a3daf6e56ce2692fce4ff09186092eaf067cb3e3916d398df6933d3b3f13",
+      "content_hash": "826cb4d44662238806ced2de31d92e143781173bdd2cdb436ccf9fed66f49f3d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "749f33c434ef029ee11f07c0308c6aed593b06829347f191c0d2311534a9bd29",
+      "content_hash": "dc81020dfe467ab0fad2685aed03cdfb131ee704dbb71e36343dc36579550bde",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "d1ac72a0ab609844b30a3f4231737382f9d9735d78c1ec725009e4a876cc283b",
+      "content_hash": "9fe0595e00598c267442d524218ac14b9aaa869c15aa2e5e02aab5be6c71f5dc",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "3f3117f1fc2fd3f749346d958adecfe7dc758cab3432832844afc48248bb9c7c",
+      "content_hash": "4001770635451b48ed8645a7017060b361190af66ca21811b5799bc8995c709b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "50b0f67dc6c1e110012b3f76226022b779ab4fe1c49ecde7accc92ab5e4a3b90",
+      "content_hash": "a10fbf0e575dc444dbc052b9c6713b6079554927f5ef2e10e01f801ee392e837",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "c54ad6a7ad1d9bba798cf2aa8bd647b9e7257beb17645bef43998f2b1d41ea34",
+      "content_hash": "401f4c6535fea8a5ca802b21392afbb8cb019164168ab52530e1303b0b95196d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "fa30a76c9e16a8edab30f996c91d6f04cf72aab32c00fb88c8b5d3b16e72510c",
+      "content_hash": "dd745c10ea95ffe6c430a7aaa68c668defd16bbaeed1a5b339876bedaff8300b",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,4 +1,6 @@
-# Operations
+# Operations## Capability Operations
+
+Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -36,10 +38,6 @@
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Capability Operations
-
-Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.
 
 ## Operational Readiness Checklist
 - [ ] On-call ownership defined (local development tool — typically self-serve)
@@ -280,7 +278,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -1,46 +1,4 @@
-# Semantics
-
-<!-- decapod:capability-overlay:background-processing:start -->
-
-## Background Processing Semantics Overlay
-
-### Retry Semantics
-- Retry and backoff behavior MUST be selected and documented for each work class
-- Poison-work handling MUST be selected and documented for each work class
-- Retry MUST preserve the declared side-effect and idempotency semantics
-
-### Idempotency
-- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
-- Deduplication or compensation mechanisms are project decisions and require proof
-- Duplicate execution MUST follow the job's declared duplicate-handling semantics
-
-### Poison Message Handling
-- Messages failing after max retries go to dead letter queue
-- DLQ MUST be monitored and alerted
-- Manual replay capability for DLQ messages
-<!-- decapod:capability-overlay:background-processing:end -->
-
-<!-- decapod:capability-overlay:persistent-state:start -->
-
-## Persistent State Semantics Overlay
-
-### Transaction Semantics
-- All multi-entity operations MUST be atomic
-- Read-after-write consistency within transaction boundaries
-- Eventual consistency windows MUST be documented
-
-### Migration Semantics
-- Schema migrations MUST be backward-compatible
-- Migration rollback procedures MUST be documented
-- Data integrity checks post-migration
-
-### Recovery Semantics
-- Point-in-time recovery capability
-- Recovery objectives MUST be selected for the project and recorded as proof obligations
-- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
-<!-- decapod:capability-overlay:persistent-state:end -->
-
-## State Machines
+# Semantics## State Machines
 
 ### Workspace State
 ```mermaid
@@ -128,6 +86,46 @@ stateDiagram-v2
     Active --> Expired: no heartbeat > 30min
     Expired --> [*]: cleanup
 ```
+
+<!-- decapod:capability-overlay:background-processing:start -->
+
+## Background Processing Semantics Overlay
+
+### Retry Semantics
+- Retry and backoff behavior MUST be selected and documented for each work class
+- Poison-work handling MUST be selected and documented for each work class
+- Retry MUST preserve the declared side-effect and idempotency semantics
+
+### Idempotency
+- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
+- Deduplication or compensation mechanisms are project decisions and require proof
+- Duplicate execution MUST follow the job's declared duplicate-handling semantics
+
+### Poison Message Handling
+- Messages failing after max retries go to dead letter queue
+- DLQ MUST be monitored and alerted
+- Manual replay capability for DLQ messages
+<!-- decapod:capability-overlay:background-processing:end -->
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+## Persistent State Semantics Overlay
+
+### Transaction Semantics
+- All multi-entity operations MUST be atomic
+- Read-after-write consistency within transaction boundaries
+- Eventual consistency windows MUST be documented
+
+### Migration Semantics
+- Schema migrations MUST be backward-compatible
+- Migration rollback procedures MUST be documented
+- Data integrity checks post-migration
+
+### Recovery Semantics
+- Point-in-time recovery capability
+- Recovery objectives MUST be selected for the project and recorded as proof obligations
+- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
+<!-- decapod:capability-overlay:persistent-state:end -->
 
 ## Invariants
 
@@ -306,7 +304,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -1,4 +1,6 @@
-# Validation
+# Validation## Capability Proof Requirements
+
+When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -39,10 +41,6 @@
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Capability Proof Requirements
-
-When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.
 
 ## Validation Philosophy
 > Validation is a release gate, not documentation theater.
@@ -338,7 +336,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `28cd9ff0be0f7e489448c616bd79bd32f020e520263d0e2fcb9ff84f8d9ae419`
+- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.5 -->
-<!-- decapod-fingerprint: 75a3dc2f04c658e0b4397950731c6fdadfc3c78080980619337afccb50e579c0 -->
+<!-- decapod-release: 0.72.6 -->
+<!-- decapod-fingerprint: e9897afcd2e4eb609f8843c25bfc67b5a004afaa6d16b0c5e5ac3c0e722722f5 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.5 -->
-<!-- decapod-fingerprint: 50e8e5fc7d98ed0b108cbaf8b41a6d848a3e8249424715d9ef116c1476b9a833 -->
+<!-- decapod-release: 0.72.6 -->
+<!-- decapod-fingerprint: 8ed76b172fd2aac1c95366eb177ff9cbc02a02e5c9d0f05a8f97feab0d3ae509 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.5 -->
-<!-- decapod-fingerprint: 4d5172c41d6bfea1b46c2762b680f0ca0d1e6facc938815045dfc9af9bc0f9a0 -->
+<!-- decapod-release: 0.72.6 -->
+<!-- decapod-fingerprint: 0f509c04ae38d89d1c8f05a264fdad03b973800eb9d9bf24ccc57bc450e73105 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.5 -->
-<!-- decapod-fingerprint: 202dd8b6d0e1496f8fb5f8791fbe033c1a7dbf0757227c477730a23292dd0c05 -->
+<!-- decapod-release: 0.72.6 -->
+<!-- decapod-fingerprint: fb8760c0f8fac013c6f4d628f4a63ae77c88e9330361976010184ed9824e0c5b -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -16283,9 +16283,14 @@
         "invocation"
       ],
       "links": {
-        "references": [],
+        "references": [
+          "specs/skills/SKILL_GOVERNANCE",
+          "metadata/skills/AGENT_DECAPOD_INTERFACE",
+          "interfaces/KNOWLEDGE_SCHEMA"
+        ],
         "referenced_by": [
-          "docs/SKILL_TRANSLATION_MAP"
+          "docs/SKILL_TRANSLATION_MAP",
+          "core/METADATA"
         ]
       },
       "sections": {
@@ -16315,6 +16320,121 @@
         "proceed_when": [
           "Proceed when the skill bundle is correctly categorized and dependencies are resolved."
         ]
+      },
+      "architect_notes": [
+        "Treat metadata/skills/BUNDLE as a discovery and dependency contract, not as permission to load every skill in a category. A bundle owns its purpose, membership, prerequisites, authority, and lifecycle.",
+        "Bundle metadata should remain stable enough for retrieval while versioning the dependency and invocation assumptions that can change agent behavior.",
+        "Architect-grade bundle guidance makes selection, dependency resolution, and proof of relevance explicit so a focused task does not inherit unrelated context or hidden mutations."
+      ],
+      "init_questions": [
+        {
+          "id": "bundle_boundary",
+          "prompt": "What capability family does this bundle own, and which skills are intentionally outside its retrieval boundary?",
+          "why": "A named boundary prevents god bundles and makes future lookup behavior predictable for agents and reviewers.",
+          "answers": [
+            "one capability family",
+            "cross-cutting workflow",
+            "migration bundle",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "dependency_proof",
+          "prompt": "Which prerequisites, versions, authority rules, and compatibility checks must pass before the bundle can be invoked?",
+          "why": "Dependencies are part of bundle correctness; missing or circular prerequisites can produce unsafe or incomplete agent behavior.",
+          "answers": [
+            "manifest check",
+            "schema check",
+            "skill lookup",
+            "human approval",
+            "run proof"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Extend an existing bundle",
+          "use_when": "The new skill serves the existing capability family and shares its lifecycle, authority, and dependency contract.",
+          "avoid_when": "The skill changes risk, ownership, invocation order, or retrieval scope enough to surprise current consumers.",
+          "implications": "Update the manifest, lookup terms, dependency proof, and affected specs together; preserve the existing bundle's stable identifiers."
+        },
+        {
+          "choice": "Create a focused bundle",
+          "use_when": "The skill group has a distinct user outcome, owner, authority boundary, or dependency graph.",
+          "avoid_when": "The split only reflects naming preference and would duplicate retrieval context or lifecycle rules.",
+          "implications": "Define purpose, members, prerequisites, exclusions, version policy, and a proof that selection avoids irrelevant skills."
+        },
+        {
+          "choice": "Defer bundle invocation",
+          "use_when": "Membership, dependency version, authority, or required capability is not verified.",
+          "avoid_when": "The bundle is already explicit, bounded, and has a deterministic local proof path.",
+          "implications": "Record the missing metadata and stop selection rather than treating labels or descriptions as execution authority."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "bundle breadth versus retrieval precision",
+          "option_a": "Group related skills for convenient discovery.",
+          "option_b": "Keep bundles narrow and compose them explicitly.",
+          "guidance": "Prefer the smallest bundle that changes the next action; compose only when the dependency and proof path are visible."
+        },
+        {
+          "axis": "stable identifiers versus evolving membership",
+          "option_a": "Preserve bundle identity while versioning membership.",
+          "option_b": "Create a new bundle when membership semantics change.",
+          "guidance": "Use compatibility and authority impact, not file count, to decide whether a bundle can evolve in place."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture the bundle owner, purpose, member skills, exclusions, dependency graph, authority tier, version policy, and invocation trigger.",
+          "Record the lookup terms and proof artifact that demonstrate the bundle is relevant to the intended task."
+        ],
+        "generate": [
+          "Generate a manifest with stable identity, purpose, members, prerequisites, compatibility notes, and deterministic lookup terms.",
+          "Generate dependency and selection tests before adding optional skills, automatic composition, or broad retrieval aliases."
+        ],
+        "defer": [
+          "Defer automatic bundle composition, transitive loading, and provider-specific metadata until ownership and dependency semantics are proven.",
+          "Do not let a bundle manifest authorize control-plane mutations, network access, or high-risk actions."
+        ],
+        "proof": [
+          "Resolve the bundle from representative queries and prove required members, exclusions, dependency order, and missing-prerequisite behavior.",
+          "Repeat lookup and manifest compilation from a clean workspace to prove stable output and detect stale references."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the user outcome and capability family that justify the bundle, along with explicit non-goals for unrelated skills or workflows.",
+          "Preserve unresolved membership and dependency questions rather than inferring a broad bundle from similar names."
+        ],
+        "architecture": [
+          "Record bundle ownership, retrieval boundary, lifecycle, dependency graph, authority tier, and version compatibility.",
+          "Link bundle architecture to the concrete skill and control-plane or governance doctrine that owns invocation behavior."
+        ],
+        "interfaces": [
+          "Record manifest fields, bundle identifiers, member references, dependency versions, lookup terms, and selection outputs as compatibility surfaces.",
+          "Keep descriptive metadata separate from interfaces that grant authority or mutate Decapod state."
+        ],
+        "proof": [
+          "Map bundle selection and dependency handling to manifest, lookup, schema, and clean-replay evidence.",
+          "Validation must expose broken references, cycles, missing prerequisites, or unstable bundle output."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The bundle remains discoverable through metadata lookup terms and links to skill governance and relevant interfaces.",
+          "Structured bundle doctrine survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can select, reject, or defer a bundle using explicit purpose and dependency evidence.",
+          "Runtime selection does not load unrelated context or bypass the control-plane authority boundary."
+        ],
+        "release": [
+          "Release evidence names bundle ownership, member versions, dependency assumptions, and stale-reference checks.",
+          "Generated specs are refreshed when bundle metadata changes retrieval, interfaces, authority, operations, or validation behavior."
+        ]
       }
     },
     "metadata/skills/AGENT_DECAPOD_INTERFACE": {
@@ -16332,8 +16452,14 @@
         "control plane"
       ],
       "links": {
-        "references": [],
-        "referenced_by": []
+        "references": [
+          "interfaces/CONTROL_PLANE",
+          "interfaces/AGENT_CONTEXT_PACK",
+          "specs/skills/SKILL_GOVERNANCE"
+        ],
+        "referenced_by": [
+          "core/METADATA"
+        ]
       },
       "sections": {
         "match": [
@@ -16362,6 +16488,121 @@
         "proceed_when": [
           "Proceed when the interface skill is semantically linked to the correct CLI/RPC surface."
         ]
+      },
+      "architect_notes": [
+        "Treat metadata/skills/AGENT_DECAPOD_INTERFACE as descriptive guidance for how an agent discovers and respects Decapod CLI, RPC, receipts, context packs, and state boundaries; it does not replace the machine contract.",
+        "Interface metadata must preserve provenance to the command or schema it describes and must distinguish retrieval hints from authority, authentication, or proof claims.",
+        "Architect-grade interface metadata makes sequencing, payload interpretation, failure recovery, and control-plane custody discoverable without encouraging agents to bypass Decapod."
+      ],
+      "init_questions": [
+        {
+          "id": "interface_authority",
+          "prompt": "Which canonical command, RPC operation, schema, or receipt field does this metadata describe, and who owns that contract?",
+          "why": "An explicit authority source prevents stale skill cards from becoming an accidental replacement for executable interface contracts.",
+          "answers": [
+            "CLI contract",
+            "RPC schema",
+            "receipt or proof",
+            "context pack",
+            "ask human"
+          ]
+        },
+        {
+          "id": "failure_recovery",
+          "prompt": "What should an agent do when the described command is unavailable, rejects the payload, or returns a governance interlock?",
+          "why": "Metadata is useful only when it carries the safe next action and does not turn an error into permission to guess.",
+          "answers": [
+            "follow error recovery",
+            "query schema",
+            "stop for human",
+            "record blocker",
+            "run proof"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Link metadata to an existing contract",
+          "use_when": "The command, RPC operation, schema, or receipt surface already exists and the metadata improves discovery or interpretation.",
+          "avoid_when": "The metadata would introduce fields, sequencing, or guarantees absent from the canonical contract.",
+          "implications": "Record the exact authority reference, supported version, failure recovery, and proof that the card remains aligned."
+        },
+        {
+          "choice": "Add a new interface metadata card",
+          "use_when": "A stable interface exists but agents cannot find or safely interpret it from current retrieval terms.",
+          "avoid_when": "The underlying interface is still ambiguous, experimental, or owned by an unreviewed external artifact.",
+          "implications": "Define scope, provenance, non-guarantees, compatible payload examples, and the adjacent interface doctrine before publication."
+        },
+        {
+          "choice": "Stop on authority mismatch",
+          "use_when": "The card conflicts with the current CLI/RPC schema, claims proof it cannot produce, or omits a required custody boundary.",
+          "avoid_when": "The difference is only a documented, versioned presentation alias with unchanged semantics.",
+          "implications": "Prefer the executable contract, record the drift, and do not infer a workaround from metadata alone."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "discoverability versus contract duplication",
+          "option_a": "Add rich metadata and examples for agent retrieval.",
+          "option_b": "Keep metadata thin and defer to the canonical schema.",
+          "guidance": "Add enough context to choose and recover safely, but keep payload and authority truth in the command contracts and schemas."
+        },
+        {
+          "axis": "automation versus custody",
+          "option_a": "Let metadata suggest a next Decapod operation.",
+          "option_b": "Require explicit proof and session/permission checks before mutation.",
+          "guidance": "Metadata may route and explain; it must never imply that a suggested mutation is authorized or verified."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture the canonical interface reference, supported release, payload or receipt shape, authority owner, failure modes, and safe recovery path.",
+          "Record which agent-facing lookup terms are needed and which claims the metadata intentionally does not make."
+        ],
+        "generate": [
+          "Generate a metadata card linked to the command contract, schema, or embedded doctrine with examples that remain semantically subordinate to it.",
+          "Generate alignment tests for operation names, schema references, receipt fields, and documented recovery guidance."
+        ],
+        "defer": [
+          "Defer metadata for undocumented, experimental, provider-authenticated, or high-risk behavior until the underlying contract and proof surface exist.",
+          "Do not generate alternate RPC protocols, authentication claims, or hidden state writes from an interface card."
+        ],
+        "proof": [
+          "Resolve the card from representative agent queries and compare its references and examples with the canonical command/schema output.",
+          "Exercise a valid call and a typed failure or interlock to prove the metadata leads to safe recovery rather than guesswork."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the agent outcome the metadata supports and the non-goals that keep it from changing Decapod behavior or authority.",
+          "Preserve uncertainty about contract ownership, release compatibility, and proof instead of turning an interface hint into a guarantee."
+        ],
+        "architecture": [
+          "Record the owning CLI/RPC boundary, schema source, context-pack role, lifecycle, and failure recovery path.",
+          "Link interface metadata to interfaces/CONTROL_PLANE and the relevant specs or constitution node that owns semantics."
+        ],
+        "interfaces": [
+          "Record operation identifiers, payload schemas, receipt fields, compatibility notes, and error/interlock mappings that agents must treat as contracts.",
+          "State clearly which values are claims, which are command output, and which are verified proof artifacts."
+        ],
+        "proof": [
+          "Map metadata alignment to schema validation, command help or RPC output, typed failure, and embedded lookup evidence.",
+          "Validation should expose stale references or authority claims that cannot be traced to the current interface contract."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The card remains discoverable through metadata lookup terms and linked to the canonical control-plane and context-pack contracts.",
+          "Structured interface metadata survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative agent can use the card to select a valid Decapod operation and recover from a typed failure without bypassing custody.",
+          "Runtime proof distinguishes metadata guidance from the executable command and its returned receipt."
+        ],
+        "release": [
+          "Release evidence names the supported Decapod version, contract owner, stale-reference checks, and unverified interface claims.",
+          "Generated specs are refreshed when interface metadata changes commands, schemas, authority, operations, or validation behavior."
+        ]
       }
     },
     "metadata/skills/HUMAN_AGENT_UX": {
@@ -16379,8 +16620,14 @@
         "safety"
       ],
       "links": {
-        "references": [],
-        "referenced_by": []
+        "references": [
+          "metadata/skills/INTENT_REFINEMENT",
+          "interfaces/PROJECT_SPECS",
+          "core/DECAPOD"
+        ],
+        "referenced_by": [
+          "core/METADATA"
+        ]
       },
       "sections": {
         "match": [
@@ -16409,6 +16656,121 @@
         "proceed_when": [
           "Proceed when the UX skill facilitates clear intent capture and safe, humble interaction."
         ]
+      },
+      "architect_notes": [
+        "Treat metadata/skills/HUMAN_AGENT_UX as a safety and alignment descriptor: it should tell agents when to clarify, report progress, preserve uncertainty, and respect human authority.",
+        "Good UX metadata makes the stop conditions visible rather than optimizing for conversational smoothness. It must not conceal risk, fabricate confidence, or turn a preference into a binding requirement.",
+        "Architect-grade UX guidance connects clarification triggers, feedback cadence, accessibility, and escalation to intent, interface, security, and proof surfaces."
+      ],
+      "init_questions": [
+        {
+          "id": "clarification_trigger",
+          "prompt": "What missing fact, risk, authority choice, or acceptance criterion requires the agent to stop and ask the human?",
+          "why": "A UX skill is safe only when its threshold for clarification is concrete enough to prevent silent assumption drift.",
+          "answers": [
+            "material ambiguity",
+            "safety risk",
+            "authority choice",
+            "acceptance gap",
+            "no clarification needed"
+          ]
+        },
+        {
+          "id": "feedback_contract",
+          "prompt": "What progress, evidence, uncertainty, and next decision must remain visible to the human during the workflow?",
+          "why": "Feedback is part of custody; users need enough context to correct direction before an irreversible action or failed proof.",
+          "answers": [
+            "milestones",
+            "blocking risks",
+            "proof status",
+            "decision request",
+            "ask human"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Clarify before mutation",
+          "use_when": "The missing intent, authority, safety constraint, accessibility need, or acceptance criterion could change the result materially.",
+          "avoid_when": "The next step is reversible, bounded, and its assumption can be verified without changing user-visible scope.",
+          "implications": "Ask one focused question, preserve the unresolved state in the appropriate spec or issue, and wait before crossing the boundary."
+        },
+        {
+          "choice": "Proceed with visible assumptions",
+          "use_when": "The work is local and reversible, the user outcome is clear, and the proof plan can quickly falsify the assumption.",
+          "avoid_when": "The assumption affects safety, authority, durable data, public compatibility, or a costly operating decision.",
+          "implications": "State the assumption, communicate the next checkpoint, and tie completion to evidence rather than conversational confidence."
+        },
+        {
+          "choice": "Escalate a conflicting UX signal",
+          "use_when": "Speed, convenience, or tone conflicts with safety, accessibility, human authority, or truthful uncertainty.",
+          "avoid_when": "The difference is a reversible presentation preference with no impact on comprehension or custody.",
+          "implications": "Prefer the safety and clarity constraint, record the tradeoff, and ask the human when the priority cannot be inferred."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "interaction speed versus informed custody",
+          "option_a": "Minimize questions and move quickly through reversible work.",
+          "option_b": "Pause for clarification and make assumptions visible.",
+          "guidance": "Use speed only while the next action is reversible; surface questions when a wrong assumption would alter outcome, authority, or proof."
+        },
+        {
+          "axis": "concise feedback versus sufficient context",
+          "option_a": "Provide short status updates focused on the next action.",
+          "option_b": "Include risks, evidence, and decisions needed for correction.",
+          "guidance": "Prefer concise updates that still preserve uncertainty, blockers, ownership, and the evidence needed for a human to redirect work."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture user outcome, clarification threshold, accessibility or safety constraints, feedback cadence, decision owner, and escalation path.",
+          "Record the first human-visible checkpoint and the evidence that will let the user correct direction before completion."
+        ],
+        "generate": [
+          "Generate focused questions, acceptance prompts, progress checkpoints, accessible labels, and proof summaries only where the workflow needs them.",
+          "Generate a human-facing decision record when UX metadata changes authority, scope, safety, or an irreversible operation."
+        ],
+        "defer": [
+          "Defer autonomous action, silent intent expansion, irreversible mutation, and tone optimization when material ambiguity or safety risk remains.",
+          "Do not generate a UX layer that suppresses technical errors, uncertainty, accessibility requirements, or human escalation."
+        ],
+        "proof": [
+          "Exercise an ambiguous request, a clear reversible request, and a material-risk request to prove the metadata chooses ask, proceed, or stop correctly.",
+          "Review feedback for visible assumptions, blockers, proof status, and decision ownership rather than fluency alone."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record user outcomes, acceptance criteria, clarification decisions, non-goals, and unresolved questions surfaced by the UX metadata.",
+          "Preserve the human's authority and uncertainty instead of rewriting a vague request into fabricated certainty."
+        ],
+        "architecture": [
+          "Record interaction boundaries, human decision ownership, feedback checkpoints, accessibility requirements, escalation paths, and safety constraints.",
+          "Link UX decisions to metadata/skills/INTENT_REFINEMENT and the interface or security doctrine that owns the affected boundary."
+        ],
+        "interfaces": [
+          "Record prompts, status shapes, error explanations, accessibility labels, decision requests, and user-visible acceptance signals as interface contracts.",
+          "Do not let conversational metadata silently change a CLI, RPC, or public response contract."
+        ],
+        "proof": [
+          "Map UX metadata to representative clarification, proceed, escalation, accessibility, and evidence-visibility checks.",
+          "Validation should expose hidden assumptions, suppressed blockers, or feedback that cannot identify the next human decision."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The UX card remains discoverable through metadata lookup terms and links to intent refinement and project-spec contracts.",
+          "Structured human-agent UX doctrine survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative task can choose clarification, visible-assumption progress, or escalation from metadata/HUMAN_AGENT_UX.",
+          "Runtime interaction preserves uncertainty and presents proof status without leaving a background process or hidden mutation."
+        ],
+        "release": [
+          "Release evidence names accessibility, safety, authority, feedback, and clarification claims that remain unverified.",
+          "Generated specs are refreshed when UX metadata changes intent, interfaces, security, operations, or validation expectations."
+        ]
       }
     },
     "metadata/skills/INTENT_REFINEMENT": {
@@ -16426,8 +16788,14 @@
         "constraints"
       ],
       "links": {
-        "references": [],
-        "referenced_by": []
+        "references": [
+          "specs/INTENT",
+          "metadata/skills/HUMAN_AGENT_UX",
+          "core/DEMANDS"
+        ],
+        "referenced_by": [
+          "core/METADATA"
+        ]
       },
       "sections": {
         "match": [
@@ -16455,6 +16823,121 @@
         ],
         "proceed_when": [
           "Proceed when raw intent is distilled into a structured set of outcomes and constraints."
+        ]
+      },
+      "architect_notes": [
+        "Treat metadata/skills/INTENT_REFINEMENT as a boundary between raw language and governed work: it extracts outcomes, constraints, non-goals, owners, and acceptance evidence without pretending to choose domain architecture prematurely.",
+        "Refinement should reduce ambiguity while preserving uncertainty. A refined intent is not complete until the human can recognize the outcome and the proof plan can falsify the interpretation.",
+        "Architect-grade intent metadata routes the next question or constitution node, names what must not be inferred, and leaves a durable trail in specs or task state."
+      ],
+      "init_questions": [
+        {
+          "id": "desired_outcome",
+          "prompt": "What observable user or operator outcome should be true when this work is complete, and who accepts it?",
+          "why": "Outcome and acceptance ownership prevent an agent from optimizing for a plan, file change, or implementation detail that the user did not ask for.",
+          "answers": [
+            "user outcome",
+            "operator outcome",
+            "maintainer outcome",
+            "unknown owner",
+            "ask human"
+          ]
+        },
+        {
+          "id": "binding_constraints",
+          "prompt": "Which requirements are must-have constraints, which are preferences, and which facts remain unsafe to infer?",
+          "why": "Separating binding constraints from preferences keeps intent refinement faithful and identifies the questions that require human custody.",
+          "answers": [
+            "must and must-not",
+            "preference",
+            "non-goal",
+            "unknown constraint",
+            "defer explicitly"
+          ]
+        }
+      ],
+      "decision_matrix": [
+        {
+          "choice": "Refine into a testable intent",
+          "use_when": "The raw request has a recognizable outcome but lacks acceptance criteria, constraints, owner, or proof vocabulary.",
+          "avoid_when": "The user already supplied a precise contract and additional paraphrase would add no decision value.",
+          "implications": "Record outcome, owner, scope, non-goals, assumptions, acceptance criteria, and the next constitution route without selecting implementation prematurely."
+        },
+        {
+          "choice": "Ask a focused intent question",
+          "use_when": "Two plausible interpretations would change scope, safety, architecture, interface, data, cost, or completion proof.",
+          "avoid_when": "The ambiguity is reversible and can be isolated behind an explicit assumption with a fast proof.",
+          "implications": "Ask the smallest question that separates the alternatives and preserve the unresolved decision in task or spec state."
+        },
+        {
+          "choice": "Route to domain doctrine",
+          "use_when": "The refined outcome identifies a concrete technology, data, interface, security, operations, or methodology uncertainty.",
+          "avoid_when": "Routing would merely restate the outcome without changing the next artifact or proof surface.",
+          "implications": "Carry the refined constraints forward, retrieve the narrow owner once, and update specs or proof planning before implementation."
+        }
+      ],
+      "tradeoffs": [
+        {
+          "axis": "faithful ambiguity versus premature specificity",
+          "option_a": "Preserve uncertainty and ask before choosing.",
+          "option_b": "Fill gaps with a plausible implementation plan.",
+          "guidance": "Preserve any gap that could change the accepted outcome or safety boundary; infer only reversible details with named assumptions."
+        },
+        {
+          "axis": "question count versus decision value",
+          "option_a": "Ask every potentially useful discovery question.",
+          "option_b": "Ask only the question that changes the next step.",
+          "guidance": "Prefer one focused question tied to a branch in scope, authority, or proof; defer curiosity that cannot change action."
+        }
+      ],
+      "scaffolding": {
+        "capture": [
+          "Capture raw request, desired outcome, acceptance owner, must and must-not constraints, preferences, non-goals, assumptions, and unresolved questions.",
+          "Record the selected next constitution route and the proof surface that will confirm the refinement was useful."
+        ],
+        "generate": [
+          "Generate concise acceptance criteria, a bounded task shape, focused clarification prompts, and links to the doctrine that owns the next decision.",
+          "Generate task or spec updates before implementation when refinement changes scope, authority, interfaces, architecture, or proof."
+        ],
+        "defer": [
+          "Defer implementation, vendor, schema, interface, or deployment choices when the outcome, owner, constraint, or safety boundary remains materially ambiguous.",
+          "Do not convert an untrusted attachment, generated suggestion, or agent preference into a binding requirement without human translation and proof."
+        ],
+        "proof": [
+          "Have a reviewer or test identify the refined outcome, constraints, non-goals, and acceptance signal without relying on the original conversation.",
+          "Re-run the same refinement input and verify deterministic routing, preserved uncertainty, and stable proof planning."
+        ]
+      },
+      "spec_impacts": {
+        "intent": [
+          "Record the refined outcome, owner, acceptance criteria, scope, non-goals, preferences, and unresolved questions in the canonical intent surface.",
+          "Preserve the distinction between human requirements, agent assumptions, retrieved doctrine, and verified evidence."
+        ],
+        "architecture": [
+          "Record architectural implications only after the refined intent identifies a boundary, state owner, dependency, deployment shape, or recovery requirement.",
+          "Link the next architecture decision to the narrower doctrine node selected by the refined constraints."
+        ],
+        "interfaces": [
+          "Record changed commands, schemas, APIs, generated files, acceptance payloads, or compatibility promises only when the refined outcome makes them part of the contract.",
+          "Do not let intent refinement silently invent a public interface or alter authority."
+        ],
+        "proof": [
+          "Map refinement to acceptance checks, clarification evidence, deterministic routing, spec updates, and the proof command or artifact for the next step.",
+          "Validation should expose missing owners, untestable outcomes, hidden assumptions, or unresolved material ambiguity."
+        ]
+      },
+      "proof": {
+        "static": [
+          "The intent-refinement card remains discoverable through metadata lookup terms and links to specs/INTENT and human-agent UX doctrine.",
+          "Structured intent doctrine survives schema validation and embedded constitution lookup."
+        ],
+        "runtime": [
+          "A representative raw request produces a bounded outcome, constraints, one next route, and an explicit question or assumption when needed.",
+          "Repeated refinement of the same input produces the same result under fixed repository state."
+        ],
+        "release": [
+          "Release evidence names acceptance, owner, uncertainty, routing, and evidence claims that remain unverified.",
+          "Generated specs are refreshed when intent metadata changes scope, architecture, interfaces, semantics, operations, or validation."
         ]
       }
     },

--- a/assets/constitution.schema.json
+++ b/assets/constitution.schema.json
@@ -8,9 +8,10 @@
       "architecture",
       "methodology",
       "interfaces",
-      "data"
+      "data",
+      "metadata"
     ],
-    "migration_strategy": "architecture, methodology, interfaces nodes, and data nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
+    "migration_strategy": "architecture, methodology, interfaces nodes, data nodes, and metadata nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
     "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain additive doctrine fields"
   },
   "type": "object",
@@ -125,6 +126,29 @@
             "properties": {
               "category": {
                 "const": "data"
+              }
+            },
+            "required": [
+              "category"
+            ]
+          },
+          "then": {
+            "required": [
+              "architect_notes",
+              "init_questions",
+              "decision_matrix",
+              "tradeoffs",
+              "scaffolding",
+              "spec_impacts",
+              "proof"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "category": {
+                "const": "metadata"
               }
             },
             "required": [

--- a/tests/constitution_scaffolding.rs
+++ b/tests/constitution_scaffolding.rs
@@ -104,6 +104,13 @@ const DATA_NODES: &[&str] = &[
     "data/POSTGRESQL",
 ];
 
+const METADATA_NODES: &[&str] = &[
+    "metadata/skills/AGENT_DECAPOD_INTERFACE",
+    "metadata/skills/BUNDLE",
+    "metadata/skills/HUMAN_AGENT_UX",
+    "metadata/skills/INTENT_REFINEMENT",
+];
+
 const METHODOLOGY_NODES: &[&str] = &[
     "methodology/ARCHITECTURE",
     "methodology/CI_CD",
@@ -582,6 +589,84 @@ fn all_data_nodes_have_architect_grade_persistence_and_pipeline_doctrine() {
 }
 
 #[test]
+fn all_metadata_nodes_have_architect_grade_skill_and_ux_doctrine() {
+    let constitution = load_constitution_asset();
+    let nodes = constitution["nodes"].as_object().expect("nodes object");
+    let lookup = constitution["lookup"].as_object().expect("lookup object");
+
+    let actual_metadata_count = nodes
+        .values()
+        .filter(|node| node["category"].as_str() == Some("metadata"))
+        .count();
+    assert_eq!(
+        actual_metadata_count,
+        METADATA_NODES.len(),
+        "METADATA_NODES test list must cover every metadata/* node"
+    );
+
+    let core_refs = nodes["core/METADATA"]["links"]["references"]
+        .as_array()
+        .expect("core metadata references");
+
+    for node_id in METADATA_NODES {
+        let node = nodes
+            .get(*node_id)
+            .unwrap_or_else(|| panic!("missing metadata node {node_id}"));
+        assert_eq!(
+            node["category"].as_str(),
+            Some("metadata"),
+            "{node_id} must remain in the metadata namespace"
+        );
+        assert_architect_grade_fields(node_id, node);
+        assert_non_empty_array(
+            &node["links"]["references"],
+            &format!("{node_id}.links.references"),
+        );
+        assert!(
+            node["links"]["referenced_by"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/METADATA"))),
+            "{node_id} must be reachable from core/METADATA"
+        );
+        assert!(
+            core_refs
+                .iter()
+                .any(|value| value.as_str() == Some(node_id)),
+            "core/METADATA must route to {node_id}"
+        );
+
+        let sections = node["sections"].as_object().expect("sections object");
+        for section in [
+            "match",
+            "ambiguity",
+            "decisions",
+            "standards",
+            "failure_modes",
+            "proceed_when",
+        ] {
+            assert!(
+                sections
+                    .get(section)
+                    .and_then(|items| items.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                "{node_id}.{section} must preserve metadata guidance"
+            );
+        }
+
+        assert!(
+            lookup.values().any(|entries| {
+                entries.as_array().is_some_and(|entries| {
+                    entries.iter().any(|entry| entry.as_str() == Some(node_id))
+                })
+            }),
+            "{node_id} must remain reachable through at least one lookup term"
+        );
+    }
+}
+
+#[test]
 fn all_methodology_nodes_have_architect_grade_delivery_doctrine() {
     let constitution = load_constitution_asset();
     let nodes = constitution["nodes"].as_object().expect("nodes object");
@@ -663,9 +748,11 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         schema["x-doctrine_model"]["migration_strategy"]
             .as_str()
             .is_some_and(|strategy| {
-                strategy.contains("interfaces nodes") && strategy.contains("data nodes")
+                strategy.contains("interfaces nodes")
+                    && strategy.contains("data nodes")
+                    && strategy.contains("metadata nodes")
             }),
-        "schema must document in-place interfaces and data namespace migration"
+        "schema must document in-place interfaces, data, and metadata namespace migration"
     );
 
     let node_schema = &schema["definitions"]["node"];
@@ -693,6 +780,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         .iter()
         .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("data"))
         .expect("node schema must declare data doctrine conditional");
+    let metadata_rule = rules
+        .iter()
+        .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("metadata"))
+        .expect("node schema must declare metadata doctrine conditional");
 
     let required = architecture_rule["then"]["required"]
         .as_array()
@@ -731,6 +822,16 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         assert!(
             required.iter().any(|value| value.as_str() == Some(field)),
             "data schema must require {field}"
+        );
+    }
+
+    let required = metadata_rule["then"]["required"]
+        .as_array()
+        .expect("metadata doctrine required fields");
+    for field in ARCHITECTURE_DOCTRINE_FIELDS {
+        assert!(
+            required.iter().any(|value| value.as_str() == Some(field)),
+            "metadata schema must require {field}"
         );
     }
 
@@ -1176,6 +1277,31 @@ fn embedded_constitution_preserves_data_doctrine() {
                 .as_array()
                 .is_some_and(|refs| !refs.is_empty()),
             "{node_id} must preserve data cross-links in embedded output"
+        );
+    }
+}
+
+#[test]
+fn embedded_constitution_preserves_metadata_doctrine() {
+    for node_id in METADATA_NODES {
+        let output = Command::new(resolve_decapod_bin())
+            .args(["constitution", "get", node_id])
+            .output()
+            .expect("run decapod constitution get");
+        assert!(
+            output.status.success(),
+            "constitution get {node_id} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let node: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("constitution get json");
+        assert_architect_grade_fields(node_id, &node);
+        assert!(
+            node["links"]["references"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty()),
+            "{node_id} must preserve metadata cross-links in embedded output"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade all four metadata skill and UX nodes to the architect-grade doctrine contract.
- Add explicit metadata schema requirements, cross-links, lookup reachability, and embedded constitution regression coverage.
- Rebase onto the Decapod v0.72.6 release and refresh the Dockerfile, living specs, and all release-bound entrypoint fingerprints.

## Verification

- cargo fmt --all -- --check
- cargo test --test constitution_scaffolding -- --test-threads=1 (22 passed)
- Decapod v0.72.6 container validation reaches 198 gates; the remaining proof hook is blocked by unrelated shared TODO bugs_01ky13x93f0gwtaa, which is done but lacks verification artifacts.

Closes #806