### PR TITLE
feat: add run-level trajectory proof artifacts

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.72.17
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.73.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.72.17
+ARG DECAPOD_VERSION=0.73.0
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784675258Z",
-  "repo_signal_fingerprint": "893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a",
+  "generated_at": "1784678209Z",
+  "repo_signal_fingerprint": "1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -16,82 +16,82 @@
     "scheduled-jobs"
   ],
   "capability_definition_version": "1.0.0",
-  "config_input_hash": "cf1ec882bc0472d9f643e8736a36d56eea7f7c04194277cdd33e13d9872a6267",
-  "spec_input_hash": "c4b86dda046b5e1acc3dd1d6573de74df6b5788f390d62471c7a8afdb7b4a21d",
-  "decapod_release": "0.72.17",
+  "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
+  "spec_input_hash": "0eea0815479a24524c92faaa1ce3f74ad9f126c9fd9244d117ff0ab4b04f795f",
+  "decapod_release": "0.73.0",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "01ce5667894ff4eb0d880485a53e652659c7b4303f3efe4d5f1de3e582518e30",
-      "content_hash": "01ce5667894ff4eb0d880485a53e652659c7b4303f3efe4d5f1de3e582518e30",
-      "fingerprint": "2593eca977e8714aea6c25d26324eedb8d14f6701e8cb01ea6f823724c15a36b"
+      "template_hash": "f72064e18ae8d35d7c294d320795ed055c05f21ad5eeb274bbf6c8cb57a42001",
+      "content_hash": "f72064e18ae8d35d7c294d320795ed055c05f21ad5eeb274bbf6c8cb57a42001",
+      "fingerprint": "4790634a1c27c7813fc06ca3dd514d80c8a87cee0475d16de7648049feb23499"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "71ac1dccfaa35f63a1b20120d575b3e6e56db9d2c5f418954e17c38034901d39",
-      "content_hash": "71ac1dccfaa35f63a1b20120d575b3e6e56db9d2c5f418954e17c38034901d39",
-      "fingerprint": "9aac982616bc33f7c72c96b9178dca3f8657e65ace5269492dab38d767a98254"
+      "template_hash": "050541837a08eb954f2aa63993bbd8be5ad16f97d22d719bbf88f32f111d6fcf",
+      "content_hash": "050541837a08eb954f2aa63993bbd8be5ad16f97d22d719bbf88f32f111d6fcf",
+      "fingerprint": "9e1289f3d0a0bf67ef7a92fefac26c2d4ad0cdac9da0a1b61bc8664335d9e54d"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "c808430d60e19e5abe133bb8bf897da86c763279027322ee1caf9a34fa483169",
-      "content_hash": "c808430d60e19e5abe133bb8bf897da86c763279027322ee1caf9a34fa483169",
-      "fingerprint": "9692d0076622101af553f75e85fb46a4b501e0beca3e6ff92e5ee2f99517bc3e"
+      "template_hash": "13e8fffd734849c4ac726a04c9736b78b47686c245d1406a9084a7a59ef6b96a",
+      "content_hash": "13e8fffd734849c4ac726a04c9736b78b47686c245d1406a9084a7a59ef6b96a",
+      "fingerprint": "fab8b8f97c6fa17508a0dbc6d8df9c1f366ef5bf0a7aaff4397f71eff23da9d8"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "2443c82255925ac6ada6589ebbcbf451c075397ae2695dbaef25c1f18c006c16",
-      "content_hash": "2443c82255925ac6ada6589ebbcbf451c075397ae2695dbaef25c1f18c006c16",
-      "fingerprint": "c86ab9acf92578772e910a94c1404884515971093b45333d9fee82915afb1690"
+      "template_hash": "1b9eee683660985ec80084da40fd17bf1149800fef9d9a361591367a4d3a93f5",
+      "content_hash": "1b9eee683660985ec80084da40fd17bf1149800fef9d9a361591367a4d3a93f5",
+      "fingerprint": "3135bc3cdbf0e209307cdba02e05e246683d137b6db9c345c53d551f64f2ac17"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "8981afbe2f0a70c0f63c328c52ab5fb2632dc48aa4562294951f202891ab3638",
+      "content_hash": "abac429aa379660951fe0f9ce86f22e103b7e3a8b9cb9e3be3ab57bf086854da",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "409b3a30d5a0da9bbee56be3c74b103d978c3daf4981ec895df92497db8e01d3",
+      "content_hash": "5f21f1dfd819848522121bdb75fddc3e305744970647425d342e41e6588c9394",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "5e59802e2cb6a8a261af3c463e8d1926059b3238e258e2f78e68eb1f586ae9db",
+      "content_hash": "69cf0af99ffe605d42f112836e778887992abd2f44ddcef61106ba00ccf1491b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "7cf6d056452f1a97b5bc91bcc43ae9071146adb6af9aa999c6e385ca31e728d2",
+      "content_hash": "6d596b4a3f8616bf0ec3e2de0a9bbe57629430548cab37446350fca4022c6711",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "6ae000cedd2109e03eb20f55012414acbc5753a95d1d9a603023ccc69c47713c",
+      "content_hash": "708fe20ef80032b452a51806805ee518a9014689dc9c37e0f5d5020042ff5ea5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "c387d6c41fa2dd829b8da4682732f93747454e6106df3884c2aebc1963b7be7e",
+      "content_hash": "9b7ae2ea85122eed6ff78f929648efecad6196b10017f40feeb659b5074c1669",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "f0b9c1171b10ee3919089b814e9378fa5a54875ac78f1567ea33773b51f65f94",
+      "content_hash": "e59717a55f49e0d711e560b884d5fd214f4c674ea50a582aa6e75bea21d43808",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "0c2134f75017e34e49a2611e8260d064838c69df45f3f465769a3b13e51e288b",
+      "content_hash": "44e7b8845f9451b69163554b6d527137dc36b43c4f86311160a6d165f537a0a9",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -68,6 +68,7 @@ src/
 │   ├── todo.rs             # Task tracking + event sourcing + agent coordination
 │   ├── plan_governance.rs  # Governed Plan (Draft→Approved→Executing→Done)
 │   ├── workunit.rs         # WorkUnit manifests (intent/spec/state/proof)
+│   ├── trajectory.rs       # Run-level intent, scope, actions, checks, and proof verdicts
 │   ├── obligation.rs       # Obligation graph (derived status, deps, proofs)
 │   ├── context_capsule.rs  # Deterministic capsules + policy binding
 │   ├── capsule_policy.rs   # Risk-tiered token budgets, repo-revision binding
