### PR TITLE
fix: add stale workspaces cleanup gate during validation

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.8
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.9
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.8
+ARG DECAPOD_VERSION=0.72.9
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.decapod.version="$DECAPOD_VERSION"

--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -5,10 +5,12 @@
 ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.9
 FROM $DECAPOD_IMAGE
 ARG DECAPOD_VERSION=0.72.9
+ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
 LABEL org.opencontainers.image.source="https://github.com/DecapodLabs/decapod"
 LABEL org.decapod.managed="workspace"
+LABEL org.decapod.workspace.path="$DECAPOD_WORKSPACE_PATH"
 LABEL org.decapod.version="$DECAPOD_VERSION"
 RUN if command -v apk >/dev/null 2>&1; then \
 apk add --no-cache bash ca-certificates cargo coreutils curl git openssh-client rust sqlite-libs; \

--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -7,6 +7,8 @@ FROM $DECAPOD_IMAGE
 ARG DECAPOD_VERSION=0.72.9
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"
+LABEL org.opencontainers.image.source="https://github.com/DecapodLabs/decapod"
+LABEL org.decapod.managed="workspace"
 LABEL org.decapod.version="$DECAPOD_VERSION"
 RUN if command -v apk >/dev/null 2>&1; then \
 apk add --no-cache bash ca-certificates cargo coreutils curl git openssh-client rust sqlite-libs; \

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784606420Z",
-  "repo_signal_fingerprint": "589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6",
+  "generated_at": "1784607185Z",
+  "repo_signal_fingerprint": "481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "84f9c406658b2fa4413fcec766d2e785dfe0e857b4e12e659d801b9ee2d13e79",
+  "spec_input_hash": "63a022a855ec58ab0e98cbf4f44cfee0d9ae49d3f2302ab4f5fd3388d0585a33",
   "decapod_release": "0.72.9",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "df0a0add462327a9c1a957a974785ef43f893e2133e9235a460c63721abbd01c",
+      "content_hash": "40f2ef6faf83f3803af169980c4ed0b1ca4e4c09ceffc20c8559556481f7ffaa",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "7f5204d11dcd4811e47d2235bff3151ea3e279f55ebedf255e90bb23854a3fdb",
+      "content_hash": "c09ee992287f30f03c93faeabad721926affaefd7cc8b64ea610ab7741bb74eb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "e98bb68728f27026fcf88f8a106b43a95b108248530aa8bc89ec71591130342d",
+      "content_hash": "fa5c8ae71d1941d1a93bf5ec250f21ffcd73ddd5de0b97b8ab350d0b2623212f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "8d8aa0843895dc2e1d479b8dc491500e88cbd727a835dbd0b42f811c8625e682",
+      "content_hash": "e23a9170379af43b6b675eb5339be04059b5d0df94ecf53e5a18b80389a62d59",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "8b24833a7769be9e9eb6d7bb3c7b6ea837801b8d5615234f871f989e31fb64a5",
+      "content_hash": "a7a9bf189c8e28ecaea6c9fba50d2eae7f75bf2a808163bbc275aefdc228c12e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "404197ef45293025c7de40959ed48cf10b49bf5b5b9cdc07d441dfa523c974dd",
+      "content_hash": "d2c0cae0a91d90fae49800a26809b71540b51a9670ebf10f5d6393a72905d811",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "1ff93f460b8a06b57c51f519b2755df9cea7b51fcbc6369682bb2a422537fc2e",
+      "content_hash": "def3a9f289c0627eb8b4a085acd0bd2755adc9928e1163af5d93dca11779a6b7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "8e07ec3792fc1f58460341a1148cf4ddddbce0f33e8b122adca17b9273f9607e",
+      "content_hash": "da20b90435cb26f27d4e23049631d95829a225da9a077d3548575f0e5b2780a0",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784603549Z",
-  "repo_signal_fingerprint": "b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa",
+  "generated_at": "1784604508Z",
+  "repo_signal_fingerprint": "3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "3f69280b773d634bd3a6b56f42d7c5644c023072732574981142ae1546d034fd",
-  "decapod_release": "0.72.8",
+  "spec_input_hash": "ec03fef2397ba529763dae74cbeebcc1b79aaee3318b760495ebd3314fb21b8b",
+  "decapod_release": "0.72.9",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "21c8a4d14ead49e21db1221ae3690ebc3145c370a7786b27027ca3f3c415cafb",
-      "content_hash": "21c8a4d14ead49e21db1221ae3690ebc3145c370a7786b27027ca3f3c415cafb",
-      "fingerprint": "5b93160fedc113fd2ec92cb68c427962dc20d1f8b76e6f75f3438e109e45f2ad"
+      "template_hash": "1477951e56055aa3e2bab452d3b534dadc9bfaaa12e48c61527a4f09aa12b380",
+      "content_hash": "1477951e56055aa3e2bab452d3b534dadc9bfaaa12e48c61527a4f09aa12b380",
+      "fingerprint": "ec0bbfa1ed92b63f1008b9d0bb65a99e93d5cfdaac70bcb165efa11c241979a5"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "6641520252edd5a03155a77b1325df49eced881031e13550118b957ce12864d2",
-      "content_hash": "6641520252edd5a03155a77b1325df49eced881031e13550118b957ce12864d2",
-      "fingerprint": "4f0f79b6ee532ea09c8985a20dafab346680ae27d0a928dfff06dab60011d11b"
+      "template_hash": "77838ecb292c352e28a4d91ad8555ff24487292c421acb395a0b12b5e5d4c65c",
+      "content_hash": "77838ecb292c352e28a4d91ad8555ff24487292c421acb395a0b12b5e5d4c65c",
+      "fingerprint": "21578d219fe19a41da69c0944ce4d0aebaeeb9872bee88262c83d580995b0e2a"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "0ff85ad09749fe5587d51a655b34c3100096c97417a57f33a18b2cfc69d7989e",
-      "content_hash": "0ff85ad09749fe5587d51a655b34c3100096c97417a57f33a18b2cfc69d7989e",
-      "fingerprint": "cc21151711685ad1b9feec2bb24c0348ad1fdaabd0255b56ec5204bf41d2b616"
+      "template_hash": "87e18b625322b641a82d891265b733d928efc20d2d0c242de137633e8dfb2362",
+      "content_hash": "87e18b625322b641a82d891265b733d928efc20d2d0c242de137633e8dfb2362",
+      "fingerprint": "7e3e10c0d07b7df210f6213e6b2b88baf6042cbf902feb03528fd97c0fe55a21"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "0de58b12221e260d203d2b4b8ee817b19129dc3d0636debe768192ed5baeb045",
-      "content_hash": "0de58b12221e260d203d2b4b8ee817b19129dc3d0636debe768192ed5baeb045",
-      "fingerprint": "4cdbd536e425117c650d7a79a4a1b8b8461c74b3034bb9b06d2ec9e92ee58936"
+      "template_hash": "ba87fd0264228c42e00ce832d46d2e13d8345063baadea3aea9a0610abbe39c2",
+      "content_hash": "ba87fd0264228c42e00ce832d46d2e13d8345063baadea3aea9a0610abbe39c2",
+      "fingerprint": "4275ad4a2436426bf7c41b5e3f986b8590a37cd406d8453557f7ad4d1a81cc30"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "fbef96fe8e75903870e4911a09e43f3cd09f846499173d10f4f3c30eb87fec3c",
+      "content_hash": "afbc689372772d38e7caa8ba259a4c65f7840de5bb8fd2a7a8f510bd35783d2f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "3d3c4075a0d3c71c0d388bbe352f136560f05e437c995b564b82509dad7e0c6b",
+      "content_hash": "1a2771eb76e7958f49f027a57a62a437f26db63618588ebf29ed6077165172e3",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "5872bf7a1e3ba5bca495685963535fa1078de1fabaf27d7b989b521f353f60cb",
+      "content_hash": "3b934a2a82337a743976427d304578b01f8c660b38c6902eaafbf7ba2d883b8d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "bdc99b2d92068a3dcfc32bee5df68c2360a90bc8719e7408c39664a76c272d90",
+      "content_hash": "936f7ce4d30fa61ec2d782c1b09883bffe214ca9c5e26486037eb779b1ed28f4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "607ee61e10d23292a30b7d852ec92f6c6c5a8a16243ad84f5e718728b0bbe6dc",
+      "content_hash": "2463eab83a836e2cf903721640472b4d0eec2a2e88e1a790d0db4c16b00c91fe",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "076dadd1290dcec8b0b87aabccef78671b982f0fd76ce8264b399b45337e4216",
+      "content_hash": "55c2e6ad79a76da04540b773dffd5f55f039976bf11f81c53082de67a9e4781d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "a0a9b931f455bc21df9678e5e38727e8a3d4391f7f6551cfe0570efe590c7cd4",
+      "content_hash": "e82412f88bd29f562f9961548fb12feac05d3e1fee88fd3d4114f71131434ad8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "5f0c756544e49b89bd9ed2a06f1770bf8e660c0e208ad04be63ad835dddae7fd",
+      "content_hash": "189ff0801117e0f32025c47460582e277c7c233b467acb8b54a9e3d3485916f8",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784604508Z",
-  "repo_signal_fingerprint": "3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a",
+  "generated_at": "1784605488Z",
+  "repo_signal_fingerprint": "ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "ec03fef2397ba529763dae74cbeebcc1b79aaee3318b760495ebd3314fb21b8b",
+  "spec_input_hash": "35fbc226e12fbe886aae32b791d3e5ce1cfbecac037c8d291a479e981779125d",
   "decapod_release": "0.72.9",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "afbc689372772d38e7caa8ba259a4c65f7840de5bb8fd2a7a8f510bd35783d2f",
