### PR TITLE
docs: define aggressive interfaces v2 restructure

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.11
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.12
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.11
+ARG DECAPOD_VERSION=0.72.12
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/context/bugs_01ky1njgd4mdem0e.json
+++ b/.decapod/generated/context/bugs_01ky1njgd4mdem0e.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "1.1.0",
+  "topic": "canonical interfaces contract envelope adherence and proof",
+  "scope": "interfaces",
+  "task_id": "bugs_01ky1njgd4mdem0e",
+  "workunit_id": "bugs_01ky1njgd4mdem0e",
+  "sources": [
+    {
+      "path": "interfaces/DEMANDS_SCHEMA",
+      "section": "concepts"
+    },
+    {
+      "path": "interfaces/TESTING",
+      "section": "concepts"
+    },
+    {
+      "path": "interfaces/CLAIMS",
+      "section": "interfaces/CLAIMS"
+    },
+    {
+      "path": "interfaces/PROJECT_SPECS",
+      "section": "concepts"
+    }
+  ],
+  "snippets": [
+    {
+      "source_path": "interfaces/DEMANDS_SCHEMA",
+      "text": "## concepts\n\nConstraint Types: 'Must' (blocking), 'Must-Not' (forbidden), 'Prefer' (weighted optimization).\nPriority and Scope: The level of enforcement and the specific subsystems or workflows a demand constrains.\nDurability: Distinguishing between session-local preferences and persistent project-wide demands.\nConflict Handling: Rules for reconciling contradictory demands using the specs/INTENT authority."
+    },
+    {
+      "source_path": "interfaces/TESTING",
+      "text": "## concepts\n\nValidation Gate: A task cannot be marked done without decapod validate passing successfully.\nSafety Check Sequences: Run decapod capabilities, decapod docs ingest, and decapod validate regularly to verify system state.\nExpected Command: The exact shell command or script used to execute a specific test or gate.\nEvidence Capture: The structured logs, receipts, or artifacts that prove a test result and status.\nValidation Mapping: Linking test results to truth labels ('verified', 'failing', 'stale') and claims.\nRemediation: Mapping specific failure codes to automated fix paths or manual recovery steps."
+    },
+    {
+      "source_path": "interfaces/CLAIMS",
+      "text": "# interfaces/CLAIMS\n**Authority:** doctrine\n**Layer:** interfaces\n**Binding:** advisory\n\nDescribes claim type, evidence, verification status, stale claim risk, and mapping claims to proof."
+    },
+    {
+      "source_path": "interfaces/PROJECT_SPECS",
+      "text": "## concepts\n\nLiving Specs: Treat files under .decapod/generated/specs/* as dynamic contracts. Review and update INTENT.md, ARCHITECTURE.md, and INTERFACES.md to align specs with intent.\nProject Configuration: Read .decapod/config.toml as user-editable project context and update it when project scope changes.\nAcceptance Criteria: Falsifiable, testable conditions that define the success of a feature or task.\nRequirement Boundaries: The specific code paths, files, and subsystems that the spec governs.\nProof Targets: The exact test or verification script required to prove the spec is satisfied.\nSpec Drift: Detecting DELTAs where implementation has diverged from the documented intent."
+    }
+  ],
+  "capabilities": [
+    "agent-helper",
+    "authentication",
+    "authorization",
+    "background-processing",
+    "control-plane",
+    "event-driven",
+    "external-integrations",
+    "governance-kernel",
+    "persistent-state",
+    "scheduled-jobs"
+  ],
+  "policy": {
+    "risk_tier": "medium",
+    "policy_hash": "4be692d786ecc3514b98ed3228e133501360531cdcb4ef77fe3b3a111c9e38cb",
+    "policy_version": "jit-capsule-policy-v1",
+    "policy_path": ".decapod/generated/policy/context_capsule_policy.json",
+    "repo_revision": "72d3a1800f65b983341af63875490f85dc9a6c6d"
+  },
+  "capsule_hash": "9f4f7a06b7231aa969ab0f5092bd5f999b0228c8357d53546286c1a71e7bf40e",
+  "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
+  "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
+  "spec_input_hash": "11ab51a300ffb6686efc1c9b55f307142424664f6b607aaadefddb6dee0f9b27"
+}

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784617384Z",
+  "generated_at": "1784617610Z",
   "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
   "declared_capabilities": [
     "agent-helper",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "c0271a50614b08bfc026c290a1ff70453b05ac5d4528cbf0cac4f76d5c3b5a8c",
+  "spec_input_hash": "11ab51a300ffb6686efc1c9b55f307142424664f6b607aaadefddb6dee0f9b27",
   "decapod_release": "0.72.12",
   "entrypoints": [
     {
@@ -73,7 +73,7 @@
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "4cd2d8fd5ffe74aec109e0d981edc1a5a1a06b79ba09a1c20675f754eddc0bc3",
+      "content_hash": "6e24f83f28b8db83f51efc42850753b8c71f9df727dbc2113b2f8cf85e253312",
       "fingerprint": ""
     },
     {
@@ -85,7 +85,7 @@
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "8158615723bdaaaa89f705caf77fdb0e6036389e0744714fce0458b325dc1629",
+      "content_hash": "833e4ddd60d02972b1a5b9bb4915e3d8ea892090c294a9cea88039e5b6d4389c",
       "fingerprint": ""
     },
     {

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784616793Z",
+  "generated_at": "1784617384Z",
   "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
   "declared_capabilities": [
     "agent-helper",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "fc7b95ce9302ccb7d0890d586fe13ac3d137ff1a1332880c628df47520607c60",
+  "spec_input_hash": "c0271a50614b08bfc026c290a1ff70453b05ac5d4528cbf0cac4f76d5c3b5a8c",
   "decapod_release": "0.72.12",
   "entrypoints": [
     {
@@ -73,7 +73,7 @@
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "8ba1df0c87e0ce97afa1b392a571d97683f27ac6065753bf0035e267be654a6f",
+      "content_hash": "4cd2d8fd5ffe74aec109e0d981edc1a5a1a06b79ba09a1c20675f754eddc0bc3",
       "fingerprint": ""
     },
     {

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784616238Z",
+  "generated_at": "1784616263Z",
   "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
   "declared_capabilities": [
     "agent-helper",
@@ -17,31 +17,31 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "50846239859518ab14ab58ffb299afdbfbbeb087ee2862682e00e17259546590",
+  "spec_input_hash": "efe4b0dab321656f03dc0984fd0fc7f78deab77f4a906452b07f7cdc6641782b",
   "decapod_release": "0.72.12",
   "entrypoints": [
     {
       "path": "AGENTS.md",
       "template_hash": "3de88979a1ead4852c72e1da692943e14d6712bade1c4b52c687822eb4855674",
-      "content_hash": "8b30efca8c06e332d5ea97ca6f7a2b629a12d2df6c8fa82d232dfda5f9ac8f85",
+      "content_hash": "3de88979a1ead4852c72e1da692943e14d6712bade1c4b52c687822eb4855674",
       "fingerprint": "591db62cc0e83ff629a466f39a37e7981ecc62db81382f14e5502fd008b3ba8e"
     },
     {
       "path": "CLAUDE.md",
       "template_hash": "46a1327faf4d62959e09a427f8cef125d5b89ed823adc51b4fac02d88cbe677e",
-      "content_hash": "3a468dc416eb7e2cf4836890810cfd98565c90516261c7a5c394003aff80177d",
+      "content_hash": "46a1327faf4d62959e09a427f8cef125d5b89ed823adc51b4fac02d88cbe677e",
       "fingerprint": "83b66ea0c905e15d9075596721db30d1ea17b874a929a501635cbe98b6931234"
     },
     {
       "path": "GEMINI.md",
       "template_hash": "0e21b71b68661cec451e7854e51a4f18516a8d902bfbace6615f9acc8ebefc69",
-      "content_hash": "146b78b620ed895f91d7390bbc75c9d7177cd8f433a1eaf6afea20eb35ba4bc8",
+      "content_hash": "0e21b71b68661cec451e7854e51a4f18516a8d902bfbace6615f9acc8ebefc69",
       "fingerprint": "dded9dcb6a1fc4c613e8e98fcadb0aba33d3fcb40a9b335f993a8b3323d5a836"
     },
     {
       "path": "CODEX.md",
       "template_hash": "9f556bff8f95ef7f779a423cad5f91a0c78dc9ace2c93e495ffb437943211efe",
-      "content_hash": "5ee954cb5fff105d38c2ad51e109f7cc22b76d3ddd2205ad8f50d6b4dcfb2216",
+      "content_hash": "9f556bff8f95ef7f779a423cad5f91a0c78dc9ace2c93e495ffb437943211efe",
       "fingerprint": "589ef65ca76618000d38923c7b20ac50360f90cf0d8197fa4790d74b8ed2ceed"
     }
   ],
@@ -85,7 +85,7 @@
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "57a5171b57e29d9efbe2954c4afc0cae059128064b75345891133c9fa45fafad",
+      "content_hash": "8158615723bdaaaa89f705caf77fdb0e6036389e0744714fce0458b325dc1629",
       "fingerprint": ""
     },
     {

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784613810Z",
-  "repo_signal_fingerprint": "03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d",
+  "generated_at": "1784616238Z",
+  "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "cb93ba2d187915a134b64e043cc5b28830d00a184f2d506fd865cf3e52003637",
-  "decapod_release": "0.72.11",
+  "spec_input_hash": "50846239859518ab14ab58ffb299afdbfbbeb087ee2862682e00e17259546590",
+  "decapod_release": "0.72.12",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "8b30efca8c06e332d5ea97ca6f7a2b629a12d2df6c8fa82d232dfda5f9ac8f85",
+      "template_hash": "3de88979a1ead4852c72e1da692943e14d6712bade1c4b52c687822eb4855674",
       "content_hash": "8b30efca8c06e332d5ea97ca6f7a2b629a12d2df6c8fa82d232dfda5f9ac8f85",
-      "fingerprint": "c416455706e0f2e27a40b400d6c121590d625ef9f0c82c983c04c9be72d172e2"
+      "fingerprint": "591db62cc0e83ff629a466f39a37e7981ecc62db81382f14e5502fd008b3ba8e"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "3a468dc416eb7e2cf4836890810cfd98565c90516261c7a5c394003aff80177d",
+      "template_hash": "46a1327faf4d62959e09a427f8cef125d5b89ed823adc51b4fac02d88cbe677e",
       "content_hash": "3a468dc416eb7e2cf4836890810cfd98565c90516261c7a5c394003aff80177d",
-      "fingerprint": "91a356ec282b1b8d0cd2fe20b244a76c6fc70a6132349230414639c9f02840fc"
+      "fingerprint": "83b66ea0c905e15d9075596721db30d1ea17b874a929a501635cbe98b6931234"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "146b78b620ed895f91d7390bbc75c9d7177cd8f433a1eaf6afea20eb35ba4bc8",
+      "template_hash": "0e21b71b68661cec451e7854e51a4f18516a8d902bfbace6615f9acc8ebefc69",
       "content_hash": "146b78b620ed895f91d7390bbc75c9d7177cd8f433a1eaf6afea20eb35ba4bc8",
-      "fingerprint": "83eb048874ba12c36b186015d1215fd65b928e64cd06b48226255c7dfd128c94"
+      "fingerprint": "dded9dcb6a1fc4c613e8e98fcadb0aba33d3fcb40a9b335f993a8b3323d5a836"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "5ee954cb5fff105d38c2ad51e109f7cc22b76d3ddd2205ad8f50d6b4dcfb2216",
+      "template_hash": "9f556bff8f95ef7f779a423cad5f91a0c78dc9ace2c93e495ffb437943211efe",
       "content_hash": "5ee954cb5fff105d38c2ad51e109f7cc22b76d3ddd2205ad8f50d6b4dcfb2216",
-      "fingerprint": "f996b5a37ea54e9a8c1b17ddf730b20a33fbbfa1fb2916f990f7dc85e66d8f2d"
+      "fingerprint": "589ef65ca76618000d38923c7b20ac50360f90cf0d8197fa4790d74b8ed2ceed"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "6a030916150e8f600cb095bd5da7ccd90e83ae0dd1a30f3d18f0866b141be28d",
+      "content_hash": "a777be0c80d7bd2075c1b5c9cf4628846f38279852c4f69b42e38dbded1b6bd7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "81bb3c8af8eda8480a8c0324f5c6571f4f18fa1202be17c47170f64b34f45111",
+      "content_hash": "65e7e04a0322021a1e39048768faf284f49efa79bebab909f90df6fa985ea196",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "6a90d3d990d26de70b70fa059c98cd70631db08011bb923299e450b46845930e",
+      "content_hash": "a274a76915f16a48107fd9f8f68143ddff98215ed4e9ea0e0fc97d655f06cbf7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "d0e413d76a981019574e11427ea2b05a0cf0587af84615caace7706dc8754db7",
+      "content_hash": "b51c4f3c1e2fa0338ed169635fb1788587abbc75cb3d99279137cefaef8d3c9e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "1acad525aad1901b7b4c86e34821d3cfbfd4091f492d9e1e46b54b0a138aae93",
+      "content_hash": "66b5e448676ac2e94e1ce5269b21e6e2ca11159c23367c1d5c62b4cf4fcdb0c8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "0449d971f6922e4372ada0ce7d2bf9087cb904c3fc0f83b48ec440a685dd8e85",
+      "content_hash": "549f20b8967e64f9977530c6378eb950b8b4535724bfd3d578de030598ea78f7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "71cbae4881b68f984f4566e2fe733316850b56c10a196914b5e511b3d33ac526",
+      "content_hash": "57a5171b57e29d9efbe2954c4afc0cae059128064b75345891133c9fa45fafad",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "994d5cb2f6f7eb7f04cd3a1ea5116b30e4dd5e373a1d1b462ea12dfc316d6c3c",
+      "content_hash": "adc4df7cfaae9d2a2ae0604618c2f0e65fdb93c9aa8de48246bfdb05f2edf95b",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784616263Z",
+  "generated_at": "1784616793Z",
   "repo_signal_fingerprint": "f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99",
   "declared_capabilities": [
     "agent-helper",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "86ca124c86e16b80818f711d91c2d6a117527d7549483bb3760bbae4c9029549",
-  "spec_input_hash": "efe4b0dab321656f03dc0984fd0fc7f78deab77f4a906452b07f7cdc6641782b",
+  "spec_input_hash": "fc7b95ce9302ccb7d0890d586fe13ac3d137ff1a1332880c628df47520607c60",
   "decapod_release": "0.72.12",
   "entrypoints": [
     {
@@ -73,7 +73,7 @@
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "66b5e448676ac2e94e1ce5269b21e6e2ca11159c23367c1d5c62b4cf4fcdb0c8",
+      "content_hash": "8ba1df0c87e0ce97afa1b392a571d97683f27ac6065753bf0035e267be654a6f",
       "fingerprint": ""
     },
     {

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -113,7 +113,21 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 **Rollback:**
 - Binary: `cargo install decapod@<prev-version>` or download prior release
 - Workspace: `decapod workspace prune --force` + `git worktree remove`
-- Config: Manual edit `.decapod/config.toml` (schema_version backwards compatible)
+- Config: Manual edit `.decapod/config.toml` (schema_version backwards compatible)## Capacity Planning
+
+### Resource Limits
+| Resource | Limit | Enforcement |
+|----------|-------|-------------|
+| SQLite connections | 1 writer + N readers (pool) | `db_pool` with busy_timeout |
+| Workspace disk | Unbounded (user disk) | `decapod workspace prune` |
+| Event log size | Unbounded | Manual archive via `decapod data archive` |
+| Container memory | Host default | Docker `--memory` flag (not yet exposed) |
+| Token budget (capsule) | Risk-tier max (4/6/12/20) | `CapsulePolicyBinding` enforcement |
+
+### Scaling Triggers
+- Multiple concurrent agents → container workspaces mandatory
+- Large repos → `decapod validate` uses read-only DB connections
+- Many todos → pagination in `todo list` (not yet implemented)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -151,22 +165,6 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Capacity Planning
-
-### Resource Limits
-| Resource | Limit | Enforcement |
-|----------|-------|-------------|
-| SQLite connections | 1 writer + N readers (pool) | `db_pool` with busy_timeout |
-| Workspace disk | Unbounded (user disk) | `decapod workspace prune` |
-| Event log size | Unbounded | Manual archive via `decapod data archive` |
-| Container memory | Host default | Docker `--memory` flag (not yet exposed) |
-| Token budget (capsule) | Risk-tier max (4/6/12/20) | `CapsulePolicyBinding` enforcement |
-
-### Scaling Triggers
-- Multiple concurrent agents → container workspaces mandatory
-- Large repos → `decapod validate` uses read-only DB connections
-- Many todos → pagination in `todo list` (not yet implemented)
 
 ## Logging
 

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -97,7 +97,23 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 ### Post-Mortem
 - `decapod trace flight-recorder transcript --output postmortem.md`
 - Correlate attestations (`.decapod/generated/assurance_attestations.jsonl`)
-- Review validation report (`.decapod/generated/artifacts/provenance/validation_report.json`)
+- Review validation report (`.decapod/generated/artifacts/provenance/validation_report.json`)## Rollout Strategy
+
+**Binary releases via cargo-dist:**
+- Tagged releases: `v0.x.y` → GitHub Release with binaries
+- `cargo install decapod` pulls from crates.io
+- Auto-update check in `decapod capabilities` (crates.io API, cached 24h)
+
+**Config/Schema Migrations:**
+- `schema_version` in `.decapod/config.toml` (validated at startup)
+- `TODO_SCHEMA_VERSION` + additive migrations in `todo::ensure_schema`
+- `POLICY_SCHEMA_VERSION` for capsule policy
+- `decapod constitution migrate` for embedded constitution graph
+
+**Rollback:**
+- Binary: `cargo install decapod@<prev-version>` or download prior release
+- Workspace: `decapod workspace prune --force` + `git worktree remove`
+- Config: Manual edit `.decapod/config.toml` (schema_version backwards compatible)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -135,24 +151,6 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Rollout Strategy
-
-**Binary releases via cargo-dist:**
-- Tagged releases: `v0.x.y` → GitHub Release with binaries
-- `cargo install decapod` pulls from crates.io
-- Auto-update check in `decapod capabilities` (crates.io API, cached 24h)
-
-**Config/Schema Migrations:**
-- `schema_version` in `.decapod/config.toml` (validated at startup)
-- `TODO_SCHEMA_VERSION` + additive migrations in `todo::ensure_schema`
-- `POLICY_SCHEMA_VERSION` for capsule policy
-- `decapod constitution migrate` for embedded constitution graph
-
-**Rollback:**
-- Binary: `cargo install decapod@<prev-version>` or download prior release
-- Workspace: `decapod workspace prune --force` + `git worktree remove`
-- Config: Manual edit `.decapod/config.toml` (schema_version backwards compatible)
 
 ## Capacity Planning
 
@@ -266,7 +264,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -127,7 +127,25 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 ### Scaling Triggers
 - Multiple concurrent agents → container workspaces mandatory
 - Large repos → `decapod validate` uses read-only DB connections
-- Many todos → pagination in `todo list` (not yet implemented)
+- Many todos → pagination in `todo list` (not yet implemented)## Logging
+
+### Structured Logging (Internal)
+- `tracing` + `tracing-subscriber` with JSON output
+- Correlation IDs: `event_id` (ULID) per operation
+- Session IDs: `session_id` from `session.acquire`
+- Workspace IDs: git branch name (agent/todo_hash-timestamp)
+
+### Audit Logs (Immutable)
+- `broker.events.jsonl` — All mutations (The Thin Waist)
+- `todo.events.jsonl` — Task lifecycle
+- `proof.events.jsonl` — Proof execution
+- `assurance_attestations.jsonl` — Interlock decisions
+- `federation.events.jsonl` — Knowledge graph mutations
+
+### Log Redaction
+- `DECAPOD_SESSION_PASSWORD` never logged
+- `.decapod/data/` paths logged but contents not
+- Git tokens/credentials never in command args (use credential helper)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -165,26 +183,6 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Logging
-
-### Structured Logging (Internal)
-- `tracing` + `tracing-subscriber` with JSON output
-- Correlation IDs: `event_id` (ULID) per operation
-- Session IDs: `session_id` from `session.acquire`
-- Workspace IDs: git branch name (agent/todo_hash-timestamp)
-
-### Audit Logs (Immutable)
-- `broker.events.jsonl` — All mutations (The Thin Waist)
-- `todo.events.jsonl` — Task lifecycle
-- `proof.events.jsonl` — Proof execution
-- `assurance_attestations.jsonl` — Interlock decisions
-- `federation.events.jsonl` — Knowledge graph mutations
-
-### Log Redaction
-- `DECAPOD_SESSION_PASSWORD` never logged
-- `.decapod/data/` paths logged but contents not
-- Git tokens/credentials never in command args (use credential helper)
 
 ## Secrets Management
 

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -227,49 +227,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 1. **Blocking Gates**: All must pass for promotion
 2. **Auto-Remediable**: Errors include `agent_action` for self-correction
 3. **Specs Sync**: Template drift = fail (or `--refresh-specs` to acknowledge)
-4. **Config Schema**: `schema_version=1.0.0` required; forbidden keys rejected
-
-<!-- decapod:capability-overlay:background-processing:start -->
-
-## Background Processing Semantics Overlay
-
-### Retry Semantics
-- Retry and backoff behavior MUST be selected and documented for each work class
-- Poison-work handling MUST be selected and documented for each work class
-- Retry MUST preserve the declared side-effect and idempotency semantics
-
-### Idempotency
-- Each job MUST declare whether it is idempotent, transactional, compensating, or otherwise duplicate-safe
-- Deduplication or compensation mechanisms are project decisions and require proof
-- Duplicate execution MUST follow the job's declared duplicate-handling semantics
-
-### Poison Message Handling
-- Messages failing after max retries go to dead letter queue
-- DLQ MUST be monitored and alerted
-- Manual replay capability for DLQ messages
-<!-- decapod:capability-overlay:background-processing:end -->
-
-<!-- decapod:capability-overlay:persistent-state:start -->
-
-## Persistent State Semantics Overlay
-
-### Transaction Semantics
-- All multi-entity operations MUST be atomic
-- Read-after-write consistency within transaction boundaries
-- Eventual consistency windows MUST be documented
-
-### Migration Semantics
-- Schema migrations MUST be backward-compatible
-- Migration rollback procedures MUST be documented
-- Data integrity checks post-migration
-
-### Recovery Semantics
-- Point-in-time recovery capability
-- Recovery objectives MUST be selected for the project and recorded as proof obligations
-- Recovery test cadence MUST be selected for the project and recorded as a proof obligation
-<!-- decapod:capability-overlay:persistent-state:end -->
-
-## Idempotency Contracts
+4. **Config Schema**: `schema_version=1.0.0` required; forbidden keys rejected## Idempotency Contracts
 
 | Operation | Idempotency Key | Duplicate Behavior |
 |-----------|-----------------|-------------------|
@@ -282,9 +240,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 | `proof run` | `run_id` (ULID) | New run each invocation |
 | `session acquire` | `agent_id` (from password) | Returns existing token |
 | `data knowledge add` | `id` (ULID) | Fails if ID exists |
-| `broker mutation` | `op+entity+id` | Append-only event log |
-
-## Language Note
+| `broker mutation` | `op+entity+id` | Append-only event log |## Language Note
 - Primary language: Rust (edition 2024, rust-version 1.96.1)
 - Schema definitions: Rust structs + serde + SQL DDL in `schemas.rs`
 - CLI: Clap 4 derive
@@ -294,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -51,7 +51,40 @@ flowchart LR
   - `cargo fmt --check`
 - Required integration/e2e commands:
   - `decapod qa verify` (proof replay + drift check)
-  - `decapod workspace publish` (provenance gates)
+  - `decapod workspace publish` (provenance gates)## Promotion Gates
+
+### Plan Phase Governance Gate
+| Check | Failure Mode |
+|-------|--------------|
+| Phase IDs are unique and non-empty | Fail |
+| Phases enter and complete in declaration order | Fail |
+| Only one phase is active at a time | Fail |
+| Entry and exit gates pass before transition | Fail |
+| Phase-bearing plans cannot bypass incomplete phases to `DONE` | Fail |
+| Required artifact gates exist at transition time | Fail |
+
+### Blocking Gates (Must Pass)
+| Gate | Command | Evidence |
+|------|---------|----------|
+| Architecture + interface drift check | `decapod validate` | Gate output + validation report |
+| Tests pass | `cargo test --locked` | CI + local logs |
+| Lint clean | `cargo clippy -- -D warnings` | CI output |
+| Format clean | `cargo fmt --check` | CI output |
+| Docs + changelog current | `decapod validate` (docs gates) | PR diff |
+| Security critical checks | `cargo audit` + `cargo deny check` | Scanner reports |
+| Workspace isolation | `decapod workspace status` | WorkspaceStatus.can_work = true |
+| Session auth | `decapod session status` | Valid session token |
+| Specs manifest sync | `decapod validate` (specs gate) | `.manifest.json` fingerprints match |
+| Capsule policy lineage | `decapod govern capsule query --write` | Policy hash binds to HEAD |
+| Completion evidence integrity | `decapod qa verify completion <ID>` | Canonical record, artifact, epoch, and receiver-local checks |
+
+### Warning Gates (Non-Blocking, SLA Tracked)
+| Gate | Trigger | Follow-up SLA |
+|------|---------|---------------|
+| Coverage regression | Coverage drops below target | 48h |
+| Non-blocking perf drift | P95 validation > 25s | 72h |
+| Spec template stale | `template_version` < current | Next promotion |
+| Untouched scaffold specs | `template_hash` == `content_hash` | Before implementation |
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -92,41 +125,6 @@ flowchart LR
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Promotion Gates
-
-### Plan Phase Governance Gate
-| Check | Failure Mode |
-|-------|--------------|
-| Phase IDs are unique and non-empty | Fail |
-| Phases enter and complete in declaration order | Fail |
-| Only one phase is active at a time | Fail |
-| Entry and exit gates pass before transition | Fail |
-| Phase-bearing plans cannot bypass incomplete phases to `DONE` | Fail |
-| Required artifact gates exist at transition time | Fail |
-
-### Blocking Gates (Must Pass)
-| Gate | Command | Evidence |
-|------|---------|----------|
-| Architecture + interface drift check | `decapod validate` | Gate output + validation report |
-| Tests pass | `cargo test --locked` | CI + local logs |
-| Lint clean | `cargo clippy -- -D warnings` | CI output |
-| Format clean | `cargo fmt --check` | CI output |
-| Docs + changelog current | `decapod validate` (docs gates) | PR diff |
-| Security critical checks | `cargo audit` + `cargo deny check` | Scanner reports |
-| Workspace isolation | `decapod workspace status` | WorkspaceStatus.can_work = true |
-| Session auth | `decapod session status` | Valid session token |
-| Specs manifest sync | `decapod validate` (specs gate) | `.manifest.json` fingerprints match |
-| Capsule policy lineage | `decapod govern capsule query --write` | Policy hash binds to HEAD |
-| Completion evidence integrity | `decapod qa verify completion <ID>` | Canonical record, artifact, epoch, and receiver-local checks |
-
-### Warning Gates (Non-Blocking, SLA Tracked)
-| Gate | Trigger | Follow-up SLA |
-|------|---------|---------------|
-| Coverage regression | Coverage drops below target | 48h |
-| Non-blocking perf drift | P95 validation > 25s | 72h |
-| Spec template stale | `template_version` < current | Next promotion |
-| Untouched scaffold specs | `template_hash` == `content_hash` | Before implementation |
 
 ## Evidence Artifacts
 | Artifact | Path | Required For |

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -96,7 +96,10 @@ flowchart LR
 | Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
 | Changelog entry | `CHANGELOG.md` | Promotion |
 | Flight recorder transcript | `decapod trace flight-recorder transcript` | Post-mortem |
-| Broker audit log | `.decapod/data/broker.events.jsonl` | Audit |
+| Broker audit log | `.decapod/data/broker.events.jsonl` | Audit |## Regression Guardrails
+- **Baseline references**: Validation report includes gate timings; P95 tracked per gate
+- **Statistical thresholds**: Validation must complete < 30s (P95)
+- **Rollback criteria**: Any blocking gate failure blocks promotion; `workspace prune --force` + git reset for workspace issues
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -137,11 +140,6 @@ flowchart LR
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Regression Guardrails
-- **Baseline references**: Validation report includes gate timings; P95 tracked per gate
-- **Statistical thresholds**: Validation must complete < 30s (P95)
-- **Rollback criteria**: Any blocking gate failure blocks promotion; `workspace prune --force` + git reset for workspace issues
 
 ## Bounded Execution
 | Operation | Timeout | Failure Mode |

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -43,7 +43,15 @@ flowchart LR
     C --> D[Validate]
     D --> E[Assemble Evidence]
     E --> F[Promote]
-```
+```## Proof Surfaces
+- `decapod validate` (primary)
+- Required test commands:
+  - `cargo test --locked`
+  - `cargo clippy -- -D warnings`
+  - `cargo fmt --check`
+- Required integration/e2e commands:
+  - `decapod qa verify` (proof replay + drift check)
+  - `decapod workspace publish` (provenance gates)
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -84,16 +92,6 @@ flowchart LR
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Proof Surfaces
-- `decapod validate` (primary)
-- Required test commands:
-  - `cargo test --locked`
-  - `cargo clippy -- -D warnings`
-  - `cargo fmt --check`
-- Required integration/e2e commands:
-  - `decapod qa verify` (proof replay + drift check)
-  - `decapod workspace publish` (provenance gates)
 
 ## Promotion Gates
 
@@ -324,7 +322,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `03887afc79f7c6e3712ce77dde727f9df044f2389285346046bf938de7353c1d`
+- Repository signal fingerprint: `f82026e06f071878e2fae1cdddd4d04c799ce65a6a9f06645a6180875a6f5a99`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -84,7 +84,19 @@ flowchart LR
 | Coverage regression | Coverage drops below target | 48h |
 | Non-blocking perf drift | P95 validation > 25s | 72h |
 | Spec template stale | `template_version` < current | Next promotion |
-| Untouched scaffold specs | `template_hash` == `content_hash` | Before implementation |
+| Untouched scaffold specs | `template_hash` == `content_hash` | Before implementation |## Evidence Artifacts
+| Artifact | Path | Required For |
+|----------|------|--------------|
+| Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | Promotion |
+| Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
+| Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
+| Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
+| Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
+| Test logs | CI artifact store | Promotion |
+| Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
+| Changelog entry | `CHANGELOG.md` | Promotion |
+| Flight recorder transcript | `decapod trace flight-recorder transcript` | Post-mortem |
+| Broker audit log | `.decapod/data/broker.events.jsonl` | Audit |
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -125,20 +137,6 @@ flowchart LR
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Evidence Artifacts
-| Artifact | Path | Required For |
-|----------|------|--------------|
-| Validation report | `.decapod/generated/artifacts/provenance/validation_report.json` | Promotion |
-| Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
-| Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
-| Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
-| Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
-| Test logs | CI artifact store | Promotion |
-| Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
-| Changelog entry | `CHANGELOG.md` | Promotion |
-| Flight recorder transcript | `decapod trace flight-recorder transcript` | Post-mortem |
-| Broker audit log | `.decapod/data/broker.events.jsonl` | Audit |
 
 ## Regression Guardrails
 - **Baseline references**: Validation report includes gate timings; P95 tracked per gate

--- a/.decapod/governance/workunits/bugs_01ky1njgd4mdem0e.json
+++ b/.decapod/governance/workunits/bugs_01ky1njgd4mdem0e.json
@@ -1,0 +1,47 @@
+{
+  "task_id": "bugs_01ky1njgd4mdem0e",
+  "intent_ref": "docs/architecture/interfaces-v2-restructure.md",
+  "spec_refs": [
+    ".decapod/generated/specs/INTERFACES.md",
+    "docs/architecture/interfaces-v2-contract.schema.json"
+  ],
+  "state_refs": [
+    "branch:agent/unknown/bugs_01ky1njgd4mdem0e-issue-938",
+    "pr:#957"
+  ],
+  "proof_plan": [
+    "clippy",
+    "constitution-json",
+    "format",
+    "interfaces-v2-tests",
+    "spec-refresh"
+  ],
+  "proof_results": [
+    {
+      "gate": "clippy",
+      "status": "pass",
+      "artifact_ref": "tests/interfaces_v2_design.rs"
+    },
+    {
+      "gate": "constitution-json",
+      "status": "pass",
+      "artifact_ref": "assets/constitution.json"
+    },
+    {
+      "gate": "format",
+      "status": "pass",
+      "artifact_ref": "tests/interfaces_v2_design.rs"
+    },
+    {
+      "gate": "interfaces-v2-tests",
+      "status": "pass",
+      "artifact_ref": "tests/interfaces_v2_design.rs"
+    },
+    {
+      "gate": "spec-refresh",
+      "status": "pass",
+      "artifact_ref": ".decapod/generated/specs/INTERFACES.md"
+    }
+  ],
+  "status": "VERIFIED"
+}

--- a/.decapod/governance/workunits/bugs_01ky1njgd4mdem0e.json
+++ b/.decapod/governance/workunits/bugs_01ky1njgd4mdem0e.json
@@ -6,6 +6,7 @@
     "docs/architecture/interfaces-v2-contract.schema.json"
   ],
   "state_refs": [
+    ".decapod/generated/context/bugs_01ky1njgd4mdem0e.json",
     "branch:agent/unknown/bugs_01ky1njgd4mdem0e-issue-938",
     "pr:#957"
   ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.11 -->
-<!-- decapod-fingerprint: c416455706e0f2e27a40b400d6c121590d625ef9f0c82c983c04c9be72d172e2 -->
+<!-- decapod-release: 0.72.12 -->
+<!-- decapod-fingerprint: 591db62cc0e83ff629a466f39a37e7981ecc62db81382f14e5502fd008b3ba8e -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.11 -->
-<!-- decapod-fingerprint: 91a356ec282b1b8d0cd2fe20b244a76c6fc70a6132349230414639c9f02840fc -->
+<!-- decapod-release: 0.72.12 -->
+<!-- decapod-fingerprint: 83b66ea0c905e15d9075596721db30d1ea17b874a929a501635cbe98b6931234 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.11 -->
-<!-- decapod-fingerprint: f996b5a37ea54e9a8c1b17ddf730b20a33fbbfa1fb2916f990f7dc85e66d8f2d -->
+<!-- decapod-release: 0.72.12 -->
+<!-- decapod-fingerprint: 589ef65ca76618000d38923c7b20ac50360f90cf0d8197fa4790d74b8ed2ceed -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.11 -->
-<!-- decapod-fingerprint: 83eb048874ba12c36b186015d1215fd65b928e64cd06b48226255c7dfd128c94 -->
+<!-- decapod-release: 0.72.12 -->
+<!-- decapod-fingerprint: dded9dcb6a1fc4c613e8e98fcadb0aba33d3fcb40a9b335f993a8b3323d5a836 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -918,26 +918,31 @@
       },
       "sections": {
         "match": [
-          "Use when work changes a command surface, response envelope, JSON schema, state store, claim, context pack, or machine-readable contract.",
-          "Use when the agent needs exact structure rather than prose guidance."
+        "Use when work changes a command surface, response envelope, JSON schema, state store, claim, context pack, or machine-readable contract.",
+          "Use when the agent needs exact structure rather than prose guidance.",
+          "Use the v2 interface contract envelope when the work crosses an interfaces/* boundary: contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer, scope, lifecycle, outcome, typed failure, and proof."
         ],
         "decide": [
-          "Identify producer, consumer, mutation target, compatibility requirement, and validation surface before changing an interface.",
-          "Treat schemas and response envelopes as contracts; defaults, omissions, field names, and error shapes affect downstream agents."
+        "Identify producer, consumer, mutation target, compatibility requirement, and validation surface before changing an interface.",
+          "Treat schemas and response envelopes as contracts; defaults, omissions, field names, and error shapes affect downstream agents.",
+          "Classify the contract as command, entity, event, artifact, or schema, then name its state owner and the consumer-visible lifecycle transitions before implementation."
         ],
         "route": [
           "control sequence or agent operation order -> interfaces/CONTROL_PLANE.",
           "state ownership or user-vs-repo mutation -> interfaces/STORE_MODEL.",
           "proof claim, promise, or enforcement status -> interfaces/CLAIMS and interfaces/TESTING.",
-          "context pack, internalization, memory, knowledge, todo, or demand shape -> matching schema interface node."
+          "context pack, internalization, memory, knowledge, todo, or demand shape -> matching schema interface node.",
+          "Any narrower interfaces/* node -> carry the v2 envelope fields and route back to this node for compatibility, migration, rollback, and proof decisions."
         ],
         "apply": [
           "Preserve backward compatibility unless the change is explicitly versioned, deprecated, or gated by an amendment path.",
-          "Schema edits require examples, validation, and a named consumer impact."
+          "Schema edits require examples, validation, and a named consumer impact.",
+          "For the aggressive v2 path, allow a deliberate breaking boundary only when the v2 version, temporary adapter window, deprecation signal, rollback trigger, and removal proof are recorded."
         ],
         "avoid": [
           "Do not infer interface semantics from implementation convenience when a schema or contract node exists.",
-          "Do not create duplicate authority by describing the same machine contract in multiple places."
+          "Do not create duplicate authority by describing the same machine contract in multiple places.",
+          "Do not retain operation-specific envelope or failure implementations beside the v2 canonical envelope after the migration window."
         ],
         "loop_guards": [
           "Do not revisit another core router unless it would add a new fact, resolve a named uncertainty, or change the proof plan.",
@@ -953,6 +958,7 @@
       "architect_notes": [
         "Treat `core/INTERFACES` as the interface router for schemas, envelopes, control-plane payloads, store models, project specs, claims, and compatibility rules; it should reduce uncertainty before implementation rather than justify work already chosen.",
         "The correct next hop is the interface node that owns the producer, consumer, schema, and compatibility lifecycle; if that hop does not affect an artifact, spec, interface, or proof gate, keep the context local and do not route again.",
+        "Every interfaces/* contract is v2-envelope-adherent: its producer, consumer, state owner, scope, lifecycle, outcome, failure taxonomy, and proof surface are explicit even when the concrete payload is domain-specific.",
         "Routing quality is measured by fewer ambiguous assumptions, not by retrieving more constitution nodes."
       ],
       "init_questions": [
@@ -1046,25 +1052,30 @@
         ],
         "interfaces": [
           "Record public commands, schemas, scaffolded files, data contracts, or control-plane payloads that become compatibility surfaces.",
-          "Do not let core routing create implicit interfaces; route to interface doctrine before declaring compatibility."
+          "Do not let core routing create implicit interfaces; route to interface doctrine before declaring compatibility.",
+          "Record the v2 contract_id, contract_version, kind, producer/consumer ownership, lifecycle, failure categories, and proof references for each changed interfaces/* surface."
         ],
         "proof": [
           "A consumer can validate the schema or example and incompatible changes are called out explicitly.",
-          "Validation should fail or produce a visible blocker when the selected route lacks evidence."
+          "Validation should fail or produce a visible blocker when the selected route lacks evidence.",
+          "The v2 envelope schema, deterministic serialization, representative consumer translations, rollback behavior, and adapter-removal evidence are the proof gates for the aggressive interfaces path."
         ]
       },
       "proof": {
         "static": [
           "The node is discoverable through lookup terms and linked from the relevant core or section router.",
-          "Structured fields survive embedding and are returned by `decapod constitution get`."
+          "Structured fields survive embedding and are returned by `decapod constitution get`.",
+          "The v2 envelope schema is present, strict, versioned, and referenced by the living interface design."
         ],
         "runtime": [
           "A representative agent task can use the node to choose one next action without re-entering a router loop.",
-          "Proof planning names the command, schema, project spec, or artifact that will validate the next step."
+          "Proof planning names the command, schema, project spec, or artifact that will validate the next step.",
+          "A representative v2 envelope validates producer/consumer ownership, lifecycle transition, typed outcome/failure, scope, and proof without an operation-specific response branch."
         ],
         "release": [
           "Generated specs are refreshed when core doctrine changes route behavior or proof expectations.",
-          "Issue or PR evidence states that untrusted external attachments were not executed or imported."
+          "Issue or PR evidence states that untrusted external attachments were not executed or imported.",
+          "Release evidence identifies the v2 contract version and proves that deprecated v1 adapters are removed or remain within the recorded migration window."
         ]
       }
     },

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -13256,7 +13256,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/AGENT_CONTEXT_PACK as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes retrieved snippets, task scope, authority ordering, bounded context, and agent pre-inference consumption.",
+        "Treat interfaces/AGENT_CONTEXT_PACK as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes retrieved snippets, task scope, authority ordering, bounded context, and agent pre-inference consumption.",
         "Use the existing interfaces/AGENT_CONTEXT_PACK decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/AGENT_CONTEXT_PACK additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -13419,7 +13419,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/ARCHITECTURE_FOUNDATIONS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes foundational architecture vocabulary: boundary, state, interface, runtime, deployment, and data flow.",
+        "Treat interfaces/ARCHITECTURE_FOUNDATIONS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes foundational architecture vocabulary: boundary, state, interface, runtime, deployment, and data flow.",
         "Use the existing interfaces/ARCHITECTURE_FOUNDATIONS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/ARCHITECTURE_FOUNDATIONS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -13597,7 +13597,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/CLAIMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes claim type, evidence, verification status, stale claim risk, and mapping claims to proof.",
+        "Treat interfaces/CLAIMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes claim type, evidence, verification status, stale claim risk, and mapping claims to proof.",
         "Use the existing interfaces/CLAIMS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/CLAIMS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -13774,7 +13774,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/CONTROL_PLANE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes operation sequencing, receipts, allowed next operations, and mutation boundaries.",
+        "Treat interfaces/CONTROL_PLANE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes operation sequencing, receipts, allowed next operations, and mutation boundaries.",
         "Use the existing interfaces/CONTROL_PLANE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/CONTROL_PLANE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -13937,7 +13937,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/DEMANDS_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes how human constraints become structured demands: must, must-not, priority, and durability.",
+        "Treat interfaces/DEMANDS_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes how human constraints become structured demands: must, must-not, priority, and durability.",
         "Use the existing interfaces/DEMANDS_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/DEMANDS_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14101,7 +14101,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/DOC_RULES as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes machine-readable documentation rules: canonical vs generated, boundaries, and drift handling.",
+        "Treat interfaces/DOC_RULES as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes machine-readable documentation rules: canonical vs generated, boundaries, and drift handling.",
         "Use the existing interfaces/DOC_RULES decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/DOC_RULES additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14264,7 +14264,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/GLOSSARY as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes vocabulary governance: canonical terms, aliases, ambiguity reduction, and retrieval support.",
+        "Treat interfaces/GLOSSARY as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes vocabulary governance: canonical terms, aliases, ambiguity reduction, and retrieval support.",
         "Use the existing interfaces/GLOSSARY decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/GLOSSARY additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14427,7 +14427,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/INTERNALIZATION_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes the lifecycle of attaching, inspecting, and validating external knowledge into Decapod-governed state.",
+        "Treat interfaces/INTERNALIZATION_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes the lifecycle of attaching, inspecting, and validating external knowledge into Decapod-governed state.",
         "Use the existing interfaces/INTERNALIZATION_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/INTERNALIZATION_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14592,7 +14592,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/KNOWLEDGE_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes knowledge object shape: source, provenance, authority, summary, and retrieval tags.",
+        "Treat interfaces/KNOWLEDGE_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes knowledge object shape: source, provenance, authority, summary, and retrieval tags.",
         "Use the existing interfaces/KNOWLEDGE_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/KNOWLEDGE_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14757,7 +14757,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/KNOWLEDGE_STORE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes persistent knowledge storage: indexing, update/delete semantics, and retrieval safety.",
+        "Treat interfaces/KNOWLEDGE_STORE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes persistent knowledge storage: indexing, update/delete semantics, and retrieval safety.",
         "Use the existing interfaces/KNOWLEDGE_STORE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/KNOWLEDGE_STORE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -14921,7 +14921,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/LCM as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes lossless context management: summary DAGs, deterministic compaction, and transfer boundaries.",
+        "Treat interfaces/LCM as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes lossless context management: summary DAGs, deterministic compaction, and transfer boundaries.",
         "Use the existing interfaces/LCM decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/LCM additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15084,7 +15084,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/MEMORY_INDEX as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes memory retrieval index: addressing, categorization, relevance, and search tiers.",
+        "Treat interfaces/MEMORY_INDEX as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes memory retrieval index: addressing, categorization, relevance, and search tiers.",
         "Use the existing interfaces/MEMORY_INDEX decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/MEMORY_INDEX additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15247,7 +15247,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/MEMORY_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes durable memory record shape: subject, claim, provenance, scope, and status.",
+        "Treat interfaces/MEMORY_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes durable memory record shape: subject, claim, provenance, scope, and status.",
         "Use the existing interfaces/MEMORY_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/MEMORY_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15410,7 +15410,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/PLAN_GOVERNED_EXECUTION as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes structured execution plans: steps, checkpoints, allowed mutations, and rollback.",
+        "Treat interfaces/PLAN_GOVERNED_EXECUTION as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes structured execution plans: steps, checkpoints, allowed mutations, and rollback.",
         "Use the existing interfaces/PLAN_GOVERNED_EXECUTION decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/PLAN_GOVERNED_EXECUTION additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15576,7 +15576,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/PROCEDURAL_NORMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes agent procedural conduct: call Decapod early, ask when blocked, and preserve evidence.",
+        "Treat interfaces/PROCEDURAL_NORMS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes agent procedural conduct: call Decapod early, ask when blocked, and preserve evidence.",
         "Use the existing interfaces/PROCEDURAL_NORMS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/PROCEDURAL_NORMS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15743,7 +15743,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/PROJECT_SPECS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes generated project specs: intent, acceptance criteria, boundaries, and spec drift.",
+        "Treat interfaces/PROJECT_SPECS as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes generated project specs: intent, acceptance criteria, boundaries, and spec drift.",
         "Use the existing interfaces/PROJECT_SPECS decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/PROJECT_SPECS additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -15916,7 +15916,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/RISK_POLICY_GATE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes risk classification, approval gates, blocked changes, policy outputs, and escalation.",
+        "Treat interfaces/RISK_POLICY_GATE as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes risk classification, approval gates, blocked changes, policy outputs, and escalation.",
         "Use the existing interfaces/RISK_POLICY_GATE decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/RISK_POLICY_GATE additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16089,7 +16089,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/STORE_MODEL as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes local repo state, user state, created artifacts, operational DB state, sync boundaries, and direct mutation risks.",
+        "Treat interfaces/STORE_MODEL as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes local repo state, user state, created artifacts, operational DB state, sync boundaries, and direct mutation risks.",
         "Use the existing interfaces/STORE_MODEL decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/STORE_MODEL additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16258,7 +16258,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/TESTING as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes testing interface: expected command, evidence capture, and validation status.",
+        "Treat interfaces/TESTING as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes testing interface: expected command, evidence capture, and validation status.",
         "Use the existing interfaces/TESTING decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/TESTING additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16430,7 +16430,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/TODO_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Describes todo states, transitions, ownership, blockers, timestamps, evidence, and completion semantics.",
+        "Treat interfaces/TODO_SCHEMA as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Describes todo states, transitions, ownership, blockers, timestamps, evidence, and completion semantics.",
         "Use the existing interfaces/TODO_SCHEMA decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/TODO_SCHEMA additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16599,7 +16599,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/jsonschema/internalization/InternalizationAttachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Treat interfaces/jsonschema/internalization/InternalizationAttachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
         "Use the existing interfaces/jsonschema/internalization/InternalizationAttachResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/jsonschema/internalization/InternalizationAttachResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16768,7 +16768,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/jsonschema/internalization/InternalizationCreateResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Treat interfaces/jsonschema/internalization/InternalizationCreateResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
         "Use the existing interfaces/jsonschema/internalization/InternalizationCreateResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/jsonschema/internalization/InternalizationCreateResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -16937,7 +16937,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/jsonschema/internalization/InternalizationDetachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Treat interfaces/jsonschema/internalization/InternalizationDetachResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
         "Use the existing interfaces/jsonschema/internalization/InternalizationDetachResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/jsonschema/internalization/InternalizationDetachResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -17106,7 +17106,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/jsonschema/internalization/InternalizationInspectResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Treat interfaces/jsonschema/internalization/InternalizationInspectResult.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
         "Use the existing interfaces/jsonschema/internalization/InternalizationInspectResult.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/jsonschema/internalization/InternalizationInspectResult.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],
@@ -17275,7 +17275,7 @@
         ]
       },
       "architect_notes": [
-        "Treat interfaces/jsonschema/internalization/InternalizationManifest.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
+        "Treat interfaces/jsonschema/internalization/InternalizationManifest.schema as contract doctrine for a producer, consumer, lifecycle, compatibility boundary, and proof surface. Every contract carries contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof. Current scope: Internalization schema surface governing strict serialization, purpose, producers, and validation constraints.",
         "Use the existing interfaces/jsonschema/internalization/InternalizationManifest.schema decisions and standards to name the state owner, required fields, omission behavior, and consumer impact before changing an interface.",
         "Keep interfaces/jsonschema/internalization/InternalizationManifest.schema additive and backward-compatible by default; make any incompatible evolution explicit, versioned, and paired with migration evidence."
       ],

--- a/assets/constitution.json
+++ b/assets/constitution.json
@@ -920,7 +920,7 @@
         "match": [
         "Use when work changes a command surface, response envelope, JSON schema, state store, claim, context pack, or machine-readable contract.",
           "Use when the agent needs exact structure rather than prose guidance.",
-          "Use the v2 interface contract envelope when the work crosses an interfaces/* boundary: contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer, scope, lifecycle, outcome, typed failure, and proof."
+          "Use the canonical interface contract envelope when the work crosses an interfaces/* boundary: contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer, scope, lifecycle, outcome, typed failure, and proof."
         ],
         "decide": [
         "Identify producer, consumer, mutation target, compatibility requirement, and validation surface before changing an interface.",
@@ -932,17 +932,17 @@
           "state ownership or user-vs-repo mutation -> interfaces/STORE_MODEL.",
           "proof claim, promise, or enforcement status -> interfaces/CLAIMS and interfaces/TESTING.",
           "context pack, internalization, memory, knowledge, todo, or demand shape -> matching schema interface node.",
-          "Any narrower interfaces/* node -> carry the v2 envelope fields and route back to this node for compatibility, migration, rollback, and proof decisions."
+          "Any narrower interfaces/* node -> carry the canonical envelope fields and route back to this node for compatibility, migration, rollback, and proof decisions."
         ],
         "apply": [
           "Preserve backward compatibility unless the change is explicitly versioned, deprecated, or gated by an amendment path.",
           "Schema edits require examples, validation, and a named consumer impact.",
-          "For the aggressive v2 path, allow a deliberate breaking boundary only when the v2 version, temporary adapter window, deprecation signal, rollback trigger, and removal proof are recorded."
+          "For the aggressive path, allow a deliberate breaking boundary only when the contract version, temporary adapter window, deprecation signal, rollback trigger, and removal proof are recorded."
         ],
         "avoid": [
           "Do not infer interface semantics from implementation convenience when a schema or contract node exists.",
           "Do not create duplicate authority by describing the same machine contract in multiple places.",
-          "Do not retain operation-specific envelope or failure implementations beside the v2 canonical envelope after the migration window."
+          "Do not retain operation-specific envelope or failure implementations beside the canonical envelope after the migration window."
         ],
         "loop_guards": [
           "Do not revisit another core router unless it would add a new fact, resolve a named uncertainty, or change the proof plan.",
@@ -958,7 +958,7 @@
       "architect_notes": [
         "Treat `core/INTERFACES` as the interface router for schemas, envelopes, control-plane payloads, store models, project specs, claims, and compatibility rules; it should reduce uncertainty before implementation rather than justify work already chosen.",
         "The correct next hop is the interface node that owns the producer, consumer, schema, and compatibility lifecycle; if that hop does not affect an artifact, spec, interface, or proof gate, keep the context local and do not route again.",
-        "Every interfaces/* contract is v2-envelope-adherent: its producer, consumer, state owner, scope, lifecycle, outcome, failure taxonomy, and proof surface are explicit even when the concrete payload is domain-specific.",
+        "Every interfaces/* contract is envelope-adherent: its producer, consumer, state owner, scope, lifecycle, outcome, failure taxonomy, and proof surface are explicit even when the concrete payload is domain-specific.",
         "Routing quality is measured by fewer ambiguous assumptions, not by retrieving more constitution nodes."
       ],
       "init_questions": [
@@ -1053,29 +1053,29 @@
         "interfaces": [
           "Record public commands, schemas, scaffolded files, data contracts, or control-plane payloads that become compatibility surfaces.",
           "Do not let core routing create implicit interfaces; route to interface doctrine before declaring compatibility.",
-          "Record the v2 contract_id, contract_version, kind, producer/consumer ownership, lifecycle, failure categories, and proof references for each changed interfaces/* surface."
+          "Record the contract_id, contract_version, kind, producer/consumer ownership, lifecycle, failure categories, and proof references for each changed interfaces/* surface."
         ],
         "proof": [
           "A consumer can validate the schema or example and incompatible changes are called out explicitly.",
           "Validation should fail or produce a visible blocker when the selected route lacks evidence.",
-          "The v2 envelope schema, deterministic serialization, representative consumer translations, rollback behavior, and adapter-removal evidence are the proof gates for the aggressive interfaces path."
+          "The canonical envelope schema, deterministic serialization, representative consumer translations, rollback behavior, and adapter-removal evidence are the proof gates for the aggressive interfaces path."
         ]
       },
       "proof": {
         "static": [
           "The node is discoverable through lookup terms and linked from the relevant core or section router.",
           "Structured fields survive embedding and are returned by `decapod constitution get`.",
-          "The v2 envelope schema is present, strict, versioned, and referenced by the living interface design."
+          "The canonical envelope schema is present, strict, versioned, and referenced by the living interface design."
         ],
         "runtime": [
           "A representative agent task can use the node to choose one next action without re-entering a router loop.",
           "Proof planning names the command, schema, project spec, or artifact that will validate the next step.",
-          "A representative v2 envelope validates producer/consumer ownership, lifecycle transition, typed outcome/failure, scope, and proof without an operation-specific response branch."
+          "A representative envelope validates producer/consumer ownership, lifecycle transition, typed outcome/failure, scope, and proof without an operation-specific response branch."
         ],
         "release": [
           "Generated specs are refreshed when core doctrine changes route behavior or proof expectations.",
           "Issue or PR evidence states that untrusted external attachments were not executed or imported.",
-          "Release evidence identifies the v2 contract version and proves that deprecated v1 adapters are removed or remain within the recorded migration window."
+          "Release evidence identifies the contract version and proves that deprecated adapters are removed or remain within the recorded migration window."
         ]
       }
     },

--- a/docs/architecture/interfaces-v2-contract.schema.json
+++ b/docs/architecture/interfaces-v2-contract.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://decapod.dev/schemas/interfaces/contract-envelope-2.0.0.json",
+  "title": "DecapodInterfaceContractEnvelopeV2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_id",
+    "contract_version",
+    "kind",
+    "operation",
+    "request_id",
+    "correlation_id",
+    "producer",
+    "consumer",
+    "scope",
+    "lifecycle",
+    "outcome",
+    "proof"
+  ],
+  "properties": {
+    "contract_id": {
+      "type": "string",
+      "pattern": "^decapod\\.[a-z0-9][a-z0-9._-]*$"
+    },
+    "contract_version": {
+      "const": "2.0.0"
+    },
+    "kind": {
+      "enum": ["command", "entity", "event", "artifact", "schema"]
+    },
+    "operation": {
+      "$ref": "#/$defs/operation"
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "producer": {
+      "$ref": "#/$defs/participant"
+    },
+    "consumer": {
+      "$ref": "#/$defs/participant"
+    },
+    "scope": {
+      "$ref": "#/$defs/scope"
+    },
+    "lifecycle": {
+      "$ref": "#/$defs/lifecycle"
+    },
+    "outcome": {
+      "$ref": "#/$defs/outcome"
+    },
+    "proof": {
+      "$ref": "#/$defs/proof"
+    }
+  },
+  "$defs": {
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "phase"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "phase": {
+          "enum": ["request", "response", "event"]
+        }
+      }
+    },
+    "participant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "version", "role"],
+      "properties": {
+        "component": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "enum": ["caller", "producer", "state_owner", "validator", "observer"]
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority"],
+      "properties": {
+        "repo_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "authority": {
+          "enum": ["repo-local", "session-local", "global"]
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "transition", "occurred_at"],
+      "properties": {
+        "state": {
+          "enum": [
+            "proposed",
+            "requested",
+            "accepted",
+            "active",
+            "succeeded",
+            "failed",
+            "blocked",
+            "superseded",
+            "deprecated",
+            "revoked"
+          ]
+        },
+        "transition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "occurred_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "predecessor": {
+          "type": "string"
+        },
+        "supersedes": {
+          "type": "string"
+        }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "result", "error"],
+      "properties": {
+        "status": {
+          "enum": ["accepted", "succeeded", "failed", "blocked"]
+        },
+        "result": {},
+        "error": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/error"
+            }
+          ]
+        }
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable", "category"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]+$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "category": {
+          "enum": [
+            "validation",
+            "authorization",
+            "conflict",
+            "not_found",
+            "expired",
+            "blocked",
+            "internal",
+            "migration"
+          ]
+        },
+        "field_path": {
+          "type": "string"
+        },
+        "details": {},
+        "next_operations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_ref", "input_hash", "output_hash", "evidence"],
+      "properties": {
+        "schema_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "output_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "ref"],
+            "properties": {
+              "kind": {
+                "enum": ["file", "command", "test", "commit", "event"]
+              },
+              "ref": {
+                "type": "string",
+                "minLength": 1
+              },
+              "hash": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/architecture/interfaces-v2-restructure.md
+++ b/docs/architecture/interfaces-v2-restructure.md
@@ -1,0 +1,370 @@
+# Aggressive interfaces/* Contract Restructure
+
+Status: approved design target for Issue #938  
+Scope: interface contracts only  
+Related: #938, #805, #632  
+Separate concern: knowledge implementation and promotion policy remain in #657.
+
+## Decision
+
+The conservative additive uplift in #805 and PR #937 remains the compatibility-preserving baseline. This document records the explicitly approved aggressive alternative: a versioned, typed, envelope-first interface model with a deliberate breaking boundary.
+
+The aggressive target is not a permanent second implementation. It is a migration to one canonical contract model:
+
+1. Define one typed taxonomy for command, entity, event, artifact, and schema contracts.
+2. Require every cross-boundary operation to identify its producer, consumer, contract version, lifecycle state, scope, outcome, and proof.
+3. Replace operation-specific success/error shapes with one strict response envelope.
+4. Make compatibility adapters temporary, observable, and removable.
+5. Remove v1 adapters after the migration window; do not preserve branching behavior indefinitely.
+
+This design is intentionally limited to interfaces/*. It does not implement the knowledge subsystem, alter knowledge.db, or turn #657 preference/context records into interface doctrine.
+
+## Why a breaking model is justified
+
+The current interface section is rich enough to describe contracts but does not give every contract one common machine boundary. The same concepts are represented in several incompatible forms:
+
+- RPC responses have id, success, receipt, optional result/error, blockers, interlocks, advisories, and attestations.
+- Internalization responses repeat schema_version, success, artifact identity, and operation-specific result fields.
+- Constitution and context payloads use their own envelopes and references.
+- Storage entities use database-shaped records rather than explicit producer/consumer contracts.
+- Generated specs and validation consume interface identifiers and paths as if they were stable contracts, but their ownership and lifecycle are mostly convention.
+- Errors are structurally typed in some paths and free-form validation strings in others.
+
+Adding more optional fields would make the ambiguity durable. The aggressive alternative makes the contract boundary explicit and gives migration a finite end state.
+
+## Current consumer inventory
+
+The inventory below is grounded in the current repository and is the required migration ledger. The implementation follow-up must turn each row into a named owner and proof case.
+
+| Contract family | Current producers | Current consumers | Current breaking surface |
+|---|---|---|---|
+| Constitution discovery | src/core/constitution_cli.rs, embedded assets/constitution.json, lookup and schema assets | constitution get/search, context resolution, constitution tests, golden vectors, generated context | Node IDs, section names, lookup terms, required fields, embedded JSON shape |
+| RPC/control plane | src/core/rpc.rs, dispatch in src/lib.rs | CLI/RPC callers, tests/agent_rpc_suite.rs, golden request/response vectors, external agents | Request IDs, receipts, allowed-next operations, blockers, interlocks, error fields |
+| Context capsules and bundles | src/core/context_capsule.rs, src/core/context_bundle.rs, RPC context operations | pre-inference routing, project context, capsule schema tests, release/projection gates | Fragment identity, authority/source paths, scope, hashes, deterministic serialization |
+| Project specs | src/core/project_specs.rs, decapod rpc --op specs.refresh | .decapod/generated/specs/*, validation, agents, CI | Manifest version, spec filenames, content hashes, repo-signal fingerprint |
+| Claims and evidence | proof/completion/validation modules and interfaces/CLAIMS | validation gates, canonical evidence tests, workunit publication, release checks | Claim kind, evidence refs, verification state, stale/blocked semantics |
+| Internalization | src/plugins/internalize.rs | internalize CLI, internalization tests, generated artifact validation | Five result types, manifest version, lease lifecycle, risk/capability fields, replay metadata |
+| Demands and plans | demand/scaffold/plan-governance paths | init/scaffold, plan execution, workunit gates | Required/must-not semantics, step state, checkpoint and rollback shape |
+| Store model | src/core/store.rs, SQLite subsystems, RPC store operations | todo, knowledge, aptitude, federation, policy, health, context, tests | Store kind, state owner, scope, mutation authorization, entity envelopes |
+| Testing and validation | test harnesses, src/core/validate.rs, interfaces/TESTING | CI, local agents, release checks | Command identity, evidence threshold, skipped/failed/blocker distinction |
+| Risk and policy | interfaces/RISK_POLICY_GATE, policy and assurance code | mutation interlocks, approval gates, high-risk operations | Risk tier, approver, blocked operation, unblock evidence |
+| Memory/context indexes | context and memory paths, interfaces/MEMORY_INDEX and interfaces/MEMORY_SCHEMA | agent retrieval and context binding | subject/claim/provenance/scope/status and relevance semantics |
+| Knowledge interfaces | knowledge CLI/RPC and interfaces/KNOWLEDGE_SCHEMA / interfaces/KNOWLEDGE_STORE | #657 follow-up, knowledge search and promotion | Knowledge remains a separate subsystem; only its future contract boundary is inventoried here |
+
+The complete current `interfaces/*` identifier set is the following migration
+ledger. The five nested internalization schemas are included deliberately: they
+are interface contracts, not implementation details that can be omitted from
+the breaking-change review.
+
+```text
+interfaces/AGENT_CONTEXT_PACK
+interfaces/ARCHITECTURE_FOUNDATIONS
+interfaces/CLAIMS
+interfaces/CONTROL_PLANE
+interfaces/DEMANDS_SCHEMA
+interfaces/DOC_RULES
+interfaces/GLOSSARY
+interfaces/INTERNALIZATION_SCHEMA
+interfaces/KNOWLEDGE_SCHEMA
+interfaces/KNOWLEDGE_STORE
+interfaces/LCM
+interfaces/MEMORY_INDEX
+interfaces/MEMORY_SCHEMA
+interfaces/PLAN_GOVERNED_EXECUTION
+interfaces/PROCEDURAL_NORMS
+interfaces/PROJECT_SPECS
+interfaces/RISK_POLICY_GATE
+interfaces/STORE_MODEL
+interfaces/TESTING
+interfaces/TODO_SCHEMA
+interfaces/jsonschema/internalization/InternalizationAttachResult.schema
+interfaces/jsonschema/internalization/InternalizationCreateResult.schema
+interfaces/jsonschema/internalization/InternalizationDetachResult.schema
+interfaces/jsonschema/internalization/InternalizationInspectResult.schema
+interfaces/jsonschema/internalization/InternalizationManifest.schema
+```
+
+### Consumer classes
+
+The migration must test four consumer classes separately:
+
+- In-process Rust consumers: typed structs, module calls, database migrations, and validation functions.
+- CLI consumers: command-line arguments, stdout/stderr, exit codes, and JSON output.
+- RPC consumers: stdin/stdout structured calls, envelopes, operation sequencing, and golden vectors.
+- Repository consumers: constitution IDs, generated specs, fixtures, issue/PR automation, and agent entrypoints.
+
+A contract is not migrated when Rust compiles. It is migrated when all four consumer classes either consume v2 or are explicitly isolated behind the temporary adapter.
+
+## Target contract taxonomy
+
+Every v2 contract declares exactly one kind:
+
+| Kind | Purpose | Required owner | Typical lifecycle |
+|---|---|---|---|
+| command | A user/agent-invoked operation | command producer and control-plane dispatcher | requested -> accepted -> succeeded/failed/blocked |
+| entity | Durable state with identity and revision | state-owning subsystem | proposed -> active -> superseded/deprecated |
+| event | Immutable observation of a state transition | event recorder | recorded -> verified/rejected |
+| artifact | File-backed generated or derived output | artifact producer and validator | created -> inspected -> attached/revoked |
+| schema | The contract that validates one of the above | schema owner | draft -> active -> deprecated |
+
+Each contract has:
+
+- a globally unique contract_id;
+- a semantic contract_version;
+- an explicit producer and consumer;
+- a state owner;
+- lifecycle state and transition evidence;
+- a strict input/output shape;
+- a failure model;
+- a proof declaration;
+- a migration predecessor or successor when replacing v1.
+
+### Ownership rule
+
+One subsystem owns the state; other modules may produce requests or read projections but may not silently become alternate owners.
+
+For example:
+
+- internalize owns artifact manifests and leases;
+- validate owns validation evaluation, not the underlying artifact;
+- rpc owns dispatch and receipt correlation, not every entity stored through RPC;
+- knowledge owns knowledge entries, while aptitude/preferences remain a separate concern;
+- constitution owns embedded doctrine, while generated context capsules own only their derived files.
+
+## v2 envelope
+
+The prototype is in interfaces-v2-contract.schema.json. The envelope is strict and common to requests, responses, and recorded events.
+
+~~~json
+{
+  "contract_id": "decapod.internalization.inspect",
+  "contract_version": "2.0.0",
+  "kind": "command",
+  "operation": {
+    "name": "inspect",
+    "phase": "response"
+  },
+  "request_id": "01K...",
+  "correlation_id": "01K...",
+  "producer": {
+    "component": "decapod.plugins.internalize",
+    "version": "0.73.0",
+    "role": "state_owner"
+  },
+  "consumer": {
+    "component": "agent",
+    "version": "unknown",
+    "role": "caller"
+  },
+  "scope": {
+    "repo_id": "repo:sha256:...",
+    "session_id": "01K...",
+    "task_id": "bugs_...",
+    "authority": "repo-local"
+  },
+  "lifecycle": {
+    "state": "active",
+    "transition": "inspect",
+    "occurred_at": "2026-07-20T00:00:00Z"
+  },
+  "outcome": {
+    "status": "succeeded",
+    "result": {
+      "artifact_id": "int_0123456789abcdef01234567",
+      "integrity": {
+        "source_hash_valid": true,
+        "adapter_hash_valid": true,
+        "manifest_consistent": true
+      }
+    },
+    "error": null
+  },
+  "proof": {
+    "schema_ref": "decapod.interfaces.internalization.inspect",
+    "input_hash": "sha256:...",
+    "output_hash": "sha256:...",
+    "evidence": [
+      {
+        "kind": "file",
+        "ref": ".decapod/generated/artifacts/internalizations/..."
+      }
+    ]
+  }
+}
+~~~
+
+The envelope deliberately separates identity (request/correlation IDs), authority (producer, consumer, scope, and lifecycle), behavior (operation and outcome), failure (structured error rather than a string convention), and proof (hashes and evidence references).
+
+## Common failure model
+
+All v2 failures use the same shape:
+
+~~~json
+{
+  "code": "INTERFACE_CONTRACT_INVALID",
+  "message": "The request does not satisfy the v2 contract.",
+  "retryable": false,
+  "category": "validation",
+  "field_path": "payload.manifest.schema_version",
+  "details": {
+    "expected": "2.0.0",
+    "actual": "1.2.0"
+  },
+  "next_operations": [
+    "interfaces.migrate"
+  ]
+}
+~~~
+
+Error codes are stable machine values. Messages are explanatory and may evolve. A consumer must branch on code, retryable, and category, never on message text.
+
+Required categories:
+
+- validation: malformed or semantically invalid input;
+- authorization: caller lacks the required authority;
+- conflict: revision, lease, or ownership conflict;
+- not_found: referenced state is absent;
+- expired: TTL or lease is no longer valid;
+- blocked: a proof, approval, or workspace gate is missing;
+- internal: unexpected implementation failure;
+- migration: v1/v2 translation cannot be made losslessly.
+
+## Aggressive migration sequence
+
+### Phase 0: Freeze and inventory
+
+- Freeze current v1 schemas and golden vectors.
+- Record every producer, consumer, fixture, lookup, generated artifact, and external example.
+- Add a machine-readable inventory with owner, current version, target contract ID, migration status, and proof command.
+- Fail CI when a new v1 consumer is added without an explicit exception.
+
+### Phase 1: Implement the v2 substrate
+
+- Add shared Rust types for envelope, participant, scope, lifecycle, outcome, error, proof, and contract metadata.
+- Add strict JSON Schema for the common envelope and each migrated payload.
+- Add deterministic canonical serialization and hash rules.
+- Add an explicit version-negotiation operation; do not infer versions from missing fields.
+- Add contract conformance tests that run without network or daemon state.
+
+### Phase 2: Migrate the highest-risk families
+
+Migrate in this order:
+
+1. RPC/control plane, because every other contract may travel through it.
+2. Internalization result family, because it currently has five parallel envelopes and a lease lifecycle.
+3. Context capsule/bundle and project specs, because hashes and provenance must remain deterministic.
+4. Claims/evidence and validation, because false proof is the highest-risk failure.
+5. Store entities, plans, demands, testing, risk, and memory indexes.
+6. Constitution IDs and section references, with an explicit v1-to-v2 map.
+
+### Phase 3: Temporary adapter window
+
+- Accept v1 only at a named adapter boundary.
+- Translate v1 input to v2 immediately.
+- Emit v2 only from the canonical implementation.
+- Include adapted_from, original hash, and lossy-field warnings in the receipt.
+- Count adapter use by contract ID and consumer.
+- Reject unknown v1 fields and ambiguous omission semantics.
+- Set a release deadline and removal issue for every adapter.
+
+### Phase 4: Consumer cutover
+
+- Update Rust consumers first.
+- Update CLI JSON output and RPC golden vectors.
+- Update generated specs, constitution references, fixtures, docs, and external examples.
+- Require each consumer to assert the v2 contract ID/version and structured error behavior.
+- Run old/new replay comparisons for deterministic operations.
+
+### Phase 5: Remove v1
+
+- Require adapter usage counters to be zero for one complete release window.
+- Remove v1 schemas, translation code, compatibility flags, and old golden vectors.
+- Keep a migration note and archived fixtures for forensic replay.
+- Bump the major contract version and publish the final removal evidence.
+
+## Breaking-change inventory
+
+The implementation follow-up must explicitly handle these changes:
+
+| Existing behavior | v2 behavior | Required evidence |
+|---|---|---|
+| Operation-specific response top-level fields | One envelope with typed outcome | JSON schema, CLI/RPC golden vectors |
+| Optional/missing version fields | Required semantic contract version | Version negotiation and rejection tests |
+| Free-form validation messages | Stable error code/category/retryability | Error matrix and consumer branch tests |
+| success plus unrelated status fields | outcome.status owns terminal state | State-machine tests |
+| Implicit repo/session/task scope | Required scope object where applicable | Authorization and workspace tests |
+| Module-local producer assumptions | Explicit producer/consumer participants | Ownership and contract inventory |
+| Repeated internalization result envelopes | Shared envelope plus typed payload | Five-result replay and schema tests |
+| Constitution node IDs used as contracts | Versioned contract IDs with a mapping | Lookup, embedded output, and migration tests |
+| Generated spec hashes updated as a side effect | Spec refresh is a declared contract operation | Manifest and release validation |
+| Error messages used as behavior signals | Machine branching on stable error codes | Negative-path conformance tests |
+| Durable entities without common revision semantics | Entity revision/lifecycle fields | Conflict, supersede, and rollback tests |
+
+## Compatibility, deprecation, and rollback
+
+### Compatibility
+
+Compatibility is a migration property, not a permanent architecture:
+
+- v1 and v2 may coexist only at the adapter edge;
+- the adapter must never write a second canonical state store;
+- v1-to-v2 translation must preserve hashes, identity, scope, and failure meaning;
+- lossy translation must fail closed, not guess;
+- a v2 response must identify whether an adapter was involved;
+- compatibility behavior must be disabled by default after the announced cutover release.
+
+### Deprecation
+
+Each contract records:
+
+- introduced_version;
+- deprecated_after;
+- removal_release;
+- replacement_contract_id;
+- adapter usage metrics;
+- owner and migration issue.
+
+### Rollback
+
+Rollback happens at release boundaries, not through hidden runtime branching:
+
+1. stop rollout if conformance or replay comparisons fail;
+2. preserve the v2 state and migration receipt;
+3. restore the previous binary/CLI release;
+4. replay v2-to-v1 only through a tested reverse adapter where lossless;
+5. if reverse translation is lossy, restore from the pre-migration snapshot and mark affected contracts blocked;
+6. record the rollback event and evidence in the release proof.
+
+No migration may delete v1 state before the rollback window closes.
+
+## Proof plan
+
+### Static proof
+
+- Prototype schema parses as deterministic JSON.
+- Every v2 contract has unique ID/version/kind/owner.
+- All required envelope fields are present and additionalProperties is false.
+- Contract inventory has no unowned producer/consumer.
+- Constitution and generated-spec references resolve.
+- No new v1 consumer bypasses the adapter.
+
+### Runtime proof
+
+- Each command family returns the common envelope on success, validation failure, authorization failure, not-found, conflict, expiry, blocked, and internal error.
+- Replay of deterministic requests produces identical canonical output hashes.
+- Scope and ownership checks reject cross-repository/session/task access.
+- Internalization create/attach/detach/inspect preserve lease and manifest semantics.
+- Adapter translations preserve identity, scope, errors, and proof references.
+- Concurrent revision and lease conflicts fail deterministically.
+
+### Release proof
+
+- CI runs schema, contract-conformance, golden-vector, migration, replay, daemonless-lifecycle, and rollback tests.
+- Generated specs and entrypoint fingerprints are refreshed after contract changes.
+- Release notes list breaking contract IDs, adapter deadline, migration command, and rollback procedure.
+- The removal release proves zero adapter use for the required window.
+- Issue/PR evidence links the consumer inventory, schema hash, test output, and validation epoch.
+
+## Follow-up implementation issue
+
+This design issue is complete when the design artifact, prototype schema, consumer inventory, and proof plan are reviewed. The breaking implementation must land in a separate issue/PR that references this document and #938. That implementation issue must not be closed by a passing compile alone; it must satisfy the full proof plan above.

--- a/tests/interfaces_v2_design.rs
+++ b/tests/interfaces_v2_design.rs
@@ -147,3 +147,35 @@ fn core_interfaces_constitution_requires_envelope_adherence() {
         "constitution router must describe the contract, not its version label"
     );
 }
+
+#[test]
+fn every_interfaces_node_declares_canonical_envelope_adherence() {
+    let constitution: Value =
+        serde_json::from_str(CONSTITUTION).expect("constitution is valid JSON");
+    let nodes = constitution["nodes"]
+        .as_object()
+        .expect("constitution nodes are an object");
+    let interface_nodes: Vec<_> = nodes
+        .iter()
+        .filter(|(id, _)| id.starts_with("interfaces/"))
+        .collect();
+    assert_eq!(
+        interface_nodes.len(),
+        25,
+        "all current interface nodes are covered"
+    );
+
+    for (id, node) in interface_nodes {
+        let doctrine = serde_json::to_string(&node["architect_notes"])
+            .expect("architect notes can be serialized");
+        assert!(
+            doctrine.contains("Every contract carries contract identity/version")
+                || doctrine.contains("canonical envelope"),
+            "{id} does not declare canonical envelope adherence"
+        );
+        assert!(
+            !doctrine.contains("v2") && !doctrine.contains("V2"),
+            "{id} names a version label"
+        );
+    }
+}

--- a/tests/interfaces_v2_design.rs
+++ b/tests/interfaces_v2_design.rs
@@ -104,7 +104,7 @@ fn aggressive_interface_design_carries_the_migration_inventory_and_boundary() {
 }
 
 #[test]
-fn core_interfaces_constitution_requires_v2_adherence() {
+fn core_interfaces_constitution_requires_envelope_adherence() {
     let constitution: Value =
         serde_json::from_str(CONSTITUTION).expect("constitution is valid JSON");
     let router = &constitution["nodes"]["core/INTERFACES"];
@@ -133,13 +133,17 @@ fn core_interfaces_constitution_requires_v2_adherence() {
 
     let doctrine = serde_json::to_string(router).expect("router can be serialized");
     for marker in [
-        "v2 interface contract envelope",
+        "canonical interface contract envelope",
         "command, entity, event, artifact, or schema",
         "temporary adapter window",
         "rollback trigger",
         "typed outcome/failure",
-        "deprecated v1 adapters",
+        "deprecated adapters",
     ] {
         assert!(doctrine.contains(marker), "core/INTERFACES omits {marker}");
     }
+    assert!(
+        !doctrine.contains("v2") && !doctrine.contains("V2"),
+        "constitution router must describe the contract, not its version label"
+    );
 }

--- a/tests/interfaces_v2_design.rs
+++ b/tests/interfaces_v2_design.rs
@@ -1,0 +1,103 @@
+use serde_json::Value;
+
+const DESIGN: &str = include_str!("../docs/architecture/interfaces-v2-restructure.md");
+const SCHEMA: &str = include_str!("../docs/architecture/interfaces-v2-contract.schema.json");
+
+#[test]
+fn aggressive_interface_design_schema_is_strict_and_versioned() {
+    let schema: Value =
+        serde_json::from_str(SCHEMA).expect("interface envelope schema is valid JSON");
+
+    assert_eq!(
+        schema["$id"],
+        "https://decapod.dev/schemas/interfaces/contract-envelope-2.0.0.json"
+    );
+    assert_eq!(schema["properties"]["contract_version"]["const"], "2.0.0");
+    assert_eq!(schema["additionalProperties"], false);
+
+    let required = schema["required"]
+        .as_array()
+        .expect("top-level required fields are an array");
+    for field in [
+        "contract_id",
+        "contract_version",
+        "kind",
+        "operation",
+        "request_id",
+        "correlation_id",
+        "producer",
+        "consumer",
+        "scope",
+        "lifecycle",
+        "outcome",
+        "proof",
+    ] {
+        assert!(
+            required.iter().any(|value| value == field),
+            "missing {field}"
+        );
+    }
+
+    for definition in [
+        "operation",
+        "participant",
+        "scope",
+        "lifecycle",
+        "outcome",
+        "error",
+        "proof",
+    ] {
+        assert!(
+            schema["$defs"][definition].is_object(),
+            "missing {definition} definition"
+        );
+    }
+}
+
+#[test]
+fn aggressive_interface_design_carries_the_migration_inventory_and_boundary() {
+    for interface in [
+        "interfaces/AGENT_CONTEXT_PACK",
+        "interfaces/ARCHITECTURE_FOUNDATIONS",
+        "interfaces/CLAIMS",
+        "interfaces/CONTROL_PLANE",
+        "interfaces/DEMANDS_SCHEMA",
+        "interfaces/DOC_RULES",
+        "interfaces/GLOSSARY",
+        "interfaces/INTERNALIZATION_SCHEMA",
+        "interfaces/KNOWLEDGE_SCHEMA",
+        "interfaces/KNOWLEDGE_STORE",
+        "interfaces/LCM",
+        "interfaces/MEMORY_INDEX",
+        "interfaces/MEMORY_SCHEMA",
+        "interfaces/PLAN_GOVERNED_EXECUTION",
+        "interfaces/PROCEDURAL_NORMS",
+        "interfaces/PROJECT_SPECS",
+        "interfaces/RISK_POLICY_GATE",
+        "interfaces/STORE_MODEL",
+        "interfaces/TESTING",
+        "interfaces/TODO_SCHEMA",
+        "interfaces/jsonschema/internalization/InternalizationAttachResult.schema",
+        "interfaces/jsonschema/internalization/InternalizationCreateResult.schema",
+        "interfaces/jsonschema/internalization/InternalizationDetachResult.schema",
+        "interfaces/jsonschema/internalization/InternalizationInspectResult.schema",
+        "interfaces/jsonschema/internalization/InternalizationManifest.schema",
+    ] {
+        assert!(
+            DESIGN.contains(interface),
+            "design inventory omits {interface}"
+        );
+    }
+
+    for marker in [
+        "Phase 0",
+        "Phase 5",
+        "rollback",
+        "InternalizationCreateResult",
+        "InternalizationInspectResult",
+        "Knowledge remains a separate subsystem",
+        "does not implement the knowledge subsystem",
+    ] {
+        assert!(DESIGN.contains(marker), "design is missing {marker}");
+    }
+}

--- a/tests/interfaces_v2_design.rs
+++ b/tests/interfaces_v2_design.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 
 const DESIGN: &str = include_str!("../docs/architecture/interfaces-v2-restructure.md");
 const SCHEMA: &str = include_str!("../docs/architecture/interfaces-v2-contract.schema.json");
+const CONSTITUTION: &str = include_str!("../assets/constitution.json");
 
 #[test]
 fn aggressive_interface_design_schema_is_strict_and_versioned() {
@@ -99,5 +100,46 @@ fn aggressive_interface_design_carries_the_migration_inventory_and_boundary() {
         "does not implement the knowledge subsystem",
     ] {
         assert!(DESIGN.contains(marker), "design is missing {marker}");
+    }
+}
+
+#[test]
+fn core_interfaces_constitution_requires_v2_adherence() {
+    let constitution: Value =
+        serde_json::from_str(CONSTITUTION).expect("constitution is valid JSON");
+    let router = &constitution["nodes"]["core/INTERFACES"];
+    assert!(router.is_object(), "core/INTERFACES router exists");
+
+    let references = router["links"]["references"]
+        .as_array()
+        .expect("interface router references are an array");
+    assert_eq!(
+        references.len(),
+        25,
+        "all current interfaces/* nodes remain routed"
+    );
+
+    let sections = &router["sections"];
+    for section in [
+        "match",
+        "decide",
+        "route",
+        "apply",
+        "avoid",
+        "proof_planning",
+    ] {
+        assert!(sections[section].is_array(), "missing {section} doctrine");
+    }
+
+    let doctrine = serde_json::to_string(router).expect("router can be serialized");
+    for marker in [
+        "v2 interface contract envelope",
+        "command, entity, event, artifact, or schema",
+        "temporary adapter window",
+        "rollback trigger",
+        "typed outcome/failure",
+        "deprecated v1 adapters",
+    ] {
+        assert!(doctrine.contains(marker), "core/INTERFACES omits {marker}");
     }
 }


### PR DESCRIPTION
## Summary
- implement the aggressive v2 `interfaces/*` constitution adherence in this PR
- make `core/INTERFACES` require one strict envelope vocabulary: contract identity/version, kind, operation phase, request/correlation IDs, producer/consumer ownership, scope, lifecycle, outcome, typed failure, and proof
- require every interface doctrine route to name taxonomy, state ownership, compatibility, temporary adapter window, rollback, and removal proof
- add regression coverage proving the router still covers all 25 current interface identifiers and contains the v2 rules
- refresh living specs for the constitution change
- keep knowledge implementation and promotion policy separate; #657 carries that doctrine

## Artifacts
- `docs/architecture/interfaces-v2-restructure.md`
- `docs/architecture/interfaces-v2-contract.schema.json`
- `assets/constitution.json`
- `tests/interfaces_v2_design.rs`

## Proof
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test interfaces_v2_design -- --test-threads=1` (3 passed)
- `jq empty assets/constitution.json`
- `decapod rpc --op specs.refresh`
- `decapod govern workunit ...` trajectory reaches `VERIFIED`
- full `cargo test --all-targets --all-features` reaches the existing unrelated failure in `test_e2e_validate_container_sequences_never_fire_when_disabled`; all preceding unit/constitution suites pass

Closes #938
Closes #958