### PR TITLE
feat: expose governed trajectory motion status

### DIFF
--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784687250Z",
-  "repo_signal_fingerprint": "259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c",
+  "generated_at": "1784741496Z",
+  "repo_signal_fingerprint": "a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "d83100e85c2a80e299264746ef3a6f153d5b6eb8bbf10ccf4b48d5ad9c9b1de7",
-  "decapod_release": "0.73.2",
+  "spec_input_hash": "9275e0e24da126dd3f5f4a842acd5a79b8a3051ffae74d7ba07d49fcadc55cf7",
+  "decapod_release": "0.73.3",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "fb7976df287938465c1e94ee93687b8deba9b595f3aabe8d79a38ea9dd738a63",
-      "content_hash": "fb7976df287938465c1e94ee93687b8deba9b595f3aabe8d79a38ea9dd738a63",
-      "fingerprint": "39ec0738ab08b721c71957e6e54394163860179e72eb232bb7c8bc4351217f52"
+      "template_hash": "804ac88676c808beab16c66ff16d2d08598bfab9a80100724fc43e6dd10b6215",
+      "content_hash": "804ac88676c808beab16c66ff16d2d08598bfab9a80100724fc43e6dd10b6215",
+      "fingerprint": "860b43272d9969b04db56053085c099ca4c6db9b3bfc66b0a305773b05b3df54"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "f650ff0989ac90281fda1be940d2ad826192cdd259eb3fe6a0ddd4f033f6015b",
-      "content_hash": "f650ff0989ac90281fda1be940d2ad826192cdd259eb3fe6a0ddd4f033f6015b",
-      "fingerprint": "c6b791c97733e9f92f159a5ec060b72e02ffd6d5c76af0abdb3f15b0999d36f5"
+      "template_hash": "7384aa30a0dc3ad99f291e85de04c34b6f4f54833a6016cc688c99bb9d0afc06",
+      "content_hash": "7384aa30a0dc3ad99f291e85de04c34b6f4f54833a6016cc688c99bb9d0afc06",
+      "fingerprint": "32d75e5273c4108eb2710db53d399e2f9928918974941ec818b7cefc713b6642"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "be2f03585ab5c704b29bfe1d7b68b9fecb87569b35ae804d3b2a3c6681f1763e",
-      "content_hash": "be2f03585ab5c704b29bfe1d7b68b9fecb87569b35ae804d3b2a3c6681f1763e",
-      "fingerprint": "d352da8f3b589069287d4ade7f06ee6947df62836bd58d151db3a8937bf44037"
+      "template_hash": "ea96a87323c2669ef435b7395ebb4d4f9ba85a50fd3f819e8d757186481a49cd",
+      "content_hash": "ea96a87323c2669ef435b7395ebb4d4f9ba85a50fd3f819e8d757186481a49cd",
+      "fingerprint": "fb2ead69fa750219e79b75218d04377ec45dedf087c564fe3c8497072105d419"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "7ba56cbb900c77bf5c80e19b8f219c880740a703ec4e5db0d085aa74f6a61dbc",
-      "content_hash": "7ba56cbb900c77bf5c80e19b8f219c880740a703ec4e5db0d085aa74f6a61dbc",
-      "fingerprint": "5a97c4cbc5b646b4f0dc2168ccf0cfd6bd396617a8c6c1a996401f12154f8643"
+      "template_hash": "eda5cd7258255ed1ed830a7a5edf13d14bde2dd8c91b98959b9d4dcac412c79a",
+      "content_hash": "eda5cd7258255ed1ed830a7a5edf13d14bde2dd8c91b98959b9d4dcac412c79a",
+      "fingerprint": "5d3549368ad9d29a48ebed512569b283e953f2f90c04edc3c4373f399ecae988"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "7a85d851e4e267dd9eec6ae0dee0417fd6ff3dbca435bc92c6e9aa7c26487813",
-      "content_hash": "88e60b02556eb7799fa7eced831b8a881fbcdcd46f5d061bbdf5e58b6f3652d8",
+      "content_hash": "f2a678363ea4ab72085ec28eefe57398ae38110c3109632b711329ce761c6605",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "01871c291b19d9f7ce2344403df18efe1352742bc165557fdd4260c7432d4ff9",
+      "content_hash": "78a21ece3a8a864055a504ea1bf8e01a708c4d86e0cbd97d4e4b8357513ec574",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "68cde7c57b1923122e867c093759c479fe3e4956c57d3df6e3b0c421ef292312",
+      "content_hash": "f79339c249fde46d3ecf50bdc6e3aae429fb43fa990a00496e5b906595996681",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "d3565152c5f77bee7bd8619df343dea260690ed93aed39687f4ec79db84b6f78",
+      "content_hash": "adda49c25f6fe746d7c1b814cc1392ce43bcfa319e76e23ba7e9cad9d17aa78e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "66c5f8821df14298ff57951351980899465cce41a3e4de98c3893c00116e51fb",
-      "content_hash": "83420b0ea624c94376bb5cc4c07e53df02d509ef5825007e599ecd981993590d",
+      "content_hash": "06cedccf0b4068b3127fe5bcfce993a58450f87172beaf0a429d32cfa592d2a1",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "92b9d15d6d0aaf06a5335403ff5629f7cfeda0f5b64721cdd9d161b2f9547ab4",
+      "content_hash": "65f595dc1579b1e3c1fc04e7d143ee0ea2eb28b73dcc1f80641f9f4d685069fc",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "285905c18df898ce41c12a0dfcd1562dc3774f0274bf15b95755bef8da2edc2f",
+      "content_hash": "a31b9edd19c23d4e67db7e5a30e0835a07dc6f5b87130189270230607e7c4cd1",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "387e8187441b5de97f2356eabb36ebe188bd7ad6d6e57f56eebe111aaf564908",
+      "content_hash": "53f16ac9e74c04720511c4f782a4c165098fb091afa639b23a72d21a43d7a5a4",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -349,7 +349,7 @@ Verification and artifact emission:
 | knowledge.db | Repo store | `data knowledge add/search/promote` |
 | lcm.db | Repo store | `data context ingest/summarize` |
 | WorkUnit manifests | `.decapod/governance/workunits/` | `govern workunit.*` |
