### PR TITLE
feat: complete guided init governance configuration

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.16
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.17
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.16
+ARG DECAPOD_VERSION=0.72.17
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784670104Z",
-  "repo_signal_fingerprint": "ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842",
+  "generated_at": "1784675258Z",
+  "repo_signal_fingerprint": "893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "cf1ec882bc0472d9f643e8736a36d56eea7f7c04194277cdd33e13d9872a6267",
-  "spec_input_hash": "91fdd82d336e439845bf0f84450e539549c2171022903baa43a9268352fa7f0c",
-  "decapod_release": "0.72.16",
+  "spec_input_hash": "c4b86dda046b5e1acc3dd1d6573de74df6b5788f390d62471c7a8afdb7b4a21d",
+  "decapod_release": "0.72.17",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "48fbaa679b3ef6ca712491441e2165ac7a06c279ffd0442ba82bfe8e24c20806",
-      "content_hash": "48fbaa679b3ef6ca712491441e2165ac7a06c279ffd0442ba82bfe8e24c20806",
-      "fingerprint": "5cda5f37f8f0861d4da34116f0977e2568c52a09adeb649e80511408f24f8827"
+      "template_hash": "01ce5667894ff4eb0d880485a53e652659c7b4303f3efe4d5f1de3e582518e30",
+      "content_hash": "01ce5667894ff4eb0d880485a53e652659c7b4303f3efe4d5f1de3e582518e30",
+      "fingerprint": "2593eca977e8714aea6c25d26324eedb8d14f6701e8cb01ea6f823724c15a36b"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "1a6e8834b3d1fa75f62cba14f7702db9c716faee63e590833116b96ecb1b0fc2",
-      "content_hash": "1a6e8834b3d1fa75f62cba14f7702db9c716faee63e590833116b96ecb1b0fc2",
-      "fingerprint": "1f983c24666a1f41d84a5e5ea3f8b5941981752411ec8fd22dddafbf5b95394e"
+      "template_hash": "71ac1dccfaa35f63a1b20120d575b3e6e56db9d2c5f418954e17c38034901d39",
+      "content_hash": "71ac1dccfaa35f63a1b20120d575b3e6e56db9d2c5f418954e17c38034901d39",
+      "fingerprint": "9aac982616bc33f7c72c96b9178dca3f8657e65ace5269492dab38d767a98254"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "6a2dde574607f3a59e92f8f8ba2cda53340ed9c0a69cf41d63646a3bf440b72f",
-      "content_hash": "6a2dde574607f3a59e92f8f8ba2cda53340ed9c0a69cf41d63646a3bf440b72f",
-      "fingerprint": "a952a85e11180bbdd9192521932ebf41289187f7a69b17ba5cdb0d33819f3606"
+      "template_hash": "c808430d60e19e5abe133bb8bf897da86c763279027322ee1caf9a34fa483169",
+      "content_hash": "c808430d60e19e5abe133bb8bf897da86c763279027322ee1caf9a34fa483169",
+      "fingerprint": "9692d0076622101af553f75e85fb46a4b501e0beca3e6ff92e5ee2f99517bc3e"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "d133490547ab2fa67e300fdb75dd34b3637505815032e1f9345d703280e581e8",
-      "content_hash": "d133490547ab2fa67e300fdb75dd34b3637505815032e1f9345d703280e581e8",
-      "fingerprint": "4b73d322dddc92be7fd6035430abc84924081bf0de751ecbe76bc3bc5b73b26c"
+      "template_hash": "2443c82255925ac6ada6589ebbcbf451c075397ae2695dbaef25c1f18c006c16",
+      "content_hash": "2443c82255925ac6ada6589ebbcbf451c075397ae2695dbaef25c1f18c006c16",
+      "fingerprint": "c86ab9acf92578772e910a94c1404884515971093b45333d9fee82915afb1690"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "3020eddc5421a277dd47bfd6a60a477394709c9acaecd49a291b52399f787840",
+      "content_hash": "8981afbe2f0a70c0f63c328c52ab5fb2632dc48aa4562294951f202891ab3638",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "bfad2b311535c2581a4174da50c17629ceed5ed479c26f3fdca0f28f6fdbff07",
+      "content_hash": "409b3a30d5a0da9bbee56be3c74b103d978c3daf4981ec895df92497db8e01d3",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "73d3f05b42436a701d4db433218eb6c927096415e437b906363789162c67d908",
+      "content_hash": "5e59802e2cb6a8a261af3c463e8d1926059b3238e258e2f78e68eb1f586ae9db",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "bc2d41a8bd636d3c7c11c5db5d18cb104489a725076cabd96fcca4eb645c1544",
+      "content_hash": "7cf6d056452f1a97b5bc91bcc43ae9071146adb6af9aa999c6e385ca31e728d2",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "3a2608ab029853e4a73dfee104b13e602791fe039d73f9d3a1d042ee7cf5f939",
+      "content_hash": "6ae000cedd2109e03eb20f55012414acbc5753a95d1d9a603023ccc69c47713c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "958ea22cb8a0b4f4fb8b9a83b59284992a978a9e449e4358f33b55257fc3d2a6",
+      "content_hash": "c387d6c41fa2dd829b8da4682732f93747454e6106df3884c2aebc1963b7be7e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "e67b69074be069bad4a9f9f1833937423d95da4717cdf583b02e03a53e9bacc5",
+      "content_hash": "f0b9c1171b10ee3919089b814e9378fa5a54875ac78f1567ea33773b51f65f94",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "e549e2a6783ab92e50e49f7c262a396ec50a9089e268f68dd28e82a0830ad476",
+      "content_hash": "0c2134f75017e34e49a2611e8260d064838c69df45f3f465769a3b13e51e288b",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -401,7 +401,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -55,7 +55,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -268,7 +268,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `ff9d86bc6bf5b2d92efdc07c061770dc7188745d577ff2b0d547382d6744e842`
+- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.16 -->
-<!-- decapod-fingerprint: 5cda5f37f8f0861d4da34116f0977e2568c52a09adeb649e80511408f24f8827 -->
+<!-- decapod-release: 0.72.17 -->
+<!-- decapod-fingerprint: 2593eca977e8714aea6c25d26324eedb8d14f6701e8cb01ea6f823724c15a36b -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.16 -->
-<!-- decapod-fingerprint: 1f983c24666a1f41d84a5e5ea3f8b5941981752411ec8fd22dddafbf5b95394e -->
+<!-- decapod-release: 0.72.17 -->
+<!-- decapod-fingerprint: 9aac982616bc33f7c72c96b9178dca3f8657e65ace5269492dab38d767a98254 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.16 -->
-<!-- decapod-fingerprint: 4b73d322dddc92be7fd6035430abc84924081bf0de751ecbe76bc3bc5b73b26c -->
+<!-- decapod-release: 0.72.17 -->
+<!-- decapod-fingerprint: c86ab9acf92578772e910a94c1404884515971093b45333d9fee82915afb1690 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.16 -->
-<!-- decapod-fingerprint: a952a85e11180bbdd9192521932ebf41289187f7a69b17ba5cdb0d33819f3606 -->
+<!-- decapod-release: 0.72.17 -->
+<!-- decapod-fingerprint: 9692d0076622101af553f75e85fb46a4b501e0beca3e6ff92e5ee2f99517bc3e -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/docs/agent/config-schema.md
+++ b/docs/agent/config-schema.md
@@ -5,6 +5,16 @@ pub struct DecapodProjectConfig {
     pub schema_version: String,
     pub init: InitConfigSection,
     pub repo: RepoContext,
+    #[serde(default)]
+    pub governance: GovernanceConfig,
+    #[serde(default)]
+    pub proof: crate::core::proof::ProjectProofConfig,
+    #[serde(default)]
+    pub custody: CustodyConfig,
+    #[serde(default)]
+    pub tracker: TrackerConfig,
+    #[serde(default)]
+    pub context: DeclaredContextConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud: Option<CloudConfigSection>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use crate::plugins::{
 
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -210,6 +210,30 @@ pub(crate) struct InitGroupCli {
     /// in this repository.
     #[clap(long = "no-container-workspaces", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub container_workspaces: bool,
+    /// Protect repository-relative paths from agent mutations (repeatable/comma-separated).
+    #[clap(long = "protected-path", value_delimiter = ',')]
+    pub protected_paths: Vec<String>,
+    /// Approval classifier names to enable (repeatable/comma-separated).
+    #[clap(long = "approval-category", value_delimiter = ',')]
+    pub approval_categories: Vec<String>,
+    /// Configure the local isolation mode: worktree or container.
+    #[clap(long, value_enum)]
+    pub isolation_mode: Option<IsolationMode>,
+    /// External tracker provider metadata (for example, beads).
+    #[clap(long)]
+    pub tracker_provider: Option<String>,
+    /// External tracker project metadata (non-secret).
+    #[clap(long)]
+    pub tracker_project: Option<String>,
+    /// External tracker URL metadata (non-secret).
+    #[clap(long)]
+    pub tracker_url: Option<String>,
+    /// Repository-relative context source (repeatable/comma-separated).
+    #[clap(long = "declared-context-source", value_delimiter = ',')]
+    pub declared_context_sources: Vec<String>,
+    /// Proof command in `name=command` form (repeatable/comma-separated).
+    #[clap(long = "proof-command", value_delimiter = ',')]
+    pub proof_commands: Vec<String>,
     /// Init storage boundary: 'local' (default) or 'cloud' (experimental, account required).
     ///
     /// Cloud mode records non-secret Decapod Cloud intent in `.decapod/config.toml`.
@@ -315,6 +339,30 @@ pub(crate) struct InitWithCli {
     /// in this repository.
     #[clap(long = "no-container-workspaces", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub container_workspaces: bool,
+    /// Protect repository-relative paths from agent mutations (repeatable/comma-separated).
+    #[clap(long = "protected-path", value_delimiter = ',')]
+    pub protected_paths: Vec<String>,
+    /// Approval classifier names to enable (repeatable/comma-separated).
+    #[clap(long = "approval-category", value_delimiter = ',')]
+    pub approval_categories: Vec<String>,
+    /// Configure the local isolation mode: worktree or container.
+    #[clap(long, value_enum)]
+    pub isolation_mode: Option<IsolationMode>,
+    /// External tracker provider metadata (for example, beads).
+    #[clap(long)]
+    pub tracker_provider: Option<String>,
+    /// External tracker project metadata (non-secret).
+    #[clap(long)]
+    pub tracker_project: Option<String>,
+    /// External tracker URL metadata (non-secret).
+    #[clap(long)]
+    pub tracker_url: Option<String>,
+    /// Repository-relative context source (repeatable/comma-separated).
+    #[clap(long = "declared-context-source", value_delimiter = ',')]
+    pub declared_context_sources: Vec<String>,
+    /// Proof command in `name=command` form (repeatable/comma-separated).
+    #[clap(long = "proof-command", value_delimiter = ',')]
+    pub proof_commands: Vec<String>,
     /// Init storage boundary: 'local' (default) or 'cloud' (experimental, account required).
     ///
     /// Cloud mode records non-secret Decapod Cloud intent in `.decapod/config.toml`.
@@ -341,6 +389,16 @@ pub struct DecapodProjectConfig {
     pub schema_version: String,
     pub init: InitConfigSection,
     pub repo: RepoContext,
+    #[serde(default)]
+    pub governance: GovernanceConfig,
+    #[serde(default)]
+    pub proof: crate::core::proof::ProjectProofConfig,
+    #[serde(default)]
+    pub custody: CustodyConfig,
+    #[serde(default)]
+    pub tracker: TrackerConfig,
+    #[serde(default)]
+    pub context: DeclaredContextConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud: Option<CloudConfigSection>,
 }
@@ -365,6 +423,104 @@ pub enum BackendType {
     #[default]
     Local,
     Cloud,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum IsolationMode {
+    Worktree,
+    #[default]
+    Container,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct GovernanceConfig {
+    #[serde(default)]
+    pub protected_paths: Vec<String>,
+    #[serde(default)]
+    pub approval_categories: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct CustodyConfig {
+    #[serde(default)]
+    pub isolation: IsolationMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrackerConfig {
+    #[serde(default = "default_tracker_provider")]
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+fn default_tracker_provider() -> String {
+    "decapod".to_string()
+}
+
+impl Default for TrackerConfig {
+    fn default() -> Self {
+        Self {
+            provider: default_tracker_provider(),
+            project: None,
+            url: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DeclaredContextConfig {
+    #[serde(default)]
+    pub declared_sources: Vec<String>,
+}
+
+/// Canonicalize a repository-relative path used by governance configuration.
+/// Absolute paths and traversal are rejected before any consumer sees them.
+pub fn canonical_repo_relative_path(raw: &str) -> Result<String, String> {
+    let normalized = raw.trim().replace('\\', "/");
+    if normalized.is_empty() {
+        return Err("path must not be empty".to_string());
+    }
+    let path = Path::new(&normalized);
+    if path.is_absolute() {
+        return Err(format!("path must be repository-relative: {raw}"));
+    }
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!("path must not escape the repository: {raw}"));
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err(format!(
+            "path must name a repository file or directory: {raw}"
+        ));
+    }
+    Ok(parts.join("/"))
+}
+
+pub fn canonical_repo_relative_paths(raw: &[String]) -> Result<Vec<String>, String> {
+    let mut paths = raw
+        .iter()
+        .map(|path| canonical_repo_relative_path(path))
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort();
+    for pair in paths.windows(2) {
+        if pair[0] == pair[1] {
+            return Err(format!("duplicate repository-relative path: {}", pair[0]));
+        }
+    }
+    Ok(paths)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -497,6 +653,11 @@ impl Default for DecapodProjectConfig {
                 ],
             },
             repo: RepoContext::default(),
+            governance: GovernanceConfig::default(),
+            proof: crate::core::proof::ProjectProofConfig::default(),
+            custody: CustodyConfig::default(),
+            tracker: TrackerConfig::default(),
+            context: DeclaredContextConfig::default(),
             cloud: None,
         }
     }

--- a/src/core/gatekeeper.rs
+++ b/src/core/gatekeeper.rs
@@ -19,6 +19,8 @@ pub struct GatekeeperConfig {
     pub allow_paths: Vec<String>,
     /// Paths that are blocked
     pub block_paths: Vec<String>,
+    /// Repository-relative paths that require a protected-path finding
+    pub protected_paths: Vec<String>,
     /// Enable secret scanning
     pub scan_secrets: bool,
     /// Enable dangerous pattern detection
@@ -36,6 +38,7 @@ impl Default for GatekeeperConfig {
                 "**/secrets/**".to_string(),
                 "**/.credentials".to_string(),
             ],
+            protected_paths: Vec::new(),
             scan_secrets: true,
             scan_dangerous_patterns: true,
         }
@@ -64,6 +67,7 @@ pub enum ViolationKind {
     DiffTooLarge,
     SecretDetected,
     DangerousPattern,
+    ProtectedPath,
 }
 
 impl std::fmt::Display for ViolationKind {
@@ -73,6 +77,7 @@ impl std::fmt::Display for ViolationKind {
             Self::DiffTooLarge => write!(f, "Diff too large"),
             Self::SecretDetected => write!(f, "Secret detected"),
             Self::DangerousPattern => write!(f, "Dangerous pattern"),
+            Self::ProtectedPath => write!(f, "Protected path"),
         }
     }
 }
@@ -103,6 +108,17 @@ pub fn run_gatekeeper(
     for path in paths {
         let path_str = path.to_string_lossy();
 
+        for pattern in &config.protected_paths {
+            if glob_match(pattern, &path_str) {
+                violations.push(Violation {
+                    kind: ViolationKind::ProtectedPath,
+                    path: path.clone(),
+                    line: None,
+                    message: format!("Path is protected by guided init policy: {pattern}"),
+                });
+            }
+        }
+
         // Check blocklist first
         for pattern in &config.block_paths {
             if glob_match(pattern, &path_str) {
@@ -128,6 +144,16 @@ pub fn run_gatekeeper(
 
     let passed = violations.is_empty();
     Ok(GateResult { passed, violations })
+}
+
+impl GatekeeperConfig {
+    pub fn from_repo_config(repo_root: &Path) -> Self {
+        let mut config = Self::default();
+        if let Ok(project) = crate::cli::DecapodProjectConfig::load(repo_root) {
+            config.protected_paths = project.governance.protected_paths;
+        }
+        config
+    }
 }
 
 /// Scan files for secrets
@@ -278,6 +304,7 @@ fn glob_match(pattern: &str, text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_glob_match() {
@@ -324,5 +351,25 @@ mod tests {
         assert!(config.scan_secrets);
         assert!(config.scan_dangerous_patterns);
         assert!(!config.block_paths.is_empty());
+    }
+
+    #[test]
+    fn protected_paths_produce_typed_findings() {
+        let tmp = tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("README.md"), "safe\n").expect("write fixture");
+        let config = GatekeeperConfig {
+            protected_paths: vec!["README.md".to_string()],
+            ..GatekeeperConfig::default()
+        };
+
+        let result = run_gatekeeper(tmp.path(), &[PathBuf::from("README.md")], 0, &config)
+            .expect("run gatekeeper");
+        assert!(!result.passed);
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|violation| violation.kind == ViolationKind::ProtectedPath)
+        );
     }
 }

--- a/src/core/proof.rs
+++ b/src/core/proof.rs
@@ -21,6 +21,18 @@ pub struct ProofDef {
     pub required: bool,
 }
 
+/// Project-level proof declarations stored in `.decapod/config.toml`.
+///
+/// The legacy `.decapod/proofs.toml` registry remains supported; this typed
+/// projection lets guided init capture proof intent without creating a second
+/// execution engine.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectProofConfig {
+    #[serde(default)]
+    pub commands: Vec<ProofDef>,
+}
+
 /// Result of running a single proof
 #[derive(Debug, Clone, Serialize)]
 pub struct ProofResult {
@@ -130,6 +142,22 @@ pub fn load_proof_config(decapod_dir: &Path) -> Result<ProofConfig, DecapodError
             let config: ProofConfig = toml::from_str(&content)
                 .map_err(|e| DecapodError::ValidationError(e.to_string()))?;
             return Ok(config);
+        }
+    }
+
+    let project_config_path = if decapod_dir.join(".decapod").exists() {
+        decapod_dir.join(".decapod").join("config.toml")
+    } else {
+        decapod_dir.join("config.toml")
+    };
+    if project_config_path.exists() {
+        let content = fs::read_to_string(&project_config_path).map_err(DecapodError::IoError)?;
+        let config: crate::cli::DecapodProjectConfig = toml::from_str(&content)
+            .map_err(|e| DecapodError::ValidationError(format!("Invalid project config: {e}")))?;
+        if !config.proof.commands.is_empty() {
+            return Ok(ProofConfig {
+                proof: config.proof.commands,
+            });
         }
     }
 
@@ -338,4 +366,42 @@ pub fn schema() -> serde_json::Value {
         "events": ["proof.run"],
         "storage": ["proof.events.jsonl"]
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn project_config_proof_commands_feed_legacy_registry_loader() {
+        let tmp = tempdir().expect("tempdir");
+        let decapod_dir = tmp.path().join(".decapod");
+        fs::create_dir_all(&decapod_dir).expect("create decapod dir");
+        fs::write(
+            decapod_dir.join("config.toml"),
+            r#"schema_version = "1.0.0"
+
+[init]
+diagram_style = "ascii"
+entrypoints = []
+
+[repo]
+
+[proof]
+[[proof.commands]]
+name = "lint"
+command = "cargo"
+args = ["test", "--lib"]
+required = true
+"#,
+        )
+        .expect("write config");
+
+        let config = load_proof_config(tmp.path()).expect("load proof config");
+        assert_eq!(config.proof.len(), 1);
+        assert_eq!(config.proof[0].name, "lint");
+        assert_eq!(config.proof[0].args, vec!["test", "--lib"]);
+    }
 }

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -22,6 +22,7 @@ use crate::core::project_specs::{
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Scaffolding operation configuration.
 ///
@@ -66,6 +67,9 @@ pub struct ScaffoldSummary {
     pub ci_created: usize,
     pub ci_unchanged: usize,
     pub ci_preserved: usize,
+    /// Runtime files already tracked by Git despite the managed ignore rules.
+    /// These require an agent task because `.gitignore` cannot untrack them.
+    pub tracked_runtime_paths: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1395,6 +1399,39 @@ fn ensure_gitignore_entry(target_dir: &Path, entry: &str) -> Result<(), error::D
     Ok(())
 }
 
+/// Return Decapod runtime files already tracked by Git.
+///
+/// Adding `.gitignore` rules only affects untracked files. Existing projects
+/// can have committed state under `.decapod/data`, so init must surface the
+/// exact paths for the agent to remove from the index deliberately. The
+/// promotion ledger is an intentional allowlist and is excluded.
+fn tracked_runtime_data_paths(target_dir: &Path) -> Vec<String> {
+    let Ok(output) = Command::new("git")
+        .arg("-C")
+        .arg(target_dir)
+        .args(["ls-files", "--cached", "--", ".decapod/data"])
+        .output()
+    else {
+        return Vec::new();
+    };
+
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    let mut paths = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|path| {
+            path.starts_with(".decapod/data/")
+                && *path != ".decapod/data/knowledge.promotions.jsonl"
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
 fn remove_deprecated_gitignore_entries(target_dir: &Path) -> Result<(), error::DecapodError> {
     let gitignore_path = target_dir.join(".gitignore");
     let Ok(content) = fs::read_to_string(&gitignore_path) else {
@@ -1648,6 +1685,8 @@ pub fn scaffold_project_entrypoints(
             }
         }
     }
+
+    let tracked_runtime_paths = tracked_runtime_data_paths(&opts.target_dir);
 
     // Determine which agent files to generate
     // If --all flag is set, force generate all five regardless of existing state
@@ -1980,6 +2019,7 @@ pub fn scaffold_project_entrypoints(
         ci_created,
         ci_unchanged,
         ci_preserved,
+        tracked_runtime_paths,
     })
 }
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -1244,6 +1244,11 @@ fn validate_project_config_toml(
     let value: toml::Value = toml::from_str(&raw).map_err(|e| {
         error::DecapodError::ValidationError(format!("Invalid .decapod/config.toml syntax: {e}"))
     })?;
+    let typed_config: crate::cli::DecapodProjectConfig = toml::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "Unsupported or malformed guided init config in .decapod/config.toml: {e}"
+        ))
+    })?;
     let schema_version = value
         .get("schema_version")
         .and_then(|v| v.as_str())
@@ -1383,6 +1388,134 @@ fn validate_project_config_toml(
                 );
             }
         }
+    }
+
+    match crate::cli::canonical_repo_relative_paths(&typed_config.governance.protected_paths) {
+        Ok(canonical) if canonical == typed_config.governance.protected_paths => pass(
+            "Guided init protected paths are canonical and repository-relative",
+            ctx,
+        ),
+        Ok(_) => fail(
+            "Guided init protected paths must be deterministically sorted and canonical",
+            ctx,
+        ),
+        Err(message) => fail(
+            &format!("Invalid guided init protected path: {message}"),
+            ctx,
+        ),
+    }
+
+    const APPROVAL_CATEGORIES: &[&str] = &["destructive_operations", "policy_changes"];
+    let unsupported_categories: Vec<_> = typed_config
+        .governance
+        .approval_categories
+        .iter()
+        .filter(|category| !APPROVAL_CATEGORIES.contains(&category.as_str()))
+        .collect();
+    let categories_are_canonical = typed_config
+        .governance
+        .approval_categories
+        .windows(2)
+        .all(|pair| pair[0] < pair[1]);
+    if unsupported_categories.is_empty() && categories_are_canonical {
+        pass("Guided init approval categories have policy consumers", ctx);
+    } else {
+        fail(
+            &format!(
+                "Unsupported or non-canonical guided init approval categories: {unsupported_categories:?}"
+            ),
+            ctx,
+        );
+    }
+
+    let isolation = value
+        .get("custody")
+        .and_then(|table| table.get("isolation"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(if typed_config.repo.container_workspaces {
+            "container"
+        } else {
+            "worktree"
+        });
+    if isolation == "container" && !typed_config.repo.container_workspaces {
+        pass(
+            "Guided init custody isolation is disabled by the legacy repo.container_workspaces=false opt-out",
+            ctx,
+        );
+    } else if matches!(isolation, "container" | "worktree") {
+        pass(
+            "Guided init custody isolation is supported and coherent",
+            ctx,
+        );
+    } else {
+        fail(
+            "Guided init custody.isolation must be either 'container' or 'worktree'",
+            ctx,
+        );
+    }
+
+    let proof_names: Vec<_> = typed_config
+        .proof
+        .commands
+        .iter()
+        .map(|proof| proof.name.trim())
+        .collect();
+    let proof_commands_valid = typed_config
+        .proof
+        .commands
+        .iter()
+        .all(|proof| !proof.name.trim().is_empty() && !proof.command.trim().is_empty());
+    let proof_names_unique = proof_names.windows(2).all(|pair| pair[0] < pair[1]);
+    if proof_commands_valid && proof_names_unique {
+        pass(
+            "Guided init proof commands are non-empty, unique, and deterministic",
+            ctx,
+        );
+    } else {
+        fail(
+            "Guided init proof commands must have non-empty sorted unique names and commands",
+            ctx,
+        );
+    }
+
+    let tracker_provider = typed_config.tracker.provider.trim();
+    let tracker_coherent = !tracker_provider.is_empty()
+        && (typed_config.repo.external_tracker == (tracker_provider != "decapod"));
+    if tracker_coherent {
+        pass(
+            "Guided init tracker metadata is coherent and non-secret",
+            ctx,
+        );
+    } else {
+        fail(
+            "Guided init tracker metadata must agree with repo.external_tracker and include a provider",
+            ctx,
+        );
+    }
+
+    match crate::cli::canonical_repo_relative_paths(&typed_config.context.declared_sources) {
+        Ok(canonical) if canonical == typed_config.context.declared_sources => {
+            let missing: Vec<_> = canonical
+                .iter()
+                .filter(|source| !repo_root.join(source).exists())
+                .collect();
+            if missing.is_empty() {
+                pass("Guided init context sources are declared and present", ctx);
+            } else {
+                fail(
+                    &format!("Guided init context sources are missing: {missing:?}"),
+                    ctx,
+                );
+            }
+        }
+        Ok(_) => fail(
+            "Guided init context sources must be deterministically sorted and canonical",
+            ctx,
+        ),
+        Err(message) => fail(
+            &format!("Invalid guided init context source: {message}"),
+            ctx,
+        ),
     }
     Ok(())
 }
@@ -5446,7 +5579,7 @@ fn validate_gatekeeper_gate(
         return Ok(());
     }
 
-    let config = crate::core::gatekeeper::GatekeeperConfig::default();
+    let config = crate::core::gatekeeper::GatekeeperConfig::from_repo_config(working_root);
     let result = crate::core::gatekeeper::run_gatekeeper(working_root, &staged_paths, 0, &config)?;
 
     if result.passed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,6 +1280,23 @@ fn prompt_line_default(prompt: &str, default_value: &str) -> Result<String, erro
     )
 }
 
+fn prompt_csv_default(
+    prompt: &str,
+    default_value: &str,
+) -> Result<Vec<String>, error::DecapodError> {
+    let raw = prompt_text_field(
+        prompt,
+        "Enter comma-separated values, or press Enter to keep the inferred value.",
+        default_value,
+    )?;
+    Ok(raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
 fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool, error::DecapodError> {
     use crate::core::ansi::AnsiExt;
     let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
@@ -1438,6 +1455,20 @@ fn init_with_from_config(
         detected_surfaces: config.repo.detected_surfaces.clone(),
         declared_capabilities: config.repo.capabilities.clone(),
         container_workspaces: config.repo.container_workspaces,
+        protected_paths: config.governance.protected_paths.clone(),
+        approval_categories: config.governance.approval_categories.clone(),
+        isolation_mode: Some(config.custody.isolation),
+        tracker_provider: (config.tracker.provider != "decapod")
+            .then(|| config.tracker.provider.clone()),
+        tracker_project: config.tracker.project.clone(),
+        tracker_url: config.tracker.url.clone(),
+        declared_context_sources: config.context.declared_sources.clone(),
+        proof_commands: config
+            .proof
+            .commands
+            .iter()
+            .map(|proof| format!("{}={}", proof.name, proof.command))
+            .collect(),
         mode: if config.cloud.as_ref().map(|c| c.enabled).unwrap_or(false)
             || config.repo.mode == crate::cli::BackendType::Cloud
         {
@@ -1454,6 +1485,13 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
     let cloud_enabled =
         init.mode == crate::cli::BackendType::Cloud || repo.mode == crate::cli::BackendType::Cloud;
     let mut repo = repo;
+    let external_tracker = repo.external_tracker;
+    let tracker_is_external = external_tracker
+        || init
+            .tracker_provider
+            .as_deref()
+            .is_some_and(|provider| provider != "decapod");
+    repo.external_tracker = tracker_is_external;
     // #688 adds the cloud opt-in boundary only. Fresh init config must keep
     // local storage canonical until a later sync feature explicitly changes it.
     repo.mode = crate::cli::BackendType::Local;
@@ -1472,6 +1510,32 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
     if init.all || init.cdx_ep || no_entrypoint_flags {
         entrypoints.push("CODEX.md".to_string());
     }
+    let protected_paths = canonical_repo_relative_paths(&init.protected_paths)
+        .unwrap_or_else(|_| init.protected_paths.clone());
+    let declared_context_sources = canonical_repo_relative_paths(&init.declared_context_sources)
+        .unwrap_or_else(|_| init.declared_context_sources.clone());
+    let mut proof_commands: Vec<_> = init
+        .proof_commands
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let (name, command) = value.split_once('=').unwrap_or(("", ""));
+            proof::ProofDef {
+                name: name.trim().to_string(),
+                command: command.trim().to_string(),
+                args: Vec::new(),
+                description: format!("Guided init proof command {}", index + 1),
+                required: true,
+            }
+        })
+        .collect();
+    proof_commands.sort_by(|left, right| left.name.cmp(&right.name));
+    let mut approval_categories = if init.approval_categories.is_empty() {
+        vec!["destructive_operations".to_string()]
+    } else {
+        init.approval_categories.clone()
+    };
+    approval_categories.sort();
     DecapodProjectConfig {
         schema_version: "1.0.0".to_string(),
         init: InitConfigSection {
@@ -1481,6 +1545,35 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
             entrypoints,
         },
         repo,
+        governance: GovernanceConfig {
+            protected_paths,
+            approval_categories,
+        },
+        proof: proof::ProjectProofConfig {
+            commands: proof_commands,
+        },
+        custody: CustodyConfig {
+            isolation: init.isolation_mode.unwrap_or(if init.container_workspaces {
+                IsolationMode::Container
+            } else {
+                IsolationMode::Worktree
+            }),
+        },
+        tracker: TrackerConfig {
+            provider: init.tracker_provider.clone().unwrap_or_else(|| {
+                if external_tracker {
+                    "external"
+                } else {
+                    "decapod"
+                }
+                .to_string()
+            }),
+            project: init.tracker_project.clone(),
+            url: init.tracker_url.clone(),
+        },
+        context: DeclaredContextConfig {
+            declared_sources: declared_context_sources,
+        },
         cloud: if cloud_enabled {
             Some(crate::cli::CloudConfigSection {
                 enabled: true,
@@ -1595,6 +1688,55 @@ fn enrich_repo_context_interactive(
         true,
     )?;
     repo.container_workspaces = enable_container_workspaces;
+
+    let protected_default = init.protected_paths.join(",");
+    init.protected_paths =
+        canonical_repo_relative_paths(&prompt_csv_default("Protected paths", &protected_default)?)
+            .map_err(error::DecapodError::ValidationError)?;
+
+    let approval_default = if init.approval_categories.is_empty() {
+        "destructive_operations".to_string()
+    } else {
+        init.approval_categories.join(",")
+    };
+    init.approval_categories = prompt_csv_default("Approval categories", &approval_default)?;
+
+    let proof_default = init.proof_commands.join(",");
+    init.proof_commands = prompt_csv_default("Proof commands", &proof_default)?;
+
+    if repo.external_tracker {
+        let provider = init
+            .tracker_provider
+            .clone()
+            .unwrap_or_else(|| "external".to_string());
+        init.tracker_provider = Some(prompt_line_default("External tracker provider", &provider)?);
+        let project = init.tracker_project.clone().unwrap_or_default();
+        let project = prompt_line_default("External tracker project (optional)", &project)?;
+        init.tracker_project = (!project.trim().is_empty()).then_some(project);
+        let url = init.tracker_url.clone().unwrap_or_default();
+        let url = prompt_line_default("External tracker URL (optional)", &url)?;
+        init.tracker_url = (!url.trim().is_empty()).then_some(url);
+    } else {
+        init.tracker_provider = None;
+        init.tracker_project = None;
+        init.tracker_url = None;
+    }
+
+    let context_default = if init.declared_context_sources.is_empty() {
+        "AGENTS.md".to_string()
+    } else {
+        init.declared_context_sources.join(",")
+    };
+    init.declared_context_sources = canonical_repo_relative_paths(&prompt_csv_default(
+        "Declared context sources",
+        &context_default,
+    )?)
+    .map_err(error::DecapodError::ValidationError)?;
+    init.isolation_mode = Some(if repo.container_workspaces {
+        IsolationMode::Container
+    } else {
+        IsolationMode::Worktree
+    });
 
     println!();
     println!("Enable Decapod Cloud? [experimental, account required]");
@@ -1947,6 +2089,31 @@ pub fn run() -> Result<(), error::DecapodError> {
                         if !init_group.declared_capabilities.is_empty() {
                             with.declared_capabilities = init_group.declared_capabilities.clone();
                         }
+                        if !init_group.protected_paths.is_empty() {
+                            with.protected_paths = init_group.protected_paths.clone();
+                        }
+                        if !init_group.approval_categories.is_empty() {
+                            with.approval_categories = init_group.approval_categories.clone();
+                        }
+                        if init_group.isolation_mode.is_some() {
+                            with.isolation_mode = init_group.isolation_mode;
+                        }
+                        if init_group.tracker_provider.is_some() {
+                            with.tracker_provider = init_group.tracker_provider.clone();
+                        }
+                        if init_group.tracker_project.is_some() {
+                            with.tracker_project = init_group.tracker_project.clone();
+                        }
+                        if init_group.tracker_url.is_some() {
+                            with.tracker_url = init_group.tracker_url.clone();
+                        }
+                        if !init_group.declared_context_sources.is_empty() {
+                            with.declared_context_sources =
+                                init_group.declared_context_sources.clone();
+                        }
+                        if !init_group.proof_commands.is_empty() {
+                            with.proof_commands = init_group.proof_commands.clone();
+                        }
                         with
                     } else {
                         let diagram_style = if io::stdin().is_terminal() && !init_group.proof {
@@ -1977,6 +2144,14 @@ pub fn run() -> Result<(), error::DecapodError> {
                             detected_surfaces: init_group.detected_surfaces.clone(),
                             declared_capabilities: init_group.declared_capabilities.clone(),
                             container_workspaces: init_group.container_workspaces,
+                            protected_paths: init_group.protected_paths.clone(),
+                            approval_categories: init_group.approval_categories.clone(),
+                            isolation_mode: init_group.isolation_mode,
+                            tracker_provider: init_group.tracker_provider.clone(),
+                            tracker_project: init_group.tracker_project.clone(),
+                            tracker_url: init_group.tracker_url.clone(),
+                            declared_context_sources: init_group.declared_context_sources.clone(),
+                            proof_commands: init_group.proof_commands.clone(),
                             mode: init_group.mode.clone(),
                             git: init_group.git,
                             no_git: init_group.no_git,
@@ -6045,7 +6220,7 @@ fn run_govern_command(
                     .map_err(error::DecapodError::IoError)?;
                 let diff_bytes = diff_output.stdout.len() as u64;
 
-                let mut config = gatekeeper::GatekeeperConfig::default();
+                let mut config = gatekeeper::GatekeeperConfig::from_repo_config(repo_root);
                 if let Some(max) = max_diff_bytes {
                     config.max_diff_bytes = max;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1951,6 +1951,24 @@ fn run_init_apply(
         scaffold_summary.ci_unchanged.to_string().bright_yellow(),
         scaffold_summary.ci_preserved.to_string().bright_white()
     );
+    if !scaffold_summary.tracked_runtime_paths.is_empty() {
+        println!(
+            "\n{}",
+            "TASK: Decapod runtime files are already tracked by Git. `.gitignore` now covers them, but it cannot remove files that were previously committed.".bright_yellow()
+        );
+        println!(
+            "{}",
+            "      Remove these exact paths from the index before committing the project:"
+                .bright_yellow()
+        );
+        for path in &scaffold_summary.tracked_runtime_paths {
+            println!("      - {path}");
+        }
+        println!(
+            "{}",
+            "      Use `git rm --cached -- <path>` for each path; keep the local runtime files if Decapod needs them.".bright_yellow()
+        );
+    }
     println!("  Backups: {}", backup_count.to_string().bright_magenta());
     println!(
         "  Diagram Notation: {}",

--- a/src/plugins/context.rs
+++ b/src/plugins/context.rs
@@ -27,13 +27,28 @@ pub struct ContextManager {
 impl ContextManager {
     pub fn new(root: &Path) -> Result<Self, error::DecapodError> {
         let config_path = root.join("CONTEXT.json");
-        let config = if config_path.exists() {
+        let mut config = if config_path.exists() {
             let content = fs::read_to_string(config_path).map_err(error::DecapodError::IoError)?;
             serde_json::from_str(&content)
                 .map_err(|e| error::DecapodError::ValidationError(format!("AUTOREMEDIABLE_VALIDATION_ERROR code=CONTEXT_CONFIG_PARSE severity=transient auto_remediable=true audience=agent agent_action=\"verify the CONTEXT.json syntax and schema\" user_note=\"Context configuration parse error; the agent should correct the JSON format.\"\n{e}")))?
         } else {
             Self::default_config()
         };
+
+        // Guided init declarations are additive inputs to the existing context
+        // profile. They do not replace CONTEXT.json or create a second authority.
+        let project_config_path = root.join(".decapod").join("config.toml");
+        if project_config_path.exists()
+            && let Ok(project) = crate::cli::DecapodProjectConfig::load(root)
+            && let Some(main) = config.profiles.get_mut("main")
+        {
+            for source in project.context.declared_sources {
+                if !main.required_files.contains(&source) {
+                    main.required_files.push(source);
+                }
+            }
+            main.required_files.sort();
+        }
 
         Ok(Self {
             root: root.to_path_buf(),

--- a/src/plugins/policy.rs
+++ b/src/plugins/policy.rs
@@ -531,6 +531,36 @@ fn risk_zone_for_operation(op_name: &str) -> &'static str {
     "control.mutate"
 }
 
+fn configured_approval_categories(root: &Path) -> Result<Vec<String>, error::DecapodError> {
+    let main_root =
+        crate::core::workspace::get_main_repo_root(root).unwrap_or_else(|_| root.to_path_buf());
+    let config_path = main_root.join(".decapod").join("config.toml");
+    if !config_path.exists() {
+        return Ok(Vec::new());
+    }
+    let config = crate::cli::DecapodProjectConfig::load(&main_root)
+        .map_err(|e| error::DecapodError::Config(format!("Unable to load approval policy: {e}")))?;
+    Ok(config.governance.approval_categories)
+}
+
+fn configured_approval_required(categories: &[String], op_name: &str) -> bool {
+    categories.iter().any(|category| match category.as_str() {
+        "destructive_operations" => {
+            !op_name.contains("_internal")
+                && !op_name.ends_with(".register")
+                && (op_name.contains("archive")
+                    || op_name.contains("delete")
+                    || op_name.contains("purge")
+                    || op_name.contains("rebuild")
+                    || op_name.contains("supersede")
+                    || op_name.contains("dispute")
+                    || op_name.contains("deprecate"))
+        }
+        "policy_changes" => op_name.starts_with("policy."),
+        _ => false,
+    })
+}
+
 fn zone_policy_from_todo(
     root: &Path,
     zone_name: &str,
@@ -598,6 +628,21 @@ pub fn enforce_broker_mutation_policy(
 
     let risk = risk_level_for_operation(op_name);
     let zone_name = risk_zone_for_operation(op_name);
+    let configured_categories = configured_approval_categories(root)?;
+    let approval_required = !configured_categories.is_empty()
+        && configured_approval_required(&configured_categories, op_name);
+    if approval_required {
+        initialize_policy_db(root)?;
+        let store = Store {
+            kind: crate::core::store::StoreKind::Repo,
+            root: root.to_path_buf(),
+        };
+        if !check_approval(&store, zone_name, None, "global")? {
+            return Err(error::DecapodError::ValidationError(format!(
+                "Policy gate denied for '{op_name}': configured approval category requires human approval"
+            )));
+        }
+    }
     if let Some((zone_trust, zone_requires_approval)) = zone_policy_from_todo(root, zone_name)? {
         if trust_level_to_int(&actor_trust) < trust_level_to_int(&zone_trust) {
             return Err(error::DecapodError::ValidationError(format!(

--- a/tests/core/core.rs
+++ b/tests/core/core.rs
@@ -731,6 +731,9 @@ fn scaffold_store_and_docs_cli_behaviors() {
         specs_seed: None,
         capabilities: vec![],
     };
+    fs::create_dir_all(&live_target).expect("create live target");
+    fs::write(live_target.join(".gitignore"), "target/\n")
+        .expect("seed existing project gitignore");
     scaffold_project_entrypoints(&live_opts).expect("live scaffold");
     assert!(live_target.join("AGENTS.md").exists());
     assert!(live_target.join(".decapod/OVERRIDE.md").exists());
@@ -759,6 +762,36 @@ fn scaffold_store_and_docs_cli_behaviors() {
         gitignore.contains("!.decapod/data/knowledge.promotions.jsonl"),
         "decapod init must allowlist knowledge promotion ledger in .gitignore"
     );
+    assert!(
+        gitignore.lines().any(|line| line.trim() == "target/"),
+        "decapod init must preserve existing gitignore rules"
+    );
+
+    // Existing projects may already have committed runtime state. Verify init
+    // reports exact paths because adding .gitignore rules cannot untrack them.
+    init_git_repo(&live_target);
+    fs::create_dir_all(live_target.join(".decapod/data")).expect("create runtime data");
+    fs::write(live_target.join(".decapod/data/todo.db"), "runtime\n")
+        .expect("write tracked runtime data");
+    let add_runtime = Command::new("git")
+        .current_dir(&live_target)
+        .args(["add", "-f", ".decapod/data/todo.db"])
+        .output()
+        .expect("git add runtime data");
+    assert!(add_runtime.status.success());
+    let tracked_runtime = scaffold_project_entrypoints(&live_opts)
+        .expect("refresh scaffold with tracked runtime data")
+        .tracked_runtime_paths;
+    assert_eq!(tracked_runtime, vec![".decapod/data/todo.db"]);
+    fs::write(live_target.join(".decapod/data/untracked.db"), "runtime\n")
+        .expect("write untracked runtime data");
+    let ignored = Command::new("git")
+        .current_dir(&live_target)
+        .args(["check-ignore", "--quiet", ".decapod/data/untracked.db"])
+        .status()
+        .expect("git check-ignore runtime data");
+    assert!(ignored.success(), "fresh runtime data must be ignored");
+
     let generated_dockerfile = live_target.join(".decapod/generated/Dockerfile");
     assert!(
         generated_dockerfile.exists(),

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -874,3 +874,87 @@ fn init_supports_and_preserves_declared_capabilities() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+#[test]
+fn init_persists_guided_governance_and_reuses_it_on_refresh() {
+    let tmp = tempdir().expect("tempdir");
+    fs::write(tmp.path().join("README.md"), "# project\n").expect("write readme");
+
+    let out = run_decapod(
+        tmp.path(),
+        &[
+            "init",
+            "with",
+            "--protected-path",
+            "README.md",
+            "--approval-category",
+            "policy_changes",
+            "--isolation-mode",
+            "worktree",
+            "--tracker-provider",
+            "beads",
+            "--tracker-project",
+            "project-1",
+            "--tracker-url",
+            "https://tracker.invalid/project-1",
+            "--declared-context-source",
+            "README.md",
+            "--proof-command",
+            "lint=cargo test --lib",
+            "--force",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "guided init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let config_path = tmp.path().join(".decapod/config.toml");
+    let config = fs::read_to_string(&config_path).expect("read config");
+    assert!(config.contains("[governance]"));
+    assert!(config.contains("protected_paths = [\"README.md\"]"));
+    assert!(config.contains("approval_categories = [\"policy_changes\"]"));
+    assert!(config.contains("isolation = \"worktree\""));
+    assert!(config.contains("provider = \"beads\""));
+    assert!(config.contains("declared_sources = [\"README.md\"]"));
+    assert!(config.contains("name = \"lint\""));
+
+    let refresh = run_decapod(tmp.path(), &["init", "--force"]);
+    assert!(
+        refresh.status.success(),
+        "guided init refresh failed: {}",
+        String::from_utf8_lossy(&refresh.stderr)
+    );
+    let refreshed = fs::read_to_string(config_path).expect("read refreshed config");
+    assert!(refreshed.contains("provider = \"beads\""));
+    assert!(refreshed.contains("name = \"lint\""));
+    assert!(refreshed.contains("declared_sources = [\"README.md\"]"));
+}
+
+#[test]
+fn init_validation_rejects_traversal_in_guided_paths() {
+    let tmp = tempdir().expect("tempdir");
+    let out = run_decapod(
+        tmp.path(),
+        &["init", "with", "--protected-path", "../outside", "--force"],
+    );
+    assert!(
+        out.status.success(),
+        "init should preserve noninteractive behavior"
+    );
+
+    let validate = run_decapod(tmp.path(), &["validate"]);
+    assert!(
+        !validate.status.success(),
+        "validate must reject traversal paths: {}",
+        String::from_utf8_lossy(&validate.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&validate.stdout).contains("protected path")
+            || String::from_utf8_lossy(&validate.stderr).contains("protected path"),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Closes #683. Completes the guided decapod init governance interview and carries its answers through the existing typed config and enforcement paths.

- Adds backward-compatible typed [governance], [proof], [custody], [tracker], and [context] config sections.
- Adds interactive and noninteractive init inputs for protected paths, proof commands, approval categories, isolation, tracker metadata, and declared context sources.
- Enforces canonical repository-relative paths through validation and gatekeeper typed findings.
- Feeds config proof commands into the existing proof registry, approval categories into policy enforcement, and declared sources into context profiles.
- Preserves legacy config fields and external-tracker compatibility.
- Refreshes root entrypoint release and fingerprint metadata to the checked-in 0.72.16 source version.

## Verification

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib: 171 passed
- cargo test --tests: full suite passed
- cargo test --test init_config_behavior
- cargo test --test gatling: 48 passed, 1 ignored

Decapod validate reached 200 passing gates; the local host run still reports the repository container-workspace proof and pre-existing unverified-todo gates, so containerized validation remains the CI/environment proof surface.