### PR TITLE
docs: clarify idiomatic error handling and CLI failures

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.15
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.16
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.15
+ARG DECAPOD_VERSION=0.72.16
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784664915Z",
-  "repo_signal_fingerprint": "52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a",
+  "generated_at": "1784670104Z",
+  "repo_signal_fingerprint": "ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "cf1ec882bc0472d9f643e8736a36d56eea7f7c04194277cdd33e13d9872a6267",
-  "spec_input_hash": "8d40711adeacd15fcef9a8b4f1b3df98e24525aa00010b6d2f84611c4dac55fc",
-  "decapod_release": "0.72.15",
+  "spec_input_hash": "91fdd82d336e439845bf0f84450e539549c2171022903baa43a9268352fa7f0c",
+  "decapod_release": "0.72.16",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "a1f1fa62d00a7ed29feda56d4319c898e40c4023b0d648ec08920908f3038269",
-      "content_hash": "a1f1fa62d00a7ed29feda56d4319c898e40c4023b0d648ec08920908f3038269",
-      "fingerprint": "5cbb2834e975bb9e7fe94c6595e1bba388acdbe0d83fd7d59a5b4a655473a96e"
+      "template_hash": "48fbaa679b3ef6ca712491441e2165ac7a06c279ffd0442ba82bfe8e24c20806",
+      "content_hash": "48fbaa679b3ef6ca712491441e2165ac7a06c279ffd0442ba82bfe8e24c20806",
+      "fingerprint": "5cda5f37f8f0861d4da34116f0977e2568c52a09adeb649e80511408f24f8827"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "15d5754d81d57863f25c6d6b5763b0aaf93346655a9cf01cc8d3badbc22d6b42",
-      "content_hash": "15d5754d81d57863f25c6d6b5763b0aaf93346655a9cf01cc8d3badbc22d6b42",
-      "fingerprint": "4db8f659fe6a07bf250c1cf6b3a9aacb93ddb2933be1ebd374974452be8db8f6"
+      "template_hash": "1a6e8834b3d1fa75f62cba14f7702db9c716faee63e590833116b96ecb1b0fc2",
+      "content_hash": "1a6e8834b3d1fa75f62cba14f7702db9c716faee63e590833116b96ecb1b0fc2",
+      "fingerprint": "1f983c24666a1f41d84a5e5ea3f8b5941981752411ec8fd22dddafbf5b95394e"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "c8fb3dbf33734eab466e21073b857de69d57b686fa4e2c2cc626caa22624af4f",
-      "content_hash": "c8fb3dbf33734eab466e21073b857de69d57b686fa4e2c2cc626caa22624af4f",
-      "fingerprint": "1b12bb188de273d9aeef92988c7fbb3a8869c56917fc0c38765f3c435bde46be"
+      "template_hash": "6a2dde574607f3a59e92f8f8ba2cda53340ed9c0a69cf41d63646a3bf440b72f",
+      "content_hash": "6a2dde574607f3a59e92f8f8ba2cda53340ed9c0a69cf41d63646a3bf440b72f",
+      "fingerprint": "a952a85e11180bbdd9192521932ebf41289187f7a69b17ba5cdb0d33819f3606"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "63d0ee4a524fd4850d4f27c064e2b4917c77caacddccea7e9f01cb736868283a",
-      "content_hash": "63d0ee4a524fd4850d4f27c064e2b4917c77caacddccea7e9f01cb736868283a",
-      "fingerprint": "7da184d042a891c249693535f3c36e6c9047be696a0d446eb26ae5e7a51c1718"
+      "template_hash": "d133490547ab2fa67e300fdb75dd34b3637505815032e1f9345d703280e581e8",
+      "content_hash": "d133490547ab2fa67e300fdb75dd34b3637505815032e1f9345d703280e581e8",
+      "fingerprint": "4b73d322dddc92be7fd6035430abc84924081bf0de751ecbe76bc3bc5b73b26c"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "e9197dca7f3092fea5f443c727948f458255e36e401d8c5bde04764406f5f670",
+      "content_hash": "3020eddc5421a277dd47bfd6a60a477394709c9acaecd49a291b52399f787840",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "c5a39b1b7f20af36617afbbc0995ca2306642368385e105a1cd283dd6b62fc45",
+      "content_hash": "bfad2b311535c2581a4174da50c17629ceed5ed479c26f3fdca0f28f6fdbff07",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "169eee8f698b6d250c56311bbaf924ee5d076f45258d7f44e6fff1edc6f55123",
+      "content_hash": "73d3f05b42436a701d4db433218eb6c927096415e437b906363789162c67d908",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "edb2041e74281c2f8e0fc26c739fcf68822f3c5bb881863bf7b26b177a83accb",
+      "content_hash": "bc2d41a8bd636d3c7c11c5db5d18cb104489a725076cabd96fcca4eb645c1544",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "8df315f6c73cdc36a4fe37fdb315e31dbe3b67f3950d51b3a3b374ccbc0248dc",
+      "content_hash": "3a2608ab029853e4a73dfee104b13e602791fe039d73f9d3a1d042ee7cf5f939",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "93b4d6544557c63b9737836e7093d6a34be891f5ba990ccef580576256c5daef",
+      "content_hash": "958ea22cb8a0b4f4fb8b9a83b59284992a978a9e449e4358f33b55257fc3d2a6",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "efc14c4f5cdda18427b7dbafe31005b9ac9c135b62eca9873d9b51b6d2633af6",
+      "content_hash": "e67b69074be069bad4a9f9f1833937423d95da4717cdf583b02e03a53e9bacc5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "50e8d3e0d53e7715d93f7ab8eaa6db543030db18afe753bfe3f0a114d0bcaf0c",
+      "content_hash": "e549e2a6783ab92e50e49f7c262a396ec50a9089e268f68dd28e82a0830ad476",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -268,7 +268,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `52fd70d3357fa57a754bcc5b8c1c444d15371443528d47f1032f72e0f848218a`
+- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.15 -->
-<!-- decapod-fingerprint: 5cbb2834e975bb9e7fe94c6595e1bba388acdbe0d83fd7d59a5b4a655473a96e -->
+<!-- decapod-release: 0.72.16 -->
+<!-- decapod-fingerprint: 5cda5f37f8f0861d4da34116f0977e2568c52a09adeb649e80511408f24f8827 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.15 -->
-<!-- decapod-fingerprint: 4db8f659fe6a07bf250c1cf6b3a9aacb93ddb2933be1ebd374974452be8db8f6 -->
+<!-- decapod-release: 0.72.16 -->
+<!-- decapod-fingerprint: 1f983c24666a1f41d84a5e5ea3f8b5941981752411ec8fd22dddafbf5b95394e -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.15 -->
-<!-- decapod-fingerprint: 7da184d042a891c249693535f3c36e6c9047be696a0d446eb26ae5e7a51c1718 -->
+<!-- decapod-release: 0.72.16 -->
+<!-- decapod-fingerprint: 4b73d322dddc92be7fd6035430abc84924081bf0de751ecbe76bc3bc5b73b26c -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.15 -->
-<!-- decapod-fingerprint: 1b12bb188de273d9aeef92988c7fbb3a8869c56917fc0c38765f3c435bde46be -->
+<!-- decapod-release: 0.72.16 -->
+<!-- decapod-fingerprint: a952a85e11180bbdd9192521932ebf41289187f7a69b17ba5cdb0d33819f3606 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/docs/book/src/reference/errors.md
+++ b/docs/book/src/reference/errors.md
@@ -1,29 +1,74 @@
-# Error Codes
+# Error Handling
 