-| Trajectory artifacts | `.decapod/governance/trajectories/` | `govern trajectory.*` |
+| Trajectory cookie | `.decapod/governance/trajectory.json` | `govern trajectory.*`; Git history stores prior cookies |
 | Plan artifact | `.decapod/governance/plan.json` | `govern plan.*` |
 | Context capsules | `.decapod/generated/context/` | `infer.*`, `govern capsule.*` |
 | Capsule policy | `.decapod/generated/policy/` or override | `init`, `scaffold` |
@@ -397,7 +397,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -220,7 +220,7 @@ Response envelope (`RpcResponse`):
 | `.decapod/generated/policy/context_capsule_policy.json` | `init` / scaffold | Capsule query resolution |
 | `.decapod/generated/specs/*.md` | `init --force` / `rpc specs.refresh` | Validation, agents |
 | `.decapod/generated/artifacts/provenance/*.json` | `workspace publish` / `validate` | Promotion, CI |
-| `.decapod/governance/trajectories/*.json` | `govern trajectory` / `validate` | Run custody and proof review |
+| `.decapod/governance/trajectory.json` | `govern trajectory` / `validate` | Current run custody and proof review; historical states are recovered from Git |
 
 ## Error Taxonomy
 
@@ -407,7 +407,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -25,7 +25,7 @@ These files are the project-local contract for humans and agents.
 - `.decapod/generated/policy/context_capsule_policy.json`: repo-native JIT context policy contract.
 - `.decapod/generated/artifacts/provenance/`: promotion manifests and convergence checklist.
 - `.decapod/generated/artifacts/custody/`: epistemic custody artifacts (assumptions, contradictions, deferred questions).
