### PR TITLE
Uplift specification constitution doctrine for Issue #810

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.7
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.8
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.7
+ARG DECAPOD_VERSION=0.72.8
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784602028Z",
-  "repo_signal_fingerprint": "e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225",
+  "generated_at": "1784603549Z",
+  "repo_signal_fingerprint": "b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "1a9c3549058e5f37db1324b969d1af6ab567ea5ada4ee2f1d67bfff0f99949d5",
-  "decapod_release": "0.72.7",
+  "spec_input_hash": "3f69280b773d634bd3a6b56f42d7c5644c023072732574981142ae1546d034fd",
+  "decapod_release": "0.72.8",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "60f4240d2f5400a43b17d487a9618de7768c6284c719de6e009d5f509d348988",
-      "content_hash": "60f4240d2f5400a43b17d487a9618de7768c6284c719de6e009d5f509d348988",
-      "fingerprint": "0123bf512289c45ad33891016490ed69441397a404d3b14153e6bdbd7b80a4a2"
+      "template_hash": "21c8a4d14ead49e21db1221ae3690ebc3145c370a7786b27027ca3f3c415cafb",
+      "content_hash": "21c8a4d14ead49e21db1221ae3690ebc3145c370a7786b27027ca3f3c415cafb",
+      "fingerprint": "5b93160fedc113fd2ec92cb68c427962dc20d1f8b76e6f75f3438e109e45f2ad"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "2628f587917771c57890ae09a063f45415f1fd61ab3cdf58a7d79dbb1beaf007",
-      "content_hash": "2628f587917771c57890ae09a063f45415f1fd61ab3cdf58a7d79dbb1beaf007",
-      "fingerprint": "3577cf2f877eeff2d9f0fb701d1720d9276bce64740c39f2d66d322080411fc8"
+      "template_hash": "6641520252edd5a03155a77b1325df49eced881031e13550118b957ce12864d2",
+      "content_hash": "6641520252edd5a03155a77b1325df49eced881031e13550118b957ce12864d2",
+      "fingerprint": "4f0f79b6ee532ea09c8985a20dafab346680ae27d0a928dfff06dab60011d11b"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "45272a1ad8955a1227091df4aa9090b08f449be6d8ef00ddfe2fb918a2f928bc",
-      "content_hash": "45272a1ad8955a1227091df4aa9090b08f449be6d8ef00ddfe2fb918a2f928bc",
-      "fingerprint": "3ceba16d1bda54bb3119f5fa115107d0c183285853bc32c1b69c323d2983c88a"
+      "template_hash": "0ff85ad09749fe5587d51a655b34c3100096c97417a57f33a18b2cfc69d7989e",
+      "content_hash": "0ff85ad09749fe5587d51a655b34c3100096c97417a57f33a18b2cfc69d7989e",
+      "fingerprint": "cc21151711685ad1b9feec2bb24c0348ad1fdaabd0255b56ec5204bf41d2b616"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "7e6a98d53ee2329c70127986a3b5d3445362eb9d3910d62f6e7bbc5f8f51a120",
-      "content_hash": "7e6a98d53ee2329c70127986a3b5d3445362eb9d3910d62f6e7bbc5f8f51a120",
-      "fingerprint": "b6a7b3fbc62997cc187b545046440a197fff01f1e90de68395a05302ff0b5563"
+      "template_hash": "0de58b12221e260d203d2b4b8ee817b19129dc3d0636debe768192ed5baeb045",
+      "content_hash": "0de58b12221e260d203d2b4b8ee817b19129dc3d0636debe768192ed5baeb045",
+      "fingerprint": "4cdbd536e425117c650d7a79a4a1b8b8461c74b3034bb9b06d2ec9e92ee58936"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "0057c320cc1b12f84c4e9e86872cd29f577fd0f3c811c60f9600e1297076472d",
+      "content_hash": "fbef96fe8e75903870e4911a09e43f3cd09f846499173d10f4f3c30eb87fec3c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "3adcd6a2cb1b971c6f6d2d6dfe354e80873bc72d7728899f6f961277f561b16a",
+      "content_hash": "3d3c4075a0d3c71c0d388bbe352f136560f05e437c995b564b82509dad7e0c6b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "dc011e38b5f9eec7c56d6e0762707f6f884c46b480087505005634be528bac49",
+      "content_hash": "5872bf7a1e3ba5bca495685963535fa1078de1fabaf27d7b989b521f353f60cb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "e2ff0d1c981ed4ce882aeefb2ed6eb3262820790f91835b25e503c05c30ceec2",
+      "content_hash": "bdc99b2d92068a3dcfc32bee5df68c2360a90bc8719e7408c39664a76c272d90",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "fc8106e5b03b4e448a61a1e66cf8cf4fa3a8e79c397c55353cad8a4912cc62ea",
+      "content_hash": "607ee61e10d23292a30b7d852ec92f6c6c5a8a16243ad84f5e718728b0bbe6dc",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "36071ba17963cffeb4e6c94d3267075d83fa76dc17ee65a32e31a2f4850b5047",
+      "content_hash": "076dadd1290dcec8b0b87aabccef78671b982f0fd76ce8264b399b45337e4216",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "e9beb28426ebee0853c21990fd7168c73b97f0e1daac98a52bc0ec3a8c9ddef5",
+      "content_hash": "a0a9b931f455bc21df9678e5e38727e8a3d4391f7f6551cfe0570efe590c7cd4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "e83e92cfacb958438019769d3b509f11ce25527c60bfb1bd3e93e9ae17009572",
+      "content_hash": "5f0c756544e49b89bd9ed2a06f1770bf8e660c0e208ad04be63ad835dddae7fd",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -5,7 +5,19 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - [ ] SLOs defined for validation latency and workspace creation
 - [ ] Runbooks linked for validation failures and workspace interlocks
 - [ ] Rollback plan: `decapod workspace prune --force` + git reset
