### PR TITLE
Uplift plugin subsystem constitution doctrine for Issue #808

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.6
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.7
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.6
+ARG DECAPOD_VERSION=0.72.7
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784596843Z",
-  "repo_signal_fingerprint": "2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c",
+  "generated_at": "1784602028Z",
+  "repo_signal_fingerprint": "e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "a15db84c0b4cea38d9dbce4f95667515f7e8a64543eaf0c8c16530d20acdd1a8",
-  "decapod_release": "0.72.6",
+  "spec_input_hash": "1a9c3549058e5f37db1324b969d1af6ab567ea5ada4ee2f1d67bfff0f99949d5",
+  "decapod_release": "0.72.7",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "129f9b1afcb95a391f72cc3fa3900ef743167c5012075d799a7827ee77336174",
-      "content_hash": "129f9b1afcb95a391f72cc3fa3900ef743167c5012075d799a7827ee77336174",
-      "fingerprint": "e9897afcd2e4eb609f8843c25bfc67b5a004afaa6d16b0c5e5ac3c0e722722f5"
+      "template_hash": "60f4240d2f5400a43b17d487a9618de7768c6284c719de6e009d5f509d348988",
+      "content_hash": "60f4240d2f5400a43b17d487a9618de7768c6284c719de6e009d5f509d348988",
+      "fingerprint": "0123bf512289c45ad33891016490ed69441397a404d3b14153e6bdbd7b80a4a2"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "e54945ebebd4eeb139a3cfd567f04cd9af88f3227ff62d2e36001bb8422d9f1e",
-      "content_hash": "e54945ebebd4eeb139a3cfd567f04cd9af88f3227ff62d2e36001bb8422d9f1e",
-      "fingerprint": "8ed76b172fd2aac1c95366eb177ff9cbc02a02e5c9d0f05a8f97feab0d3ae509"
+      "template_hash": "2628f587917771c57890ae09a063f45415f1fd61ab3cdf58a7d79dbb1beaf007",
+      "content_hash": "2628f587917771c57890ae09a063f45415f1fd61ab3cdf58a7d79dbb1beaf007",
+      "fingerprint": "3577cf2f877eeff2d9f0fb701d1720d9276bce64740c39f2d66d322080411fc8"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "b427cbb127fa5d1b095465c9b237517ae086b006e9c20a246a537db6f6ac72ed",
-      "content_hash": "b427cbb127fa5d1b095465c9b237517ae086b006e9c20a246a537db6f6ac72ed",
-      "fingerprint": "fb8760c0f8fac013c6f4d628f4a63ae77c88e9330361976010184ed9824e0c5b"
+      "template_hash": "45272a1ad8955a1227091df4aa9090b08f449be6d8ef00ddfe2fb918a2f928bc",
+      "content_hash": "45272a1ad8955a1227091df4aa9090b08f449be6d8ef00ddfe2fb918a2f928bc",
+      "fingerprint": "3ceba16d1bda54bb3119f5fa115107d0c183285853bc32c1b69c323d2983c88a"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "90e639174a5444cde8669f0c635b62d329543cdb5ed4a4a905da9d4b91513f45",
-      "content_hash": "90e639174a5444cde8669f0c635b62d329543cdb5ed4a4a905da9d4b91513f45",
-      "fingerprint": "0f509c04ae38d89d1c8f05a264fdad03b973800eb9d9bf24ccc57bc450e73105"
+      "template_hash": "7e6a98d53ee2329c70127986a3b5d3445362eb9d3910d62f6e7bbc5f8f51a120",
+      "content_hash": "7e6a98d53ee2329c70127986a3b5d3445362eb9d3910d62f6e7bbc5f8f51a120",
+      "fingerprint": "b6a7b3fbc62997cc187b545046440a197fff01f1e90de68395a05302ff0b5563"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "61fc0dd7036a0adaa46d6addeeec5425784875b620bca2722c00fb851f15e077",
+      "content_hash": "0057c320cc1b12f84c4e9e86872cd29f577fd0f3c811c60f9600e1297076472d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "826cb4d44662238806ced2de31d92e143781173bdd2cdb436ccf9fed66f49f3d",
+      "content_hash": "3adcd6a2cb1b971c6f6d2d6dfe354e80873bc72d7728899f6f961277f561b16a",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "dc81020dfe467ab0fad2685aed03cdfb131ee704dbb71e36343dc36579550bde",
+      "content_hash": "dc011e38b5f9eec7c56d6e0762707f6f884c46b480087505005634be528bac49",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "9fe0595e00598c267442d524218ac14b9aaa869c15aa2e5e02aab5be6c71f5dc",
+      "content_hash": "e2ff0d1c981ed4ce882aeefb2ed6eb3262820790f91835b25e503c05c30ceec2",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "4001770635451b48ed8645a7017060b361190af66ca21811b5799bc8995c709b",
+      "content_hash": "fc8106e5b03b4e448a61a1e66cf8cf4fa3a8e79c397c55353cad8a4912cc62ea",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "a10fbf0e575dc444dbc052b9c6713b6079554927f5ef2e10e01f801ee392e837",
+      "content_hash": "36071ba17963cffeb4e6c94d3267075d83fa76dc17ee65a32e31a2f4850b5047",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "401f4c6535fea8a5ca802b21392afbb8cb019164168ab52530e1303b0b95196d",
+      "content_hash": "e9beb28426ebee0853c21990fd7168c73b97f0e1daac98a52bc0ec3a8c9ddef5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "dd745c10ea95ffe6c430a7aaa68c668defd16bbaeed1a5b339876bedaff8300b",
+      "content_hash": "e83e92cfacb958438019769d3b509f11ce25527c60bfb1bd3e93e9ae17009572",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -1,6 +1,11 @@
 # Operations## Capability Operations
 
-Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.
+Operational ownership follows the declared surfaces: session/authentication and policy/authorization protect mutations; SQLite/JSONL state and migrations require executable proof; workflow and scheduled jobs require bounded execution and failure visibility; Git/Cargo/container integrations remain explicit external actions; and CLI/JSON-RPC contracts remain machine-facing compatibility surfaces. Capability declarations must not be used as a substitute for command-level evidence.## Operational Readiness Checklist
+- [ ] On-call ownership defined (local development tool — typically self-serve)
+- [ ] SLOs defined for validation latency and workspace creation
+- [ ] Runbooks linked for validation failures and workspace interlocks
+- [ ] Rollback plan: `decapod workspace prune --force` + git reset
+- [ ] Capacity guardrails: workspace disk quota, SQLite connection limits
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -38,13 +43,6 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Operational Readiness Checklist
-- [ ] On-call ownership defined (local development tool — typically self-serve)
-- [ ] SLOs defined for validation latency and workspace creation
-- [ ] Runbooks linked for validation failures and workspace interlocks
-- [ ] Rollback plan: `decapod workspace prune --force` + git reset
-- [ ] Capacity guardrails: workspace disk quota, SQLite connection limits
 
 ## Deployment Model
 