+      "content_hash": "08487cca12e30703d8357d7791035e7f01e142381cd36ad97e11c93ca7b18a3f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "1a2771eb76e7958f49f027a57a62a437f26db63618588ebf29ed6077165172e3",
+      "content_hash": "4df4e247f2ab099a076582dd798906f753bc8d4ff16e65588f16402c47c3eb0c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "3b934a2a82337a743976427d304578b01f8c660b38c6902eaafbf7ba2d883b8d",
+      "content_hash": "7551b2413cc9e25dd2bfbe65e5435f002ea6ad4d5a1977793b0af5c48ec44b6e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "936f7ce4d30fa61ec2d782c1b09883bffe214ca9c5e26486037eb779b1ed28f4",
+      "content_hash": "4bbb77c8234b95b9debff9bc8e90c8012e9b0583b87c7c707453dd96010b769f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "2463eab83a836e2cf903721640472b4d0eec2a2e88e1a790d0db4c16b00c91fe",
+      "content_hash": "328c654868947c9432efebae06d5e9a2ef6dadda3b077a1d66aa5b249f4507f0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "55c2e6ad79a76da04540b773dffd5f55f039976bf11f81c53082de67a9e4781d",
+      "content_hash": "7414ed24dd15b223c6081b117ed074a4e82a7daa4b5c93611b6d35b9c9f1d895",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "e82412f88bd29f562f9961548fb12feac05d3e1fee88fd3d4114f71131434ad8",
+      "content_hash": "5e8b34fe9195e367ff07708ba5fa6e345d9b8e12db67cb2e5a3a6d0128e87f81",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "189ff0801117e0f32025c47460582e277c7c233b467acb8b54a9e3d3485916f8",
+      "content_hash": "30217dd0c22e707fc1af224ea07faf7b27176b5075bee7bed50e71a326100bc7",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784605488Z",
-  "repo_signal_fingerprint": "ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49",
+  "generated_at": "1784606420Z",
+  "repo_signal_fingerprint": "589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "35fbc226e12fbe886aae32b791d3e5ce1cfbecac037c8d291a479e981779125d",
+  "spec_input_hash": "84f9c406658b2fa4413fcec766d2e785dfe0e857b4e12e659d801b9ee2d13e79",
   "decapod_release": "0.72.9",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "08487cca12e30703d8357d7791035e7f01e142381cd36ad97e11c93ca7b18a3f",
+      "content_hash": "df0a0add462327a9c1a957a974785ef43f893e2133e9235a460c63721abbd01c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "4df4e247f2ab099a076582dd798906f753bc8d4ff16e65588f16402c47c3eb0c",
+      "content_hash": "7f5204d11dcd4811e47d2235bff3151ea3e279f55ebedf255e90bb23854a3fdb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "7551b2413cc9e25dd2bfbe65e5435f002ea6ad4d5a1977793b0af5c48ec44b6e",
+      "content_hash": "e98bb68728f27026fcf88f8a106b43a95b108248530aa8bc89ec71591130342d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "4bbb77c8234b95b9debff9bc8e90c8012e9b0583b87c7c707453dd96010b769f",
+      "content_hash": "8d8aa0843895dc2e1d479b8dc491500e88cbd727a835dbd0b42f811c8625e682",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "328c654868947c9432efebae06d5e9a2ef6dadda3b077a1d66aa5b249f4507f0",
+      "content_hash": "8b24833a7769be9e9eb6d7bb3c7b6ea837801b8d5615234f871f989e31fb64a5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "7414ed24dd15b223c6081b117ed074a4e82a7daa4b5c93611b6d35b9c9f1d895",
+      "content_hash": "404197ef45293025c7de40959ed48cf10b49bf5b5b9cdc07d441dfa523c974dd",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "5e8b34fe9195e367ff07708ba5fa6e345d9b8e12db67cb2e5a3a6d0128e87f81",
+      "content_hash": "1ff93f460b8a06b57c51f519b2755df9cea7b51fcbc6369682bb2a422537fc2e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "30217dd0c22e707fc1af224ea07faf7b27176b5075bee7bed50e71a326100bc7",
+      "content_hash": "8e07ec3792fc1f58460341a1148cf4ddddbce0f33e8b122adca17b9273f9607e",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -272,7 +272,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -272,7 +272,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -272,7 +272,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -17,7 +17,16 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - Git 2.30+ (worktree support)
 - Rust 1.96+ (for building from source)
 - Docker/Podman (optional, for container workspaces)
-- SQLite 3.35+ (bundled via rusqlite)
+- SQLite 3.35+ (bundled via rusqlite)## Service Level Objectives
+
+| SLI | SLO Target | Measurement Window | Notes |
+|-----|------------|-------------------|-------|
+| Validate latency (P95) | < 30s | Per invocation | Bounded by `INV-BOUNDED-VALIDATE` |
+| Workspace creation (P95) | < 30s | Per invocation | Excludes container build |
+| Workspace creation + container (P95) | < 300s | Per invocation | Docker build time variable |
+| Validation gate pass rate | 100% blocking gates | Per promotion | Zero tolerance for blocking gate failures |
+| SQLite lock contention retry | < 5 retries | Per connection | Exponential backoff + jitter |
+| Capabilities discovery | < 500ms | Per call | Includes crates.io version check |
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -55,17 +64,6 @@ Operational ownership follows the declared surfaces: session/authentication and 
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Service Level Objectives
-
-| SLI | SLO Target | Measurement Window | Notes |
-|-----|------------|-------------------|-------|
-| Validate latency (P95) | < 30s | Per invocation | Bounded by `INV-BOUNDED-VALIDATE` |
-| Workspace creation (P95) | < 30s | Per invocation | Excludes container build |
-| Workspace creation + container (P95) | < 300s | Per invocation | Docker build time variable |
-| Validation gate pass rate | 100% blocking gates | Per promotion | Zero tolerance for blocking gate failures |
-| SQLite lock contention retry | < 5 retries | Per connection | Exponential backoff + jitter |
-| Capabilities discovery | < 500ms | Per call | Includes crates.io version check |
 
 ## Monitoring
 
@@ -274,7 +272,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -99,49 +99,7 @@ stateDiagram-v2
 | Capability-gated external actions | Security | Every `git`/`docker`/`cargo` call declares capability |
 | No secrets in config.toml | Security | `validate` config gate rejects forbidden keys |
 | Specs manifest tracks template drift | Governance | `validate` specs gate fails on stale template_hash |
