### PR TITLE
fix: make houseboat workspace cleanup recoverable

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.73.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.73.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.73.0
+ARG DECAPOD_VERSION=0.73.1
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784678209Z",
-  "repo_signal_fingerprint": "1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054",
+  "generated_at": "1784680225Z",
+  "repo_signal_fingerprint": "6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "0eea0815479a24524c92faaa1ce3f74ad9f126c9fd9244d117ff0ab4b04f795f",
-  "decapod_release": "0.73.0",
+  "spec_input_hash": "7f92daf3afb81bca2e86e36e371892263b965cb26dc65a02f5b0bbbc0d508cf9",
+  "decapod_release": "0.73.1",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "f72064e18ae8d35d7c294d320795ed055c05f21ad5eeb274bbf6c8cb57a42001",
-      "content_hash": "f72064e18ae8d35d7c294d320795ed055c05f21ad5eeb274bbf6c8cb57a42001",
-      "fingerprint": "4790634a1c27c7813fc06ca3dd514d80c8a87cee0475d16de7648049feb23499"
+      "template_hash": "b0a6ac18560dc2e1ee823669a5e8995e438fbf23d54419d4a28deb67c05b68f7",
+      "content_hash": "b0a6ac18560dc2e1ee823669a5e8995e438fbf23d54419d4a28deb67c05b68f7",
+      "fingerprint": "6591da6a49b2929317e7c0f8c903cbc783167214b2056a924d2cf82a498af08c"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "050541837a08eb954f2aa63993bbd8be5ad16f97d22d719bbf88f32f111d6fcf",
-      "content_hash": "050541837a08eb954f2aa63993bbd8be5ad16f97d22d719bbf88f32f111d6fcf",
-      "fingerprint": "9e1289f3d0a0bf67ef7a92fefac26c2d4ad0cdac9da0a1b61bc8664335d9e54d"
+      "template_hash": "5fda941297740adddaef3cf50124df42e6211f25d1c77a818e3ed9106c4a1392",
+      "content_hash": "5fda941297740adddaef3cf50124df42e6211f25d1c77a818e3ed9106c4a1392",
+      "fingerprint": "5cd79e4bfa6c5681ba9533129305ed2e68b3692f6ef69815b1f536bb6541f599"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "13e8fffd734849c4ac726a04c9736b78b47686c245d1406a9084a7a59ef6b96a",
-      "content_hash": "13e8fffd734849c4ac726a04c9736b78b47686c245d1406a9084a7a59ef6b96a",
-      "fingerprint": "fab8b8f97c6fa17508a0dbc6d8df9c1f366ef5bf0a7aaff4397f71eff23da9d8"
+      "template_hash": "05e771884ed3425639f93fca39037a8e11a5726396e79dcf6c3aa2856ce110b6",
+      "content_hash": "05e771884ed3425639f93fca39037a8e11a5726396e79dcf6c3aa2856ce110b6",
+      "fingerprint": "3dde6470a77319105a61f7b72b040c8aa314a1e3a4fd8db30421f16cb3b6fcd3"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "1b9eee683660985ec80084da40fd17bf1149800fef9d9a361591367a4d3a93f5",
-      "content_hash": "1b9eee683660985ec80084da40fd17bf1149800fef9d9a361591367a4d3a93f5",
-      "fingerprint": "3135bc3cdbf0e209307cdba02e05e246683d137b6db9c345c53d551f64f2ac17"
+      "template_hash": "3e0b8b9da226399382a822a427f74ce76efdc4ac9cb3fe4f4e5fc41291f9c310",
+      "content_hash": "3e0b8b9da226399382a822a427f74ce76efdc4ac9cb3fe4f4e5fc41291f9c310",
+      "fingerprint": "5a1e52b73dc79f7205a9d4908bc7fd5683818c924a275f2b317a614fecf43b1b"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "abac429aa379660951fe0f9ce86f22e103b7e3a8b9cb9e3be3ab57bf086854da",
+      "content_hash": "af819ec7be201db84da186a6333a9087b133bc057b1264c5eea56e3bcad61bdb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "5f21f1dfd819848522121bdb75fddc3e305744970647425d342e41e6588c9394",
+      "content_hash": "afe24f2c742ce535bd4e9b9fcda35840c9d252cef97115d8d56d300e0bb467f8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "69cf0af99ffe605d42f112836e778887992abd2f44ddcef61106ba00ccf1491b",
+      "content_hash": "46d2e22a6e8c3ff3cd085298256b1613f861a2babeff03383398ea3593cfb669",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "6d596b4a3f8616bf0ec3e2de0a9bbe57629430548cab37446350fca4022c6711",
+      "content_hash": "b28e6847dbf0df0a9dcdd1e9d60bf832fdf3d60282af8d0a11e27c5d129f6015",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "708fe20ef80032b452a51806805ee518a9014689dc9c37e0f5d5020042ff5ea5",
+      "content_hash": "5f3e83357c3f4a314ea23421684a8f84c92c4c29220ba3195b6e0c39e47bf80f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "9b7ae2ea85122eed6ff78f929648efecad6196b10017f40feeb659b5074c1669",
+      "content_hash": "b3f7667a6430968df0188e4c49f41334fc6b0e866fc8901cb0081d08556b3018",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "e59717a55f49e0d711e560b884d5fd214f4c674ea50a582aa6e75bea21d43808",
+      "content_hash": "6a41e3ce466c08d1d2e60554802031cfce4b0c3bc309c675ff6583341f154d3e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "44e7b8845f9451b69163554b6d527137dc36b43c4f86311160a6d165f537a0a9",
+      "content_hash": "95ca377146b6cd4f2ea5fb3cf40d28e9a372192c030588026d935619dd46c863",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -397,7 +397,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -407,7 +407,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -269,7 +269,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `1955f6e6d4c17dbc083d13b1242d492103176f4b7d93cb1810cc3a6552be5054`
+- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.0 -->
-<!-- decapod-fingerprint: 4790634a1c27c7813fc06ca3dd514d80c8a87cee0475d16de7648049feb23499 -->
+<!-- decapod-release: 0.73.1 -->
+<!-- decapod-fingerprint: 6591da6a49b2929317e7c0f8c903cbc783167214b2056a924d2cf82a498af08c -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.0 -->
-<!-- decapod-fingerprint: 9e1289f3d0a0bf67ef7a92fefac26c2d4ad0cdac9da0a1b61bc8664335d9e54d -->
+<!-- decapod-release: 0.73.1 -->
+<!-- decapod-fingerprint: 5cd79e4bfa6c5681ba9533129305ed2e68b3692f6ef69815b1f536bb6541f599 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.0 -->
-<!-- decapod-fingerprint: 3135bc3cdbf0e209307cdba02e05e246683d137b6db9c345c53d551f64f2ac17 -->
+<!-- decapod-release: 0.73.1 -->
+<!-- decapod-fingerprint: 5a1e52b73dc79f7205a9d4908bc7fd5683818c924a275f2b317a614fecf43b1b -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.0 -->
-<!-- decapod-fingerprint: fab8b8f97c6fa17508a0dbc6d8df9c1f366ef5bf0a7aaff4397f71eff23da9d8 -->
+<!-- decapod-release: 0.73.1 -->
+<!-- decapod-fingerprint: 3dde6470a77319105a61f7b72b040c8aa314a1e3a4fd8db30421f16cb3b6fcd3 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -6391,17 +6391,37 @@ fn validate_stale_workspaces(
     }
 
     use crate::core::{container_runtime, workspace};