@@ -148,6 +149,7 @@ flowchart TD
 | `Todo` + events | `core/todo.rs` | Task CRUD, claims, event sourcing, deterministic rebuild |
 | `GovernedPlan` | `src/plan_governance.rs` | State machine with scope constraints, ordered phases, and proof gates |
 | `WorkUnitManifest` | `core/workunit.rs` | Intent/spec/state/proof chain with canonical hashing |
+| `TrajectoryArtifact` | `core/trajectory.rs` | Local-first run custody artifact with canonical hashing and computed proof/verdict status |
 | `ObligationNode` | `core/obligation.rs` | Dependency graph, derived status, proof gating |
 | `DeterministicContextCapsule` | `core/context_capsule.rs` | Immutable sources + snippets, SHA256 hash, policy binding |
 | `CapsulePolicyBinding` | `core/capsule_policy.rs` | Risk tiers, scope allowlists, repo-revision binding |
@@ -347,6 +349,7 @@ Verification and artifact emission:
 | knowledge.db | Repo store | `data knowledge add/search/promote` |
 | lcm.db | Repo store | `data context ingest/summarize` |
 | WorkUnit manifests | `.decapod/governance/workunits/` | `govern workunit.*` |
+| Trajectory artifacts | `.decapod/governance/trajectories/` | `govern trajectory.*` |
 | Plan artifact | `.decapod/governance/plan.json` | `govern plan.*` |
 | Context capsules | `.decapod/generated/context/` | `infer.*`, `govern capsule.*` |
 | Capsule policy | `.decapod/generated/policy/` or override | `init`, `scaffold` |
@@ -394,7 +397,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -16,6 +16,7 @@ Generated interface specs include:
 - JSONL event log formats (one per subsystem)
 - Context Capsule schema with policy binding
 - WorkUnit / Plan / Obligation manifest schemas
+- Agent trajectory artifact schema with computed proof status and run-level verdicts
 - Capabilities report schema for agent discovery
 
 ## CLI / RPC Contracts
@@ -47,6 +48,10 @@ Generated interface specs include:
 | `decapod govern plan check-execute` | Verify plan ready for execution | `--todo-id` | Plan / Error |
 | `decapod govern workunit init` | Create workunit manifest | `--task-id`, `--intent-ref` | WorkUnitManifest |
 | `decapod govern workunit transition` | Transition workunit status | `--task-id`, `--to` | WorkUnitManifest |
+| `decapod govern trajectory init` | Create inspectable run trajectory | `--run-id`, `--original-intent`, `--derived-intent`, `--boundary`, `--scope` | TrajectoryArtifact |
+| `decapod govern trajectory record` | Record run actions, checks, assumptions, and claims | `--run-id`, `--inspected-file`, `--modified-file`, `--command`, `--check` | TrajectoryArtifact |
+| `decapod govern trajectory get` | Inspect the complete run trajectory artifact | `--run-id` | TrajectoryArtifact |
+| `decapod govern trajectory status` | Show computed trajectory proof and verdicts | `--run-id` | TrajectoryStatus |
 | `decapod govern capsule query` | Deterministic context capsule | `--topic`, `--scope`, `--limit`, `--risk-tier`, `--write` | DeterministicContextCapsule |
 | `decapod obligation add` | Add obligation node | `--intent`, `--risk`, `--depends-on`, `--proofs` | ObligationNode |
 | `decapod obligation verify` | Derive obligation status | `--id` | ObligationValidationResult |
@@ -215,6 +220,7 @@ Response envelope (`RpcResponse`):
 | `.decapod/generated/policy/context_capsule_policy.json` | `init` / scaffold | Capsule query resolution |
 | `.decapod/generated/specs/*.md` | `init --force` / `rpc specs.refresh` | Validation, agents |
 | `.decapod/generated/artifacts/provenance/*.json` | `workspace publish` / `validate` | Promotion, CI |
+| `.decapod/governance/trajectories/*.json` | `govern trajectory` / `validate` | Run custody and proof review |
 
 ## Error Taxonomy
 
@@ -401,7 +407,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -25,6 +25,7 @@ These files are the project-local contract for humans and agents.
 - `.decapod/generated/policy/context_capsule_policy.json`: repo-native JIT context policy contract.
 - `.decapod/generated/artifacts/provenance/`: promotion manifests and convergence checklist.
 - `.decapod/generated/artifacts/custody/`: epistemic custody artifacts (assumptions, contradictions, deferred questions).
+- `.decapod/governance/trajectories/`: local-first run trajectory artifacts with intent, scope, actions, checks, and proof verdicts.
 - `.decapod/generated/artifacts/inventory/`: deterministic release inventory.
 - `.decapod/generated/artifacts/diagnostics/`: opt-in diagnostics artifacts.
 - `.decapod/workspaces/`: isolated todo-scoped git worktrees.
@@ -55,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -91,6 +91,7 @@ flowchart LR
 | Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
 | Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
 | Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
+| Trajectory artifacts | `.decapod/governance/trajectories/*.json` | Run-level custody schema, hash, and computed proof status |
 | Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
 | Test logs | CI artifact store | Promotion |
 | Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