-| Ordered phase completion | Governance | Phase transitions reject out-of-order, concurrent, or incomplete execution |
-
-<!-- decapod:capability-overlay:background-processing:start -->
-
-## Background Processing Semantics Overlay
-
-### Retry Semantics
-- Retry and backoff behavior MUST be selected and documented for each work class
-- Poison-work handling MUST be selected and documented for each work class
-- Retry MUST preserve the declared side-effect and idempotency semantics
-
-### Idempotency
-- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
-- Deduplication or compensation mechanisms are project decisions and require proof
-- Duplicate execution MUST follow the job's declared duplicate-handling semantics
-
-### Poison Message Handling
-- Messages failing after max retries go to dead letter queue
-- DLQ MUST be monitored and alerted
-- Manual replay capability for DLQ messages
-<!-- decapod:capability-overlay:background-processing:end -->
-
-<!-- decapod:capability-overlay:persistent-state:start -->
-
-## Persistent State Semantics Overlay
-
-### Transaction Semantics
-- All multi-entity operations MUST be atomic
-- Read-after-write consistency within transaction boundaries
-- Eventual consistency windows MUST be documented
-
-### Migration Semantics
-- Schema migrations MUST be backward-compatible
-- Migration rollback procedures MUST be documented
-- Data integrity checks post-migration
-
-### Recovery Semantics
-- Point-in-time recovery capability
-- Recovery objectives MUST be selected for the project and recorded as proof obligations
-- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
-<!-- decapod:capability-overlay:persistent-state:end -->
-
-## Event Sourcing Schema
+| Ordered phase completion | Governance | Phase transitions reject out-of-order, concurrent, or incomplete execution |## Event Sourcing Schema
 
 ### Common Event Fields
 | Field | Type | Description |
@@ -189,6 +147,46 @@ stateDiagram-v2
 | Event Type | Payload | Trigger |
 |------------|---------|---------|
 | `attestation` | `{id, op, timestamp, input_hash, touched_paths[], interlock_code?, outcome}` | `assurance.evaluate` |
+
+<!-- decapod:capability-overlay:background-processing:start -->
+
+## Background Processing Semantics Overlay
+
+### Retry Semantics
+- Retry and backoff behavior MUST be selected and documented for each work class
+- Poison-work handling MUST be selected and documented for each work class
+- Retry MUST preserve the declared side-effect and idempotency semantics
+
+### Idempotency
+- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
+- Deduplication or compensation mechanisms are project decisions and require proof
+- Duplicate execution MUST follow the job's declared duplicate-handling semantics
+
+### Poison Message Handling
+- Messages failing after max retries go to dead letter queue
+- DLQ MUST be monitored and alerted
+- Manual replay capability for DLQ messages
+<!-- decapod:capability-overlay:background-processing:end -->
+
+<!-- decapod:capability-overlay:persistent-state:start -->
+
+## Persistent State Semantics Overlay
+
+### Transaction Semantics
+- All multi-entity operations MUST be atomic
+- Read-after-write consistency within transaction boundaries
+- Eventual consistency windows MUST be documented
+
+### Migration Semantics
+- Schema migrations MUST be backward-compatible
+- Migration rollback procedures MUST be documented
+- Data integrity checks post-migration
+
+### Recovery Semantics
+- Point-in-time recovery capability
+- Recovery objectives MUST be selected for the project and recorded as proof obligations
+- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
+<!-- decapod:capability-overlay:persistent-state:end -->
 
 ## Replay Semantics
 
@@ -302,7 +300,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -85,7 +85,21 @@ stateDiagram-v2
     [*] --> Active: heartbeat
     Active --> Expired: no heartbeat > 30min
     Expired --> [*]: cleanup
-```
+```## Invariants
+
+| Invariant | Type | Validation |
+|-----------|------|------------|
+| No promoted change without proof | System | `workspace.publish` requires proof_manifest + artifact_manifest + workunit VERIFIED |
+| Canonical source-of-truth per entity | Data | Single store root per kind; `validate` checks no external `.db`/`.jsonl` |
+| Mutation events are replayable | Data | `todo rebuild` + `broker verify` round-trip; deterministic JSONL |
+| Workspace isolation enforced | System | `workspace.status` blocks protected branch + main repo work |
+| Context capsules deterministic | Data | `canonical_json_bytes` + SHA256; policy binding includes repo_revision |
+| Obligation status derived, never asserted | Data | `obligation verify` computes from deps/proofs/commit |
+| Session required for mutations | Auth | Broker rejects mutating ops without valid session |
+| Capability-gated external actions | Security | Every `git`/`docker`/`cargo` call declares capability |
+| No secrets in config.toml | Security | `validate` config gate rejects forbidden keys |
+| Specs manifest tracks template drift | Governance | `validate` specs gate fails on stale template_hash |
+| Ordered phase completion | Governance | Phase transitions reject out-of-order, concurrent, or incomplete execution |
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -126,22 +140,6 @@ stateDiagram-v2
 - Recovery objectives MUST be selected for the project and recorded as proof obligations
 - Recovery test cadence MUST be selected for the project and recorded as a proof obligation
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Invariants
-
-| Invariant | Type | Validation |
-|-----------|------|------------|
-| No promoted change without proof | System | `workspace.publish` requires proof_manifest + artifact_manifest + workunit VERIFIED |
-| Canonical source-of-truth per entity | Data | Single store root per kind; `validate` checks no external `.db`/`.jsonl` |
-| Mutation events are replayable | Data | `todo rebuild` + `broker verify` round-trip; deterministic JSONL |
-| Workspace isolation enforced | System | `workspace.status` blocks protected branch + main repo work |
-| Context capsules deterministic | Data | `canonical_json_bytes` + SHA256; policy binding includes repo_revision |
-| Obligation status derived, never asserted | Data | `obligation verify` computes from deps/proofs/commit |
-| Session required for mutations | Auth | Broker rejects mutating ops without valid session |
-| Capability-gated external actions | Security | Every `git`/`docker`/`cargo` call declares capability |
-| No secrets in config.toml | Security | `validate` config gate rejects forbidden keys |
-| Specs manifest tracks template drift | Governance | `validate` specs gate fails on stale template_hash |
-| Ordered phase completion | Governance | Phase transitions reject out-of-order, concurrent, or incomplete execution |
 
 ## Event Sourcing Schema
 
@@ -304,7 +302,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -146,7 +146,23 @@ stateDiagram-v2
 ### Attestation Events (`assurance_attestations.jsonl`)
 | Event Type | Payload | Trigger |
 |------------|---------|---------|
-| `attestation` | `{id, op, timestamp, input_hash, touched_paths[], interlock_code?, outcome}` | `assurance.evaluate` |
+| `attestation` | `{id, op, timestamp, input_hash, touched_paths[], interlock_code?, outcome}` | `assurance.evaluate` |## Replay Semantics
+
+### Todo Rebuild
+- **Order**: FIFO by `ts` (event log order)
+- **Conflict Resolution**: Last-write-wins per task ID (events are append-only)
+- **Snapshot Cadence**: None (full rebuild from genesis on demand)
+- **Determinism Proof**: `todo rebuild` produces byte-identical `todo.db` from same `todo.events.jsonl`
+
+### Broker Verify
+- **Order**: FIFO by event sequence
+- **Conflict Detection**: Divergence = pending mutations at crash (detected via `verify_replay`)
+- **Resolution**: Manual reconciliation; `broker verify` reports gaps
+
+### Obligation Graph
+- **Order**: Topological (dependencies before dependents)
+- **Conflict**: Cycles detected at add-time (`detect_cycle`)
+- **Resolution**: Reject add; human must restructure
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -187,24 +203,6 @@ stateDiagram-v2
 - Recovery objectives MUST be selected for the project and recorded as proof obligations
 - Recovery test cadence MUST be selected for the project and recorded as a proof obligation
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Replay Semantics
-
-### Todo Rebuild
-- **Order**: FIFO by `ts` (event log order)
-- **Conflict Resolution**: Last-write-wins per task ID (events are append-only)
-- **Snapshot Cadence**: None (full rebuild from genesis on demand)
-- **Determinism Proof**: `todo rebuild` produces byte-identical `todo.db` from same `todo.events.jsonl`
-
-### Broker Verify
-- **Order**: FIFO by event sequence
-- **Conflict Detection**: Divergence = pending mutations at crash (detected via `verify_replay`)
-- **Resolution**: Manual reconciliation; `broker verify` reports gaps
-
-### Obligation Graph
-- **Order**: Topological (dependencies before dependents)
-- **Conflict**: Cycles detected at add-time (`detect_cycle`)
-- **Resolution**: Reject add; human must restructure
 
 ## Error Code Semantics
 