-    match workspace::prune_workspaces(working_root, false) {
-        Ok(pruned) => {
-            if pruned.is_empty() {
+    match workspace::prune_workspaces_report(working_root, false) {
+        Ok(report) => {
+            if report.pruned.is_empty() && report.skipped.is_empty() {
                 pass("No stale workspaces found to clean up", ctx);
-            } else {
-                let list: Vec<String> = pruned
+            } else if !report.pruned.is_empty() {
+                let list: Vec<String> = report
+                    .pruned
                     .iter()
                     .map(|pw| format!("{} ({})", pw.path, pw.reason))
                     .collect();
                 pass(
                     &format!("Successfully pruned stale workspaces: {}", list.join(", ")),
+                    ctx,
+                );
+            }
+            if !report.skipped.is_empty() {
+                let list: Vec<String> = report
+                    .skipped
+                    .iter()
+                    .map(|workspace| {
+                        format!(
+                            "{} ({}: {})",
+                            workspace.path, workspace.reason, workspace.detail
+                        )
+                    })
+                    .collect();
+                warn(
+                    &format!(
+                        "Stale workspaces preserved for explicit review: {}",
+                        list.join(", ")
+                    ),
                     ctx,
                 );
             }

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -1567,8 +1567,26 @@ pub fn get_allowed_ops(status: &WorkspaceStatus) -> Vec<AllowedOp> {
 pub struct PrunedWorkspace {
     /// Absolute path of the pruned workspace
     pub path: String,
-    /// Reason for pruning: not_registered, branch_deleted, no_matching_task, task_completed, no_active_claim
+    /// Reason for pruning: branch_deleted, no_matching_task, task_completed, no_active_claim, not_registered
     pub reason: String,
+}
+
+/// Workspace that was identified as stale but intentionally preserved.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SkippedWorkspace {
+    /// Absolute path of the preserved workspace.
+    pub path: String,
+    /// Why automatic cleanup was skipped.
+    pub reason: String,
+    /// Actionable explanation for the operator or agent.
+    pub detail: String,
+}
+
+/// Result of a stale workspace cleanup pass.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WorkspacePruneReport {
+    pub pruned: Vec<PrunedWorkspace>,
+    pub skipped: Vec<SkippedWorkspace>,
 }
 
 /// Prune stale/unused agent workspaces
@@ -1576,10 +1594,21 @@ pub fn prune_workspaces(
     repo_root: &Path,
     force: bool,
 ) -> Result<Vec<PrunedWorkspace>, DecapodError> {
+    Ok(prune_workspaces_report(repo_root, force)?.pruned)
+}
+
+/// Prune stale/unused agent workspaces and report candidates preserved by safety gates.
+pub fn prune_workspaces_report(
+    repo_root: &Path,
+    force: bool,
+) -> Result<WorkspacePruneReport, DecapodError> {
     let main_repo = get_main_repo_root(repo_root)?;
     let workspaces_dir = main_repo.join(".decapod").join("workspaces");
     if !workspaces_dir.is_dir() {
-        return Ok(vec![]);
+        return Ok(WorkspacePruneReport {
+            pruned: vec![],
+            skipped: vec![],
+        });
     }
 
     // 1) Parse all current git worktrees
@@ -1645,6 +1674,7 @@ pub fn prune_workspaces(
     };
 
     let mut pruned = Vec::new();
+    let mut skipped = Vec::new();
     let process_dir = std::env::current_dir().ok();
 
     // 3) Iterate over the directory entries under .decapod/workspaces/
@@ -1803,8 +1833,37 @@ pub fn prune_workspaces(
         }
 
         if is_stale {
-            if container_runtime::container_runtime_available() {
-                let _ = container_runtime::remove_workspace_images_for_path(&dir_path);
+            if !force {
+                if matching_wt.is_none() {
+                    skipped.push(SkippedWorkspace {
+                        path: dir_path.to_string_lossy().to_string(),
+                        reason: "unregistered_workspace".to_string(),
+                        detail: "workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files".to_string(),
+                    });
+                    continue;
+                }
+
+                match worktree_is_dirty(&dir_path) {
+                    Ok(true) => {
+                        skipped.push(SkippedWorkspace {
+                            path: dir_path.to_string_lossy().to_string(),
+                            reason: "dirty_workspace".to_string(),
+                            detail: "workspace contains tracked or untracked changes; preserve or review them before rerunning with --force".to_string(),
+                        });
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        skipped.push(SkippedWorkspace {
+                            path: dir_path.to_string_lossy().to_string(),
+                            reason: "workspace_status_unavailable".to_string(),
+                            detail: format!(
+                                "could not establish that the workspace is clean: {error}; rerun after inspection or use --force deliberately"
+                            ),
+                        });
+                        continue;
+                    }
+                }
             }
 
             // Attempt to remove git worktree if registered
@@ -1815,10 +1874,39 @@ pub fn prune_workspaces(
                 }
                 args.push(dir_path.to_str().unwrap_or("."));
 
-                let _ = Command::new("git")
+                let remove_output = Command::new("git")
                     .args(["-C", main_repo.to_str().unwrap_or(".")])
                     .args(&args)
                     .output();
+                match remove_output {
+                    Ok(output) if output.status.success() || force => {}
+                    Ok(output) => {
+                        skipped.push(SkippedWorkspace {
+                            path: dir_path.to_string_lossy().to_string(),
+                            reason: "git_remove_failed".to_string(),
+                            detail: format!(
+                                "git refused worktree removal: {}; no files were deleted",
+                                String::from_utf8_lossy(&output.stderr).trim()
+                            ),
+                        });
+                        continue;
+                    }
+                    Err(error) if !force => {
+                        skipped.push(SkippedWorkspace {
+                            path: dir_path.to_string_lossy().to_string(),
+                            reason: "git_remove_failed".to_string(),
+                            detail: format!(
+                                "could not invoke git for worktree removal: {error}; no files were deleted"
+                            ),
+                        });
+                        continue;
+                    }
+                    Err(_) => {}
+                }
+            }
+
+            if container_runtime::container_runtime_available() {
+                let _ = container_runtime::remove_workspace_images_for_path(&dir_path);
             }
 
             // Fallback: forcefully remove from disk if it still exists
@@ -1836,7 +1924,27 @@ pub fn prune_workspaces(
     // Call prune_stale_worktree_config to scrub .git/config entries
     let _ = prune_stale_worktree_config(repo_root);
 
-    Ok(pruned)
+    Ok(WorkspacePruneReport { pruned, skipped })
+}
+
+fn worktree_is_dirty(path: &Path) -> Result<bool, DecapodError> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            path.to_str().unwrap_or("."),
+            "status",
+            "--porcelain=1",
+            "--untracked-files=all",
+        ])
+        .output()
+        .map_err(DecapodError::IoError)?;
+    if !output.status.success() {
+        return Err(DecapodError::ValidationError(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(!output.stdout.is_empty())
 }
 
 fn workspace_image_tag(agent_id: &str, branch: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7627,12 +7627,13 @@ fn run_workspace_command(
             );
         }
         WorkspaceCommand::Prune { force } => {
-            let pruned = workspace::prune_workspaces(project_root, force)?;
+            let report = workspace::prune_workspaces_report(project_root, force)?;
             println!(
                 "{}",
                 serde_json::json!({
                     "status": "ok",
-                    "pruned": pruned,
+                    "pruned": report.pruned,
+                    "skipped": report.skipped,
                 })
             );
         }

--- a/tests/workspace_prune_regression.rs
+++ b/tests/workspace_prune_regression.rs
@@ -362,6 +362,113 @@ fn test_workspace_prune_unmerged_prevention() {
 }
 
 #[test]
+fn test_workspace_prune_non_force_preserves_dirty_and_unregistered_data() {
+    let tmp = tempdir().expect("tempdir");
+    let main_root = tmp.path().join("main_repo");
+    fs::create_dir_all(&main_root).expect("create main_repo");
+
+    git_init(&main_root);
+    git_commit(&main_root, "init");
+
+    let store_root = main_root.join(".decapod").join("data");
+    fs::create_dir_all(&store_root).expect("create data dir");
+    initialize_todo_db(&store_root).expect("init todo db");
+    let store = Store {
+        kind: StoreKind::Repo,
+        root: store_root.clone(),
+    };
+
+    let task = add_task(
+        &store_root,
+        &TodoCommand::Add {
+            title: "Dirty stale workspace".to_string(),
+            description: "".to_string(),
+            tags: "".to_string(),
+            owner: "test-agent".to_string(),
+            due: None,
+            r#ref: "".to_string(),
+            scope: "".to_string(),
+            dir: Some(main_root.to_string_lossy().to_string()),
+            priority: "medium".to_string(),
+            depends_on: "".to_string(),
+            blocks: "".to_string(),
+            parent: None,
+            one_shot: 0,
+        },
+    )
+    .expect("add task");
+    let task_id = task.get("id").unwrap().as_str().unwrap();
+    let db_path = decapod::core::todo::todo_db_path(&store_root);
+    let conn = rusqlite::Connection::open(&db_path).expect("open todo db");
+    conn.execute(
+        "UPDATE tasks SET hash = 'hashdirty' WHERE id = ?",
+        [task_id],
+    )
+    .expect("update task hash");
+    claim_task(&store_root, task_id, "test-agent", ClaimMode::Exclusive).expect("claim task");
+    update_status(&store, task_id, "done", "task.done", serde_json::json!({}))
+        .expect("complete task");
+
+    let workspaces_dir = main_root.join(".decapod").join("workspaces");
+    fs::create_dir_all(&workspaces_dir).expect("create workspaces dir");
+    let dirty_path = workspaces_dir.join("test-agent-todo-hashdirty-dirty");
+    run_git_cmd(
+        &main_root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "agent/test-agent/todo-hashdirty",
+            dirty_path.to_str().unwrap(),
+        ],
+    );
+    fs::write(dirty_path.join("uncommitted.txt"), "preserve me").expect("write uncommitted change");
+
+    let orphan_path = workspaces_dir.join("orphaned-houseboat-workspace");
+    fs::create_dir_all(&orphan_path).expect("create orphan workspace");
+    fs::write(orphan_path.join("evidence.txt"), "inspect me").expect("write orphan evidence");
+
+    let report =
+        workspace::prune_workspaces_report(&main_root, false).expect("non-force prune report");
+    assert!(dirty_path.exists(), "dirty workspace must be preserved");
+    assert!(orphan_path.exists(), "orphan workspace must be preserved");
+    assert!(report.pruned.is_empty());
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|workspace| workspace.path == dirty_path.to_string_lossy()
+                && workspace.reason == "dirty_workspace")
+    );
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|workspace| workspace.path == orphan_path.to_string_lossy()
+                && workspace.reason == "unregistered_workspace")
+    );
+
+    let forced = workspace::prune_workspaces_report(&main_root, true).expect("force prune report");
+    assert!(!dirty_path.exists(), "force must remove the stale worktree");
+    assert!(
+        !orphan_path.exists(),
+        "force must remove the orphan workspace"
+    );
+    assert!(
+        forced
+            .pruned
+            .iter()
+            .any(|workspace| workspace.path == dirty_path.to_string_lossy())
+    );
+    assert!(
+        forced
+            .pruned
+            .iter()
+            .any(|workspace| workspace.path == orphan_path.to_string_lossy())
+    );
+}
+
+#[test]
 fn test_validate_stale_workspaces_cleanup() {
     let tmp = tempdir().expect("tempdir");
     let main_root = tmp.path().join("main_repo");


### PR DESCRIPTION
## Summary

Progresses Houseboat Issues #853 and #858 in one bounded slice.

- Make non-force stale workspace cleanup preserve dirty and unregistered directories instead of deleting them.
- Return machine-readable pruned/skipped cleanup results and surface preserved candidates during validation.
- Keep --force as the explicit destructive cleanup path.
- Add regression coverage for dirty and orphaned workspace data.
- Refresh Decapod 0.73.1 entrypoint, Dockerfile, and generated-spec fingerprints through the CLI.

## Verification

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib (175 passed)
- cargo test --test workspace_prune_regression (4 passed)

The broader Houseboat lifecycle and resilience issues remain open for follow-up work; this PR is a progress slice, not a full closure claim.