-- [ ] Capacity guardrails: workspace disk quota, SQLite connection limits
+- [ ] Capacity guardrails: workspace disk quota, SQLite connection limits## Deployment Model
+
+**Local-first CLI tool** — No server deployment. Decapod is distributed as:
+- Cargo-installable binary (`cargo install decapod`)
+- Prebuilt binaries via `cargo-dist` (GitHub Releases): linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64
+- Runs entirely in user's repository context
+- State stored in `.decapod/` within each repository
+
+**Runtime Requirements:**
+- Git 2.30+ (worktree support)
+- Rust 1.96+ (for building from source)
+- Docker/Podman (optional, for container workspaces)
+- SQLite 3.35+ (bundled via rusqlite)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -43,20 +55,6 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Deployment Model
-
-**Local-first CLI tool** — No server deployment. Decapod is distributed as:
-- Cargo-installable binary (`cargo install decapod`)
-- Prebuilt binaries via `cargo-dist` (GitHub Releases): linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64
-- Runs entirely in user's repository context
-- State stored in `.decapod/` within each repository
-
-**Runtime Requirements:**
-- Git 2.30+ (worktree support)
-- Rust 1.96+ (for building from source)
-- Docker/Podman (optional, for container workspaces)
-- SQLite 3.35+ (bundled via rusqlite)
 
 ## Service Level Objectives
 
@@ -276,7 +274,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -304,7 +304,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -1,6 +1,15 @@
 # Validation## Capability Proof Requirements
 