@@ -300,7 +298,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -302,7 +302,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -9,7 +9,19 @@ Decapod's validation suite (`src/core/validate.rs`) enforces methodology complia
 - **Auto-Remediable Errors**: Structured error codes with `agent_action` and `user_note` for self-correction
 - **Bounded Execution**: `INV-BOUNDED-VALIDATE` — validation terminates within 30s
 - **Spec Refresh**: `--refresh-specs` regenerates stale scaffold templates
-- **Dual Store Modes**: `user` (blank slate) and `repo` (dogfood backlog)
+- **Dual Store Modes**: `user` (blank slate) and `repo` (dogfood backlog)## Generated Spec Refresh Gates
+Decapod keeps generated specs synchronized at governance pressure points. When repository surfaces change, validation either fails with a concrete refresh instruction or, when explicitly requested, regenerates spec files and updates the manifest fingerprint.
+
+### Refresh-Capable Paths
+- `decapod validate --refresh-specs`
+- `decapod rpc --op specs.refresh`
+- Initialization/scaffold refresh paths that regenerate `.decapod/generated/specs/*.md`
+
+### Refresh Output Requirements
+- Preserve hand-maintained epistemic custody fields where possible
+- Blend repo context into existing canonical spec files
+- Update `.decapod/generated/specs/.manifest.json` after writing files
+- Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -50,20 +62,6 @@ Decapod's validation suite (`src/core/validate.rs`) enforces methodology complia
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Generated Spec Refresh Gates
-Decapod keeps generated specs synchronized at governance pressure points. When repository surfaces change, validation either fails with a concrete refresh instruction or, when explicitly requested, regenerates spec files and updates the manifest fingerprint.
-
-### Refresh-Capable Paths
-- `decapod validate --refresh-specs`
-- `decapod rpc --op specs.refresh`
-- Initialization/scaffold refresh paths that regenerate `.decapod/generated/specs/*.md`
-
-### Refresh Output Requirements
-- Preserve hand-maintained epistemic custody fields where possible
-- Blend repo context into existing canonical spec files
-- Update `.decapod/generated/specs/.manifest.json` after writing files
-- Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set
 
 ## Release-Bound Agent Entrypoint Integrity
 The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and compiled binary SHA-256; `.decapod/generated/specs/.manifest.json` records the same release identity plus `template_hash` and `content_hash` entries for `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `CODEX.md`. Default validation independently checks the compiled release contract, declared metadata, canonical payload, regular-file type, and manifest synchronization. Regeneration must be explicit through the installed Decapod release.
@@ -332,7 +330,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
+- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -330,7 +330,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
+- Repository signal fingerprint: `481537107777a7d60cd662a91c399b96d71c78a8aa30287e0bed64151ca207f9`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -330,7 +330,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ed85be1e423b8c1464fa499098d9a0cc1f60b68739b3b2f7c6feec5753514f49`
+- Repository signal fingerprint: `589d4c94282c84867b589a9040f8577cc26df5f3ed04b7fadd544abae3990cb6`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -332,7 +332,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b4d094742c96fe993853e27ef3f1a2de1000f81fbaf202222ade966a9cc04daa`
+- Repository signal fingerprint: `3ecf7ce8b828c3114f4397b57999d376a0ac517e32aad03a278174d79633a22a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,12 +138,10 @@ jobs:
         include:
           - variant: glibc
             tag_suffix: ""
-            latest_tag: latest
             build_image: rust:1.96.1-slim-bookworm
             runtime_image: debian:bookworm-slim
           - variant: musl
             tag_suffix: "-alpine"
-            latest_tag: latest-alpine
             build_image: rust:1.96.1-alpine
             runtime_image: alpine:3.20
     steps:
@@ -167,8 +165,6 @@ jobs:
           images: ghcr.io/decapodlabs/decapod
           tags: |
             type=raw,value=${{ github.ref_name }}${{ matrix.tag_suffix }}
-            type=raw,value=sha-${{ steps.commit.outputs.sha_short }}${{ matrix.tag_suffix }}
-            type=raw,value=${{ matrix.latest_tag }},enable=${{ !contains(github.ref_name, '-') }}
       - name: Build and push Decapod image
         uses: docker/build-push-action@v6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.8 -->
-<!-- decapod-fingerprint: 5b93160fedc113fd2ec92cb68c427962dc20d1f8b76e6f75f3438e109e45f2ad -->
+<!-- decapod-release: 0.72.9 -->
+<!-- decapod-fingerprint: ec0bbfa1ed92b63f1008b9d0bb65a99e93d5cfdaac70bcb165efa11c241979a5 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.8 -->
-<!-- decapod-fingerprint: 4f0f79b6ee532ea09c8985a20dafab346680ae27d0a928dfff06dab60011d11b -->
+<!-- decapod-release: 0.72.9 -->
+<!-- decapod-fingerprint: 21578d219fe19a41da69c0944ce4d0aebaeeb9872bee88262c83d580995b0e2a -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.8 -->
-<!-- decapod-fingerprint: 4cdbd536e425117c650d7a79a4a1b8b8461c74b3034bb9b06d2ec9e92ee58936 -->
+<!-- decapod-release: 0.72.9 -->
+<!-- decapod-fingerprint: 4275ad4a2436426bf7c41b5e3f986b8590a37cd406d8453557f7ad4d1a81cc30 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.8 -->
-<!-- decapod-fingerprint: cc21151711685ad1b9feec2bb24c0348ad1fdaabd0255b56ec5204bf41d2b616 -->
+<!-- decapod-release: 0.72.9 -->
+<!-- decapod-fingerprint: 7e3e10c0d07b7df210f6213e6b2b88baf6042cbf902feb03528fd97c0fe55a21 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/container_runtime.rs
+++ b/src/core/container_runtime.rs
@@ -40,7 +40,6 @@ pub fn is_current_decapod_image(repository: &str, tag: &str, version_tag: &str) 
         DECAPOD_RELEASE_IMAGE_REPOSITORY => {
             tag == version_tag || tag == format!("{version_tag}-alpine")
         }
-        DECAPOD_WORKSPACE_IMAGE_REPOSITORY => tag.starts_with(&format!("{version_tag}-")),
         _ => false,
     }
 }
@@ -75,7 +74,7 @@ pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
         let Some(tag) = fields.next() else {
             continue;
         };
-        if !is_decapod_image_repository(repository)
+        if repository != DECAPOD_RELEASE_IMAGE_REPOSITORY
             || tag == "<none>"
             || is_current_decapod_image(repository, tag, &version_tag)
         {
@@ -142,12 +141,37 @@ pub fn remove_image(image_ref: &str) -> Result<bool, error::DecapodError> {
         String::from_utf8_lossy(&removed.stderr).trim()
     )))
 }
+pub fn remove_workspace_images_for_path(
+    workspace_path: &Path,
+) -> Result<usize, error::DecapodError> {
+    let runtime = find_container_runtime()?;
+    let label = format!(
+        "label=org.decapod.workspace.path={}",
+        workspace_path.display()
+    );
+    let listed = Command::new(&runtime)
+        .args(["image", "ls", "--quiet", "--filter", &label])
+        .output()
+        .map_err(error::DecapodError::IoError)?;
+    if !listed.status.success() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "Failed to list workspace images for {}: {}",
+            workspace_path.display(),
+            String::from_utf8_lossy(&listed.stderr).trim()
+        )));
+    }
 
-fn is_decapod_image_repository(repository: &str) -> bool {
-    matches!(
-        repository,
-        DECAPOD_RELEASE_IMAGE_REPOSITORY | DECAPOD_WORKSPACE_IMAGE_REPOSITORY
-    )
+    let mut removed = 0;
+    for image_id in String::from_utf8_lossy(&listed.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        if remove_image(image_id)? {
+            removed += 1;
+        }
+    }
+    Ok(removed)
 }
 
 fn command_present(cmd: &str) -> bool {
@@ -197,11 +221,6 @@ mod tests {
             "v0.72.9-alpine",
             "v0.72.9"
         ));