-- `.decapod/governance/trajectories/`: local-first run trajectory artifacts with intent, scope, actions, checks, and proof verdicts.
+- `.decapod/governance/trajectory.json`: current local-first trajectory cookie with intent, scope, actions, checks, and proof verdicts; Git history is the historical store.
 - `.decapod/generated/artifacts/inventory/`: deterministic release inventory.
 - `.decapod/generated/artifacts/diagnostics/`: opt-in diagnostics artifacts.
 - `.decapod/workspaces/`: isolated todo-scoped git worktrees.
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -220,7 +220,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -250,7 +250,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -91,7 +91,7 @@ flowchart LR
 | Proof manifest | `.decapod/generated/artifacts/provenance/proof_manifest.json` | Promotion |
 | Artifact manifest | `.decapod/generated/artifacts/provenance/artifact_manifest.json` | Promotion |
 | Completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/*.json` | Reproducible completion review |
-| Trajectory artifacts | `.decapod/governance/trajectories/*.json` | Run-level custody schema, hash, and computed proof status |
+| Trajectory cookie | `.decapod/governance/trajectory.json` | Current run custody schema, hash, and computed proof status; Git history preserves prior cookies |
 | Imported completion evidence | `.decapod/generated/artifacts/provenance/completion_evidence/imports/*.json` | Untrusted external evidence inspection |
 | Test logs | CI artifact store | Promotion |
 | Architecture diagram | `ARCHITECTURE.md` (in specs) | Promotion |
@@ -269,7 +269,7 @@ No legacy `globex` or `codex` namespace references in repo text sources
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `259ca51ae8db07091f6cd1d14325ed07e4e21b19c68edd808c170610ad01137c`
+- Repository signal fingerprint: `a49bf87219aa3ca6743a96657b47ecba55a29b88ab0224260d103efe1fb417b3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (91 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -16,7 +16,21 @@
   ],
   "inspected_files": [],
   "modified_files": [
+    ".decapod/generated/specs/.manifest.json",
+    ".decapod/generated/specs/ARCHITECTURE.md",
+    ".decapod/generated/specs/INTENT.md",
+    ".decapod/generated/specs/INTERFACES.md",
+    ".decapod/generated/specs/OPERATIONS.md",
+    ".decapod/generated/specs/README.md",
+    ".decapod/generated/specs/SECURITY.md",
+    ".decapod/generated/specs/SEMANTICS.md",
+    ".decapod/generated/specs/VALIDATION.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODEX.md",
+    "GEMINI.md",
     "src/cli.rs",
+    "src/core/assets.rs",
     "src/core/trajectory.rs",
     "src/core/validate.rs",
     "src/lib.rs",
@@ -24,17 +38,24 @@
     "tests/validate_optional_artifact_gates.rs"
   ],
   "declared_commands": [
+    "cargo build --bin decapod",
     "cargo clippy --all-targets -- -D warnings",
     "cargo fmt --all",
     "cargo test --lib trajectory",
     "cargo test --test trajectory_cli",
     "cargo test --test validate_optional_artifact_gates validate_fails_on_invalid_trajectory_artifact_if_present",
-    "decapod validate --format json"
+    "decapod validate --format json",
+    "target/debug/decapod init --proof",
+    "target/debug/decapod rpc --op specs.refresh"
   ],
   "tool_calls": [
     "decapod rpc --op specs.refresh"
   ],
   "checks": [
+    {
+      "name": "cargo_build",
+      "status": "passed"
+    },
     {
       "name": "cargo_clippy",
       "status": "passed"
@@ -46,6 +67,14 @@
     {
       "name": "decapod_validate",
       "status": "failed"
+    },
+    {
+      "name": "entrypoint_regeneration",
+      "status": "passed"
+    },
+    {
+      "name": "specs_refresh",
+      "status": "passed"
     },
     {
       "name": "trajectory_cli",
@@ -61,6 +90,8 @@
     }
   ],
   "evidence": [
+    "entrypoint fingerprints regenerated from embedded contract",
+    "entrypoint release refs bumped to 0.73.3",
     "git history is the historical trajectory store; no per-run directory is authoritative",
     "single cookie path: .decapod/governance/trajectory.json",
     "src/core/trajectory.rs",
@@ -72,6 +103,7 @@
   "unresolved_assumptions": [
     "Generated release/fingerprint churn from specs.refresh is not part of this feature slice",
     "Git merge history is the reverse-lookup mechanism for prior trajectory cookies",
+    "Release-bound entrypoint metadata is refreshed with the current Decapod binary release; no new product version is invented in this PR",
     "The broader Houseboat issue programs remain open; this PR is a bounded progress slice for Issues #857 and #860"
   ],
   "proof_status": "failed",
@@ -81,5 +113,5 @@
     "shortcut_risk": "supported",
     "completion_proof": "unsupported"
   },
-  "artifact_hash": "sha256:4041ed9c1b1c34052b31f722dbba48e55a47b52219b925c3559984467bcbfca4"
+  "artifact_hash": "sha256:bed284687aa06835014dc2050f8e57c74dcdde9cc0653bf5806f87a8f3e14fd8"
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.0.0",
+  "run_id": "run_houseboat_trajectory_status",
+  "task_id": "feat_01ky5c74ep1pbghf",
+  "original_intent": "Complete a bounded Houseboat trajectory and observability slice in one PR",
+  "derived_intent": "Extend existing trajectory artifacts with explicit motion context and deterministic status output",
+  "active_boundaries": [
+    "src/**",
+    "tests/**"
+  ],
+  "repo_scope": [
+    "src/cli.rs",
+    "src/core/trajectory.rs",
+    "src/lib.rs",
+    "tests/trajectory_cli.rs"
+  ],
+  "inspected_files": [],
+  "modified_files": [
+    "src/cli.rs",
+    "src/core/trajectory.rs",
+    "src/core/validate.rs",
+    "src/lib.rs",
+    "tests/trajectory_cli.rs",
+    "tests/validate_optional_artifact_gates.rs"
+  ],
+  "declared_commands": [
+    "cargo clippy --all-targets -- -D warnings",
+    "cargo fmt --all",
+    "cargo test --lib trajectory",
+    "cargo test --test trajectory_cli",
+    "cargo test --test validate_optional_artifact_gates validate_fails_on_invalid_trajectory_artifact_if_present",
+    "decapod validate --format json"
+  ],
+  "tool_calls": [
+    "decapod rpc --op specs.refresh"
+  ],
+  "checks": [
+    {
+      "name": "cargo_clippy",
+      "status": "passed"
+    },
+    {
+      "name": "cargo_fmt",
+      "status": "passed"
+    },
+    {
+      "name": "decapod_validate",
+      "status": "failed"
+    },
+    {
+      "name": "trajectory_cli",
+      "status": "passed"
+    },
+    {
+      "name": "trajectory_cookie_validation",
+      "status": "passed"
+    },
+    {
+      "name": "trajectory_unit",
+      "status": "passed"
+    }
+  ],
+  "evidence": [
+    "git history is the historical trajectory store; no per-run directory is authoritative",
+    "single cookie path: .decapod/governance/trajectory.json",
+    "src/core/trajectory.rs",
+    "tests/trajectory_cli.rs",
+    "validation blockers: container_workspace_required; claimed_todos_unverified",
+    "validation: container_workspace_required; claimed_todos_unverified; dirty_tree_before_commit"
+  ],
+  "shortcut_risk_signals": [],
+  "unresolved_assumptions": [
+    "Generated release/fingerprint churn from specs.refresh is not part of this feature slice",
+    "Git merge history is the reverse-lookup mechanism for prior trajectory cookies",
+    "The broader Houseboat issue programs remain open; this PR is a bounded progress slice for Issues #857 and #860"
+  ],
+  "proof_status": "failed",
+  "verdicts": {
+    "intent_alignment": "supported",
+    "boundary_discipline": "supported",
+    "shortcut_risk": "supported",
+    "completion_proof": "unsupported"
+  },
+  "artifact_hash": "sha256:4041ed9c1b1c34052b31f722dbba48e55a47b52219b925c3559984467bcbfca4"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.2 -->
-<!-- decapod-fingerprint: 39ec0738ab08b721c71957e6e54394163860179e72eb232bb7c8bc4351217f52 -->
+<!-- decapod-release: 0.73.3 -->
+<!-- decapod-fingerprint: 860b43272d9969b04db56053085c099ca4c6db9b3bfc66b0a305773b05b3df54 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**
@@ -87,7 +87,7 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 4. **Clarification Trigger**: Stop if a critical assumption cannot be proven.
 
 ## Run-Level Trajectory and Proof
-Record a local artifact under `.decapod/governance/trajectories/`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`.
+Record the current run cookie at `.decapod/governance/trajectory.json`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`. Git merge history is the historical trajectory store.
 Use `decapod govern trajectory init --run-id <run-id> --original-intent "..." --derived-intent "..." --boundary "..." --scope "..."` and `decapod govern trajectory record --run-id <run-id> --inspected-file <path> --check "name=status"`.
 Completion claims never prove completion: `passed`, `failed`, `partial`, `unavailable`, and `no_checks_run` remain distinct, and no checks means an `unsupported` completion verdict.
 ## Invariants (Normative)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.2 -->
-<!-- decapod-fingerprint: c6b791c97733e9f92f159a5ec060b72e02ffd6d5c76af0abdb3f15b0999d36f5 -->
+<!-- decapod-release: 0.73.3 -->
+<!-- decapod-fingerprint: 32d75e5273c4108eb2710db53d399e2f9928918974941ec818b7cefc713b6642 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.2 -->
-<!-- decapod-fingerprint: 5a97c4cbc5b646b4f0dc2168ccf0cfd6bd396617a8c6c1a996401f12154f8643 -->
+<!-- decapod-release: 0.73.3 -->
+<!-- decapod-fingerprint: 5d3549368ad9d29a48ebed512569b283e953f2f90c04edc3c4373f399ecae988 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.73.2 -->
-<!-- decapod-fingerprint: d352da8f3b589069287d4ade7f06ee6947df62836bd58d151db3a8937bf44037 -->
+<!-- decapod-release: 0.73.3 -->
+<!-- decapod-fingerprint: fb2ead69fa750219e79b75218d04377ec45dedf087c564fe3c8497072105d419 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -955,6 +955,14 @@ pub(crate) enum TrajectoryCommand {
         original_intent: String,
         #[clap(long)]
         derived_intent: String,
+        #[clap(long)]
+        destination: Option<String>,
+        #[clap(long = "phase")]
+        current_phase: Option<String>,
+        #[clap(long = "next-transition")]
+        next_transitions: Vec<String>,
+        #[clap(long = "blocker")]
+        blockers: Vec<String>,
         #[clap(long = "boundary")]
         active_boundaries: Vec<String>,
         #[clap(long = "scope")]
@@ -964,6 +972,16 @@ pub(crate) enum TrajectoryCommand {
     Record {
         #[clap(long)]
         run_id: String,
+        #[clap(long)]
+        destination: Option<String>,
+        #[clap(long = "phase")]
+        current_phase: Option<String>,
+        #[clap(long = "next-transition")]
+        next_transitions: Vec<String>,
+        #[clap(long = "blocker")]
+        blockers: Vec<String>,
+        #[clap(long, default_value_t = false)]
+        clear_blockers: bool,
         #[clap(long = "boundary")]
         active_boundaries: Vec<String>,
         #[clap(long = "scope")]

--- a/src/core/assets.rs
+++ b/src/core/assets.rs
@@ -399,7 +399,7 @@ Preserve the chain between intent, context, assumptions, action, and proof.
 4. **Clarification Trigger**: Stop if a critical assumption cannot be proven.
 
 ## Run-Level Trajectory and Proof
-Record a local artifact under `.decapod/governance/trajectories/`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`.
+Record the current run cookie at `.decapod/governance/trajectory.json`: initialize with intent/boundaries/scope, record inspected/modified files, commands/tool calls, checks, evidence, assumptions, and shortcut signals, then inspect with `decapod govern trajectory status --run-id <run-id>`. Git merge history is the historical trajectory store.
 Use `decapod govern trajectory init --run-id <run-id> --original-intent "..." --derived-intent "..." --boundary "..." --scope "..."` and `decapod govern trajectory record --run-id <run-id> --inspected-file <path> --check "name=status"`.
 Completion claims never prove completion: `passed`, `failed`, `partial`, `unavailable`, and `no_checks_run` remain distinct, and no checks means an `unsupported` completion verdict.
 ## Invariants (Normative)

--- a/src/core/trajectory.rs
+++ b/src/core/trajectory.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const TRAJECTORY_SCHEMA_VERSION: &str = "1.0.0";
-pub const TRAJECTORY_DIR: &str = ".decapod/governance/trajectories";
+pub const TRAJECTORY_PATH: &str = ".decapod/governance/trajectory.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
@@ -50,6 +50,15 @@ pub enum TrajectoryVerdict {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryMotionState {
+    Active,
+    Blocked,
+    Waiting,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrajectoryVerdicts {
     pub intent_alignment: TrajectoryVerdict,
     pub boundary_discipline: TrajectoryVerdict,
@@ -65,6 +74,14 @@ pub struct TrajectoryArtifact {
     pub task_id: Option<String>,
     pub original_intent: String,
     pub derived_intent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_transitions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blockers: Vec<String>,
     pub active_boundaries: Vec<String>,
     pub repo_scope: Vec<String>,
     pub inspected_files: Vec<String>,
@@ -84,6 +101,11 @@ pub struct TrajectoryArtifact {
 
 #[derive(Debug, Default)]
 pub struct TrajectoryUpdate {
+    pub destination: Option<String>,
+    pub current_phase: Option<String>,
+    pub next_transitions: Vec<String>,
+    pub blockers: Vec<String>,
+    pub clear_blockers: bool,
     pub active_boundaries: Vec<String>,
     pub repo_scope: Vec<String>,
     pub inspected_files: Vec<String>,
@@ -107,6 +129,8 @@ impl TrajectoryArtifact {
             &mut out.modified_files,
             &mut out.declared_commands,
             &mut out.tool_calls,
+            &mut out.next_transitions,
+            &mut out.blockers,
             &mut out.evidence,
             &mut out.shortcut_risk_signals,
             &mut out.unresolved_assumptions,
@@ -139,11 +163,26 @@ impl TrajectoryArtifact {
     }
 }
 
+pub fn motion_state(artifact: &TrajectoryArtifact) -> TrajectoryMotionState {
+    if !artifact.blockers.is_empty() {
+        return TrajectoryMotionState::Blocked;
+    }
+    if artifact.completion_claim.is_some() {
+        return match artifact.proof_status {
+            TrajectoryProofStatus::Passed => TrajectoryMotionState::Completed,
+            _ => TrajectoryMotionState::Waiting,
+        };
+    }
+    TrajectoryMotionState::Active
+}
+
 pub fn trajectory_path(project_root: &Path, run_id: &str) -> Result<PathBuf, error::DecapodError> {
     validate_run_id(run_id)?;
-    Ok(project_root
-        .join(TRAJECTORY_DIR)
-        .join(format!("{run_id}.json")))
+    Ok(trajectory_cookie_path(project_root))
+}
+
+pub fn trajectory_cookie_path(project_root: &Path) -> PathBuf {
+    project_root.join(TRAJECTORY_PATH)
 }
 
 pub fn validate_run_id(run_id: &str) -> Result<(), error::DecapodError> {
@@ -159,16 +198,36 @@ pub fn validate_run_id(run_id: &str) -> Result<(), error::DecapodError> {
     Ok(())
 }
 
+pub struct TrajectoryInit {
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub original_intent: String,
+    pub derived_intent: String,
+    pub active_boundaries: Vec<String>,
+    pub repo_scope: Vec<String>,
+    pub destination: Option<String>,
+    pub current_phase: Option<String>,
+    pub next_transitions: Vec<String>,
+    pub blockers: Vec<String>,
+}
+
 pub fn init_trajectory(
     project_root: &Path,
-    run_id: &str,
-    task_id: Option<String>,
-    original_intent: String,
-    derived_intent: String,
-    active_boundaries: Vec<String>,
-    repo_scope: Vec<String>,
+    input: TrajectoryInit,
 ) -> Result<TrajectoryArtifact, error::DecapodError> {
-    let path = trajectory_path(project_root, run_id)?;
+    let TrajectoryInit {
+        run_id,
+        task_id,
+        original_intent,
+        derived_intent,
+        active_boundaries,
+        repo_scope,
+        destination,
+        current_phase,
+        next_transitions,
+        blockers,
+    } = input;
+    let path = trajectory_path(project_root, &run_id)?;
     if path.exists() {
         return Err(error::DecapodError::ValidationError(format!(
             "trajectory '{run_id}' already exists"
@@ -186,6 +245,10 @@ pub fn init_trajectory(
         task_id,
         original_intent,
         derived_intent,
+        destination,
+        current_phase,
+        next_transitions,
+        blockers,
         active_boundaries,
         repo_scope,
         inspected_files: Vec::new(),
@@ -253,6 +316,23 @@ pub fn load_trajectory(
     Ok(artifact)
 }
 
+pub fn load_trajectory_cookie(
+    project_root: &Path,
+) -> Result<Option<TrajectoryArtifact>, error::DecapodError> {
+    let path = trajectory_cookie_path(project_root);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).map_err(error::DecapodError::IoError)?;
+    let artifact: TrajectoryArtifact = serde_json::from_str(&raw).map_err(|e| {
+        error::DecapodError::ValidationError(format!(
+            "invalid trajectory artifact {}: {e}",
+            path.display()
+        ))
+    })?;
+    load_trajectory(project_root, &artifact.run_id).map(Some)
+}
+
 pub fn write_trajectory(
     project_root: &Path,
     artifact: &TrajectoryArtifact,
@@ -282,6 +362,17 @@ pub fn record_trajectory(
     update: TrajectoryUpdate,
 ) -> Result<TrajectoryArtifact, error::DecapodError> {
     let mut artifact = load_trajectory(project_root, run_id)?;
+    if update.destination.is_some() {
+        artifact.destination = update.destination;
+    }
+    if update.current_phase.is_some() {
+        artifact.current_phase = update.current_phase;
+    }
+    artifact.next_transitions.extend(update.next_transitions);
+    if update.clear_blockers {
+        artifact.blockers.clear();
+    }
+    artifact.blockers.extend(update.blockers);
     artifact.active_boundaries.extend(update.active_boundaries);
     artifact.repo_scope.extend(update.repo_scope);
     artifact.inspected_files.extend(update.inspected_files);
@@ -413,12 +504,18 @@ mod tests {
         let temp = tempdir().unwrap();
         let artifact = init_trajectory(
             temp.path(),
-            "run_1",
-            Some("task_1".to_string()),
-            "original intent".to_string(),
-            "derived intent".to_string(),
-            vec!["src/**".to_string()],
-            vec!["src/lib.rs".to_string()],
+            TrajectoryInit {
+                run_id: "run_1".to_string(),
+                task_id: Some("task_1".to_string()),
+                original_intent: "original intent".to_string(),
+                derived_intent: "derived intent".to_string(),
+                active_boundaries: vec!["src/**".to_string()],
+                repo_scope: vec!["src/lib.rs".to_string()],
+                destination: None,
+                current_phase: None,
+                next_transitions: Vec::new(),
+                blockers: Vec::new(),
+            },
         )
         .unwrap();
 
@@ -435,12 +532,18 @@ mod tests {
         let temp = tempdir().unwrap();
         init_trajectory(
             temp.path(),
-            "run_2",
-            None,
-            "original".to_string(),
-            "derived".to_string(),
-            vec!["src/**".to_string()],
-            vec!["src/lib.rs".to_string()],
+            TrajectoryInit {
+                run_id: "run_2".to_string(),
+                task_id: None,
+                original_intent: "original".to_string(),
+                derived_intent: "derived".to_string(),
+                active_boundaries: vec!["src/**".to_string()],
+                repo_scope: vec!["src/lib.rs".to_string()],
+                destination: None,
+                current_phase: None,
+                next_transitions: Vec::new(),
+                blockers: Vec::new(),
+            },
         )
         .unwrap();
 
@@ -484,12 +587,18 @@ mod tests {
         let temp = tempdir().unwrap();
         init_trajectory(
             temp.path(),
-            "run_3",
-            None,
-            "original".to_string(),
-            "derived".to_string(),
-            vec!["src/**".to_string()],
-            vec!["src/lib.rs".to_string()],
+            TrajectoryInit {
+                run_id: "run_3".to_string(),
+                task_id: None,
+                original_intent: "original".to_string(),
+                derived_intent: "derived".to_string(),
+                active_boundaries: vec!["src/**".to_string()],
+                repo_scope: vec!["src/lib.rs".to_string()],
+                destination: None,
+                current_phase: None,
+                next_transitions: Vec::new(),
+                blockers: Vec::new(),
+            },
         )
         .unwrap();
         let artifact = record_trajectory(
@@ -518,5 +627,48 @@ mod tests {
             TrajectoryCheckStatus::Passed
         );
         assert!(parse_check_spec("cargo test=maybe").is_err());
+    }
+
+    #[test]
+    fn motion_context_is_recorded_and_state_stays_proof_backed() {
+        let temp = tempdir().unwrap();
+        init_trajectory(
+            temp.path(),
+            TrajectoryInit {
+                run_id: "run_motion".to_string(),
+                task_id: None,
+                original_intent: "original".to_string(),
+                derived_intent: "derived".to_string(),
+                active_boundaries: vec!["src/**".to_string()],
+                repo_scope: vec!["src/lib.rs".to_string()],
+                destination: Some("published PR".to_string()),
+                current_phase: Some("implementation".to_string()),
+                next_transitions: vec!["validate".to_string(), "publish".to_string()],
+                blockers: vec!["awaiting CI".to_string()],
+            },
+        )
+        .unwrap();
+        let blocked = load_trajectory(temp.path(), "run_motion").unwrap();
+        assert_eq!(motion_state(&blocked), TrajectoryMotionState::Blocked);
+
+        let completed = record_trajectory(
+            temp.path(),
+            "run_motion",
+            TrajectoryUpdate {
+                blockers: Vec::new(),
+                clear_blockers: true,
+                checks: vec![TrajectoryCheck {
+                    name: "validate".to_string(),
+                    status: TrajectoryCheckStatus::Passed,
+                }],
+                completion_claim: Some("complete".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(motion_state(&completed), TrajectoryMotionState::Completed);
+        assert_eq!(completed.destination.as_deref(), Some("published PR"));
+        assert_eq!(completed.current_phase.as_deref(), Some("implementation"));
+        assert_eq!(completed.next_transitions, vec!["publish", "validate"]);
     }
 }

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -2188,8 +2188,7 @@ fn validate_trajectory_artifacts_if_present(
 ) -> Result<(), error::DecapodError> {
     info("Agent Trajectory Artifact Gate");
 
-    let trajectories_dir = repo_root.join(trajectory::TRAJECTORY_DIR);
-    if !trajectories_dir.exists() {
+    if !trajectory::trajectory_cookie_path(repo_root).exists() {
         skip(
             "No trajectory artifacts found; skipping trajectory artifact gate",
             ctx,
@@ -2197,34 +2196,10 @@ fn validate_trajectory_artifacts_if_present(
         return Ok(());
     }
 
-    let mut files = 0usize;
-    for entry in fs::read_dir(&trajectories_dir).map_err(error::DecapodError::IoError)? {
-        let entry = entry.map_err(error::DecapodError::IoError)?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        files += 1;
-        let run_id = path
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .ok_or_else(|| {
-                error::DecapodError::ValidationError(format!(
-                    "trajectory artifact has an invalid filename: {}",
-                    path.display()
-                ))
-            })?;
-        let artifact = trajectory::load_trajectory(repo_root, run_id)?;
-        if artifact.run_id != run_id {
-            return Err(error::DecapodError::ValidationError(format!(
-                "trajectory artifact run_id '{}' does not match filename '{}'",
-                artifact.run_id, run_id
-            )));
-        }
-    }
+    trajectory::load_trajectory_cookie(repo_root)?;
 
     pass(
-        &format!("Trajectory artifact schema check passed for {files} file(s)"),
+        "Trajectory cookie schema check passed for trajectory.json",
         ctx,
     );
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6440,17 +6440,27 @@ fn run_trajectory_command(
             task_id,
             original_intent,
             derived_intent,
+            destination,
+            current_phase,
+            next_transitions,
+            blockers,
             active_boundaries,
             repo_scope,
         } => {
             let artifact = core::trajectory::init_trajectory(
                 workspace_root,
-                &run_id,
-                task_id,
-                original_intent,
-                derived_intent,
-                active_boundaries,
-                repo_scope,
+                core::trajectory::TrajectoryInit {
+                    run_id: run_id.clone(),
+                    task_id,
+                    original_intent,
+                    derived_intent,
+                    active_boundaries,
+                    repo_scope,
+                    destination,
+                    current_phase,
+                    next_transitions,
+                    blockers,
+                },
             )?;
             let path = core::trajectory::trajectory_path(workspace_root, &run_id)?;
             println!(
@@ -6466,6 +6476,11 @@ fn run_trajectory_command(
         }
         TrajectoryCommand::Record {
             run_id,
+            destination,
+            current_phase,
+            next_transitions,
+            blockers,
+            clear_blockers,
             active_boundaries,
             repo_scope,
             inspected_files,
@@ -6486,6 +6501,11 @@ fn run_trajectory_command(
                 workspace_root,
                 &run_id,
                 core::trajectory::TrajectoryUpdate {
+                    destination,
+                    current_phase,
+                    next_transitions,
+                    blockers,
+                    clear_blockers,
                     active_boundaries,
                     repo_scope,
                     inspected_files,
@@ -6513,6 +6533,11 @@ fn run_trajectory_command(
                 serde_json::to_string_pretty(&serde_json::json!({
                     "status": "ok",
                     "run_id": artifact.run_id,
+                    "motion_state": core::trajectory::motion_state(&artifact),
+                    "destination": artifact.destination,
+                    "current_phase": artifact.current_phase,
+                    "next_transitions": artifact.next_transitions,
+                    "blockers": artifact.blockers,
                     "proof_status": artifact.proof_status,
                     "verdicts": artifact.verdicts,
                     "completion_claim": artifact.completion_claim,

--- a/tests/trajectory_cli.rs
+++ b/tests/trajectory_cli.rs
@@ -69,6 +69,14 @@ fn trajectory_cli_records_scope_actions_checks_and_verdicts() {
             "preserve intent",
             "--derived-intent",
             "implement bounded change",
+            "--destination",
+            "published PR",
+            "--phase",
+            "implementation",
+            "--next-transition",
+            "validate",
+            "--blocker",
+            "awaiting proof",
             "--boundary",
             "src/**",
             "--scope",
@@ -78,6 +86,8 @@ fn trajectory_cli_records_scope_actions_checks_and_verdicts() {
     );
     let init_json = json(&init, "trajectory init");
     assert_eq!(init_json["marker"], "TRAJECTORY_INITIALIZED");
+    assert_eq!(init_json["trajectory"]["destination"], "published PR");
+    assert_eq!(init_json["trajectory"]["current_phase"], "implementation");
 
     let record = run_decapod(
         &root,
@@ -87,6 +97,9 @@ fn trajectory_cli_records_scope_actions_checks_and_verdicts() {
             "record",
             "--run-id",
             "run_cli_1",
+            "--blocker",
+            "awaiting proof",
+            "--clear-blockers",
             "--inspected-file",
             "src/lib.rs",
             "--modified-file",
@@ -119,10 +132,9 @@ fn trajectory_cli_records_scope_actions_checks_and_verdicts() {
     );
     let status_json = json(&status, "trajectory status");
     assert_eq!(status_json["proof_status"], "passed");
-    assert!(
-        root.join(".decapod/governance/trajectories/run_cli_1.json")
-            .exists()
-    );
+    assert_eq!(status_json["motion_state"], "blocked");
+    assert_eq!(status_json["blockers"][0], "awaiting proof");
+    assert!(root.join(".decapod/governance/trajectory.json").exists());
 }
 
 #[test]

--- a/tests/validate_optional_artifact_gates.rs
+++ b/tests/validate_optional_artifact_gates.rs
@@ -325,9 +325,9 @@ fn validate_fails_on_invalid_workunit_manifest_if_present() {
 #[test]
 fn validate_fails_on_invalid_trajectory_artifact_if_present() {
     let (_tmp, dir, password) = setup_repo();
-    let trajectories = dir.join(".decapod").join("governance").join("trajectories");
-    fs::create_dir_all(&trajectories).expect("create trajectory directory");
-    fs::write(trajectories.join("run_BAD.json"), "{not-json").expect("write malformed trajectory");
+    let governance = dir.join(".decapod").join("governance");
+    fs::create_dir_all(&governance).expect("create governance directory");
+    fs::write(governance.join("trajectory.json"), "{not-json").expect("write malformed trajectory");
 
     let validate = run_decapod(
         &dir,


### PR DESCRIPTION
## Summary

Progresses Houseboat Issues #857 and #860 in one bounded slice.

- Extends the existing trajectory artifact with destination, current phase, next allowed transitions, and blockers.
- Adds deterministic motion states: active, blocked, waiting, and completed.
- Adds CLI init/record flags and exposes the same projection from `govern trajectory status`.
- Replaces the per-run trajectory directory with one `.decapod/governance/trajectory.json` cookie; Git history remains the historical store for prior PR states.
- Keeps old artifacts compatible through optional fields and validates the fixed cookie path.
- Aligns the embedded agent contract and living specs with the cookie path, and refreshes release-bound entrypoints/manifest from Decapod `0.73.3` with new fingerprints.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test trajectory_cli` (4 passed)
- `cargo test --test validate_optional_artifact_gates validate_fails_on_invalid_trajectory_artifact_if_present` (1 passed)
- `cargo test --lib trajectory` (5 passed)
- `git diff --check`

`decapod validate --format json` reached 206 passing gates but remains blocked by the host container-workspace proof requirement and eight pre-existing claimed-but-unverified TODO proof hooks. It also auto-healed unrelated release metadata in the worktree; those generated changes were restored and are not part of this PR.

The broader Houseboat programs remain open: this PR advances trajectory/observability contracts but does not close either issue.
