### PR TITLE
fix: initialize git quietly during init

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.73.1
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.73.2
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.73.1
+ARG DECAPOD_VERSION=0.73.2
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784680225Z",
-  "repo_signal_fingerprint": "6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3",
+  "generated_at": "1784687250Z",
+  "repo_signal_fingerprint": "259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "7f92daf3afb81bca2e86e36e371892263b965cb26dc65a02f5b0bbbc0d508cf9",
-  "decapod_release": "0.73.1",
+  "spec_input_hash": "d83100e85c2a80e299264746ef3a6f153d5b6eb8bbf10ccf4b48d5ad9c9b1de7",
+  "decapod_release": "0.73.2",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "b0a6ac18560dc2e1ee823669a5e8995e438fbf23d54419d4a28deb67c05b68f7",
-      "content_hash": "b0a6ac18560dc2e1ee823669a5e8995e438fbf23d54419d4a28deb67c05b68f7",
-      "fingerprint": "6591da6a49b2929317e7c0f8c903cbc783167214b2056a924d2cf82a498af08c"
+      "template_hash": "fb7976df287938465c1e94ee93687b8deba9b595f3aabe8d79a38ea9dd738a63",
+      "content_hash": "fb7976df287938465c1e94ee93687b8deba9b595f3aabe8d79a38ea9dd738a63",
+      "fingerprint": "39ec0738ab08b721c71957e6e54394163860179e72eb232bb7c8bc4351217f52"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "5fda941297740adddaef3cf50124df42e6211f25d1c77a818e3ed9106c4a1392",
-      "content_hash": "5fda941297740adddaef3cf50124df42e6211f25d1c77a818e3ed9106c4a1392",
-      "fingerprint": "5cd79e4bfa6c5681ba9533129305ed2e68b3692f6ef69815b1f536bb6541f599"
+      "template_hash": "f650ff0989ac90281fda1be940d2ad826192cdd259eb3fe6a0ddd4f033f6015b",
+      "content_hash": "f650ff0989ac90281fda1be940d2ad826192cdd259eb3fe6a0ddd4f033f6015b",
+      "fingerprint": "c6b791c97733e9f92f159a5ec060b72e02ffd6d5c76af0abdb3f15b0999d36f5"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "05e771884ed3425639f93fca39037a8e11a5726396e79dcf6c3aa2856ce110b6",
-      "content_hash": "05e771884ed3425639f93fca39037a8e11a5726396e79dcf6c3aa2856ce110b6",
-      "fingerprint": "3dde6470a77319105a61f7b72b040c8aa314a1e3a4fd8db30421f16cb3b6fcd3"
+      "template_hash": "be2f03585ab5c704b29bfe1d7b68b9fecb87569b35ae804d3b2a3c6681f1763e",
+      "content_hash": "be2f03585ab5c704b29bfe1d7b68b9fecb87569b35ae804d3b2a3c6681f1763e",
+      "fingerprint": "d352da8f3b589069287d4ade7f06ee6947df62836bd58d151db3a8937bf44037"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "3e0b8b9da226399382a822a427f74ce76efdc4ac9cb3fe4f4e5fc41291f9c310",
-      "content_hash": "3e0b8b9da226399382a822a427f74ce76efdc4ac9cb3fe4f4e5fc41291f9c310",
-      "fingerprint": "5a1e52b73dc79f7205a9d4908bc7fd5683818c924a275f2b317a614fecf43b1b"
+      "template_hash": "7ba56cbb900c77bf5c80e19b8f219c880740a703ec4e5db0d085aa74f6a61dbc",
+      "content_hash": "7ba56cbb900c77bf5c80e19b8f219c880740a703ec4e5db0d085aa74f6a61dbc",
+      "fingerprint": "5a97c4cbc5b646b4f0dc2168ccf0cfd6bd396617a8c6c1a996401f12154f8643"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "af819ec7be201db84da186a6333a9087b133bc057b1264c5eea56e3bcad61bdb",
+      "content_hash": "88e60b02556eb7799fa7eced831b8a881fbcdcd46f5d061bbdf5e58b6f3652d8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "afe24f2c742ce535bd4e9b9fcda35840c9d252cef97115d8d56d300e0bb467f8",
+      "content_hash": "01871c291b19d9f7ce2344403df18efe1352742bc165557fdd4260c7432d4ff9",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "46d2e22a6e8c3ff3cd085298256b1613f861a2babeff03383398ea3593cfb669",
+      "content_hash": "68cde7c57b1923122e867c093759c479fe3e4956c57d3df6e3b0c421ef292312",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "b28e6847dbf0df0a9dcdd1e9d60bf832fdf3d60282af8d0a11e27c5d129f6015",
+      "content_hash": "d3565152c5f77bee7bd8619df343dea260690ed93aed39687f4ec79db84b6f78",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "5f3e83357c3f4a314ea23421684a8f84c92c4c29220ba3195b6e0c39e47bf80f",
+      "content_hash": "83420b0ea624c94376bb5cc4c07e53df02d509ef5825007e599ecd981993590d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "b3f7667a6430968df0188e4c49f41334fc6b0e866fc8901cb0081d08556b3018",
+      "content_hash": "92b9d15d6d0aaf06a5335403ff5629f7cfeda0f5b64721cdd9d161b2f9547ab4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "6a41e3ce466c08d1d2e60554802031cfce4b0c3bc309c675ff6583341f154d3e",
+      "content_hash": "285905c18df898ce41c12a0dfcd1562dc3774f0274bf15b95755bef8da2edc2f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "95ca377146b6cd4f2ea5fb3cf40d28e9a372192c030588026d935619dd46c863",
+      "content_hash": "387e8187441b5de97f2356eabb36ebe188bd7ad6d6e57f56eebe111aaf564908",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -397,7 +397,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -407,7 +407,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -269,7 +269,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `6b738380a42160e61c06b70145a48577e4b2f0ccaf2982e2328e87f6a3a4e3c3`
+- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.1 -->
-<!-- decapod-fingerprint: 6591da6a49b2929317e7c0f8c903cbc783167214b2056a924d2cf82a498af08c -->
+<!-- decapod-release: 0.73.2 -->
+<!-- decapod-fingerprint: 39ec0738ab08b721c71957e6e54394163860179e72eb232bb7c8bc4351217f52 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.1 -->
-<!-- decapod-fingerprint: 5cd79e4bfa6c5681ba9533129305ed2e68b3692f6ef69815b1f536bb6541f599 -->
+<!-- decapod-release: 0.73.2 -->
+<!-- decapod-fingerprint: c6b791c97733e9f92f159a5ec060b72e02ffd6d5c76af0abdb3f15b0999d36f5 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.1 -->
-<!-- decapod-fingerprint: 5a1e52b73dc79f7205a9d4908bc7fd5683818c924a275f2b317a614fecf43b1b -->
+<!-- decapod-release: 0.73.2 -->
+<!-- decapod-fingerprint: 5a97c4cbc5b646b4f0dc2168ccf0cfd6bd396617a8c6c1a996401f12154f8643 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.1 -->
-<!-- decapod-fingerprint: 3dde6470a77319105a61f7b72b040c8aa314a1e3a4fd8db30421f16cb3b6fcd3 -->
+<!-- decapod-release: 0.73.2 -->
+<!-- decapod-fingerprint: d352da8f3b589069287d4ade7f06ee6947df62836bd58d151db3a8937bf44037 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,10 +240,10 @@ pub(crate) struct InitGroupCli {
     /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
-    /// Explicitly opt into local Git repository initialization.
+    /// Explicitly request local Git repository initialization (the default unless --no-git is set).
     #[clap(long = "git", action = clap::ArgAction::SetTrue)]
     pub git: bool,
-    /// Explicitly decline local Git repository initialization.
+    /// Skip local Git repository initialization.
     #[clap(long = "no-git", action = clap::ArgAction::SetTrue)]
     pub no_git: bool,
 }