-        assert!(is_current_decapod_image(
-            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
-            "v0.72.9-agent-unknown-task",
-            "v0.72.9"
-        ));
         assert!(!is_current_decapod_image(
             DECAPOD_RELEASE_IMAGE_REPOSITORY,
             "latest",
@@ -210,11 +229,6 @@ mod tests {
         assert!(!is_current_decapod_image(
             DECAPOD_RELEASE_IMAGE_REPOSITORY,
             "v0.72.8",
-            "v0.72.9"
-        ));
-        assert!(!is_current_decapod_image(
-            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
-            "agent-unknown-old-task",
             "v0.72.9"
         ));
         assert!(!is_current_decapod_image(

--- a/src/core/container_runtime.rs
+++ b/src/core/container_runtime.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -8,6 +9,12 @@ pub const DECAPOD_WORKSPACE_IMAGE_REPOSITORY: &str = "localhost/decapod-workspac
 const DECAPOD_SOURCE_LABEL: &str =
     "org.opencontainers.image.source=https://github.com/DecapodLabs/decapod";
 const DECAPOD_WORKSPACE_LABEL: &str = "org.decapod.managed=workspace";
+const DECAPOD_SOURCE_LABEL_KEY: &str = "org.opencontainers.image.source";
+const DECAPOD_SOURCE_LABEL_VALUE: &str = "https://github.com/DecapodLabs/decapod";
+const DECAPOD_WORKSPACE_LABEL_KEY: &str = "org.decapod.managed";
+const DECAPOD_WORKSPACE_LABEL_VALUE: &str = "workspace";
+const DECAPOD_VERSION_LABEL_KEY: &str = "org.decapod.version";
+const DECAPOD_WORKSPACE_PATH_LABEL_KEY: &str = "org.decapod.workspace.path";
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ImagePruneReport {
@@ -44,15 +51,57 @@ pub fn is_current_decapod_image(repository: &str, tag: &str, version_tag: &str) 
     }
 }
 
-/// Remove Decapod-owned image tags from older releases and reclaim their
-/// unreferenced layers without touching unrelated container images.
-pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
-    let runtime = find_container_runtime()?;
-    let version_tag = current_decapod_version_tag();
-    let listed = Command::new(&runtime)
+#[derive(Debug)]
+struct ImageRecord {
+    repository: String,
+    tag: String,
+    image_id: String,
+    labels: BTreeMap<String, String>,
+}
+
+fn is_decapod_image_repository(repository: &str) -> bool {
+    repository == DECAPOD_RELEASE_IMAGE_REPOSITORY
+        || repository == DECAPOD_WORKSPACE_IMAGE_REPOSITORY
+        || repository.starts_with("decapod-local-")
+}
+
+fn is_decapod_managed_image(repository: &str, labels: &BTreeMap<String, String>) -> bool {
+    is_decapod_image_repository(repository)
+        || (labels.get(DECAPOD_SOURCE_LABEL_KEY).map(String::as_str)
+            == Some(DECAPOD_SOURCE_LABEL_VALUE))
+        || (labels.get(DECAPOD_WORKSPACE_LABEL_KEY).map(String::as_str)
+            == Some(DECAPOD_WORKSPACE_LABEL_VALUE))
+}
+
+fn is_current_decapod_image_record(
+    repository: &str,
+    tag: &str,
+    labels: &BTreeMap<String, String>,
+    version: &str,
+    version_tag: &str,
+) -> bool {
+    if repository == DECAPOD_RELEASE_IMAGE_REPOSITORY {
+        return is_current_decapod_image(repository, tag, version_tag);
+    }
+
+    is_decapod_image_repository(repository)
+        && repository != DECAPOD_RELEASE_IMAGE_REPOSITORY
+        && tag != "<none>"
+        && !tag.starts_with(&format!("{version_tag}-"))
+        && labels.get(DECAPOD_WORKSPACE_LABEL_KEY).map(String::as_str)
+            == Some(DECAPOD_WORKSPACE_LABEL_VALUE)
+        && labels.get(DECAPOD_VERSION_LABEL_KEY).map(String::as_str) == Some(version)
+        && labels
+            .get(DECAPOD_WORKSPACE_PATH_LABEL_KEY)
+            .is_some_and(|path| !path.is_empty())
+}
+
+fn list_decapod_images(runtime: &str) -> Result<Vec<ImageRecord>, error::DecapodError> {
+    let listed = Command::new(runtime)
         .args([
             "image",
             "ls",
+            "--all",
             "--format",
             "{{.Repository}}|{{.Tag}}|{{.ID}}",
         ])
@@ -65,7 +114,8 @@ pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
         )));
     }
 
-    let mut report = ImagePruneReport::default();
+    let mut image_ids = BTreeSet::new();
+    let mut entries = Vec::new();
     for line in String::from_utf8_lossy(&listed.stdout).lines() {
         let mut fields = line.split('|');
         let Some(repository) = fields.next() else {
@@ -74,24 +124,115 @@ pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
         let Some(tag) = fields.next() else {
             continue;
         };
-        if repository != DECAPOD_RELEASE_IMAGE_REPOSITORY
-            || tag == "<none>"
-            || is_current_decapod_image(repository, tag, &version_tag)
+        let Some(image_id) = fields.next() else {
+            continue;
+        };
+        if repository.is_empty() || image_id.is_empty() {
+            continue;
+        }
+        image_ids.insert(image_id.to_string());
+        entries.push((
+            repository.to_string(),
+            tag.to_string(),
+            image_id.to_string(),
+        ));
+    }
+
+    let mut labels_by_id = BTreeMap::new();
+    for image_id in image_ids {
+        let inspected = Command::new(runtime)
+            .args([
+                "image",
+                "inspect",
+                "--format",
+                "{{json .Config.Labels}}",
+                &image_id,
+            ])
+            .output()
+            .map_err(error::DecapodError::IoError)?;
+        if !inspected.status.success() {
+            return Err(error::DecapodError::ValidationError(format!(
+                "Failed to inspect container image {image_id}: {}",
+                String::from_utf8_lossy(&inspected.stderr).trim()
+            )));
+        }
+
+        let parsed: serde_json::Value = serde_json::from_slice(&inspected.stdout).map_err(|e| {
+            error::DecapodError::ValidationError(format!(
+                "Failed to parse labels for container image {image_id}: {e}"
+            ))
+        })?;
+        let labels = parsed
+            .as_object()
+            .map(|object| {
+                object
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        value.as_str().map(|value| (key.clone(), value.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        labels_by_id.insert(image_id, labels);
+    }
+
+    Ok(entries
+        .into_iter()
+        .map(|(repository, tag, image_id)| ImageRecord {
+            repository,
+            tag,
+            labels: labels_by_id.remove(&image_id).unwrap_or_default(),
+            image_id,
+        })
+        .collect())
+}
+
+/// Remove Decapod-owned image tags whose version does not match this binary,
+/// then reclaim their unreferenced layers without touching unrelated images.
+pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
+    let runtime = find_container_runtime()?;
+    let version = env!("CARGO_PKG_VERSION");
+    let version_tag = current_decapod_version_tag();
+    let records = list_decapod_images(&runtime)?;
+    let current_image_ids: BTreeSet<String> = records
+        .iter()
+        .filter(|record| {
+            is_current_decapod_image_record(
+                &record.repository,
+                &record.tag,
+                &record.labels,
+                version,
+                &version_tag,
+            )
+        })
+        .map(|record| record.image_id.clone())
+        .collect();
+    let mut report = ImagePruneReport::default();
+    let mut removal_targets = BTreeSet::new();
+    for record in records {
+        if !is_decapod_managed_image(&record.repository, &record.labels)
+            || is_current_decapod_image_record(
+                &record.repository,
+                &record.tag,
+                &record.labels,
+                version,
+                &version_tag,
+            )
         {
             continue;
         }
 
-        let image_ref = format!("{repository}:{tag}");
-        let removed = Command::new(&runtime)
-            .args(["image", "rm", "--force", &image_ref])
-            .output()
-            .map_err(error::DecapodError::IoError)?;
-        if !removed.status.success() {
-            return Err(error::DecapodError::ValidationError(format!(
-                "Failed to remove stale Decapod image {image_ref}: {}",
-                String::from_utf8_lossy(&removed.stderr).trim()
-            )));
+        if record.tag == "<none>" {
+            if !current_image_ids.contains(&record.image_id) {
+                removal_targets.insert(record.image_id);
+            }
+        } else {
+            removal_targets.insert(format!("{}:{}", record.repository, record.tag));
         }
+    }
+
+    for image_ref in removal_targets {
+        remove_image_with_runtime(&runtime, &image_ref)?;
         report.removed_images.push(image_ref);
     }
 
@@ -118,9 +259,8 @@ pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
     Ok(report)
 }
 
-pub fn remove_image(image_ref: &str) -> Result<bool, error::DecapodError> {
-    let runtime = find_container_runtime()?;
-    let removed = Command::new(&runtime)
+fn remove_image_with_runtime(runtime: &str, image_ref: &str) -> Result<bool, error::DecapodError> {
+    let removed = Command::new(runtime)
         .args(["image", "rm", "--force", image_ref])
         .output()
         .map_err(error::DecapodError::IoError)?;
@@ -140,6 +280,11 @@ pub fn remove_image(image_ref: &str) -> Result<bool, error::DecapodError> {
         "Failed to remove Decapod image {image_ref}: {}",
         String::from_utf8_lossy(&removed.stderr).trim()
     )))
+}
+
+pub fn remove_image(image_ref: &str) -> Result<bool, error::DecapodError> {
+    let runtime = find_container_runtime()?;
+    remove_image_with_runtime(&runtime, image_ref)
 }
 pub fn remove_workspace_images_for_path(
     workspace_path: &Path,
@@ -234,6 +379,76 @@ mod tests {
         assert!(!is_current_decapod_image(
             "docker.io/library/alpine",
             "3.20",
+            "v0.72.9"
+        ));
+    }
+
+    #[test]
+    fn image_inventory_scopes_cleanup_to_decapod_artifacts() {
+        let workspace_labels = BTreeMap::from([
+            (
+                DECAPOD_WORKSPACE_LABEL_KEY.to_string(),
+                DECAPOD_WORKSPACE_LABEL_VALUE.to_string(),
+            ),
+            (DECAPOD_VERSION_LABEL_KEY.to_string(), "0.72.9".to_string()),
+            (
+                DECAPOD_WORKSPACE_PATH_LABEL_KEY.to_string(),
+                "/tmp/workspace".to_string(),
+            ),
+        ]);
+        let empty_labels = BTreeMap::new();
+
+        assert!(is_decapod_managed_image(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            &empty_labels
+        ));
+        assert!(is_decapod_managed_image(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            &empty_labels
+        ));
+        assert!(!is_decapod_managed_image(
+            "localhost/malware-analyzer",
+            &empty_labels
+        ));
+
+        assert!(is_current_decapod_image_record(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            "v0.72.9",
+            &empty_labels,
+            "0.72.9",
+            "v0.72.9"
+        ));
+        assert!(is_current_decapod_image_record(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            "agent-branch",
+            &workspace_labels,
+            "0.72.9",
+            "v0.72.9"
+        ));
+        assert!(!is_current_decapod_image_record(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            "v0.72.9-agent-branch",
+            &workspace_labels,
+            "0.72.9",
+            "v0.72.9"
+        ));
+
+        let stale_workspace_labels = BTreeMap::from([
+            (
+                DECAPOD_WORKSPACE_LABEL_KEY.to_string(),
+                DECAPOD_WORKSPACE_LABEL_VALUE.to_string(),
+            ),
+            (DECAPOD_VERSION_LABEL_KEY.to_string(), "0.72.8".to_string()),
+            (
+                DECAPOD_WORKSPACE_PATH_LABEL_KEY.to_string(),
+                "/tmp/workspace".to_string(),
+            ),
+        ]);
+        assert!(!is_current_decapod_image_record(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            "agent-branch",
+            &stale_workspace_labels,
+            "0.72.9",
             "v0.72.9"
         ));
     }

--- a/src/core/container_runtime.rs
+++ b/src/core/container_runtime.rs
@@ -3,6 +3,18 @@ use std::process::{Command, Stdio};
 
 use crate::core::error;
 
+pub const DECAPOD_RELEASE_IMAGE_REPOSITORY: &str = "ghcr.io/decapodlabs/decapod";
+pub const DECAPOD_WORKSPACE_IMAGE_REPOSITORY: &str = "localhost/decapod-workspace";
+const DECAPOD_SOURCE_LABEL: &str =
+    "org.opencontainers.image.source=https://github.com/DecapodLabs/decapod";
+const DECAPOD_WORKSPACE_LABEL: &str = "org.decapod.managed=workspace";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImagePruneReport {
+    pub removed_images: Vec<String>,
+    pub pruned_layer_sets: usize,
+}
+
 pub fn container_runtime_available() -> bool {
     find_container_runtime().is_ok()
 }
@@ -17,6 +29,125 @@ pub fn find_container_runtime() -> Result<String, error::DecapodError> {
     Err(error::DecapodError::NotFound(
         "No container runtime found (docker/podman)".to_string(),
     ))
+}
+
+pub fn current_decapod_version_tag() -> String {
+    format!("v{}", env!("CARGO_PKG_VERSION"))
+}
+
+pub fn is_current_decapod_image(repository: &str, tag: &str, version_tag: &str) -> bool {
+    match repository {
+        DECAPOD_RELEASE_IMAGE_REPOSITORY => {
+            tag == version_tag || tag == format!("{version_tag}-alpine")
+        }
+        DECAPOD_WORKSPACE_IMAGE_REPOSITORY => tag.starts_with(&format!("{version_tag}-")),
+        _ => false,
+    }
+}
+
+/// Remove Decapod-owned image tags from older releases and reclaim their
+/// unreferenced layers without touching unrelated container images.
+pub fn prune_decapod_images() -> Result<ImagePruneReport, error::DecapodError> {
+    let runtime = find_container_runtime()?;
+    let version_tag = current_decapod_version_tag();
+    let listed = Command::new(&runtime)
+        .args([
+            "image",
+            "ls",
+            "--format",
+            "{{.Repository}}|{{.Tag}}|{{.ID}}",
+        ])
+        .output()
+        .map_err(error::DecapodError::IoError)?;
+    if !listed.status.success() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "Failed to list container images: {}",
+            String::from_utf8_lossy(&listed.stderr).trim()
+        )));
+    }
+
+    let mut report = ImagePruneReport::default();
+    for line in String::from_utf8_lossy(&listed.stdout).lines() {
+        let mut fields = line.split('|');
+        let Some(repository) = fields.next() else {
+            continue;
+        };
+        let Some(tag) = fields.next() else {
+            continue;
+        };
+        if !is_decapod_image_repository(repository)
+            || tag == "<none>"
+            || is_current_decapod_image(repository, tag, &version_tag)
+        {
+            continue;
+        }
+
+        let image_ref = format!("{repository}:{tag}");
+        let removed = Command::new(&runtime)
+            .args(["image", "rm", "--force", &image_ref])
+            .output()
+            .map_err(error::DecapodError::IoError)?;
+        if !removed.status.success() {
+            return Err(error::DecapodError::ValidationError(format!(
+                "Failed to remove stale Decapod image {image_ref}: {}",
+                String::from_utf8_lossy(&removed.stderr).trim()
+            )));
+        }
+        report.removed_images.push(image_ref);
+    }
+
+    for label in [DECAPOD_SOURCE_LABEL, DECAPOD_WORKSPACE_LABEL] {
+        let pruned = Command::new(&runtime)
+            .args([
+                "image",
+                "prune",
+                "--force",
+                "--filter",
+                &format!("label={label}"),
+            ])
+            .output()
+            .map_err(error::DecapodError::IoError)?;
+        if !pruned.status.success() {
+            return Err(error::DecapodError::ValidationError(format!(
+                "Failed to prune stale Decapod image layers for {label}: {}",
+                String::from_utf8_lossy(&pruned.stderr).trim()
+            )));
+        }
+        report.pruned_layer_sets += 1;
+    }
+
+    Ok(report)
+}
+
+pub fn remove_image(image_ref: &str) -> Result<bool, error::DecapodError> {
+    let runtime = find_container_runtime()?;
+    let removed = Command::new(&runtime)
+        .args(["image", "rm", "--force", image_ref])
+        .output()
+        .map_err(error::DecapodError::IoError)?;
+    if removed.status.success() {
+        return Ok(true);
+    }
+
+    let stderr = String::from_utf8_lossy(&removed.stderr).to_ascii_lowercase();
+    if stderr.contains("no such image")
+        || stderr.contains("does not exist")
+        || stderr.contains("not found")
+    {
+        return Ok(false);
+    }
+
+    Err(error::DecapodError::ValidationError(format!(
+        "Failed to remove Decapod image {image_ref}: {}",
+        String::from_utf8_lossy(&removed.stderr).trim()
+    )))
+}
+
+fn is_decapod_image_repository(repository: &str) -> bool {
+    matches!(
+        repository,
+        DECAPOD_RELEASE_IMAGE_REPOSITORY | DECAPOD_WORKSPACE_IMAGE_REPOSITORY
+    )
 }
 
 fn command_present(cmd: &str) -> bool {
@@ -52,5 +183,44 @@ mod tests {
         let err =
             error::DecapodError::NotFound("No container runtime found (docker/podman)".to_string());
         assert!(err.to_string().contains("docker/podman"));
+    }
+
+    #[test]
+    fn image_retention_keeps_only_current_decapod_versions() {
+        assert!(is_current_decapod_image(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            "v0.72.9",
+            "v0.72.9"
+        ));
+        assert!(is_current_decapod_image(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            "v0.72.9-alpine",
+            "v0.72.9"
+        ));
+        assert!(is_current_decapod_image(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            "v0.72.9-agent-unknown-task",
+            "v0.72.9"
+        ));
+        assert!(!is_current_decapod_image(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            "latest",
+            "v0.72.9"
+        ));
+        assert!(!is_current_decapod_image(
+            DECAPOD_RELEASE_IMAGE_REPOSITORY,
+            "v0.72.8",
+            "v0.72.9"
+        ));
+        assert!(!is_current_decapod_image(
+            DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+            "agent-unknown-old-task",
+            "v0.72.9"
+        ));
+        assert!(!is_current_decapod_image(
+            "docker.io/library/alpine",
+            "3.20",
+            "v0.72.9"
+        ));
     }
 }

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -5942,6 +5942,13 @@ pub fn run_validation(
             s,
             timings,
             ctx,
+            "validate_stale_workspaces",
+            validate_stale_workspaces(ctx, main_root)
+        );
+        gate!(
+            s,
+            timings,
+            ctx,
             "validate_git_protected_branch",
             validate_git_protected_branch(ctx, working_root)
         );
@@ -6141,6 +6148,44 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
             "validation needs attention".bright_yellow().bold()
         );
     }