-Decapod uses descriptive error messages and idiomatic exit codes.
+Decapod uses Rust's `Result<T, DecapodError>` contract internally. Commands
+return errors to the process boundary, where Decapod prints a human-readable
+message on stderr and exits unsuccessfully. The error variant is useful for
+the message and recovery guidance; it does not currently select a distinct
+process exit status.
 
-## Exit Codes
+## Process Exit Status
 
-| Code | Meaning | Description |
+| Status | Meaning | Description |
 |---|---|---|
 | 0 | Success | The operation completed successfully. |
-| 1 | Validation Failure | `decapod validate` found issues in the repo state. |
-| 2 | Configuration Error | Problem with `config.toml` or environment variables. |
-| 3 | Permission Denied | Missing `DECAPOD_SESSION_PASSWORD` or insufficient rights. |
-| 4 | Not Found | A requested task, workspace, or artifact was not found. |
-| 5 | Conflict | Another agent has already claimed the task or workspace. |
-| 127 | Command Not Found | A required external tool (git, docker) is missing. |
+| 1 | Decapod operation failure | A domain, validation, configuration, session, I/O, or storage error was returned. `decapod validate` also uses status 1 when a gate fails. |
+| 2 | CLI syntax failure | Clap rejected an unknown command, argument, or option before Decapod ran the operation. |
+| 127 | Shell command not found | This is normally emitted by the calling shell when `decapod` or another command is absent; Decapod does not use 127 for its Rust errors. |
 
-## Common Error Messages
+Do not infer a unique status from `DecapodError::Config`, `NotFound`, or
+`SessionError`: all of those domain errors currently use status 1. Scripts
+that need to distinguish failures should inspect the command output or use a
+structured command surface rather than depend on the error text as a stable
+API.
 
-### `ValidationError("AGENTS.md missing")`
-The repository lacks the mandatory `AGENTS.md` entrypoint. Run `decapod init` to restore it.
+## Idiomatic Rust Error Handling
 
-### `Conflict("TODO already claimed")`
-The task you are trying to claim is already owned by another agent. Use `decapod todo list` to see current owners.
+Functions that can fail return `Result` and use `?` to propagate errors. Use
+`map_err` when a lower-level error needs to be translated into Decapod's
+domain error type or given application context:
 