@@ -369,10 +369,10 @@ pub(crate) struct InitWithCli {
     /// It does not perform login, provisioning, or sync during init.
     #[clap(long, value_enum, default_value_t = BackendType::Local)]
     pub mode: BackendType,
-    /// Explicitly opt into local Git repository initialization.
+    /// Explicitly request local Git repository initialization (the default unless --no-git is set).
     #[clap(long = "git", action = clap::ArgAction::SetTrue)]
     pub git: bool,
-    /// Explicitly decline local Git repository initialization.
+    /// Skip local Git repository initialization.
     #[clap(long = "no-git", action = clap::ArgAction::SetTrue)]
     pub no_git: bool,
 }

--- a/src/core/workspace.rs
+++ b/src/core/workspace.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Workspace status information
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -876,6 +876,8 @@ fn git_ref_exists(repo_root: &Path, git_ref: &str) -> bool {
             "--quiet",
             git_ref,
         ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
@@ -997,6 +999,8 @@ pub fn detect_base_branch(repo_root: &Path) -> Option<String> {
                 "--quiet",
                 &reference,
             ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .status()
             .map(|status| status.success())
             .unwrap_or(false);
@@ -2040,6 +2044,13 @@ mod tests {
         );
 
         assert_eq!(detect_base_branch(tmp.path()).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn detects_no_base_branch_outside_git_without_failing() {
+        let tmp = tempdir().expect("tempdir");
+
+        assert_eq!(detect_base_branch(tmp.path()), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2228,8 +2228,9 @@ pub fn run() -> Result<(), error::DecapodError> {
                     );
                     prompt_yes_no("Initialize Git repository for this project?", true)?
                 } else {
-                    // Non-interactive: do not automatically initialize git unless explicitly requested via --git
-                    false
+                    // Non-interactive init follows the same safe default as the prompt:
+                    // initialize Git unless the caller explicitly opted out with --no-git.
+                    true
                 };
 
                 if opt_in {

--- a/tests/entrypoint_correctness.rs
+++ b/tests/entrypoint_correctness.rs
@@ -129,7 +129,7 @@ fn test_validate_passes_after_init_without_git_repo() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let temp_path = temp_dir.path().to_path_buf();
 
-    let init = run_raw(&temp_path, &["init", "--force"], &[]);
+    let init = run_raw(&temp_path, &["init", "--force", "--no-git"], &[]);
     assert!(
         init.status.success(),
         "decapod init should succeed. Output:\n{}{}",

--- a/tests/git_init_regression.rs
+++ b/tests/git_init_regression.rs
@@ -70,6 +70,30 @@ fn test_init_in_non_git_directory_with_git_opt_in() {
 }
 
 #[test]
+fn test_init_in_non_git_directory_initializes_git_by_default() {
+    let tmp = TempDir::new().expect("tmpdir");
+    let dir = tmp.path();
+
+    let out = run_decapod(dir, &["init", "--force"], &[]);
+
+    assert!(
+        out.status.success(),
+        "decapod init should initialize Git by default: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        dir.join(".git").exists(),
+        "Expected .git to be created by init"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("fatal:") && !stderr.contains("error:"),
+        "expected Git probes to remain quiet, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_init_in_existing_git_repository_preserves_state() {
     let tmp = TempDir::new().expect("tmpdir");
     let dir = tmp.path();
@@ -183,10 +207,15 @@ fn test_init_with_no_git_declined() {
 
     // Verify stdout/stderr contains warning
     let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stdout.contains("Git repository was not initialized")
-            || String::from_utf8_lossy(&out.stderr).contains("Git repository was not initialized"),
+            || stderr.contains("Git repository was not initialized"),
         "Warning message should be printed"
+    );
+    assert!(
+        !stderr.contains("fatal:") && !stderr.contains("error:"),
+        "expected Git probe failures to remain quiet, got stderr: {stderr}"
     );
 }
 

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -821,6 +821,7 @@ fn init_supports_and_preserves_declared_capabilities() {
             "--declared-capability",
             "scheduled-jobs",
             "--force",
+            "--no-git",
         ],
     );
     assert!(
@@ -852,7 +853,7 @@ fn init_supports_and_preserves_declared_capabilities() {
     );
 
     // 2. Re-init with --force, and verify it PRESERVES them
-    let out = run_decapod(tmp.path(), &["init", "--force"]);
+    let out = run_decapod(tmp.path(), &["init", "--force", "--no-git"]);
     assert!(
         out.status.success(),
         "decapod init --force failed: {}",
@@ -937,7 +938,14 @@ fn init_validation_rejects_traversal_in_guided_paths() {
     let tmp = tempdir().expect("tempdir");
     let out = run_decapod(
         tmp.path(),
-        &["init", "with", "--protected-path", "../outside", "--force"],
+        &[
+            "init",
+            "with",
+            "--protected-path",
+            "../outside",
+            "--force",
+            "--no-git",
+        ],
     );
     assert!(
         out.status.success(),


### PR DESCRIPTION
## Summary

- Make non-interactive decapod init initialize a local Git repository by default when one is absent.
- Keep explicit --no-git as the opt-out for projects that intentionally do not want Git.
- Silence expected git show-ref probes outside a Git repository while preserving actionable git init failures.
- Add regression coverage for default initialization, explicit opt-out, and clean stderr.
- Refresh Decapod 0.73.2 entrypoint, Dockerfile, and generated-spec fingerprints through the CLI.

## Verification

- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib (176 passed)
- cargo test --test git_init_regression (5 passed)
- cargo test --test entrypoint_correctness (23 passed, 4 ignored)
- cargo test --test init_validate_green_field (5 passed)
- cargo test --test init_config_behavior (23 passed, 1 ignored)
- Direct rebuilt-binary init smoke test: .git created with no fatal or error output.