@@ -268,7 +269,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `893a77c64a44b2fdf92d555ab857170c2c0f0a9e6a6716419e57e35a3a6ad07a`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (90 files), `tests/` (4 files)
+- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/trajectories/run_01ky3g3dv3qmrwda.json
+++ b/.decapod/governance/trajectories/run_01ky3g3dv3qmrwda.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "1.0.0",
+  "run_id": "run_01ky3g3dv3qmrwda",
+  "task_id": "feat_01ky3g3dv3qmrwda",
+  "original_intent": "Determine whether Issue #678 can close; otherwise implement its broader run-level custody and proof artifact MVP in a dedicated PR.",
+  "derived_intent": "Add local-first trajectory artifacts with typed checks, computed proof/verdicts, CLI inspection, validation integrity checks, guidance, specs, and tests.",
+  "active_boundaries": [
+    "no direct .decapod store mutation",
+    "single decapod workspace worktree"
+  ],
+  "repo_scope": [
+    ".decapod/generated/specs",
+    "agent entrypoints",
+    "src/cli.rs",
+    "src/core/trajectory.rs",
+    "src/core/validate.rs",
+    "src/lib.rs",
+    "tests"
+  ],
+  "inspected_files": [
+    "src/cli.rs",
+    "src/core/validate.rs",
+    "src/core/workunit.rs",
+    "src/lib.rs",
+    "tests/entrypoint_correctness.rs",
+    "tests/validate_optional_artifact_gates.rs"
+  ],
+  "modified_files": [
+    ".decapod/generated/specs/INTERFACES.md",
+    "AGENTS.md",
+    "src/cli.rs",
+    "src/core/trajectory.rs",
+    "src/core/validate.rs",
+    "src/lib.rs",
+    "tests/trajectory_cli.rs",
+    "tests/validate_optional_artifact_gates.rs"
+  ],
+  "declared_commands": [
+    "cargo clippy --all-targets -- -D warnings",
+    "cargo fmt -- --check",
+    "cargo test --lib",
+    "cargo test --test entrypoint_correctness",
+    "cargo test --test trajectory_cli",
+    "target/debug/decapod validate --format json"
+  ],
+  "tool_calls": [
+    "decapod govern trajectory status --run-id run_01ky3g3dv3qmrwda",
+    "gh issue view 678",
+    "gh pr view 908"
+  ],
+  "checks": [
+    {
+      "name": "cargo clippy",
+      "status": "passed"
+    },
+    {
+      "name": "cargo fmt",
+      "status": "passed"
+    },
+    {
+      "name": "cargo test --lib",
+      "status": "passed"
+    },
+    {
+      "name": "cargo test --tests",
+      "status": "partial"
+    },
+    {
+      "name": "decapod validate",
+      "status": "partial"
+    },
+    {
+      "name": "entrypoint_correctness",
+      "status": "passed"
+    },
+    {
+      "name": "trajectory_cli",
+      "status": "passed"
+    }
+  ],
+  "evidence": [
+    "Focused trajectory, validation-gate, entrypoint, library, and clippy tests passed.",
+    "Issue #678 remains open because PR #908 only added activation conformance and did not implement the broader trajectory artifact.",
+    "Validation passed the trajectory artifact gate but was blocked by host container-workspace, commit-often, and pre-existing claimed-TODO proof gates."
+  ],
+  "shortcut_risk_signals": [
+    "Aggregate integration suite daemonless lifecycle snapshot observed transient decapod processes."
+  ],
+  "unresolved_assumptions": [
+    "Container-backed validation will be supplied by GitHub CI or a Decapod container workspace."
+  ],
+  "completion_claim": "Dedicated Issue #678 implementation is ready for review and publication; issue remains open until this PR lands.",
+  "proof_status": "partial",
+  "verdicts": {
+    "intent_alignment": "supported",
+    "boundary_discipline": "supported",
+    "shortcut_risk": "caution",
+    "completion_proof": "caution"
+  },
+  "artifact_hash": "sha256:82576f1f729047fe44737e4057faf2f4588187d7b1e96b536bcd01242851ee2f"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.17 -->
-<!-- decapod-fingerprint: 2593eca977e8714aea6c25d26324eedb8d14f6701e8cb01ea6f823724c15a36b -->
+<!-- decapod-release: 0.73.0 -->
+<!-- decapod-fingerprint: 4790634a1c27c7813fc06ca3dd514d80c8a87cee0475d16de7648049feb23499 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**
@@ -86,6 +86,10 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 3. **Evidence-Based Claims**: Claims of completion must be tied to measured evidence.
 4. **Clarification Trigger**: Stop if a critical assumption cannot be proven.
 
+## Run-Level Trajectory and Proof
+Record a local artifact under `.decapod/governance/trajectories/`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`.
+Use `decapod govern trajectory init --run-id <run-id> --original-intent "..." --derived-intent "..." --boundary "..." --scope "..."` and `decapod govern trajectory record --run-id <run-id> --inspected-file <path> --check "name=status"`.
+Completion claims never prove completion: `passed`, `failed`, `partial`, `unavailable`, and `no_checks_run` remain distinct, and no checks means an `unsupported` completion verdict.
 ## Invariants (Normative)
 - **INV-DAEMONLESS**: Decapod MUST NOT leave background processes running.
 - **INV-BOUNDED-VALIDATE**: `decapod validate` MUST terminate within bounded time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.17 -->
-<!-- decapod-fingerprint: 9aac982616bc33f7c72c96b9178dca3f8657e65ace5269492dab38d767a98254 -->
+<!-- decapod-release: 0.73.0 -->
+<!-- decapod-fingerprint: 9e1289f3d0a0bf67ef7a92fefac26c2d4ad0cdac9da0a1b61bc8664335d9e54d -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.17 -->
-<!-- decapod-fingerprint: c86ab9acf92578772e910a94c1404884515971093b45333d9fee82915afb1690 -->
+<!-- decapod-release: 0.73.0 -->
+<!-- decapod-fingerprint: 3135bc3cdbf0e209307cdba02e05e246683d137b6db9c345c53d551f64f2ac17 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.72.17 -->
-<!-- decapod-fingerprint: 9692d0076622101af553f75e85fb46a4b501e0beca3e6ff92e5ee2f99517bc3e -->
+<!-- decapod-release: 0.73.0 -->
+<!-- decapod-fingerprint: fab8b8f97c6fa17508a0dbc6d8df9c1f366ef5bf0a7aaff4397f71eff23da9d8 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -747,6 +747,9 @@ pub(crate) enum GovernCommand {
     /// Work unit manifest artifacts (intent/spec/state/proof chain)
     Workunit(WorkunitCli),
 
+    /// Inspectable local-first agent run trajectory artifacts
+    Trajectory(TrajectoryCli),
+
     /// Deterministic context capsule query over embedded constitution docs
     Capsule(CapsuleCli),
 
@@ -932,6 +935,69 @@ pub(crate) enum PlanCommand {
 pub(crate) struct WorkunitCli {
     #[clap(subcommand)]
     pub command: WorkunitCommand,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct TrajectoryCli {
+    #[clap(subcommand)]
+    pub command: TrajectoryCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum TrajectoryCommand {
+    /// Create a trajectory artifact for an agent run
+    Init {
+        #[clap(long)]
+        run_id: String,
+        #[clap(long)]
+        task_id: Option<String>,
+        #[clap(long)]
+        original_intent: String,
+        #[clap(long)]
+        derived_intent: String,
+        #[clap(long = "boundary")]
+        active_boundaries: Vec<String>,
+        #[clap(long = "scope")]
+        repo_scope: Vec<String>,
+    },
+    /// Record inspected files, actions, checks, assumptions, and completion claims
+    Record {
+        #[clap(long)]
+        run_id: String,
+        #[clap(long = "boundary")]
+        active_boundaries: Vec<String>,
+        #[clap(long = "scope")]
+        repo_scope: Vec<String>,
+        #[clap(long = "inspected-file")]
+        inspected_files: Vec<String>,
+        #[clap(long = "modified-file")]
+        modified_files: Vec<String>,
+        #[clap(long = "command")]
+        declared_commands: Vec<String>,
+        #[clap(long = "tool-call")]
+        tool_calls: Vec<String>,
+        /// Check in name=status form: passed, failed, partial, or unavailable
+        #[clap(long = "check")]
+        checks: Vec<String>,
+        #[clap(long = "evidence")]
+        evidence: Vec<String>,
+        #[clap(long = "shortcut-signal")]
+        shortcut_risk_signals: Vec<String>,
+        #[clap(long = "assumption")]
+        unresolved_assumptions: Vec<String>,
+        #[clap(long)]
+        completion_claim: Option<String>,
+    },
+    /// Inspect a trajectory artifact and its computed proof/verdict status
+    Get {
+        #[clap(long)]
+        run_id: String,
+    },
+    /// Show compact trajectory proof status
+    Status {
+        #[clap(long)]
+        run_id: String,
+    },
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -398,6 +398,10 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 3. **Evidence-Based Claims**: Claims of completion must be tied to measured evidence.
 4. **Clarification Trigger**: Stop if a critical assumption cannot be proven.
 
+## Run-Level Trajectory and Proof
+Record a local artifact under `.decapod/governance/trajectories/`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`.
+Use `decapod govern trajectory init --run-id <run-id> --original-intent "..." --derived-intent "..." --boundary "..." --scope "..."` and `decapod govern trajectory record --run-id <run-id> --inspected-file <path> --check "name=status"`.
+Completion claims never prove completion: `passed`, `failed`, `partial`, `unavailable`, and `no_checks_run` remain distinct, and no checks means an `unsupported` completion verdict.
 ## Invariants (Normative)
 - **INV-DAEMONLESS**: Decapod MUST NOT leave background processes running.
 - **INV-BOUNDED-VALIDATE**: `decapod validate` MUST terminate within bounded time.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -49,6 +49,7 @@ pub mod store;
 pub mod time;
 pub mod todo;
 pub mod trace;