+}
+
+fn validate_stale_workspaces(
+    ctx: &ValidationContext,
+    main_root: &Path,
+) -> Result<(), error::DecapodError> {
+    info("Stale Workspaces Cleanup Gate");
+
+    if std::env::var("DECAPOD_VALIDATE_SKIP_GIT_GATES").is_ok() {
+        skip(
+            "Skipped stale workspaces cleanup (DECAPOD_VALIDATE_SKIP_GIT_GATES set)",
+            ctx,
+        );
+        return Ok(());
+    }
+
+    use crate::core::workspace;
+    match workspace::prune_workspaces(main_root, false) {
+        Ok(pruned) => {
+            if pruned.is_empty() {
+                pass("No stale workspaces found to clean up", ctx);
+            } else {
+                let list: Vec<String> = pruned
+                    .iter()
+                    .map(|pw| format!("{} ({})", pw.path, pw.reason))
+                    .collect();
+                pass(
+                    &format!("Successfully pruned stale workspaces: {}", list.join(", ")),
+                    ctx,
+                );
+            }
+        }
+        Err(e) => {
+            warn(&format!("Failed to prune stale workspaces: {e}"), ctx);
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -6164,7 +6164,7 @@ fn validate_stale_workspaces(
         return Ok(());
     }
 
-    use crate::core::workspace;
+    use crate::core::{container_runtime, workspace};
     match workspace::prune_workspaces(main_root, false) {
         Ok(pruned) => {
             if pruned.is_empty() {
@@ -6183,6 +6183,25 @@ fn validate_stale_workspaces(
         Err(e) => {
             warn(&format!("Failed to prune stale workspaces: {e}"), ctx);
         }
+    }
+
+    if container_runtime::container_runtime_available() {
+        match container_runtime::prune_decapod_images() {
+            Ok(report) => pass(
+                &format!(
+                    "Decapod image retention verified: removed {} stale image tags and pruned {} labelled layer sets",
+                    report.removed_images.len(),
+                    report.pruned_layer_sets
+                ),
+                ctx,
+            ),
+            Err(e) => warn(&format!("Failed to prune stale Decapod images: {e}"), ctx),
+        }
+    } else {
+        skip(
+            "Skipped Decapod image cleanup because no container runtime is available",
+            ctx,
+        );
     }
 
     Ok(())

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -572,11 +572,7 @@ pub fn ensure_workspace(
     // 2. Ensure container (if requested)
     if config.use_container {
         crate::plugins::container::prepare_generated_container_profile(&worktree_path)?;
-        let image_tag = format!(
-            "localhost/decapod-workspace:{}-{}",
-            sanitize_agent_id(agent_id),
-            branch.replace('/', "-")
-        );
+        let image_tag = workspace_image_tag(&worktree_path);
         build_workspace_image(&worktree_path, &image_tag)?;
 
         // Return blocker telling agent to enter container
@@ -1799,6 +1795,11 @@ pub fn prune_workspaces(
         }
 
         if is_stale {
+            if container_runtime::container_runtime_available() {
+                let image_tag = workspace_image_tag(&dir_path);
+                container_runtime::remove_image(&image_tag)?;
+            }
+
             // Attempt to remove git worktree if registered
             if matching_wt.is_some() {
                 let mut args = vec!["worktree", "remove"];
@@ -1829,6 +1830,21 @@ pub fn prune_workspaces(
     let _ = prune_stale_worktree_config(repo_root);
 
     Ok(pruned)
+}
+
+fn workspace_image_tag(workspace_path: &Path) -> String {
+    let workspace_name = workspace_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(sanitize_agent_id)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "workspace".to_string());
+    format!(
+        "{}:{}-{}",
+        container_runtime::DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
+        container_runtime::current_decapod_version_tag(),
+        workspace_name
+    )
 }
 
 #[cfg(test)]

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -572,7 +572,7 @@ pub fn ensure_workspace(
     // 2. Ensure container (if requested)
     if config.use_container {
         crate::plugins::container::prepare_generated_container_profile(&worktree_path)?;
-        let image_tag = workspace_image_tag(&worktree_path);
+        let image_tag = workspace_image_tag(agent_id, branch);
         build_workspace_image(&worktree_path, &image_tag)?;
 
         // Return blocker telling agent to enter container
@@ -725,7 +725,12 @@ fn build_workspace_image(workspace_path: &Path, image_tag: &str) -> Result<(), D
         .arg("-t")
         .arg(image_tag)
         .arg("-f")
-        .arg(dockerfile_path.to_str().unwrap_or("Dockerfile"));
+        .arg(dockerfile_path.to_str().unwrap_or("Dockerfile"))
+        .arg("--build-arg")
+        .arg(format!(
+            "DECAPOD_WORKSPACE_PATH={}",
+            workspace_path.display()
+        ));
     if env_bool("DECAPOD_CONTAINER_LOCAL_BINARY_FALLBACK", false) {
         build
             .arg("--build-arg")
@@ -1796,8 +1801,7 @@ pub fn prune_workspaces(
 
         if is_stale {
             if container_runtime::container_runtime_available() {
-                let image_tag = workspace_image_tag(&dir_path);
-                container_runtime::remove_image(&image_tag)?;
+                let _ = container_runtime::remove_workspace_images_for_path(&dir_path);
             }
 
             // Attempt to remove git worktree if registered
@@ -1832,18 +1836,12 @@ pub fn prune_workspaces(
     Ok(pruned)
 }
 
-fn workspace_image_tag(workspace_path: &Path) -> String {
-    let workspace_name = workspace_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(sanitize_agent_id)
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| "workspace".to_string());
+fn workspace_image_tag(agent_id: &str, branch: &str) -> String {
     format!(
         "{}:{}-{}",
         container_runtime::DECAPOD_WORKSPACE_IMAGE_REPOSITORY,
-        container_runtime::current_decapod_version_tag(),
-        workspace_name
+        sanitize_agent_id(agent_id),
+        branch.replace('/', "-")
     )
 }
 

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -980,6 +980,8 @@ fn render_generated_dockerfile(capabilities: &ProjectCapabilities) -> String {
          ARG DECAPOD_VERSION={decapod_version}\n\
          ARG DECAPOD_USE_LOCAL_BINARY=0\n\
          LABEL org.opencontainers.image.base.name=\"$DECAPOD_IMAGE\"\n\
+         LABEL org.opencontainers.image.source=\"https://github.com/DecapodLabs/decapod\"\n\
+         LABEL org.decapod.managed=\"workspace\"\n\
          LABEL org.decapod.version=\"$DECAPOD_VERSION\"\n\
          RUN if command -v apk >/dev/null 2>&1; then \\\n\
                  apk add --no-cache {apk_pkg_line}; \\\n\

--- a/src/plugins/container.rs
+++ b/src/plugins/container.rs
@@ -978,10 +978,12 @@ fn render_generated_dockerfile(capabilities: &ProjectCapabilities) -> String {
          ARG DECAPOD_IMAGE={decapod_image}\n\
          FROM $DECAPOD_IMAGE\n\
          ARG DECAPOD_VERSION={decapod_version}\n\
+         ARG DECAPOD_WORKSPACE_PATH=unknown\n\
          ARG DECAPOD_USE_LOCAL_BINARY=0\n\
          LABEL org.opencontainers.image.base.name=\"$DECAPOD_IMAGE\"\n\
          LABEL org.opencontainers.image.source=\"https://github.com/DecapodLabs/decapod\"\n\
          LABEL org.decapod.managed=\"workspace\"\n\
+         LABEL org.decapod.workspace.path=\"$DECAPOD_WORKSPACE_PATH\"\n\
          LABEL org.decapod.version=\"$DECAPOD_VERSION\"\n\
          RUN if command -v apk >/dev/null 2>&1; then \\\n\
                  apk add --no-cache {apk_pkg_line}; \\\n\
@@ -1699,6 +1701,9 @@ mod tests {
         )));
         assert!(content.contains("FROM $DECAPOD_IMAGE"));
         assert!(content.contains("ARG DECAPOD_USE_LOCAL_BINARY=0"));
+        assert!(content.contains("ARG DECAPOD_WORKSPACE_PATH=unknown"));
+        assert!(content.contains("LABEL org.decapod.managed=\"workspace\""));
+        assert!(content.contains("LABEL org.decapod.workspace.path=\"$DECAPOD_WORKSPACE_PATH\""));
         assert!(content.contains("git"));
         assert!(content.contains("openssh-client"));
         assert!(content.contains("coreutils"));

--- a/tests/release_workflow_policy.rs
+++ b/tests/release_workflow_policy.rs
@@ -45,16 +45,18 @@ fn release_workflow_publishes_decapod_ghcr_image() {
         "release workflow should compute the preferred 7-character commit SHA"
     );
     assert!(
-        workflow.contains("type=raw,value=sha-${{ steps.commit.outputs.sha_short }}"),
-        "release workflow should publish a short-SHA image tag"
+        workflow.contains("type=raw,value=${{ github.ref_name }}${{ matrix.tag_suffix }}"),
+        "release workflow should publish the version-matching workspace image tag"
     );
     assert!(
-        workflow.contains("type=raw,value=${{ github.ref_name }}${{ matrix.tag_suffix }}")
-            && workflow.contains(
-                "type=raw,value=sha-${{ steps.commit.outputs.sha_short }}${{ matrix.tag_suffix }}"
-            )
-            && workflow.contains("latest-alpine"),
-        "release workflow should publish glibc and alpine Decapod image variants"
+        !workflow.contains("type=raw,value=sha-")
+            && !workflow.contains("latest_tag:")
+            && !workflow.contains("type=raw,value=${{ matrix.latest_tag }}"),
+        "release workflow should not retain SHA or floating workspace image tags"
+    );
+    assert!(
+        workflow.contains("tag_suffix: \"\"") && workflow.contains("tag_suffix: \"-alpine\""),
+        "release workflow should publish glibc and alpine Decapod workspace image variants"
     );
     assert!(
         workflow.contains("file: Dockerfile.workspace"),

--- a/tests/workspace_prune_regression.rs
+++ b/tests/workspace_prune_regression.rs
@@ -419,7 +419,7 @@ fn test_validate_stale_workspaces_cleanup() {
             "worktree",
             "add",
             "-b",
-            &wt_branch,
+            wt_branch,
             wt_path.to_str().unwrap(),
         ],
     );

--- a/tests/workspace_prune_regression.rs
+++ b/tests/workspace_prune_regression.rs
@@ -360,3 +360,79 @@ fn test_workspace_prune_unmerged_prevention() {
             .any(|p| p.path == wt_f_path.to_string_lossy() && p.reason == "task_completed")
     );
 }
+
+#[test]
+fn test_validate_stale_workspaces_cleanup() {
+    let tmp = tempdir().expect("tempdir");
+    let main_root = tmp.path().join("main_repo");
+    fs::create_dir_all(&main_root).expect("create main_repo");
+
+    git_init(&main_root);
+    git_commit(&main_root, "init");
+
+    let store_root = main_root.join(".decapod").join("data");
+    fs::create_dir_all(&store_root).expect("create data dir");
+    initialize_todo_db(&store_root).expect("init todo db");
+
+    let store = Store {
+        kind: StoreKind::Repo,
+        root: store_root.clone(),
+    };
+
+    let task_res = add_task(
+        &store_root,
+        &TodoCommand::Add {
+            title: "Task Prunable".to_string(),
+            description: "".to_string(),
+            tags: "".to_string(),
+            owner: "test-agent".to_string(),
+            due: None,
+            r#ref: "".to_string(),
+            scope: "".to_string(),
+            dir: Some(main_root.to_string_lossy().to_string()),
+            priority: "medium".to_string(),
+            depends_on: "".to_string(),
+            blocks: "".to_string(),
+            parent: None,
+            one_shot: 0,
+        },
+    )
+    .expect("add task");
+    let id = task_res.get("id").unwrap().as_str().unwrap();
+
+    let db_path = decapod::core::todo::todo_db_path(&store_root);
+    let conn = rusqlite::Connection::open(&db_path).expect("open db");
+    conn.execute("UPDATE tasks SET hash = 'hashprune' WHERE id = ?", [id])
+        .expect("update hash");
+
+    claim_task(&store_root, id, "test-agent", ClaimMode::Exclusive).expect("claim task");
+    update_status(&store, id, "done", "task.done", serde_json::json!({})).expect("done task");
+
+    let workspaces_dir = main_root.join(".decapod").join("workspaces");
+    fs::create_dir_all(&workspaces_dir).expect("create workspaces dir");
+
+    let wt_path = workspaces_dir.join("test-agent-todo-hashprune-todo");
+    let wt_branch = "agent/test-agent/todo-hashprune";
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &wt_branch,
+            wt_path.to_str().unwrap(),
+        ],
+    );
+
+    assert!(wt_path.exists());
+
+    // Run validation to trigger auto-prune
+    let _report =
+        decapod::core::validate::run_validation(&store, &main_root, &wt_path, true, false, false)
+            .expect("validate run");
+
+    assert!(
+        !wt_path.exists(),
+        "Stale workspace must have been pruned by validation"
+    );
+}


### PR DESCRIPTION
Resolves Issue #814. Automatically prunes stale/completed workspaces (including their cargo target directories) during decapod validation.