-When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.
+When `persistent-state` is declared, validation executes the human-governed `[repo.migration_validation]` command from `.decapod/config.toml`. The command defines its arguments, repository-relative working directory, timeout, expected exit code, and bounded evidence output. A non-empty migration file or recognized migration layout never satisfies this gate independently. Missing configuration, startup failure, timeout, unexpected exit status, or evidence-recording failure blocks validation.## Validation Philosophy
+> Validation is a release gate, not documentation theater.## Validation Harness
+Decapod's validation suite (`src/core/validate.rs`) enforces methodology compliance through deterministic, bounded gates.
+
+### Key Features
+- **Automated Gates**: 20+ validation gates covering workspace, store, schema, entrypoints, specs, health, generated artifacts
+- **Auto-Remediable Errors**: Structured error codes with `agent_action` and `user_note` for self-correction
+- **Bounded Execution**: `INV-BOUNDED-VALIDATE` — validation terminates within 30s
+- **Spec Refresh**: `--refresh-specs` regenerates stale scaffold templates
+- **Dual Store Modes**: `user` (blank slate) and `repo` (dogfood backlog)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -41,19 +50,6 @@ When `persistent-state` is declared, validation executes the human-governed `[re
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Validation Philosophy
-> Validation is a release gate, not documentation theater.
-
-## Validation Harness
-Decapod's validation suite (`src/core/validate.rs`) enforces methodology compliance through deterministic, bounded gates.
-
-### Key Features
-- **Automated Gates**: 20+ validation gates covering workspace, store, schema, entrypoints, specs, health, generated artifacts
-- **Auto-Remediable Errors**: Structured error codes with `agent_action` and `user_note` for self-correction
-- **Bounded Execution**: `INV-BOUNDED-VALIDATE` — validation terminates within 30s
-- **Spec Refresh**: `--refresh-specs` regenerates stale scaffold templates
-- **Dual Store Modes**: `user` (blank slate) and `repo` (dogfood backlog)
 
 ## Generated Spec Refresh Gates
 Decapod keeps generated specs synchronized at governance pressure points. When repository surfaces change, validation either fails with a concrete refresh instruction or, when explicitly requested, regenerates spec files and updates the manifest fingerprint.
@@ -336,7 +332,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `e7da5369d966ae4d12e0392afe8fb4a36394fbdfadb1aac1703792de88263225`
+- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.7 -->
-<!-- decapod-fingerprint: 0123bf512289c45ad33891016490ed69441397a404d3b14153e6bdbd7b80a4a2 -->
+<!-- decapod-release: 0.72.8 -->
+<!-- decapod-fingerprint: 5b93160fedc113fd2ec92cb68c427962dc20d1f8b76e6f75f3438e109e45f2ad -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.7 -->
-<!-- decapod-fingerprint: 3577cf2f877eeff2d9f0fb701d1720d9276bce64740c39f2d66d322080411fc8 -->
+<!-- decapod-release: 0.72.8 -->
+<!-- decapod-fingerprint: 4f0f79b6ee532ea09c8985a20dafab346680ae27d0a928dfff06dab60011d11b -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.7 -->
-<!-- decapod-fingerprint: b6a7b3fbc62997cc187b545046440a197fff01f1e90de68395a05302ff0b5563 -->
+<!-- decapod-release: 0.72.8 -->
+<!-- decapod-fingerprint: 4cdbd536e425117c650d7a79a4a1b8b8461c74b3034bb9b06d2ec9e92ee58936 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.7 -->
-<!-- decapod-fingerprint: 3ceba16d1bda54bb3119f5fa115107d0c183285853bc32c1b69c323d2983c88a -->
+<!-- decapod-release: 0.72.8 -->
+<!-- decapod-fingerprint: cc21151711685ad1b9feec2bb24c0348ad1fdaabd0255b56ec5204bf41d2b616 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -24323,6 +24323,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for AMENDMENTS.",
+      "architect_notes": [
+        "AMENDMENTS is a binding specification for constitutional changes, binding authority, and compatibility migration; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep AMENDMENTS distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat AMENDMENTS drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the amendment records contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for AMENDMENTS, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the authority, compatibility, and rollback contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this AMENDMENTS change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the constitutional changes, binding authority, and compatibility migration contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update amendment records, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on AMENDMENTS risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep AMENDMENTS binding where it protects authority, compatibility, and rollback; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the AMENDMENTS owner, binding statements, non-goals, assumptions, affected consumers, and amendment records acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal AMENDMENTS update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer authority, compatibility, and rollback decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the AMENDMENTS contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when AMENDMENTS is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about amendment records or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how AMENDMENTS changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by AMENDMENTS.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the AMENDMENTS contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how AMENDMENTS protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect AMENDMENTS drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible AMENDMENTS states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie AMENDMENTS completion to executable evidence for amendment records, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The AMENDMENTS node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured AMENDMENTS doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative AMENDMENTS change produces bounded behavior consistent with its amendment records contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified AMENDMENTS path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when AMENDMENTS changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred AMENDMENTS risk."
+        ]
+      }
+,
       "terms": [
         "controlled",
         "amendments",
@@ -24338,10 +24476,13 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS"
         ]
       },
       "sections": {
@@ -24381,6 +24522,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for DB BROKER QUEUE.",
+      "architect_notes": [
+        "DB_BROKER_QUEUE is a binding specification for database broker queue semantics, claims, retries, and persistence; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep DB_BROKER_QUEUE distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat DB_BROKER_QUEUE drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the broker queue contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for DB_BROKER_QUEUE, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the ownership, retry, and migration contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this DB_BROKER_QUEUE change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the database broker queue semantics, claims, retries, and persistence contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update broker queue contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on DB_BROKER_QUEUE risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep DB_BROKER_QUEUE binding where it protects ownership, retry, and migration; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the DB_BROKER_QUEUE owner, binding statements, non-goals, assumptions, affected consumers, and broker queue contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal DB_BROKER_QUEUE update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer ownership, retry, and migration decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the DB_BROKER_QUEUE contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when DB_BROKER_QUEUE is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about broker queue contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how DB_BROKER_QUEUE changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by DB_BROKER_QUEUE.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the DB_BROKER_QUEUE contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how DB_BROKER_QUEUE protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect DB_BROKER_QUEUE drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible DB_BROKER_QUEUE states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie DB_BROKER_QUEUE completion to executable evidence for broker queue contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The DB_BROKER_QUEUE node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured DB_BROKER_QUEUE doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative DB_BROKER_QUEUE change produces bounded behavior consistent with its broker queue contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified DB_BROKER_QUEUE path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when DB_BROKER_QUEUE changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred DB_BROKER_QUEUE risk."
+        ]
+      }
+,
       "terms": [
         "ordering",
         "database",
@@ -24397,12 +24676,15 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "data/DATABASE",
-          "core/DEMANDS",
-          "docs/MIGRATIONS"
+        "data/DATABASE",
+        "core/DEMANDS",
+        "docs/MIGRATIONS",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24442,6 +24724,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for GIT.",
+      "architect_notes": [
+        "GIT is a binding specification for branch, worktree, commit, rebase, and publication behavior; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep GIT distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat GIT drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the git workflow contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for GIT, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the branch custody and publication contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this GIT change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the branch, worktree, commit, rebase, and publication behavior contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update git workflow contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on GIT risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep GIT binding where it protects branch custody and publication; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the GIT owner, binding statements, non-goals, assumptions, affected consumers, and git workflow contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal GIT update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer branch custody and publication decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the GIT contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when GIT is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about git workflow contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how GIT changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by GIT.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the GIT contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how GIT protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect GIT drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible GIT states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie GIT completion to executable evidence for git workflow contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The GIT node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured GIT doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative GIT change produces bounded behavior consistent with its git workflow contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified GIT path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when GIT changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred GIT risk."
+        ]
+      }
+,
       "terms": [
         "worktrees",
         "promotion",
@@ -24458,12 +24878,15 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "architecture/CI_CD_PIPELINES",
-          "core/DEMANDS",
-          "docs/RELEASE_PROCESS"
+        "architecture/CI_CD_PIPELINES",
+        "core/DEMANDS",
+        "docs/RELEASE_PROCESS",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24503,6 +24926,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "This domain covers raw human intent, explicit constraints, assumptions, acceptance criteria, mutation authority, and drift recovery.",
+      "architect_notes": [
+        "INTENT is a binding specification for raw human intent, constraints, assumptions, acceptance criteria, and drift recovery; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep INTENT distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat INTENT drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the intent records contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for INTENT, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the human authority and requirement drift contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this INTENT change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the raw human intent, constraints, assumptions, acceptance criteria, and drift recovery contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update intent records, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on INTENT risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep INTENT binding where it protects human authority and requirement drift; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the INTENT owner, binding statements, non-goals, assumptions, affected consumers, and intent records acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal INTENT update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer human authority and requirement drift decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the INTENT contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when INTENT is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about intent records or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how INTENT changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by INTENT.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the INTENT contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how INTENT protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect INTENT drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible INTENT states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie INTENT completion to executable evidence for intent records, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The INTENT node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured INTENT doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative INTENT change produces bounded behavior consistent with its intent records contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified INTENT path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when INTENT changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred INTENT risk."
+        ]
+      }
+,
       "terms": [
         "capture",
         "constraints",
@@ -24518,16 +25079,18 @@
         "authority"
       ],
       "links": {
-        "references": [
-          "core/DECAPOD",
-          "core/DEMANDS",
-          "interfaces/PROJECT_SPECS",
-          "plugins/DECIDE",
-          "specs/SYSTEM"
+      "references": [
+        "core/DECAPOD",
+        "core/DEMANDS",
+        "interfaces/PROJECT_SPECS",
+        "plugins/DECIDE",
+        "specs/SYSTEM",
+        "core/SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS",
-          "specs/SYSTEM"
+        "core/DEMANDS",
+        "specs/SYSTEM",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24572,6 +25135,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for SECURITY.",
+      "architect_notes": [
+        "SECURITY is a binding specification for security posture, threat boundaries, secrets, trust, and session risk; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep SECURITY distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat SECURITY drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the security constraints contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for SECURITY, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the threat models, secrets, and authorization contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this SECURITY change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the security posture, threat boundaries, secrets, trust, and session risk contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update security constraints, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on SECURITY risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep SECURITY binding where it protects threat models, secrets, and authorization; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the SECURITY owner, binding statements, non-goals, assumptions, affected consumers, and security constraints acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal SECURITY update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer threat models, secrets, and authorization decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the SECURITY contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when SECURITY is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about security constraints or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how SECURITY changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by SECURITY.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the SECURITY contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how SECURITY protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect SECURITY drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible SECURITY states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie SECURITY completion to executable evidence for security constraints, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The SECURITY node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured SECURITY doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative SECURITY change produces bounded behavior consistent with its security constraints contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified SECURITY path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when SECURITY changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred SECURITY risk."
+        ]
+      }
+,
       "terms": [
         "modeling",
         "privilege",
@@ -24589,18 +25290,21 @@
         "abuse"
       ],
       "links": {
-        "references": [
-          "architecture/AUTH",
-          "architecture/ENCRYPTION",
-          "architecture/SECRETS",
-          "core/DEMANDS",
-          "docs/SECURITY_THREAT_MODEL"
+      "references": [
+        "architecture/AUTH",
+        "architecture/ENCRYPTION",
+        "architecture/SECRETS",
+        "core/DEMANDS",
+        "docs/SECURITY_THREAT_MODEL",
+        "core/SPECS",
+        "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "architecture/AUTH",
-          "architecture/SECURITY",
-          "core/DEMANDS",
-          "docs/SECURITY_THREAT_MODEL"
+        "architecture/AUTH",
+        "architecture/SECURITY",
+        "core/DEMANDS",
+        "docs/SECURITY_THREAT_MODEL",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24640,6 +25344,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for SYSTEM.",
+      "architect_notes": [
+        "SYSTEM is a binding specification for system boundaries, authority hierarchy, lifecycle, and control-plane behavior; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep SYSTEM distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat SYSTEM drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the system contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for SYSTEM, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the state ownership and control-plane authority contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this SYSTEM change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the system boundaries, authority hierarchy, lifecycle, and control-plane behavior contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update system contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on SYSTEM risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep SYSTEM binding where it protects state ownership and control-plane authority; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the SYSTEM owner, binding statements, non-goals, assumptions, affected consumers, and system contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal SYSTEM update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer state ownership and control-plane authority decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the SYSTEM contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when SYSTEM is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about system contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how SYSTEM changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by SYSTEM.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the SYSTEM contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how SYSTEM protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect SYSTEM drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible SYSTEM states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie SYSTEM completion to executable evidence for system contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The SYSTEM node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured SYSTEM doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative SYSTEM change produces bounded behavior consistent with its system contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified SYSTEM path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when SYSTEM changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred SYSTEM risk."
+        ]
+      }
+,
       "terms": [
         "level",
         "invariants",
@@ -24654,19 +25496,22 @@
         "semantics"
       ],
       "links": {
-        "references": [
-          "core/DECAPOD",
-          "core/DEMANDS",
-          "interfaces/CLAIMS",
-          "interfaces/CONTROL_PLANE",
-          "specs/INTENT"
+      "references": [
+        "core/DECAPOD",
+        "core/DEMANDS",
+        "interfaces/CLAIMS",
+        "interfaces/CONTROL_PLANE",
+        "specs/INTENT",
+        "core/SPECS",
+        "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
           "core/DEMANDS",
-          "docs/ARCHITECTURE_OVERVIEW",
-          "docs/README",
-          "plugins/VERIFY",
-          "specs/INTENT"
+        "docs/ARCHITECTURE_OVERVIEW",
+        "docs/README",
+        "plugins/VERIFY",
+        "specs/INTENT",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24706,6 +25551,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for FRONTEND BACKEND E2E.",
+      "architect_notes": [
+        "FRONTEND_BACKEND_E2E is a binding specification for end-to-end frontend/backend behavior across user-visible and service boundaries; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep FRONTEND_BACKEND_E2E distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat FRONTEND_BACKEND_E2E drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the E2E acceptance contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for FRONTEND_BACKEND_E2E, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the cross-boundary behavior and test evidence contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this FRONTEND_BACKEND_E2E change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the end-to-end frontend/backend behavior across user-visible and service boundaries contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update E2E acceptance contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on FRONTEND_BACKEND_E2E risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep FRONTEND_BACKEND_E2E binding where it protects cross-boundary behavior and test evidence; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the FRONTEND_BACKEND_E2E owner, binding statements, non-goals, assumptions, affected consumers, and E2E acceptance contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal FRONTEND_BACKEND_E2E update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer cross-boundary behavior and test evidence decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the FRONTEND_BACKEND_E2E contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when FRONTEND_BACKEND_E2E is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about E2E acceptance contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how FRONTEND_BACKEND_E2E changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by FRONTEND_BACKEND_E2E.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the FRONTEND_BACKEND_E2E contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how FRONTEND_BACKEND_E2E protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect FRONTEND_BACKEND_E2E drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible FRONTEND_BACKEND_E2E states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie FRONTEND_BACKEND_E2E completion to executable evidence for E2E acceptance contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The FRONTEND_BACKEND_E2E node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured FRONTEND_BACKEND_E2E doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative FRONTEND_BACKEND_E2E change produces bounded behavior consistent with its E2E acceptance contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified FRONTEND_BACKEND_E2E path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when FRONTEND_BACKEND_E2E changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred FRONTEND_BACKEND_E2E risk."
+        ]
+      }
+,
       "terms": [
         "interaction",
         "proof",
@@ -24720,10 +25703,13 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS"
         ]
       },
       "sections": {
@@ -24763,6 +25749,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for JUDGE CONTRACT.",
+      "architect_notes": [
+        "JUDGE_CONTRACT is a binding specification for judge inputs, outputs, rubric authority, and evaluation reproducibility; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep JUDGE_CONTRACT distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat JUDGE_CONTRACT drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the judge contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for JUDGE_CONTRACT, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the rubric authority and reproducibility contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this JUDGE_CONTRACT change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the judge inputs, outputs, rubric authority, and evaluation reproducibility contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update judge contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on JUDGE_CONTRACT risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep JUDGE_CONTRACT binding where it protects rubric authority and reproducibility; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the JUDGE_CONTRACT owner, binding statements, non-goals, assumptions, affected consumers, and judge contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal JUDGE_CONTRACT update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer rubric authority and reproducibility decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the JUDGE_CONTRACT contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when JUDGE_CONTRACT is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about judge contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how JUDGE_CONTRACT changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by JUDGE_CONTRACT.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the JUDGE_CONTRACT contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how JUDGE_CONTRACT protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect JUDGE_CONTRACT drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible JUDGE_CONTRACT states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie JUDGE_CONTRACT completion to executable evidence for judge contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The JUDGE_CONTRACT node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured JUDGE_CONTRACT doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative JUDGE_CONTRACT change produces bounded behavior consistent with its judge contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified JUDGE_CONTRACT path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when JUDGE_CONTRACT changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred JUDGE_CONTRACT risk."
+        ]
+      }
+,
       "terms": [
         "evaluation",
         "contract",
@@ -24778,11 +25902,14 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS",
-          "docs/EVAL_TRANSLATION_MAP"
+        "core/DEMANDS",
+        "docs/EVAL_TRANSLATION_MAP",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24822,6 +25949,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for VARIANCE EVALS.",
+      "architect_notes": [
+        "VARIANCE_EVALS is a binding specification for variance-aware evaluation aggregates, thresholds, and promotion decisions; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep VARIANCE_EVALS distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat VARIANCE_EVALS drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the variance evaluation records contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for VARIANCE_EVALS, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the statistical confidence and promotion authority contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this VARIANCE_EVALS change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the variance-aware evaluation aggregates, thresholds, and promotion decisions contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update variance evaluation records, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on VARIANCE_EVALS risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep VARIANCE_EVALS binding where it protects statistical confidence and promotion authority; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the VARIANCE_EVALS owner, binding statements, non-goals, assumptions, affected consumers, and variance evaluation records acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal VARIANCE_EVALS update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer statistical confidence and promotion authority decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the VARIANCE_EVALS contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when VARIANCE_EVALS is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about variance evaluation records or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how VARIANCE_EVALS changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by VARIANCE_EVALS.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the VARIANCE_EVALS contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how VARIANCE_EVALS protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect VARIANCE_EVALS drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible VARIANCE_EVALS states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie VARIANCE_EVALS completion to executable evidence for variance evaluation records, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The VARIANCE_EVALS node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured VARIANCE_EVALS doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative VARIANCE_EVALS change produces bounded behavior consistent with its variance evaluation records contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified VARIANCE_EVALS path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when VARIANCE_EVALS changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred VARIANCE_EVALS risk."
+        ]
+      }
+,
       "terms": [
         "evaluation",
         "confidence",
@@ -24837,11 +26102,14 @@
       ],
       "links": {
         "references": [
-          "core/DEMANDS"
+          "core/DEMANDS",
+          "core/SPECS",
+          "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS",
-          "docs/EVAL_TRANSLATION_MAP"
+        "core/DEMANDS",
+        "docs/EVAL_TRANSLATION_MAP",
+        "core/SPECS"
         ]
       },
       "sections": {
@@ -24881,6 +26149,144 @@
       "authority": "doctrine",
       "binding": "advisory",
       "summary": "Describes binding authority, mutation risk, compatibility, and execution obligations for SKILL GOVERNANCE.",
+      "architect_notes": [
+        "SKILL_GOVERNANCE is a binding specification for skill selection, lifecycle, authority, retrieval, and proof obligations; it must state what is authoritative, what may change, and which artifact records the decision.",
+        "Keep SKILL_GOVERNANCE distinct from implementation preference: a spec owns the contract and acceptance condition, while adjacent architecture, interface, and operations doctrine own concrete realization.",
+        "Treat SKILL_GOVERNANCE drift as a proof failure. A change is incomplete when code, generated specs, or review evidence no longer agree with the skill governance contracts contract."
+      ]
+,
+      "init_questions": [
+        {
+          "id": "contract_truth",
+          "prompt": "What must be true for SKILL_GOVERNANCE, and which human or governance authority can change that requirement?",
+          "why": "Naming the binding truth and authority prevents a local implementation choice from silently rewriting the retrieval scope and execution authority contract.",
+          "answers": [
+            "required invariant",
+            "human preference",
+            "non-goal",
+            "ask human",
+            "defer explicitly"
+          ]
+        },
+        {
+          "id": "compatibility_proof",
+          "prompt": "Which prior behavior, consumer, generated spec, or proof artifact must remain compatible with this SKILL_GOVERNANCE change?",
+          "why": "Compatibility is a decision, not an assumption; the affected evidence must be named before an amendment or migration ships.",
+          "answers": [
+            "existing consumer",
+            "generated spec",
+            "migration",
+            "runtime test",
+            "release review"
+          ]
+        }
+      ]
+,
+      "decision_matrix": [
+        {
+          "choice": "Amend the existing specification",
+          "use_when": "The requested behavior changes the skill selection, lifecycle, authority, retrieval, and proof obligations contract while preserving its stable identity and ownership.",
+          "avoid_when": "The change would make existing consumers interpret the same identifier differently without a migration or compatibility note.",
+          "implications": "Update skill governance contracts, affected specs, acceptance evidence, and compatibility notes together; preserve the existing node identity."
+        },
+        {
+          "choice": "Add a narrower specification",
+          "use_when": "The requirement has a distinct owner, lifecycle, authority, or compatibility boundary that should not broaden an existing contract.",
+          "avoid_when": "The split only duplicates terminology and would make retrieval or proof ambiguous.",
+          "implications": "Link the new node to its parent and adjacent interface or methodology contract, then define ownership and proof independently."
+        },
+        {
+          "choice": "Defer pending clarification or evidence",
+          "use_when": "Authority, compatibility impact, migration behavior, or acceptance evidence is not proven.",
+          "avoid_when": "The change is local, reversible, and its existing contract and proof surface are unambiguous.",
+          "implications": "Record the unresolved question and blocked proof; do not turn an assumption into binding doctrine by omission."
+        }
+      ]
+,
+      "tradeoffs": [
+        {
+          "axis": "stability versus precision",
+          "option_a": "Preserve a stable contract and add a compatible extension.",
+          "option_b": "Make the contract precise even when consumers must migrate.",
+          "guidance": "Choose based on SKILL_GOVERNANCE risk and consumer impact; record why compatibility or deliberate breakage is the safer contract."
+        },
+        {
+          "axis": "local autonomy versus binding authority",
+          "option_a": "Allow implementation discretion inside explicit acceptance boundaries.",
+          "option_b": "Require an amendment or human gate for authority-changing behavior.",
+          "guidance": "Keep SKILL_GOVERNANCE binding where it protects retrieval scope and execution authority; leave only reversible realization choices to implementation agents."
+        }
+      ]
+,
+      "scaffolding": {
+        "capture": [
+          "Capture the SKILL_GOVERNANCE owner, binding statements, non-goals, assumptions, affected consumers, and skill governance contracts acceptance evidence.",
+          "Capture the compatibility, amendment, migration, and drift-recovery decision before generating implementation scaffolding."
+        ],
+        "generate": [
+          "Generate the minimal SKILL_GOVERNANCE update, affected living-spec entries, acceptance checklist, and proof-plan reference.",
+          "Generate explicit placeholders for unresolved requirements rather than silently choosing authority, security, or compatibility behavior."
+        ],
+        "defer": [
+          "Defer retrieval scope and execution authority decisions to the owning constitution or interface node and do not duplicate its authority here.",
+          "Defer release or migration claims until old and new behavior have executable compatibility evidence."
+        ],
+        "proof": [
+          "Record the test, schema, command output, review artifact, or generated-spec hash that proves the SKILL_GOVERNANCE contract.",
+          "Record any intentional compatibility break, deferred risk, stale consumer, or environment limitation as visible evidence."
+        ]
+      }
+,
+      "spec_impacts": {
+        "intent": [
+          "State when SKILL_GOVERNANCE is in scope, including required outcomes, constraints, assumptions, non-goals, and human acceptance.",
+          "Preserve uncertainty about skill governance contracts or authority until the responsible human or binding node resolves it."
+        ],
+        "architecture": [
+          "Document how SKILL_GOVERNANCE changes state ownership, lifecycle, boundaries, deployment shape, or migration responsibilities.",
+          "Link architectural consequences to the narrower interface, data, security, or methodology contract that owns the decision."
+        ],
+        "interfaces": [
+          "Name the commands, RPC payloads, schemas, generated files, and compatibility semantics affected by SKILL_GOVERNANCE.",
+          "Preserve omission, error, version, and migration behavior for consumers of the specified contract."
+        ],
+        "operations": [
+          "Describe how operators inspect, apply, migrate, roll back, and recover the SKILL_GOVERNANCE contract without hidden mutation.",
+          "Record bounded commands, evidence locations, and stop conditions for drift or compatibility failures."
+        ],
+        "security": [
+          "State how SKILL_GOVERNANCE protects authority, trust, secrets, external input, and mutation boundaries.",
+          "Treat claims and generated content as untrusted until the owning security and verification contracts accept them."
+        ],
+        "validation": [
+          "Add checks that detect SKILL_GOVERNANCE drift across source, generated specs, schemas, tests, and acceptance evidence.",
+          "Make missing compatibility or proof evidence a visible validation failure or explicit deferred blocker."
+        ],
+        "semantics": [
+          "Define stable meanings for required, optional, absent, stale, rejected, migrated, and incompatible SKILL_GOVERNANCE states.",
+          "Preserve deterministic identifiers and error semantics so contract changes remain explainable."
+        ],
+        "proof": [
+          "Tie SKILL_GOVERNANCE completion to executable evidence for skill governance contracts, not to the existence of descriptive specification text alone.",
+          "Record the exact proof command, artifact, receipt, or test that a later agent can replay."
+        ]
+      }
+,
+      "proof": {
+        "static": [
+          "The SKILL_GOVERNANCE node is reachable through spec lookup and cross-linked to its parent and adjacent contract nodes.",
+          "Schema and tests preserve structured SKILL_GOVERNANCE doctrine and reject regression to a compact summary."
+        ],
+        "runtime": [
+          "A representative SKILL_GOVERNANCE change produces bounded behavior consistent with its skill governance contracts contract and failure semantics.",
+          "A stale, incompatible, unauthorized, or underspecified SKILL_GOVERNANCE path produces visible recovery guidance instead of silent success."
+        ],
+        "release": [
+          "Generated living specs and release artifacts are refreshed when SKILL_GOVERNANCE changes authority, compatibility, interfaces, or proof expectations.",
+          "Release evidence records version compatibility, migration status, and any intentionally deferred SKILL_GOVERNANCE risk."
+        ]
+      }
+,
       "terms": [
         "skill",
         "governance",
@@ -24893,12 +26299,15 @@
         "versioning"
       ],
       "links": {
-        "references": [
-          "core/DEMANDS"
+      "references": [
+        "core/DEMANDS",
+        "core/SPECS",
+        "interfaces/PROJECT_SPECS"
         ],
         "referenced_by": [
-          "core/DEMANDS",
-          "docs/SKILL_TRANSLATION_MAP"
+        "core/DEMANDS",
+        "docs/SKILL_TRANSLATION_MAP",
+        "core/SPECS"
         ]
       },
       "sections": {

--- a/assets/constitution.schema.json
+++ b/assets/constitution.schema.json
@@ -10,9 +10,10 @@
       "interfaces",
       "data",
       "metadata",
-      "plugins"
+      "plugins",
+      "specs"
     ],
-    "migration_strategy": "architecture, methodology, interfaces nodes, data nodes, metadata nodes, and plugins nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
+    "migration_strategy": "architecture, methodology, interfaces nodes, data nodes, metadata nodes, plugins nodes, and specs nodes are migrated in place; other namespaces keep the compact node contract until explicitly uplifted",
     "compatibility": "the node output shape remains stable for current consumers while uplifted namespaces gain additive doctrine fields"
   },
   "type": "object",
@@ -173,6 +174,29 @@
             "properties": {
               "category": {
                 "const": "plugins"
+              }
+            },
+            "required": [
+              "category"
+            ]
+          },
+          "then": {
+            "required": [
+              "architect_notes",
+              "init_questions",
+              "decision_matrix",
+              "tradeoffs",
+              "scaffolding",
+              "spec_impacts",
+              "proof"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "category": {
+                "const": "specs"
               }
             },
             "required": [

--- a/tests/constitution_scaffolding.rs
+++ b/tests/constitution_scaffolding.rs
@@ -136,6 +136,19 @@ const PLUGIN_NODES: &[&str] = &[
     "plugins/WATCHER",
 ];
 
+const SPEC_NODES: &[&str] = &[
+    "specs/AMENDMENTS",
+    "specs/DB_BROKER_QUEUE",
+    "specs/GIT",
+    "specs/INTENT",
+    "specs/SECURITY",
+    "specs/SYSTEM",
+    "specs/engineering/FRONTEND_BACKEND_E2E",
+    "specs/evaluations/JUDGE_CONTRACT",
+    "specs/evaluations/VARIANCE_EVALS",
+    "specs/skills/SKILL_GOVERNANCE",
+];
+
 const METHODOLOGY_NODES: &[&str] = &[
     "methodology/ARCHITECTURE",
     "methodology/CI_CD",
@@ -787,6 +800,99 @@ fn all_plugin_nodes_have_architect_grade_subsystem_doctrine() {
 }
 
 #[test]
+fn all_spec_nodes_have_architect_grade_specification_doctrine() {
+    let constitution = load_constitution_asset();
+    let nodes = constitution["nodes"].as_object().expect("nodes object");
+    let lookup = constitution["lookup"].as_object().expect("lookup object");
+
+    let actual_spec_count = nodes
+        .values()
+        .filter(|node| node["category"].as_str() == Some("specs"))
+        .count();
+    assert_eq!(
+        actual_spec_count,
+        SPEC_NODES.len(),
+        "SPEC_NODES test list must cover every specs/* node"
+    );
+
+    let core_refs = nodes["core/SPECS"]["links"]["references"]
+        .as_array()
+        .expect("core specs references");
+
+    for node_id in SPEC_NODES {
+        let node = nodes
+            .get(*node_id)
+            .unwrap_or_else(|| panic!("missing spec node {node_id}"));
+        assert_eq!(
+            node["category"].as_str(),
+            Some("specs"),
+            "{node_id} must remain in the specs namespace"
+        );
+        assert_architect_grade_fields(node_id, node);
+        assert_non_empty_array(
+            &node["links"]["references"],
+            &format!("{node_id}.links.references"),
+        );
+        assert!(
+            node["links"]["references"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/SPECS"))),
+            "{node_id} must link to core/SPECS"
+        );
+        assert!(
+            node["links"]["references"].as_array().is_some_and(|refs| {
+                refs.iter()
+                    .any(|value| value.as_str() == Some("interfaces/PROJECT_SPECS"))
+            }),
+            "{node_id} must link to the project-spec contract"
+        );
+        assert!(
+            node["links"]["referenced_by"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/SPECS"))),
+            "{node_id} must be reachable from core/SPECS"
+        );
+        assert!(
+            core_refs
+                .iter()
+                .any(|value| value.as_str() == Some(node_id)),
+            "core/SPECS must route to {node_id}"
+        );
+
+        let sections = node["sections"].as_object().expect("sections object");
+        for section in [
+            "match",
+            "ambiguity",
+            "decisions",
+            "standards",
+            "failure_modes",
+            "proceed_when",
+        ] {
+            assert!(
+                sections
+                    .get(section)
+                    .and_then(|items| items.as_array())
+                    .is_some_and(|items| !items.is_empty()),
+                "{node_id}.{section} must preserve specification guidance"
+            );
+        }
+
+        assert!(
+            lookup.values().any(|entries| {
+                entries.as_array().is_some_and(|entries| {
+                    entries.iter().any(|entry| entry.as_str() == Some(node_id))
+                })
+            }),
+            "{node_id} must remain reachable through at least one lookup term"
+        );
+    }
+}
+
+#[test]
 fn all_methodology_nodes_have_architect_grade_delivery_doctrine() {
     let constitution = load_constitution_asset();
     let nodes = constitution["nodes"].as_object().expect("nodes object");
@@ -872,8 +978,9 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
                     && strategy.contains("data nodes")
                     && strategy.contains("metadata nodes")
                     && strategy.contains("plugins nodes")
+                    && strategy.contains("specs nodes")
             }),
-        "schema must document in-place interfaces, data, metadata, and plugins namespace migration"
+        "schema must document in-place interfaces, data, metadata, plugins, and specs namespace migration"
     );
 
     let node_schema = &schema["definitions"]["node"];
@@ -909,6 +1016,10 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         .iter()
         .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("plugins"))
         .expect("node schema must declare plugin doctrine conditional");
+    let spec_rule = rules
+        .iter()
+        .find(|rule| rule["if"]["properties"]["category"]["const"].as_str() == Some("specs"))
+        .expect("node schema must declare specs doctrine conditional");
 
     let required = architecture_rule["then"]["required"]
         .as_array()
@@ -967,6 +1078,16 @@ fn schema_requires_doctrine_model_for_uplifted_namespaces() {
         assert!(
             required.iter().any(|value| value.as_str() == Some(field)),
             "plugin schema must require {field}"
+        );
+    }
+
+    let required = spec_rule["then"]["required"]
+        .as_array()
+        .expect("spec doctrine required fields");
+    for field in ARCHITECTURE_DOCTRINE_FIELDS {
+        assert!(
+            required.iter().any(|value| value.as_str() == Some(field)),
+            "spec schema must require {field}"
         );
     }
 
@@ -1464,6 +1585,33 @@ fn embedded_constitution_preserves_plugin_doctrine() {
                     .iter()
                     .any(|value| value.as_str() == Some("core/PLUGINS"))),
             "{node_id} must preserve plugin routing in embedded output"
+        );
+    }
+}
+
+#[test]
+fn embedded_constitution_preserves_spec_doctrine() {
+    for node_id in SPEC_NODES {
+        let output = Command::new(resolve_decapod_bin())
+            .args(["constitution", "get", node_id])
+            .output()
+            .expect("run decapod constitution get");
+        assert!(
+            output.status.success(),
+            "constitution get {node_id} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let node: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("constitution get json");
+        assert_architect_grade_fields(node_id, &node);
+        assert!(
+            node["links"]["references"]
+                .as_array()
+                .is_some_and(|refs| refs
+                    .iter()
+                    .any(|value| value.as_str() == Some("core/SPECS"))),
+            "{node_id} must preserve spec routing in embedded output"
         );
     }
 }


### PR DESCRIPTION
Uplifts all ten specs/* constitution nodes with architect-grade specification doctrine; enforces the contract in the schema; adds routing, embedded-output, and reachability regression tests; refreshes living specs and Decapod 0.72.8 release-bound metadata. Proof: cargo test --test constitution_scaffolding -- --test-threads=1 (26 passed); one-shot decapod validate --format json in the governed container (200 passed, 0 failed). Closes #810.