+pub mod trajectory;
 pub mod ulid;
 pub mod validate;
 pub mod validation_epoch;

--- a/src/core/trajectory.rs
+++ b/src/core/trajectory.rs
@@ -1,0 +1,522 @@
+//! Local-first run trajectory artifacts.
+//!
+//! A trajectory records the evidence needed to inspect an agent run beyond
+//! its final diff. It is deliberately explicit and append-by-update: agents
+//! declare intent, boundaries, context, actions, checks, assumptions, and
+//! completion claims while Decapod computes proof status and lightweight
+//! verdicts from the recorded evidence.
+
+use crate::core::error;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const TRAJECTORY_SCHEMA_VERSION: &str = "1.0.0";
+pub const TRAJECTORY_DIR: &str = ".decapod/governance/trajectories";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryCheckStatus {
+    Passed,
+    Failed,
+    Partial,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TrajectoryCheck {
+    pub name: String,
+    pub status: TrajectoryCheckStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryProofStatus {
+    Passed,
+    Failed,
+    Partial,
+    Unavailable,
+    NoChecksRun,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryVerdict {
+    Supported,
+    Caution,
+    Unsupported,
+    Unassessed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrajectoryVerdicts {
+    pub intent_alignment: TrajectoryVerdict,
+    pub boundary_discipline: TrajectoryVerdict,
+    pub shortcut_risk: TrajectoryVerdict,
+    pub completion_proof: TrajectoryVerdict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrajectoryArtifact {
+    pub schema_version: String,
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    pub original_intent: String,
+    pub derived_intent: String,
+    pub active_boundaries: Vec<String>,
+    pub repo_scope: Vec<String>,
+    pub inspected_files: Vec<String>,
+    pub modified_files: Vec<String>,
+    pub declared_commands: Vec<String>,
+    pub tool_calls: Vec<String>,
+    pub checks: Vec<TrajectoryCheck>,
+    pub evidence: Vec<String>,
+    pub shortcut_risk_signals: Vec<String>,
+    pub unresolved_assumptions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_claim: Option<String>,
+    pub proof_status: TrajectoryProofStatus,
+    pub verdicts: TrajectoryVerdicts,
+    pub artifact_hash: String,
+}
+
+#[derive(Debug, Default)]
+pub struct TrajectoryUpdate {
+    pub active_boundaries: Vec<String>,
+    pub repo_scope: Vec<String>,
+    pub inspected_files: Vec<String>,
+    pub modified_files: Vec<String>,
+    pub declared_commands: Vec<String>,
+    pub tool_calls: Vec<String>,
+    pub checks: Vec<TrajectoryCheck>,
+    pub evidence: Vec<String>,
+    pub shortcut_risk_signals: Vec<String>,
+    pub unresolved_assumptions: Vec<String>,
+    pub completion_claim: Option<String>,
+}
+
+impl TrajectoryArtifact {
+    pub fn canonicalized(&self) -> Self {
+        let mut out = self.clone();
+        for values in [
+            &mut out.active_boundaries,
+            &mut out.repo_scope,
+            &mut out.inspected_files,
+            &mut out.modified_files,
+            &mut out.declared_commands,
+            &mut out.tool_calls,
+            &mut out.evidence,
+            &mut out.shortcut_risk_signals,
+            &mut out.unresolved_assumptions,
+        ] {
+            values.sort();
+            values.dedup();
+        }
+        out.checks.sort();
+        out.checks.dedup_by(|left, right| left.name == right.name);
+        out.proof_status = compute_proof_status(&out.checks);
+        out.verdicts = compute_verdicts(&out);
+        out.artifact_hash.clear();
+        out
+    }
+
+    pub fn canonical_json_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(&self.canonicalized())
+    }
+
+    pub fn computed_hash_hex(&self) -> Result<String, serde_json::Error> {
+        let mut hasher = Sha256::new();
+        hasher.update(self.canonical_json_bytes()?);
+        Ok(format!("sha256:{:x}", hasher.finalize()))
+    }
+
+    pub fn with_recomputed_hash(&self) -> Result<Self, serde_json::Error> {
+        let mut out = self.canonicalized();
+        out.artifact_hash = out.computed_hash_hex()?;
+        Ok(out)
+    }
+}
+
+pub fn trajectory_path(project_root: &Path, run_id: &str) -> Result<PathBuf, error::DecapodError> {
+    validate_run_id(run_id)?;
+    Ok(project_root
+        .join(TRAJECTORY_DIR)
+        .join(format!("{run_id}.json")))
+}
+
+pub fn validate_run_id(run_id: &str) -> Result<(), error::DecapodError> {
+    if run_id.is_empty()
+        || !run_id.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        })
+    {
+        return Err(error::DecapodError::ValidationError(format!(
+            "invalid run_id '{run_id}': allowed characters are [A-Za-z0-9_-]"
+        )));
+    }
+    Ok(())
+}
+
+pub fn init_trajectory(
+    project_root: &Path,
+    run_id: &str,
+    task_id: Option<String>,
+    original_intent: String,
+    derived_intent: String,
+    active_boundaries: Vec<String>,
+    repo_scope: Vec<String>,
+) -> Result<TrajectoryArtifact, error::DecapodError> {
+    let path = trajectory_path(project_root, run_id)?;
+    if path.exists() {
+        return Err(error::DecapodError::ValidationError(format!(
+            "trajectory '{run_id}' already exists"
+        )));
+    }
+    if original_intent.trim().is_empty() || derived_intent.trim().is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "trajectory requires non-empty original_intent and derived_intent".to_string(),
+        ));
+    }
+
+    let artifact = TrajectoryArtifact {
+        schema_version: TRAJECTORY_SCHEMA_VERSION.to_string(),
+        run_id: run_id.to_string(),
+        task_id,
+        original_intent,
+        derived_intent,
+        active_boundaries,
+        repo_scope,
+        inspected_files: Vec::new(),
+        modified_files: Vec::new(),
+        declared_commands: Vec::new(),
+        tool_calls: Vec::new(),
+        checks: Vec::new(),
+        evidence: Vec::new(),
+        shortcut_risk_signals: Vec::new(),
+        unresolved_assumptions: Vec::new(),
+        completion_claim: None,
+        proof_status: TrajectoryProofStatus::NoChecksRun,
+        verdicts: TrajectoryVerdicts {
+            intent_alignment: TrajectoryVerdict::Unassessed,
+            boundary_discipline: TrajectoryVerdict::Unassessed,
+            shortcut_risk: TrajectoryVerdict::Supported,
+            completion_proof: TrajectoryVerdict::Unsupported,
+        },
+        artifact_hash: String::new(),
+    };
+    write_trajectory(project_root, &artifact)
+}
+
+pub fn load_trajectory(
+    project_root: &Path,
+    run_id: &str,
+) -> Result<TrajectoryArtifact, error::DecapodError> {
+    let path = trajectory_path(project_root, run_id)?;
+    if !path.exists() {
+        return Err(error::DecapodError::NotFound(format!(
+            "trajectory '{run_id}' not found at {}",
+            path.display()
+        )));
+    }
+    let raw = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    let artifact: TrajectoryArtifact = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "invalid trajectory artifact {}: {e}",
+            path.display()
+        ))
+    })?;
+    if artifact.schema_version != TRAJECTORY_SCHEMA_VERSION {
+        return Err(error::DecapodError::ValidationError(format!(
+            "unsupported trajectory schema version '{}'",
+            artifact.schema_version
+        )));
+    }
+    if artifact.run_id != run_id {
+        return Err(error::DecapodError::ValidationError(format!(
+            "trajectory artifact run_id '{}' does not match requested '{run_id}'",
+            artifact.run_id
+        )));
+    }
+    let expected_hash = artifact.computed_hash_hex().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "failed to compute trajectory artifact hash: {e}"
+        ))
+    })?;
+    if artifact.artifact_hash != expected_hash {
+        return Err(error::DecapodError::ValidationError(format!(
+            "trajectory artifact hash mismatch: expected {expected_hash}, found {}",
+            artifact.artifact_hash
+        )));
+    }
+    Ok(artifact)
+}
+
+pub fn write_trajectory(
+    project_root: &Path,
+    artifact: &TrajectoryArtifact,
+) -> Result<TrajectoryArtifact, error::DecapodError> {
+    let path = trajectory_path(project_root, &artifact.run_id)?;
+    let canonical = artifact.with_recomputed_hash().map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "failed to serialize trajectory artifact: {e}"
+        ))
+    })?;
+    let parent = path.parent().ok_or_else(|| {
+        error::DecapodError::ValidationError("invalid trajectory parent path".to_string())
+    })?;
+    fs::create_dir_all(parent).map_err(error::DecapodError::IoError)?;
+    let bytes = serde_json::to_vec_pretty(&canonical).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "failed to serialize trajectory artifact: {e}"
+        ))
+    })?;
+    fs::write(&path, bytes).map_err(error::DecapodError::IoError)?;
+    Ok(canonical)
+}
+
+pub fn record_trajectory(
+    project_root: &Path,
+    run_id: &str,
+    update: TrajectoryUpdate,
+) -> Result<TrajectoryArtifact, error::DecapodError> {
+    let mut artifact = load_trajectory(project_root, run_id)?;
+    artifact.active_boundaries.extend(update.active_boundaries);
+    artifact.repo_scope.extend(update.repo_scope);
+    artifact.inspected_files.extend(update.inspected_files);
+    artifact.modified_files.extend(update.modified_files);
+    artifact.declared_commands.extend(update.declared_commands);
+    artifact.tool_calls.extend(update.tool_calls);
+    for check in &update.checks {
+        artifact
+            .checks
+            .retain(|existing| existing.name != check.name);
+    }
+    artifact.checks.extend(update.checks);
+    artifact.evidence.extend(update.evidence);
+    artifact
+        .shortcut_risk_signals
+        .extend(update.shortcut_risk_signals);
+    artifact
+        .unresolved_assumptions
+        .extend(update.unresolved_assumptions);
+    if update.completion_claim.is_some() {
+        artifact.completion_claim = update.completion_claim;
+    }
+    write_trajectory(project_root, &artifact)
+}
+
+pub fn parse_check_spec(spec: &str) -> Result<TrajectoryCheck, error::DecapodError> {
+    let (name, status) = spec.split_once('=').ok_or_else(|| {
+        error::DecapodError::ValidationError(format!(
+            "invalid trajectory check '{spec}': expected name=status"
+        ))
+    })?;
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(error::DecapodError::ValidationError(
+            "trajectory check name cannot be empty".to_string(),
+        ));
+    }
+    let status = match status.trim().to_ascii_lowercase().as_str() {
+        "pass" | "passed" => TrajectoryCheckStatus::Passed,
+        "fail" | "failed" => TrajectoryCheckStatus::Failed,
+        "partial" => TrajectoryCheckStatus::Partial,
+        "unavailable" => TrajectoryCheckStatus::Unavailable,
+        other => {
+            return Err(error::DecapodError::ValidationError(format!(
+                "invalid trajectory check status '{other}': expected passed|failed|partial|unavailable"
+            )));
+        }
+    };
+    Ok(TrajectoryCheck {
+        name: name.to_string(),
+        status,
+    })
+}
+
+fn compute_proof_status(checks: &[TrajectoryCheck]) -> TrajectoryProofStatus {
+    if checks.is_empty() {
+        return TrajectoryProofStatus::NoChecksRun;
+    }
+    if checks
+        .iter()
+        .all(|check| check.status == TrajectoryCheckStatus::Passed)
+    {
+        return TrajectoryProofStatus::Passed;
+    }
+    if checks
+        .iter()
+        .any(|check| check.status == TrajectoryCheckStatus::Failed)
+    {
+        return TrajectoryProofStatus::Failed;
+    }
+    if checks
+        .iter()
+        .any(|check| check.status == TrajectoryCheckStatus::Partial)
+    {
+        return TrajectoryProofStatus::Partial;
+    }
+    if checks
+        .iter()
+        .all(|check| check.status == TrajectoryCheckStatus::Unavailable)
+    {
+        return TrajectoryProofStatus::Unavailable;
+    }
+    TrajectoryProofStatus::Partial
+}
+
+fn compute_verdicts(artifact: &TrajectoryArtifact) -> TrajectoryVerdicts {
+    let intent_alignment = if artifact.original_intent.trim().is_empty()
+        || artifact.derived_intent.trim().is_empty()
+    {
+        TrajectoryVerdict::Unassessed
+    } else {
+        TrajectoryVerdict::Supported
+    };
+    let boundary_discipline =
+        if artifact.active_boundaries.is_empty() || artifact.repo_scope.is_empty() {
+            TrajectoryVerdict::Unassessed
+        } else {
+            TrajectoryVerdict::Supported
+        };
+    let shortcut_risk = if artifact.shortcut_risk_signals.is_empty() {
+        TrajectoryVerdict::Supported
+    } else {
+        TrajectoryVerdict::Caution
+    };
+    let completion_proof = match artifact.proof_status {
+        TrajectoryProofStatus::Passed => TrajectoryVerdict::Supported,
+        TrajectoryProofStatus::Partial | TrajectoryProofStatus::Unavailable => {
+            TrajectoryVerdict::Caution
+        }
+        TrajectoryProofStatus::Failed | TrajectoryProofStatus::NoChecksRun => {
+            TrajectoryVerdict::Unsupported
+        }
+    };
+    TrajectoryVerdicts {
+        intent_alignment,
+        boundary_discipline,
+        shortcut_risk,
+        completion_proof,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn trajectory_creation_is_inspectable_and_unproven_without_checks() {
+        let temp = tempdir().unwrap();
+        let artifact = init_trajectory(
+            temp.path(),
+            "run_1",
+            Some("task_1".to_string()),
+            "original intent".to_string(),
+            "derived intent".to_string(),
+            vec!["src/**".to_string()],
+            vec!["src/lib.rs".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(artifact.proof_status, TrajectoryProofStatus::NoChecksRun);
+        assert_eq!(
+            artifact.verdicts.completion_proof,
+            TrajectoryVerdict::Unsupported
+        );
+        assert_eq!(load_trajectory(temp.path(), "run_1").unwrap(), artifact);
+    }
+
+    #[test]
+    fn trajectory_proof_status_distinguishes_check_outcomes() {
+        let temp = tempdir().unwrap();
+        init_trajectory(
+            temp.path(),
+            "run_2",
+            None,
+            "original".to_string(),
+            "derived".to_string(),
+            vec!["src/**".to_string()],
+            vec!["src/lib.rs".to_string()],
+        )
+        .unwrap();
+
+        let partial = record_trajectory(
+            temp.path(),
+            "run_2",
+            TrajectoryUpdate {
+                checks: vec![
+                    TrajectoryCheck {
+                        name: "cargo test".to_string(),
+                        status: TrajectoryCheckStatus::Passed,
+                    },
+                    TrajectoryCheck {
+                        name: "cargo clippy".to_string(),
+                        status: TrajectoryCheckStatus::Unavailable,
+                    },
+                ],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(partial.proof_status, TrajectoryProofStatus::Partial);
+
+        let failed = record_trajectory(
+            temp.path(),
+            "run_2",
+            TrajectoryUpdate {
+                checks: vec![TrajectoryCheck {
+                    name: "cargo test".to_string(),
+                    status: TrajectoryCheckStatus::Failed,
+                }],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(failed.proof_status, TrajectoryProofStatus::Failed);
+    }
+
+    #[test]
+    fn shortcut_signal_emits_caution_and_completion_claim_is_not_proof() {
+        let temp = tempdir().unwrap();
+        init_trajectory(
+            temp.path(),
+            "run_3",
+            None,
+            "original".to_string(),
+            "derived".to_string(),
+            vec!["src/**".to_string()],
+            vec!["src/lib.rs".to_string()],
+        )
+        .unwrap();
+        let artifact = record_trajectory(
+            temp.path(),
+            "run_3",
+            TrajectoryUpdate {
+                completion_claim: Some("done".to_string()),
+                shortcut_risk_signals: vec!["completion claimed before checks".to_string()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(artifact.completion_claim.as_deref(), Some("done"));
+        assert_eq!(artifact.proof_status, TrajectoryProofStatus::NoChecksRun);
+        assert_eq!(artifact.verdicts.shortcut_risk, TrajectoryVerdict::Caution);
+        assert_eq!(
+            artifact.verdicts.completion_proof,
+            TrajectoryVerdict::Unsupported
+        );
+    }
+
+    #[test]
+    fn check_specs_are_typed_and_reject_unknown_statuses() {
+        assert_eq!(
+            parse_check_spec("cargo test=passed").unwrap().status,
+            TrajectoryCheckStatus::Passed
+        );
+        assert!(parse_check_spec("cargo test=maybe").is_err());
+    }
+}

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -19,6 +19,7 @@ use crate::core::project_specs::{
 };
 use crate::core::scaffold::DECAPOD_GITIGNORE_RULES;
 use crate::core::store::{Store, StoreKind};
+use crate::core::trajectory;
 use crate::core::validation_epoch::{ValidationEpochMetadata, active_validation_epoch};
 use crate::core::workunit::{self, WorkUnitManifest, WorkUnitStatus};
 use crate::plan_governance;
@@ -2176,6 +2177,54 @@ fn validate_workunit_manifests_if_present(
 
     pass(
         &format!("Workunit manifest schema check passed for {files} file(s)"),
+        ctx,
+    );
+    Ok(())
+}
+
+fn validate_trajectory_artifacts_if_present(
+    ctx: &ValidationContext,
+    repo_root: &Path,
+) -> Result<(), error::DecapodError> {
+    info("Agent Trajectory Artifact Gate");
+
+    let trajectories_dir = repo_root.join(trajectory::TRAJECTORY_DIR);
+    if !trajectories_dir.exists() {
+        skip(
+            "No trajectory artifacts found; skipping trajectory artifact gate",
+            ctx,
+        );
+        return Ok(());
+    }
+
+    let mut files = 0usize;
+    for entry in fs::read_dir(&trajectories_dir).map_err(error::DecapodError::IoError)? {
+        let entry = entry.map_err(error::DecapodError::IoError)?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        files += 1;
+        let run_id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or_else(|| {
+                error::DecapodError::ValidationError(format!(
+                    "trajectory artifact has an invalid filename: {}",
+                    path.display()
+                ))
+            })?;
+        let artifact = trajectory::load_trajectory(repo_root, run_id)?;
+        if artifact.run_id != run_id {
+            return Err(error::DecapodError::ValidationError(format!(
+                "trajectory artifact run_id '{}' does not match filename '{}'",
+                artifact.run_id, run_id
+            )));
+        }
+    }
+
+    pass(
+        &format!("Trajectory artifact schema check passed for {files} file(s)"),
         ctx,
     );
     Ok(())
@@ -5932,6 +5981,13 @@ pub fn run_validation(
             ctx,
             "validate_workunit_manifests_if_present",
             validate_workunit_manifests_if_present(ctx, main_root)
+        );
+        gate!(
+            s,
+            timings,
+            ctx,
+            "validate_trajectory_artifacts_if_present",
+            validate_trajectory_artifacts_if_present(ctx, main_root)
         );
         gate!(
             s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6273,6 +6273,9 @@ fn run_govern_command(
         GovernCommand::Workunit(workunit_cli) => {
             run_workunit_command(workunit_cli, project_store, workspace_root)?
         }
+        GovernCommand::Trajectory(trajectory_cli) => {
+            run_trajectory_command(trajectory_cli, workspace_root)?
+        }
         GovernCommand::Capsule(capsule_cli) => {
             run_capsule_command(capsule_cli, project_store, workspace_root)?
         }
@@ -6423,6 +6426,102 @@ fn run_workunit_command(
         }
     }
 
+    Ok(())
+}
+
+fn run_trajectory_command(
+    trajectory_cli: TrajectoryCli,
+    workspace_root: &Path,
+) -> Result<(), error::DecapodError> {
+    match trajectory_cli.command {
+        TrajectoryCommand::Init {
+            run_id,
+            task_id,
+            original_intent,
+            derived_intent,
+            active_boundaries,
+            repo_scope,
+        } => {
+            let artifact = core::trajectory::init_trajectory(
+                workspace_root,
+                &run_id,
+                task_id,
+                original_intent,
+                derived_intent,
+                active_boundaries,
+                repo_scope,
+            )?;
+            let path = core::trajectory::trajectory_path(workspace_root, &run_id)?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "status": "ok",
+                    "marker": "TRAJECTORY_INITIALIZED",
+                    "path": path,
+                    "trajectory": artifact,
+                }))
+                .unwrap()
+            );
+        }
+        TrajectoryCommand::Record {
+            run_id,
+            active_boundaries,
+            repo_scope,
+            inspected_files,
+            modified_files,
+            declared_commands,
+            tool_calls,
+            checks,
+            evidence,
+            shortcut_risk_signals,
+            unresolved_assumptions,
+            completion_claim,
+        } => {
+            let checks = checks
+                .iter()
+                .map(|spec| core::trajectory::parse_check_spec(spec))
+                .collect::<Result<Vec<_>, _>>()?;
+            let artifact = core::trajectory::record_trajectory(
+                workspace_root,
+                &run_id,
+                core::trajectory::TrajectoryUpdate {
+                    active_boundaries,
+                    repo_scope,
+                    inspected_files,
+                    modified_files,
+                    declared_commands,
+                    tool_calls,
+                    checks,
+                    evidence,
+                    shortcut_risk_signals,
+                    unresolved_assumptions,
+                    completion_claim,
+                },
+            )?;
+            println!("{}", serde_json::to_string_pretty(&artifact).unwrap());
+        }
+        TrajectoryCommand::Get { run_id } => {
+            let artifact = core::trajectory::load_trajectory(workspace_root, &run_id)?;
+            println!("{}", serde_json::to_string_pretty(&artifact).unwrap());
+        }
+        TrajectoryCommand::Status { run_id } => {
+            let artifact = core::trajectory::load_trajectory(workspace_root, &run_id)?;
+            let path = core::trajectory::trajectory_path(workspace_root, &run_id)?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "status": "ok",
+                    "run_id": artifact.run_id,
+                    "proof_status": artifact.proof_status,
+                    "verdicts": artifact.verdicts,
+                    "completion_claim": artifact.completion_claim,
+                    "artifact_hash": artifact.artifact_hash,
+                    "path": path,
+                }))
+                .unwrap()
+            );
+        }
+    }
     Ok(())
 }
 

--- a/tests/trajectory_cli.rs
+++ b/tests/trajectory_cli.rs
@@ -1,0 +1,217 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn run_decapod(dir: &Path, args: &[&str], password: Option<&str>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_decapod"));
+    command
+        .current_dir(dir)
+        .args(args)
+        .env("DECAPOD_AGENT_ID", "trajectory-test-agent")
+        .env("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1")
+        .env("DECAPOD_VALIDATE_SKIP_TOOLING_GATES", "1");
+    if let Some(password) = password {
+        command.env("DECAPOD_SESSION_PASSWORD", password);
+    }
+    command.output().expect("run decapod")
+}
+
+fn setup_repo() -> (TempDir, PathBuf, String) {
+    let temp = TempDir::new().expect("create temp repository");
+    let root = temp.path().to_path_buf();
+    let git = Command::new("git")
+        .current_dir(&root)
+        .args(["init", "-b", "master"])
+        .output()
+        .expect("git init");
+    assert!(git.status.success());
+
+    let init = run_decapod(&root, &["init", "--force"], None);
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let session = run_decapod(&root, &["session", "acquire"], None);
+    assert!(session.status.success());
+    let password = String::from_utf8_lossy(&session.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("Password: ").map(str::to_string))
+        .expect("session password");
+    (temp, root, password)
+}
+
+fn json(output: &Output, operation: &str) -> Value {
+    assert!(
+        output.status.success(),
+        "{operation} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("JSON output")
+}
+
+#[test]
+fn trajectory_cli_records_scope_actions_checks_and_verdicts() {
+    let (_temp, root, password) = setup_repo();
+    let env_password = Some(password.as_str());
+    let init = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "init",
+            "--run-id",
+            "run_cli_1",
+            "--task-id",
+            "task_cli_1",
+            "--original-intent",
+            "preserve intent",
+            "--derived-intent",
+            "implement bounded change",
+            "--boundary",
+            "src/**",
+            "--scope",
+            "src/lib.rs",
+        ],
+        env_password,
+    );
+    let init_json = json(&init, "trajectory init");
+    assert_eq!(init_json["marker"], "TRAJECTORY_INITIALIZED");
+
+    let record = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "record",
+            "--run-id",
+            "run_cli_1",
+            "--inspected-file",
+            "src/lib.rs",
+            "--modified-file",
+            "src/lib.rs",
+            "--command",
+            "cargo test --lib",
+            "--tool-call",
+            "decapod validate",
+            "--check",
+            "cargo_test=passed",
+            "--evidence",
+            ".decapod/generated/artifacts/proof.json",
+            "--assumption",
+            "existing interface remains compatible",
+            "--completion-claim",
+            "implemented and verified",
+        ],
+        env_password,
+    );
+    let record_json = json(&record, "trajectory record");
+    assert_eq!(record_json["proof_status"], "passed");
+    assert_eq!(record_json["verdicts"]["completion_proof"], "supported");
+    assert_eq!(record_json["inspected_files"][0], "src/lib.rs");
+    assert_eq!(record_json["checks"][0]["status"], "passed");
+
+    let status = run_decapod(
+        &root,
+        &["govern", "trajectory", "status", "--run-id", "run_cli_1"],
+        env_password,
+    );
+    let status_json = json(&status, "trajectory status");
+    assert_eq!(status_json["proof_status"], "passed");
+    assert!(
+        root.join(".decapod/governance/trajectories/run_cli_1.json")
+            .exists()
+    );
+}
+
+#[test]
+fn trajectory_cli_does_not_promote_completion_claim_without_checks() {
+    let (_temp, root, password) = setup_repo();
+    let env_password = Some(password.as_str());
+    let init = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "init",
+            "--run-id",
+            "run_cli_2",
+            "--original-intent",
+            "preserve intent",
+            "--derived-intent",
+            "bounded implementation",
+            "--boundary",
+            "src/**",
+            "--scope",
+            "src/lib.rs",
+        ],
+        env_password,
+    );
+    json(&init, "trajectory init");
+
+    let record = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "record",
+            "--run-id",
+            "run_cli_2",
+            "--completion-claim",
+            "done",
+        ],
+        env_password,
+    );
+    let record_json = json(&record, "trajectory record");
+    assert_eq!(record_json["completion_claim"], "done");
+    assert_eq!(record_json["proof_status"], "no_checks_run");
+    assert_eq!(record_json["verdicts"]["completion_proof"], "unsupported");
+}
+
+#[test]
+fn trajectory_cli_rejects_unknown_check_status() {
+    let (_temp, root, password) = setup_repo();
+    let env_password = Some(password.as_str());
+    let init = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "init",
+            "--run-id",
+            "run_cli_3",
+            "--original-intent",
+            "preserve intent",
+            "--derived-intent",
+            "bounded implementation",
+        ],
+        env_password,
+    );
+    json(&init, "trajectory init");
+
+    let record = run_decapod(
+        &root,
+        &[
+            "govern",
+            "trajectory",
+            "record",
+            "--run-id",
+            "run_cli_3",
+            "--check",
+            "cargo_test=maybe",
+        ],
+        env_password,
+    );
+    assert!(!record.status.success());
+    assert!(String::from_utf8_lossy(&record.stderr).contains("invalid trajectory check status"));
+}
+
+#[test]
+fn generated_agent_guidance_mentions_trajectory_proof() {
+    let (_temp, root, password) = setup_repo();
+    let _ = password;
+    let agents = std::fs::read_to_string(root.join("AGENTS.md")).expect("read AGENTS.md");
+    assert!(agents.contains("govern trajectory init"));
+    assert!(agents.contains("no_checks_run"));
+}