@@ -278,7 +276,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -304,7 +304,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -336,7 +336,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `2aa6c07afeb2e903cff814160381f19abfc23dd967053e6c5438419749e6d02c`
+- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.6 -->
-<!-- decapod-fingerprint: e9897afcd2e4eb609f8843c25bfc67b5a004afaa6d16b0c5e5ac3c0e722722f5 -->
+<!-- decapod-release: 0.72.7 -->
+<!-- decapod-fingerprint: 0123bf512289c45ad33891016490ed69441397a404d3b14153e6bdbd7b80a4a2 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.6 -->
-<!-- decapod-fingerprint: 8ed76b172fd2aac1c95366eb177ff9cbc02a02e5c9d0f05a8f97feab0d3ae509 -->
+<!-- decapod-release: 0.72.7 -->
+<!-- decapod-fingerprint: 3577cf2f877eeff2d9f0fb701d1720d9276bce64740c39f2d66d322080411fc8 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.6 -->
-<!-- decapod-fingerprint: 0f509c04ae38d89d1c8f05a264fdad03b973800eb9d9bf24ccc57bc450e73105 -->
+<!-- decapod-release: 0.72.7 -->
+<!-- decapod-fingerprint: b6a7b3fbc62997cc187b545046440a197fff01f1e90de68395a05302ff0b5563 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.6 -->
-<!-- decapod-fingerprint: fb8760c0f8fac013c6f4d628f4a63ae77c88e9330361976010184ed9824e0c5b -->
+<!-- decapod-release: 0.72.7 -->
+<!-- decapod-fingerprint: 3ceba16d1bda54bb3119f5fa115107d0c183285853bc32c1b69c323d2983c88a -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -20104,6 +20104,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for APTITUDE.",
+      "architect_notes": [
+         "APTITUDE owns agent capability and task suitability signals; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep APTITUDE invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat APTITUDE proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does APTITUDE own, and which adjacent subsystem remains the source of truth for capability evidence and task fit?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that APTITUDE can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the aptitude assessments result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is agent capability and task suitability signals, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the aptitude assessments boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the capability evidence and task fit boundary or needs a schema, store, policy, or lifecycle decision outside APTITUDE.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether APTITUDE prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting aptitude assessments results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the APTITUDE owner, invocation surface, state boundary, authority label, and expected aptitude assessments evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects agent capability and task suitability signals."
+         ],
+         "generate": [
+           "Generate only the APTITUDE configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer capability evidence and task fit decisions to the owning subsystem and do not create a parallel aptitude assessments store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the APTITUDE operation and its aptitude assessments result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when APTITUDE is in scope for agent capability and task suitability signals, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about aptitude assessments freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document APTITUDE as the owner of aptitude assessments and show its boundary with capability evidence and task fit.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported APTITUDE CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop APTITUDE without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate APTITUDE advisory claims from verified authority and protect aptitude assessments from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for APTITUDE ownership, deterministic output, failure modes, and aptitude assessments freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what APTITUDE means for agent capability and task suitability signals, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie APTITUDE completion to executable evidence for aptitude assessments, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The APTITUDE node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured APTITUDE doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative APTITUDE invocation returns bounded output with explicit aptitude assessments ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable APTITUDE path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when APTITUDE changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred APTITUDE risk."
+         ]
+       },
       "terms": [
         "signals",
         "task",
@@ -20118,7 +20249,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20161,6 +20293,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for ARCHIVE.",
+      "architect_notes": [
+         "ARCHIVE owns immutable historical records and retention; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep ARCHIVE invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat ARCHIVE proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does ARCHIVE own, and which adjacent subsystem remains the source of truth for provenance and retention?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that ARCHIVE can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the archive records result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is immutable historical records and retention, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the archive records boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the provenance and retention boundary or needs a schema, store, policy, or lifecycle decision outside ARCHIVE.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether ARCHIVE prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting archive records results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the ARCHIVE owner, invocation surface, state boundary, authority label, and expected archive records evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects immutable historical records and retention."
+         ],
+         "generate": [
+           "Generate only the ARCHIVE configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer provenance and retention decisions to the owning subsystem and do not create a parallel archive records store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the ARCHIVE operation and its archive records result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when ARCHIVE is in scope for immutable historical records and retention, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about archive records freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document ARCHIVE as the owner of archive records and show its boundary with provenance and retention.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported ARCHIVE CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop ARCHIVE without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate ARCHIVE advisory claims from verified authority and protect archive records from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for ARCHIVE ownership, deterministic output, failure modes, and archive records freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what ARCHIVE means for immutable historical records and retention, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie ARCHIVE completion to executable evidence for archive records, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The ARCHIVE node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured ARCHIVE doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative ARCHIVE invocation returns bounded output with explicit archive records ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable ARCHIVE path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when ARCHIVE changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred ARCHIVE risk."
+         ]
+       },
       "terms": [
         "immutable",
         "audit",
@@ -20177,7 +20440,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20220,6 +20484,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for AUDIT.",
+      "architect_notes": [
+         "AUDIT owns reconstructable action and evidence history; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep AUDIT invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat AUDIT proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does AUDIT own, and which adjacent subsystem remains the source of truth for event custody and replay?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that AUDIT can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the audit receipts result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is reconstructable action and evidence history, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the audit receipts boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the event custody and replay boundary or needs a schema, store, policy, or lifecycle decision outside AUDIT.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether AUDIT prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting audit receipts results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the AUDIT owner, invocation surface, state boundary, authority label, and expected audit receipts evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects reconstructable action and evidence history."
+         ],
+         "generate": [
+           "Generate only the AUDIT configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer event custody and replay decisions to the owning subsystem and do not create a parallel audit receipts store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the AUDIT operation and its audit receipts result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when AUDIT is in scope for reconstructable action and evidence history, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about audit receipts freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document AUDIT as the owner of audit receipts and show its boundary with event custody and replay.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported AUDIT CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop AUDIT without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate AUDIT advisory claims from verified authority and protect audit receipts from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for AUDIT ownership, deterministic output, failure modes, and audit receipts freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what AUDIT means for reconstructable action and evidence history, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie AUDIT completion to executable evidence for audit receipts, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The AUDIT node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured AUDIT doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative AUDIT invocation returns bounded output with explicit audit receipts ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable AUDIT path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when AUDIT changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred AUDIT risk."
+         ]
+       },
       "terms": [
         "events",
         "evidence",
@@ -20236,7 +20631,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "architecture/OBSERVABILITY",
@@ -20282,6 +20678,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for AUTOUPDATE.",
+      "architect_notes": [
+         "AUTOUPDATE owns explicit release refresh and update policy; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep AUTOUPDATE invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat AUTOUPDATE proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does AUTOUPDATE own, and which adjacent subsystem remains the source of truth for version boundaries and rollback?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that AUTOUPDATE can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the update checks result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is explicit release refresh and update policy, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the update checks boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the version boundaries and rollback boundary or needs a schema, store, policy, or lifecycle decision outside AUTOUPDATE.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether AUTOUPDATE prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting update checks results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the AUTOUPDATE owner, invocation surface, state boundary, authority label, and expected update checks evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects explicit release refresh and update policy."
+         ],
+         "generate": [
+           "Generate only the AUTOUPDATE configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer version boundaries and rollback decisions to the owning subsystem and do not create a parallel update checks store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the AUTOUPDATE operation and its update checks result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when AUTOUPDATE is in scope for explicit release refresh and update policy, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about update checks freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document AUTOUPDATE as the owner of update checks and show its boundary with version boundaries and rollback.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported AUTOUPDATE CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop AUTOUPDATE without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate AUTOUPDATE advisory claims from verified authority and protect update checks from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for AUTOUPDATE ownership, deterministic output, failure modes, and update checks freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what AUTOUPDATE means for explicit release refresh and update policy, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie AUTOUPDATE completion to executable evidence for update checks, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The AUTOUPDATE node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured AUTOUPDATE doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative AUTOUPDATE invocation returns bounded output with explicit update checks ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable AUTOUPDATE path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when AUTOUPDATE changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred AUTOUPDATE risk."
+         ]
+       },
       "terms": [
         "rollout",
         "checks",
@@ -20297,7 +20824,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20340,6 +20868,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for CONTAINER.",
+      "architect_notes": [
+         "CONTAINER owns isolated workspace and image lifecycle; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep CONTAINER invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat CONTAINER proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does CONTAINER own, and which adjacent subsystem remains the source of truth for mounts, image provenance, and cleanup?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that CONTAINER can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the container workspaces result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is isolated workspace and image lifecycle, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the container workspaces boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the mounts, image provenance, and cleanup boundary or needs a schema, store, policy, or lifecycle decision outside CONTAINER.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether CONTAINER prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting container workspaces results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the CONTAINER owner, invocation surface, state boundary, authority label, and expected container workspaces evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects isolated workspace and image lifecycle."
+         ],
+         "generate": [
+           "Generate only the CONTAINER configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer mounts, image provenance, and cleanup decisions to the owning subsystem and do not create a parallel container workspaces store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the CONTAINER operation and its container workspaces result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when CONTAINER is in scope for isolated workspace and image lifecycle, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about container workspaces freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document CONTAINER as the owner of container workspaces and show its boundary with mounts, image provenance, and cleanup.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported CONTAINER CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop CONTAINER without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate CONTAINER advisory claims from verified authority and protect container workspaces from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for CONTAINER ownership, deterministic output, failure modes, and container workspaces freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what CONTAINER means for isolated workspace and image lifecycle, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie CONTAINER completion to executable evidence for container workspaces, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The CONTAINER node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured CONTAINER doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative CONTAINER invocation returns bounded output with explicit container workspaces ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable CONTAINER path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when CONTAINER changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred CONTAINER risk."
+         ]
+       },
       "terms": [
         "reproducible",
         "hygiene",
@@ -20355,7 +21014,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20398,6 +21058,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for CONTEXT.",
+      "architect_notes": [
+         "CONTEXT owns scoped context capsules and compaction; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep CONTEXT invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat CONTEXT proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does CONTEXT own, and which adjacent subsystem remains the source of truth for retrieval scope and custody?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that CONTEXT can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the context capsules result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is scoped context capsules and compaction, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the context capsules boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the retrieval scope and custody boundary or needs a schema, store, policy, or lifecycle decision outside CONTEXT.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether CONTEXT prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting context capsules results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the CONTEXT owner, invocation surface, state boundary, authority label, and expected context capsules evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects scoped context capsules and compaction."
+         ],
+         "generate": [
+           "Generate only the CONTEXT configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer retrieval scope and custody decisions to the owning subsystem and do not create a parallel context capsules store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the CONTEXT operation and its context capsules result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when CONTEXT is in scope for scoped context capsules and compaction, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about context capsules freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document CONTEXT as the owner of context capsules and show its boundary with retrieval scope and custody.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported CONTEXT CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop CONTEXT without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate CONTEXT advisory claims from verified authority and protect context capsules from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for CONTEXT ownership, deterministic output, failure modes, and context capsules freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what CONTEXT means for scoped context capsules and compaction, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie CONTEXT completion to executable evidence for context capsules, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The CONTEXT node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured CONTEXT doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative CONTEXT invocation returns bounded output with explicit context capsules ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable CONTEXT path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when CONTEXT changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred CONTEXT risk."
+         ]
+       },
       "terms": [
         "boundary",
         "scoped",
@@ -20411,12 +21202,13 @@
         "subsystem"
       ],
       "links": {
-        "references": [
-          "core/DECAPOD",
-          "core/PLUGINS",
-          "interfaces/AGENT_CONTEXT_PACK",
-          "interfaces/LCM",
-          "plugins/KNOWLEDGE"
+      "references": [
+        "core/DECAPOD",
+        "core/PLUGINS",
+        "interfaces/AGENT_CONTEXT_PACK",
+        "interfaces/LCM",
+        "plugins/KNOWLEDGE",
+        "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20459,6 +21251,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for CRON.",
+      "architect_notes": [
+         "CRON owns scheduled one-shot invocation policy; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep CRON invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat CRON proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does CRON own, and which adjacent subsystem remains the source of truth for daemonless scheduling and bounded execution?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that CRON can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the scheduled commands result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is scheduled one-shot invocation policy, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the scheduled commands boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the daemonless scheduling and bounded execution boundary or needs a schema, store, policy, or lifecycle decision outside CRON.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether CRON prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting scheduled commands results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the CRON owner, invocation surface, state boundary, authority label, and expected scheduled commands evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects scheduled one-shot invocation policy."
+         ],
+         "generate": [
+           "Generate only the CRON configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer daemonless scheduling and bounded execution decisions to the owning subsystem and do not create a parallel scheduled commands store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the CRON operation and its scheduled commands result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when CRON is in scope for scheduled one-shot invocation policy, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about scheduled commands freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document CRON as the owner of scheduled commands and show its boundary with daemonless scheduling and bounded execution.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported CRON CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop CRON without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate CRON advisory claims from verified authority and protect scheduled commands from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for CRON ownership, deterministic output, failure modes, and scheduled commands freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what CRON means for scheduled one-shot invocation policy, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie CRON completion to executable evidence for scheduled commands, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The CRON node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured CRON doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative CRON invocation returns bounded output with explicit scheduled commands ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable CRON path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when CRON changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred CRON risk."
+         ]
+       },
       "terms": [
         "based",
         "bounded",
@@ -20474,7 +21397,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20517,6 +21441,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for DB BROKER.",
+      "architect_notes": [
+         "DB_BROKER owns database-backed broker ownership and queue state; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep DB_BROKER invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat DB_BROKER proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does DB_BROKER own, and which adjacent subsystem remains the source of truth for claim, retry, and persistence boundaries?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that DB_BROKER can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the broker queue result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is database-backed broker ownership and queue state, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the broker queue boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the claim, retry, and persistence boundaries boundary or needs a schema, store, policy, or lifecycle decision outside DB_BROKER.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether DB_BROKER prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting broker queue results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the DB_BROKER owner, invocation surface, state boundary, authority label, and expected broker queue evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects database-backed broker ownership and queue state."
+         ],
+         "generate": [
+           "Generate only the DB_BROKER configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer claim, retry, and persistence boundaries decisions to the owning subsystem and do not create a parallel broker queue store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the DB_BROKER operation and its broker queue result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when DB_BROKER is in scope for database-backed broker ownership and queue state, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about broker queue freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document DB_BROKER as the owner of broker queue and show its boundary with claim, retry, and persistence boundaries.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported DB_BROKER CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop DB_BROKER without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate DB_BROKER advisory claims from verified authority and protect broker queue from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for DB_BROKER ownership, deterministic output, failure modes, and broker queue freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what DB_BROKER means for database-backed broker ownership and queue state, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie DB_BROKER completion to executable evidence for broker queue, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The DB_BROKER node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured DB_BROKER doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative DB_BROKER invocation returns bounded output with explicit broker queue ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable DB_BROKER path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when DB_BROKER changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred DB_BROKER risk."
+         ]
+       },
       "terms": [
         "mediation",
         "queueing",
@@ -20535,7 +21590,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "data/DATABASE",
@@ -20580,6 +21636,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for DECIDE.",
+      "architect_notes": [
+         "DECIDE owns architecture decision prompts and recorded choices; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep DECIDE invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat DECIDE proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does DECIDE own, and which adjacent subsystem remains the source of truth for uncertainty and human gates?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that DECIDE can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the decision records result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is architecture decision prompts and recorded choices, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the decision records boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the uncertainty and human gates boundary or needs a schema, store, policy, or lifecycle decision outside DECIDE.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether DECIDE prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting decision records results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the DECIDE owner, invocation surface, state boundary, authority label, and expected decision records evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects architecture decision prompts and recorded choices."
+         ],
+         "generate": [
+           "Generate only the DECIDE configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer uncertainty and human gates decisions to the owning subsystem and do not create a parallel decision records store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the DECIDE operation and its decision records result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when DECIDE is in scope for architecture decision prompts and recorded choices, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about decision records freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document DECIDE as the owner of decision records and show its boundary with uncertainty and human gates.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported DECIDE CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop DECIDE without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate DECIDE advisory claims from verified authority and protect decision records from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for DECIDE ownership, deterministic output, failure modes, and decision records freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what DECIDE means for architecture decision prompts and recorded choices, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie DECIDE completion to executable evidence for decision records, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The DECIDE node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured DECIDE doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative DECIDE invocation returns bounded output with explicit decision records ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable DECIDE path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when DECIDE changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred DECIDE risk."
+         ]
+       },
       "terms": [
         "capture",
         "decision",
@@ -20594,7 +21781,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS",
@@ -20638,6 +21826,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for EMERGENCY PROTOCOL.",
+      "architect_notes": [
+         "EMERGENCY_PROTOCOL owns bounded recovery for urgent failures; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep EMERGENCY_PROTOCOL invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat EMERGENCY_PROTOCOL proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does EMERGENCY_PROTOCOL own, and which adjacent subsystem remains the source of truth for least privilege and escalation?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that EMERGENCY_PROTOCOL can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the emergency recovery result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is bounded recovery for urgent failures, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the emergency recovery boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the least privilege and escalation boundary or needs a schema, store, policy, or lifecycle decision outside EMERGENCY_PROTOCOL.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether EMERGENCY_PROTOCOL prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting emergency recovery results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the EMERGENCY_PROTOCOL owner, invocation surface, state boundary, authority label, and expected emergency recovery evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects bounded recovery for urgent failures."
+         ],
+         "generate": [
+           "Generate only the EMERGENCY_PROTOCOL configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer least privilege and escalation decisions to the owning subsystem and do not create a parallel emergency recovery store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the EMERGENCY_PROTOCOL operation and its emergency recovery result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when EMERGENCY_PROTOCOL is in scope for bounded recovery for urgent failures, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about emergency recovery freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document EMERGENCY_PROTOCOL as the owner of emergency recovery and show its boundary with least privilege and escalation.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported EMERGENCY_PROTOCOL CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop EMERGENCY_PROTOCOL without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate EMERGENCY_PROTOCOL advisory claims from verified authority and protect emergency recovery from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for EMERGENCY_PROTOCOL ownership, deterministic output, failure modes, and emergency recovery freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what EMERGENCY_PROTOCOL means for bounded recovery for urgent failures, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie EMERGENCY_PROTOCOL completion to executable evidence for emergency recovery, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The EMERGENCY_PROTOCOL node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured EMERGENCY_PROTOCOL doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative EMERGENCY_PROTOCOL invocation returns bounded output with explicit emergency recovery ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable EMERGENCY_PROTOCOL path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when EMERGENCY_PROTOCOL changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred EMERGENCY_PROTOCOL risk."
+         ]
+       },
       "terms": [
         "conditions",
         "incident",
@@ -20653,7 +21972,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20696,6 +22016,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for FEDERATION.",
+      "architect_notes": [
+         "FEDERATION owns cross-repository knowledge and provenance exchange; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep FEDERATION invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat FEDERATION proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does FEDERATION own, and which adjacent subsystem remains the source of truth for source custody and trust labels?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that FEDERATION can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the federated knowledge result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is cross-repository knowledge and provenance exchange, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the federated knowledge boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the source custody and trust labels boundary or needs a schema, store, policy, or lifecycle decision outside FEDERATION.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether FEDERATION prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting federated knowledge results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the FEDERATION owner, invocation surface, state boundary, authority label, and expected federated knowledge evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects cross-repository knowledge and provenance exchange."
+         ],
+         "generate": [
+           "Generate only the FEDERATION configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer source custody and trust labels decisions to the owning subsystem and do not create a parallel federated knowledge store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the FEDERATION operation and its federated knowledge result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when FEDERATION is in scope for cross-repository knowledge and provenance exchange, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about federated knowledge freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document FEDERATION as the owner of federated knowledge and show its boundary with source custody and trust labels.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported FEDERATION CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop FEDERATION without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate FEDERATION advisory claims from verified authority and protect federated knowledge from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for FEDERATION ownership, deterministic output, failure modes, and federated knowledge freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what FEDERATION means for cross-repository knowledge and provenance exchange, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie FEDERATION completion to executable evidence for federated knowledge, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The FEDERATION node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured FEDERATION doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative FEDERATION invocation returns bounded output with explicit federated knowledge ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable FEDERATION path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when FEDERATION changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred FEDERATION risk."
+         ]
+       },
       "terms": [
         "shared",
         "trust",
@@ -20713,7 +22164,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20756,6 +22208,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for FEEDBACK.",
+      "architect_notes": [
+         "FEEDBACK owns operator feedback and improvement signals; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep FEEDBACK invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat FEEDBACK proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does FEEDBACK own, and which adjacent subsystem remains the source of truth for human control and non-authoritative hints?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that FEEDBACK can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the feedback records result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is operator feedback and improvement signals, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the feedback records boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the human control and non-authoritative hints boundary or needs a schema, store, policy, or lifecycle decision outside FEEDBACK.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether FEEDBACK prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting feedback records results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the FEEDBACK owner, invocation surface, state boundary, authority label, and expected feedback records evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects operator feedback and improvement signals."
+         ],
+         "generate": [
+           "Generate only the FEEDBACK configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer human control and non-authoritative hints decisions to the owning subsystem and do not create a parallel feedback records store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the FEEDBACK operation and its feedback records result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when FEEDBACK is in scope for operator feedback and improvement signals, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about feedback records freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document FEEDBACK as the owner of feedback records and show its boundary with human control and non-authoritative hints.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported FEEDBACK CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop FEEDBACK without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate FEEDBACK advisory claims from verified authority and protect feedback records from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for FEEDBACK ownership, deterministic output, failure modes, and feedback records freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what FEEDBACK means for operator feedback and improvement signals, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie FEEDBACK completion to executable evidence for feedback records, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The FEEDBACK node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured FEEDBACK doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative FEEDBACK invocation returns bounded output with explicit feedback records ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable FEEDBACK path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when FEEDBACK changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred FEEDBACK risk."
+         ]
+       },
       "terms": [
         "controlled",
         "capture",
@@ -20772,7 +22355,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -20815,6 +22399,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for HEALTH.",
+      "architect_notes": [
+         "HEALTH owns bounded health and readiness diagnostics; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep HEALTH invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat HEALTH proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does HEALTH own, and which adjacent subsystem remains the source of truth for purity and evidence freshness?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that HEALTH can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the health checks result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is bounded health and readiness diagnostics, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the health checks boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the purity and evidence freshness boundary or needs a schema, store, policy, or lifecycle decision outside HEALTH.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether HEALTH prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting health checks results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the HEALTH owner, invocation surface, state boundary, authority label, and expected health checks evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects bounded health and readiness diagnostics."
+         ],
+         "generate": [
+           "Generate only the HEALTH configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer purity and evidence freshness decisions to the owning subsystem and do not create a parallel health checks store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the HEALTH operation and its health checks result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when HEALTH is in scope for bounded health and readiness diagnostics, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about health checks freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document HEALTH as the owner of health checks and show its boundary with purity and evidence freshness.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported HEALTH CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop HEALTH without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate HEALTH advisory claims from verified authority and protect health checks from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for HEALTH ownership, deterministic output, failure modes, and health checks freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what HEALTH means for bounded health and readiness diagnostics, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie HEALTH completion to executable evidence for health checks, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The HEALTH node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured HEALTH doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative HEALTH invocation returns bounded output with explicit health checks ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable HEALTH path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when HEALTH changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred HEALTH risk."
+         ]
+       },
       "terms": [
         "health",
         "diagnostics",
@@ -20830,7 +22545,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "architecture/OBSERVABILITY",
@@ -20875,6 +22591,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for HEARTBEAT.",
+      "architect_notes": [
+         "HEARTBEAT owns agent presence and lease freshness; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep HEARTBEAT invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat HEARTBEAT proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does HEARTBEAT own, and which adjacent subsystem remains the source of truth for liveness without daemon state?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that HEARTBEAT can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the heartbeat records result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is agent presence and lease freshness, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the heartbeat records boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the liveness without daemon state boundary or needs a schema, store, policy, or lifecycle decision outside HEARTBEAT.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether HEARTBEAT prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting heartbeat records results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the HEARTBEAT owner, invocation surface, state boundary, authority label, and expected heartbeat records evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects agent presence and lease freshness."
+         ],
+         "generate": [
+           "Generate only the HEARTBEAT configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer liveness without daemon state decisions to the owning subsystem and do not create a parallel heartbeat records store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the HEARTBEAT operation and its heartbeat records result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when HEARTBEAT is in scope for agent presence and lease freshness, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about heartbeat records freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document HEARTBEAT as the owner of heartbeat records and show its boundary with liveness without daemon state.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported HEARTBEAT CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop HEARTBEAT without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate HEARTBEAT advisory claims from verified authority and protect heartbeat records from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for HEARTBEAT ownership, deterministic output, failure modes, and heartbeat records freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what HEARTBEAT means for agent presence and lease freshness, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie HEARTBEAT completion to executable evidence for heartbeat records, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The HEARTBEAT node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured HEARTBEAT doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative HEARTBEAT invocation returns bounded output with explicit heartbeat records ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable HEARTBEAT path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when HEARTBEAT changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred HEARTBEAT risk."
+         ]
+       },
       "terms": [
         "signals",
         "agent",
@@ -20892,7 +22739,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS",
@@ -20937,6 +22785,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for KNOWLEDGE.",
+      "architect_notes": [
+         "KNOWLEDGE owns governed knowledge retrieval and promotion; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep KNOWLEDGE invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat KNOWLEDGE proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does KNOWLEDGE own, and which adjacent subsystem remains the source of truth for authority, provenance, and promotion?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that KNOWLEDGE can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the knowledge entries result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is governed knowledge retrieval and promotion, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the knowledge entries boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the authority, provenance, and promotion boundary or needs a schema, store, policy, or lifecycle decision outside KNOWLEDGE.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether KNOWLEDGE prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting knowledge entries results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the KNOWLEDGE owner, invocation surface, state boundary, authority label, and expected knowledge entries evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects governed knowledge retrieval and promotion."
+         ],
+         "generate": [
+           "Generate only the KNOWLEDGE configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer authority, provenance, and promotion decisions to the owning subsystem and do not create a parallel knowledge entries store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the KNOWLEDGE operation and its knowledge entries result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when KNOWLEDGE is in scope for governed knowledge retrieval and promotion, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about knowledge entries freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document KNOWLEDGE as the owner of knowledge entries and show its boundary with authority, provenance, and promotion.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported KNOWLEDGE CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop KNOWLEDGE without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate KNOWLEDGE advisory claims from verified authority and protect knowledge entries from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for KNOWLEDGE ownership, deterministic output, failure modes, and knowledge entries freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what KNOWLEDGE means for governed knowledge retrieval and promotion, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie KNOWLEDGE completion to executable evidence for knowledge entries, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The KNOWLEDGE node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured KNOWLEDGE doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative KNOWLEDGE invocation returns bounded output with explicit knowledge entries ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable KNOWLEDGE path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when KNOWLEDGE changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred KNOWLEDGE risk."
+         ]
+       },
       "terms": [
         "capture",
         "retrieval",
@@ -20949,12 +22928,13 @@
         "subsystem"
       ],
       "links": {
-        "references": [
-          "architecture/KNOWLEDGE_BASE",
-          "core/PLUGINS",
-          "interfaces/KNOWLEDGE_SCHEMA",
-          "interfaces/KNOWLEDGE_STORE",
-          "methodology/KNOWLEDGE"
+      "references": [
+        "architecture/KNOWLEDGE_BASE",
+        "core/PLUGINS",
+        "interfaces/KNOWLEDGE_SCHEMA",
+        "interfaces/KNOWLEDGE_STORE",
+        "methodology/KNOWLEDGE",
+        "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS",
@@ -20998,6 +22978,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for MANIFEST.",
+      "architect_notes": [
+         "MANIFEST owns generated artifact inventory and integrity metadata; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep MANIFEST invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat MANIFEST proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does MANIFEST own, and which adjacent subsystem remains the source of truth for ownership and deterministic regeneration?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that MANIFEST can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the manifests result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is generated artifact inventory and integrity metadata, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the manifests boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the ownership and deterministic regeneration boundary or needs a schema, store, policy, or lifecycle decision outside MANIFEST.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether MANIFEST prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting manifests results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the MANIFEST owner, invocation surface, state boundary, authority label, and expected manifests evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects generated artifact inventory and integrity metadata."
+         ],
+         "generate": [
+           "Generate only the MANIFEST configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer ownership and deterministic regeneration decisions to the owning subsystem and do not create a parallel manifests store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the MANIFEST operation and its manifests result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when MANIFEST is in scope for generated artifact inventory and integrity metadata, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about manifests freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document MANIFEST as the owner of manifests and show its boundary with ownership and deterministic regeneration.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported MANIFEST CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop MANIFEST without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate MANIFEST advisory claims from verified authority and protect manifests from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for MANIFEST ownership, deterministic output, failure modes, and manifests freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what MANIFEST means for generated artifact inventory and integrity metadata, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie MANIFEST completion to executable evidence for manifests, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The MANIFEST node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured MANIFEST doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative MANIFEST invocation returns bounded output with explicit manifests ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable MANIFEST path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when MANIFEST changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred MANIFEST risk."
+         ]
+       },
       "terms": [
         "accountability",
         "provenance",
@@ -21013,7 +23124,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "architecture/CI_CD_PIPELINES",
@@ -21058,6 +23170,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for POLICY.",
+      "architect_notes": [
+         "POLICY owns policy resolution and approval boundaries; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep POLICY invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat POLICY proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does POLICY own, and which adjacent subsystem remains the source of truth for authority and escalation?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that POLICY can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the policy decisions result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is policy resolution and approval boundaries, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the policy decisions boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the authority and escalation boundary or needs a schema, store, policy, or lifecycle decision outside POLICY.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether POLICY prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting policy decisions results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the POLICY owner, invocation surface, state boundary, authority label, and expected policy decisions evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects policy resolution and approval boundaries."
+         ],
+         "generate": [
+           "Generate only the POLICY configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer authority and escalation decisions to the owning subsystem and do not create a parallel policy decisions store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the POLICY operation and its policy decisions result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when POLICY is in scope for policy resolution and approval boundaries, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about policy decisions freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document POLICY as the owner of policy decisions and show its boundary with authority and escalation.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported POLICY CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop POLICY without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate POLICY advisory claims from verified authority and protect policy decisions from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for POLICY ownership, deterministic output, failure modes, and policy decisions freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what POLICY means for policy resolution and approval boundaries, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie POLICY completion to executable evidence for policy decisions, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The POLICY node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured POLICY doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative POLICY invocation returns bounded output with explicit policy decisions ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable POLICY path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when POLICY changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred POLICY risk."
+         ]
+       },
       "terms": [
         "policy",
         "gates",
@@ -21071,7 +23314,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -21114,6 +23358,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for REFLEX.",
+      "architect_notes": [
+         "REFLEX owns small deterministic corrective responses; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep REFLEX invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat REFLEX proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does REFLEX own, and which adjacent subsystem remains the source of truth for bounded mutation and recovery?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that REFLEX can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the reflex actions result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is small deterministic corrective responses, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the reflex actions boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the bounded mutation and recovery boundary or needs a schema, store, policy, or lifecycle decision outside REFLEX.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether REFLEX prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting reflex actions results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the REFLEX owner, invocation surface, state boundary, authority label, and expected reflex actions evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects small deterministic corrective responses."
+         ],
+         "generate": [
+           "Generate only the REFLEX configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer bounded mutation and recovery decisions to the owning subsystem and do not create a parallel reflex actions store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the REFLEX operation and its reflex actions result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when REFLEX is in scope for small deterministic corrective responses, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about reflex actions freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document REFLEX as the owner of reflex actions and show its boundary with bounded mutation and recovery.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported REFLEX CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop REFLEX without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate REFLEX advisory claims from verified authority and protect reflex actions from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for REFLEX ownership, deterministic output, failure modes, and reflex actions freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what REFLEX means for small deterministic corrective responses, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie REFLEX completion to executable evidence for reflex actions, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The REFLEX node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured REFLEX doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative REFLEX invocation returns bounded output with explicit reflex actions ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable REFLEX path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when REFLEX changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred REFLEX risk."
+         ]
+       },
       "terms": [
         "bounded",
         "checks",
@@ -21129,7 +23504,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"
@@ -21173,6 +23549,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for TODO.",
+      "architect_notes": [
+         "TODO owns work ownership, lifecycle, and handoff state; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep TODO invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat TODO proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does TODO own, and which adjacent subsystem remains the source of truth for claim custody and completion proof?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that TODO can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the todo records result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is work ownership, lifecycle, and handoff state, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the todo records boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the claim custody and completion proof boundary or needs a schema, store, policy, or lifecycle decision outside TODO.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether TODO prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting todo records results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the TODO owner, invocation surface, state boundary, authority label, and expected todo records evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects work ownership, lifecycle, and handoff state."
+         ],
+         "generate": [
+           "Generate only the TODO configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer claim custody and completion proof decisions to the owning subsystem and do not create a parallel todo records store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the TODO operation and its todo records result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when TODO is in scope for work ownership, lifecycle, and handoff state, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about todo records freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document TODO as the owner of todo records and show its boundary with claim custody and completion proof.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported TODO CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop TODO without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate TODO advisory claims from verified authority and protect todo records from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for TODO ownership, deterministic output, failure modes, and todo records freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what TODO means for work ownership, lifecycle, and handoff state, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie TODO completion to executable evidence for todo records, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The TODO node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured TODO doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative TODO invocation returns bounded output with explicit todo records ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable TODO path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when TODO changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred TODO risk."
+         ]
+       },
       "terms": [
         "sourced",
         "task",
@@ -21237,6 +23744,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for TRUST.",
+      "architect_notes": [
+         "TRUST owns trust roots, evidence classes, and verification labels; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep TRUST invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat TRUST proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does TRUST own, and which adjacent subsystem remains the source of truth for claimed versus verified identity?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that TRUST can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the trust assertions result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is trust roots, evidence classes, and verification labels, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the trust assertions boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the claimed versus verified identity boundary or needs a schema, store, policy, or lifecycle decision outside TRUST.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether TRUST prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting trust assertions results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the TRUST owner, invocation surface, state boundary, authority label, and expected trust assertions evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects trust roots, evidence classes, and verification labels."
+         ],
+         "generate": [
+           "Generate only the TRUST configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer claimed versus verified identity decisions to the owning subsystem and do not create a parallel trust assertions store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the TRUST operation and its trust assertions result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when TRUST is in scope for trust roots, evidence classes, and verification labels, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about trust assertions freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document TRUST as the owner of trust assertions and show its boundary with claimed versus verified identity.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported TRUST CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop TRUST without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate TRUST advisory claims from verified authority and protect trust assertions from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for TRUST ownership, deterministic output, failure modes, and trust assertions freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what TRUST means for trust roots, evidence classes, and verification labels, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie TRUST completion to executable evidence for trust assertions, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The TRUST node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured TRUST doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative TRUST invocation returns bounded output with explicit trust assertions ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable TRUST path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when TRUST changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred TRUST risk."
+         ]
+       },
       "terms": [
         "identity",
         "confidence",
@@ -21250,7 +23888,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS",
@@ -21294,6 +23933,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for VERIFY.",
+      "architect_notes": [
+         "VERIFY owns completion proof replay and validation gates; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep VERIFY invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat VERIFY proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does VERIFY own, and which adjacent subsystem remains the source of truth for independent evidence and failure recovery?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that VERIFY can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the verification proofs result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is completion proof replay and validation gates, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the verification proofs boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the independent evidence and failure recovery boundary or needs a schema, store, policy, or lifecycle decision outside VERIFY.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether VERIFY prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting verification proofs results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the VERIFY owner, invocation surface, state boundary, authority label, and expected verification proofs evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects completion proof replay and validation gates."
+         ],
+         "generate": [
+           "Generate only the VERIFY configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer independent evidence and failure recovery decisions to the owning subsystem and do not create a parallel verification proofs store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the VERIFY operation and its verification proofs result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when VERIFY is in scope for completion proof replay and validation gates, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about verification proofs freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document VERIFY as the owner of verification proofs and show its boundary with independent evidence and failure recovery.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported VERIFY CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop VERIFY without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate VERIFY advisory claims from verified authority and protect verification proofs from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for VERIFY ownership, deterministic output, failure modes, and verification proofs freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what VERIFY means for completion proof replay and validation gates, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie VERIFY completion to executable evidence for verification proofs, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The VERIFY node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured VERIFY doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative VERIFY invocation returns bounded output with explicit verification proofs ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable VERIFY path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when VERIFY changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred VERIFY risk."
+         ]
+       },
       "terms": [
         "collection",
         "proof",
@@ -21362,6 +24132,137 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes Decapod subsystem ownership, lifecycle state, invocation boundary, and proof surface for WATCHER.",
+      "architect_notes": [
+         "WATCHER owns one-shot observation and audit of repository state; its metadata must name the state it observes or mutates and the authority that can authorize the operation.",
+         "Keep WATCHER invocation explicit and daemonless: a CLI or RPC call may produce a bounded result, but it must not imply a hidden worker, ambient lease, or background mutation.",
+         "Treat WATCHER proof as part of the subsystem contract: distinguish advisory output from durable state, identify the owning store, and make recovery from stale or partial work visible."
+       ],
+       "init_questions": [
+         {
+           "id": "owner_boundary",
+           "prompt": "Which state does WATCHER own, and which adjacent subsystem remains the source of truth for daemonless observation and audit custody?",
+           "why": "Naming ownership before invocation prevents duplicate stores, hidden mutation, and claims that WATCHER can authorize work outside its boundary.",
+           "answers": [
+             "local state",
+             "shared store",
+             "read-only view",
+             "ask human",
+             "defer explicitly"
+           ]
+         },
+         {
+           "id": "proof_boundary",
+           "prompt": "What command, RPC receipt, schema, or test proves the watcher runs result is current and safe to consume?",
+           "why": "A plugin result is useful only when its freshness, authority, and failure behavior can be checked independently of the agent narrative.",
+           "answers": [
+             "command output",
+             "RPC receipt",
+             "schema check",
+             "runtime test",
+             "release proof"
+           ]
+         }
+       ],
+       "decision_matrix": [
+         {
+           "choice": "Use the plugin's owned state",
+           "use_when": "The operation is one-shot observation and audit of repository state, the state owner is explicit, and the supported invocation surface exposes the needed proof.",
+           "avoid_when": "Another subsystem owns the same state or the result would silently broaden authority or lifecycle scope.",
+           "implications": "Record the watcher runs boundary, invocation contract, and proof artifact; preserve deterministic behavior for repeated inputs."
+         },
+         {
+           "choice": "Route to an adjacent subsystem",
+           "use_when": "The request crosses the daemonless observation and audit custody boundary or needs a schema, store, policy, or lifecycle decision outside WATCHER.",
+           "avoid_when": "Routing would only repeat the same uncertainty without naming a new artifact or proof gate.",
+           "implications": "Carry the unresolved question forward, query the owning doctrine once, and avoid duplicating a competing implementation."
+         },
+         {
+           "choice": "Defer or escalate",
+           "use_when": "Authority, freshness, compatibility, or recovery evidence is missing and a wrong assumption could change durable state.",
+           "avoid_when": "The operation is read-only, bounded, reversible, and its proof surface is available.",
+           "implications": "Record the blocker and required evidence; do not simulate success with advisory metadata or unverified output."
+         }
+       ],
+       "tradeoffs": [
+         {
+           "axis": "automation versus custody",
+           "option_a": "Automate a bounded plugin call with explicit inputs and receipts.",
+           "option_b": "Require a human or policy gate before durable or privileged mutation.",
+           "guidance": "Choose automation only when ownership, authority, and recovery are executable; escalate when the plugin would cross a trust or lifecycle boundary."
+         },
+         {
+           "axis": "freshness versus reproducibility",
+           "option_a": "Prefer the newest observable state when freshness is the task outcome.",
+           "option_b": "Prefer a captured deterministic receipt when replay and audit matter more.",
+           "guidance": "State whether WATCHER prioritizes freshness or replay, and retain enough evidence to explain stale, missing, or conflicting watcher runs results."
+         }
+       ],
+       "scaffolding": {
+         "capture": [
+           "Capture the WATCHER owner, invocation surface, state boundary, authority label, and expected watcher runs evidence.",
+           "Capture any daemonless, persistence, mount, retry, or human-approval assumption that affects one-shot observation and audit of repository state."
+         ],
+         "generate": [
+           "Generate only the WATCHER configuration, receipt, manifest, or spec fragment owned by this subsystem.",
+           "Generate deterministic placeholders for deferred values rather than inventing credentials, identities, or external state."
+         ],
+         "defer": [
+           "Defer daemonless observation and audit custody decisions to the owning subsystem and do not create a parallel watcher runs store.",
+           "Defer privileged, destructive, background, or externally sourced actions until their proof and approval boundaries are explicit."
+         ],
+         "proof": [
+           "Record the command or RPC output that proves the WATCHER operation and its watcher runs result.",
+           "Record recovery evidence for stale, partial, rejected, or unavailable plugin state."
+         ]
+       },
+       "spec_impacts": {
+         "intent": [
+           "State when WATCHER is in scope for one-shot observation and audit of repository state, including its non-goals and the human outcome it supports.",
+           "Preserve uncertainty about watcher runs freshness, authority, or recovery instead of turning it into an implicit requirement."
+         ],
+         "architecture": [
+           "Document WATCHER as the owner of watcher runs and show its boundary with daemonless observation and audit custody.",
+           "Document daemonless invocation, persistence, side effects, and the absence of hidden background workers."
+         ],
+         "interfaces": [
+           "Name the supported WATCHER CLI/RPC payload, receipt, schema, and error semantics without inventing an alternate protocol.",
+           "Keep omission, retry, authorization, and failure behavior explicit for consumers of the plugin surface."
+         ],
+         "operations": [
+           "Describe how operators invoke, inspect, retry, recover, and stop WATCHER without leaving a background process.",
+           "Record bounded timeouts, cleanup expectations, and evidence locations for operational recovery."
+         ],
+         "security": [
+           "Separate WATCHER advisory claims from verified authority and protect watcher runs from unauthorized mutation.",
+           "Treat external input as untrusted data until the owning validation and policy surfaces accept it."
+         ],
+         "validation": [
+           "Add static and runtime checks for WATCHER ownership, deterministic output, failure modes, and watcher runs freshness.",
+           "Make missing proof or stale references visible as a validation failure or explicit deferred blocker."
+         ],
+         "semantics": [
+           "Define what WATCHER means for one-shot observation and audit of repository state, including empty, stale, rejected, and partially completed results.",
+           "Preserve stable identifiers and omission/error semantics so repeated calls remain explainable."
+         ],
+         "proof": [
+           "Tie WATCHER completion to executable evidence for watcher runs, not to the presence of descriptive metadata alone.",
+           "Record the proof command, artifact, receipt, or test that a later agent can replay."
+         ]
+       },
+       "proof": {
+         "static": [
+           "The WATCHER node is reachable through plugin lookup and cross-linked to its owner and adjacent contract nodes.",
+           "Schema and tests preserve the structured WATCHER doctrine fields and reject regression to a compact summary."
+         ],
+         "runtime": [
+           "A representative WATCHER invocation returns bounded output with explicit watcher runs ownership and failure semantics.",
+           "A stale, unauthorized, or unavailable WATCHER path produces visible recovery guidance instead of silent success."
+         ],
+         "release": [
+           "Generated specs and release artifacts are refreshed when WATCHER changes state ownership, interfaces, or proof expectations.",
+           "Release evidence records version compatibility, daemonless behavior, and any intentionally deferred WATCHER risk."
+         ]
+       },
       "terms": [
         "file",
         "detection",
@@ -21378,7 +24279,8 @@
       ],
       "links": {
         "references": [
-          "core/PLUGINS"
+          "core/PLUGINS",
+          "interfaces/CONTROL_PLANE"
         ],
         "referenced_by": [
           "core/PLUGINS"

--- a/assets/constitution.schema.json
+++ b/assets/constitution.schema.json
@@ -9,9 +9,10 @@
       "methodology",
       "interfaces",
       "data",
-      "metadata"
+      "metadata",
+      "plugins"
     ],
-    "migration_strategy": "architecture, methodology, interfaces nodes, data nodes, and metadata nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
+    "migration_strategy": "architecture, methodology, interfaces nodes, data nodes, metadata nodes, and plugins nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
     "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain additive doctrine fields"
   },
   "type": "object",
@@ -149,6 +150,29 @@
             "properties": {
               "category": {
                 "const": "metadata"
+              }
+            },
+            "required": [
+              "category"
+            ]
+          },
+          "then": {
+            "required": [
+              "architect_notes",
+              "init_questions",
+              "decision_matrix",
+              "tradeoffs",
+              "scaffolding",
+              "spec_impacts",
+              "proof"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "category": {
+                "const": "plugins"
               }
             },
             "required": [

--- a/tests/constitution_scaffolding.rs
+++ b/tests/constitution_scaffolding.rs
@@ -111,6 +111,31 @@ const METADATA_NODES: &[&str] = &[
     "metadata/skills/INTENT_REFINEMENT",
 ];
 
+const PLUGIN_NODES: &[&str] = &[
+    "plugins/APTITUDE",
+    "plugins/ARCHIVE",
+    "plugins/AUDIT",
+    "plugins/AUTOUPDATE",
+    "plugins/CONTAINER",
+    "plugins/CONTEXT",
+    "plugins/CRON",
+    "plugins/DB_BROKER",
+    "plugins/DECIDE",
+    "plugins/EMERGENCY_PROTOCOL",
+    "plugins/FEDERATION",
+    "plugins/FEEDBACK",
+    "plugins/HEALTH",
+    "plugins/HEARTBEAT",
+    "plugins/KNOWLEDGE",
+    "plugins/MANIFEST",
+    "plugins/POLICY",
+    "plugins/REFLEX",
+    "plugins/TODO",
+    "plugins/TRUST",
+    "plugins/VERIFY",
+    "plugins/WATCHER",
+];
+
 const METHODOLOGY_NODES: &[&str] = &[
     "methodology/ARCHITECTURE",
     "methodology/CI_CD",
@@ -482,7 +507,6 @@ fn all_interface_nodes_have_architect_grade_contract_doctrine() {
             &node["links"]["references"],
             &format!("{node_id}.links.references"),
         );
-
         let sections = node["sections"].as_object().expect("sections object");
         for section in [
             "match",
@@ -667,6 +691,102 @@ fn all_metadata_nodes_have_architect_grade_skill_and_ux_doctrine() {
 }
 
 #[test]
+fn all_plugin_nodes_have_architect_grade_subsystem_doctrine() {
+    let constitution = load_constitution_asset();
+    let nodes = constitution["nodes"].as_object().expect("nodes object");
+    let lookup = constitution["lookup"].as_object().expect("lookup object");
+
+    let actual_plugin_count = nodes
+        .values()
+        .filter(|node| node["category"].as_str() == Some("plugins"))
+        .count();
+    assert_eq!(
+        actual_plugin_count,
+        PLUGIN_NODES.len(),
+        "PLUGIN_NODES test list must cover every plugins/* node"
+    );
+
+    let core_refs = nodes["core/PLUGINS"]["links"]["references"]
+        .as_array()
+        .expect("core plugin references");
+
+    for node_id in PLUGIN_NODES {
+        let node = nodes
+            .get(*node_id)
+            .unwrap_or_else(|| panic!("missing plugin node {node_id}"));
+        assert_eq!(
+            node["category"].as_str(),
+            Some("plugins"),
+            "{node_id} must remain in the plugins namespace"
+        );
+        assert_architect_grade_fields(node_id, node);
+        assert_non_empty_array(
+            &node["links"]["references"],
+            &format!("{node_id}.links.references"),
+        );
+        assert!(
+            node["links"]["references"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("interfaces/CONTROL_PLANE"))),
+            "{node_id} must link plugin metadata to the control-plane contract"
+        );
+        assert!(
+            node["links"]["referenced_by"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/PLUGINS"))),
+            "{node_id} must be reachable from core/PLUGINS"
+        );
+        assert!(
+            core_refs
+                .iter()
+                .any(|value| value.as_str() == Some(node_id)),
+            "core/PLUGINS must route to {node_id}"
+        );
+
+        let sections = node["sections"].as_object().expect("sections object");
+        for section in [
+            "match",
+            "ambiguity",
+            "decisions",
+            "standards",
+            "failure_modes",
+            "proceed_when",
+        ] {
+            assert!(
+                sections
+                    .get(section)
+                    .and_then(|items| items.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                "{node_id}.{section} must preserve subsystem guidance"
+            );
+        }
+
+        assert!(
+            node["architect_notes"].as_array().is_some_and(|notes| {
+                notes.iter().any(|note| {
+                    note.as_str().is_some_and(|text| {
+                        text.contains(node_id.strip_prefix("plugins/").unwrap())
+                    })
+                })
+            }),
+            "{node_id} architect notes must identify the owned plugin"
+        );
+        assert!(
+            lookup.values().any(|entries| {
+                entries.as_array().is_some_and(|entries| {
+                    entries.iter().any(|entry| entry.as_str() == Some(node_id))
+                })
+            }),
+            "{node_id} must remain reachable through at least one lookup term"
+        );
+    }
+}
+
+#[test]
 fn all_methodology_nodes_have_architect_grade_delivery_doctrine() {
     let constitution = load_constitution_asset();
     let nodes = constitution["nodes"].as_object().expect("nodes object");
@@ -751,8 +871,9 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
                 strategy.contains("interfaces nodes")
                     && strategy.contains("data nodes")
                     && strategy.contains("metadata nodes")
+                    && strategy.contains("plugins nodes")
             }),
-        "schema must document in-place interfaces, data, and metadata namespace migration"
+        "schema must document in-place interfaces, data, metadata, and plugins namespace migration"
     );
 
     let node_schema = &schema["definitions"]["node"];
@@ -784,6 +905,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         .iter()
         .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("metadata"))
         .expect("node schema must declare metadata doctrine conditional");
+    let plugin_rule = rules
+        .iter()
+        .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("plugins"))
+        .expect("node schema must declare plugin doctrine conditional");
 
     let required = architecture_rule["then"]["required"]
         .as_array()
@@ -832,6 +957,16 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         assert!(
             required.iter().any(|value| value.as_str() == Some(field)),
             "metadata schema must require {field}"
+        );
+    }
+
+    let required = plugin_rule["then"]["required"]
+        .as_array()
+        .expect("plugin doctrine required fields");
+    for field in ARCHITECTURE_DOCTRINE_FIELDS {
+        assert!(
+            required.iter().any(|value| value.as_str() == Some(field)),
+            "plugin schema must require {field}"
         );
     }
 
@@ -1302,6 +1437,33 @@ fn embedded_constitution_preserves_metadata_doctrine() {
                 .as_array()
                 .is_some_and(|refs| !refs.is_empty()),
             "{node_id} must preserve metadata cross-links in embedded output"
+        );
+    }
+}
+
+#[test]
+fn embedded_constitution_preserves_plugin_doctrine() {
+    for node_id in PLUGIN_NODES {
+        let output = Command::new(resolve_decapod_bin())
+            .args(["constitution", "get", node_id])
+            .output()
+            .expect("run decapod constitution get");
+        assert!(
+            output.status.success(),
+            "constitution get {node_id} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let node: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("constitution get json");
+        assert_architect_grade_fields(node_id, &node);
+        assert!(
+            node["links"]["referenced_by"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/PLUGINS"))),
+            "{node_id} must preserve plugin routing in embedded output"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade all 22 plugins/* constitution nodes to architect-grade subsystem doctrine.
- Document ownership, lifecycle and state boundaries, daemonless invocation, command/RPC contracts, scaffolding, living-spec impacts, failure modes, and proof expectations.
- Add plugin schema enforcement, core/control-plane cross-links, lookup coverage, embedded-output tests, and refreshed living specs.

## Verification

- cargo fmt --all -- --check
- cargo test --test constitution_scaffolding -- --test-threads=1 (24 passed)
- Decapod v0.72.7 one-shot container validation (200 gates passed)

Closes #808