-### `NotFound("Session token expired")`
-Your session has expired. Run `decapod session acquire` to get a new one.
+```rust
+fn load_config(path: &Path) -> Result<Config, DecapodError> {
+    let text = std::fs::read_to_string(path)?;
+    toml::from_str(&text).map_err(|error| DecapodError::Config(error.to_string()))
+}
 
-### `RiskGate("Action requires approval")`
-The action you are attempting is high-risk and requires human approval via `decapod govern policy approve`.
+fn run(path: &Path) -> Result<(), DecapodError> {
+    let config = load_config(path)?;
+    validate_config(&config)
+        .map_err(|message| DecapodError::ValidationError(message))?;
+    Ok(())
+}
+```
+
+The `?` operator preserves the original error when a `From` conversion exists
+(for example, `std::io::Error` becomes `DecapodError::IoError`). `map_err` is
+appropriate when the caller needs a different domain variant or additional
+context. Avoid `unwrap` and `expect` for user input, files, environment
+variables, or external commands; reserve them for proven invariants and test
+fixtures.
+
+At the CLI boundary, `src/main.rs` matches the result from `decapod::run()`,
+prints the error with its `Display` implementation, and exits with status 1.
+That keeps error propagation explicit without exposing Rust's debug-style
+enum representation to command-line users.
+
+## Error Variants and Recovery
+
+`DecapodError` currently contains these variants:
+
+- `RusqliteError`: inspect the database path, schema, and lock state.
+- `IoError`: check the referenced path, permissions, and external process.
+- `DatabaseInitializationError`: inspect repository initialization and schema setup.
+- `PathError`: correct the repository, workspace, or artifact path.
+- `EnvVarError`: check the required environment variable and its encoding.
+- `ValidationError`: follow the reported gate and remediation command.
+- `NotFound`: verify the requested task, workspace, document, or artifact ID/path.
+- `NotImplemented`: use a supported command or defer the operation.
+- `Config`: correct `.decapod/config.toml` or the relevant environment setting.
+- `ContextPackError`: inspect the context pack and its integrity metadata.
+- `SessionError`: run `decapod session acquire`, then retry the operation.
+
+The wrapped SQLite, I/O, and environment errors remain available through the
+standard `std::error::Error::source` chain, so callers can log the underlying
+cause without parsing the display string.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
-fn main() -> Result<(), decapod::core::error::DecapodError> {
-    decapod::run()
+fn main() {
+    if let Err(error) = decapod::run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
 }

--- a/tests/error_handling_contract.rs
+++ b/tests/error_handling_contract.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::process::{Command, Output};
+
+fn run_decapod(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .args(args)
+        .output()
+        .expect("failed to execute decapod")
+}
+
+#[test]
+fn clap_syntax_failures_use_status_two() {
+    let output = run_decapod(&["--definitely-not-a-command"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("error:"));
+}
+
+#[test]
+fn domain_errors_use_status_one_and_preserve_display_context() {
+    let output = run_decapod(&[
+        "docs",
+        "show",
+        "docs/agent/does-not-exist.md",
+        "--source",
+        "embedded",
+    ]);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Not found:"));
+}
+
+#[test]
+fn error_reference_matches_the_current_error_contract() {
+    let docs = fs::read_to_string("docs/book/src/reference/errors.md")
+        .expect("failed to read the error reference");
+
+    for variant in [
+        "RusqliteError",
+        "IoError",
+        "DatabaseInitializationError",
+        "PathError",
+        "EnvVarError",
+        "ValidationError",
+        "NotFound",
+        "NotImplemented",
+        "Config",
+        "ContextPackError",
+        "SessionError",
+    ] {
+        assert!(
+            docs.contains(variant),
+            "error reference is missing DecapodError::{variant}"
+        );
+    }
+
+    assert!(docs.contains("| 1 | Decapod operation failure |"));
+    assert!(docs.contains("| 2 | CLI syntax failure |"));
+    assert!(docs.contains("| 127 | Shell command not found |"));
+    assert!(docs.contains("Result<T, DecapodError>"));
+    assert!(!docs.contains("Conflict(\""));
+    assert!(!docs.contains("RiskGate(\""));
+}


### PR DESCRIPTION
Fixes #644

## Summary
- Replace the stale per-error exit-code table with the current CLI contract: success 0, domain failures 1, Clap syntax failures 2, and shell-level 127.
- Explain idiomatic Result, ?, map_err, source-chain, and recovery patterns using the actual DecapodError variants.
- Render DecapodError with Display at the binary boundary so users receive actionable messages such as `Not found: ...` instead of Rust debug enum output.
- Add executable CLI and documentation contract tests.
- Refresh the v0.72.16 governed generated artifacts required by container validation.

## Verification
- cargo fmt --all -- --check
- cargo test --test error_handling_contract -- --test-threads=1 (3 passed)
- cargo test --test doc_alignment -- --test-threads=1 (4 passed)
- cargo test --lib -- --test-threads=1 (169 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- Container validation: 202 gates passed; the only remaining failure is a pre-existing repository-wide proof hook for six unrelated claimed/verified TODO records absent from this worktree