--- a/tests/validate_optional_artifact_gates.rs
+++ b/tests/validate_optional_artifact_gates.rs
@@ -323,6 +323,33 @@ fn validate_fails_on_invalid_workunit_manifest_if_present() {
 }
 
 #[test]
+fn validate_fails_on_invalid_trajectory_artifact_if_present() {
+    let (_tmp, dir, password) = setup_repo();
+    let trajectories = dir.join(".decapod").join("governance").join("trajectories");
+    fs::create_dir_all(&trajectories).expect("create trajectory directory");
+    fs::write(trajectories.join("run_BAD.json"), "{not-json").expect("write malformed trajectory");
+
+    let validate = run_decapod(
+        &dir,
+        &["validate", "--format", "json"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+        ],
+    );
+    assert!(
+        !validate.status.success(),
+        "validate should fail for malformed trajectory artifact"
+    );
+    let stderr = combined_output(&validate);
+    assert!(
+        stderr.contains("invalid trajectory artifact"),
+        "expected trajectory artifact parse failure in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn validate_fails_on_verified_workunit_missing_passing_proofs() {
     let (_tmp, dir, password) = setup_repo();
     let workunits = dir.join(".decapod").join("governance").join("workunits");


### PR DESCRIPTION
## Summary

- Implements Issue #678 with local-first JSON trajectory artifacts under `.decapod/governance/trajectories/`.
- Records original and derived intent, boundaries, repository scope, inspected and modified files, commands, tool calls, checks, evidence, shortcut-risk signals, assumptions, completion claims, and tamper-evident hashes.
- Computes distinct proof states (`passed`, `failed`, `partial`, `unavailable`, `no_checks_run`) and lightweight intent, boundary, shortcut, and completion verdicts.
- Adds `decapod govern trajectory init|record|get|status`, validation integrity checks, AGENTS guidance, living-spec contracts, and regression tests.
- Refreshes Decapod 0.73.0 entrypoint fingerprints, generated spec attestations, and workspace image version references.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (175 passed)
- `cargo test --test trajectory_cli` (4 passed)
- `cargo test --test validate_optional_artifact_gates validate_fails_on_invalid_trajectory_artifact_if_present` (passed)
- `cargo test --test entrypoint_correctness` (23 passed, 4 ignored)
- Aggregate integration coverage was otherwise passing, but `daemonless_lifecycle` observed transient Decapod processes during its snapshot and failed; this is recorded in the committed trajectory artifact.
- Host `decapod validate --format json` passed the trajectory gate but remains blocked by the expected container-workspace requirement and pre-existing claimed-TODO proof gates.

Closes #678