### PR TITLE
fix: make validation agent-readable and parallel

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.79.0
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.79.1
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.79.0
+ARG DECAPOD_VERSION=0.79.1
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784831088Z",
+  "generated_at": "1784831710Z",
   "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
   "declared_capabilities": [
     "agent-helper",

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784771218Z",
-  "repo_signal_fingerprint": "add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55",
+  "generated_at": "1784831088Z",
+  "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "5e2056b7782b010f259e4605bd0024ab643e952e55e44dc774a835c66e4a39b8",
-  "decapod_release": "0.79.0",
+  "spec_input_hash": "adfe4aef8984fba70cfc21cc36beaa54fd639ac88ee68a92515a0ac95dea052b",
+  "decapod_release": "0.79.1",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "84991565948bb1af6fb4d6c0fe29f120cea28985ccbb2f9a75293192406ae7a6",
-      "content_hash": "84991565948bb1af6fb4d6c0fe29f120cea28985ccbb2f9a75293192406ae7a6",
-      "fingerprint": "92872fae034349a2760622dba85d4eb5f77e0250062c41bbeab36f231eb14bf5"
+      "template_hash": "a9e1f83a7c0a28d2963262850e49af0a9761b5f5d8446df08f90fba49c38b36a",
+      "content_hash": "a9e1f83a7c0a28d2963262850e49af0a9761b5f5d8446df08f90fba49c38b36a",
+      "fingerprint": "100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "7f9a6a81001b510067910919868dd793c85313267087cd2d9288d499cc4dcbb4",
-      "content_hash": "7f9a6a81001b510067910919868dd793c85313267087cd2d9288d499cc4dcbb4",
-      "fingerprint": "e77817639b6f483ad523d3fe7b8801d39d317afd59f0dfa67db9d95f110d38c4"
+      "template_hash": "ec6751c36f33c5e7845c6554af66cebe1fa2374ba1dfcbf945887c2cdca96721",
+      "content_hash": "ec6751c36f33c5e7845c6554af66cebe1fa2374ba1dfcbf945887c2cdca96721",
+      "fingerprint": "5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "e8ddf8b30bed3cc9d3ea701a857c03c48a64447d1919af54e4e8e9de39bb1db7",
-      "content_hash": "e8ddf8b30bed3cc9d3ea701a857c03c48a64447d1919af54e4e8e9de39bb1db7",
-      "fingerprint": "2858a9403de3bf6aabdff3ed1be8a37c6988c3a6dc21d0bdbdca0d35051971dd"
+      "template_hash": "451eb5868080c62c843637874e707f873178dcfd726a8472b1e7b50f81ff363b",
+      "content_hash": "451eb5868080c62c843637874e707f873178dcfd726a8472b1e7b50f81ff363b",
+      "fingerprint": "45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "66c7d1fcaa0aa69d7bcfe31eae4d5c00092db3d7f1877942749d3507cafd9d10",
-      "content_hash": "66c7d1fcaa0aa69d7bcfe31eae4d5c00092db3d7f1877942749d3507cafd9d10",
-      "fingerprint": "df8d38713abcb1f63f3737275e9c2ec736d40768dcca3380e0f482b1b15feed1"
+      "template_hash": "0a534d8ee7c1687f711426aafdb24c4c997f484368bf10b3d4178f6a0838538a",
+      "content_hash": "0a534d8ee7c1687f711426aafdb24c4c997f484368bf10b3d4178f6a0838538a",
+      "fingerprint": "d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "0b2c42ed97ae4f1637603c852e39cde761a5892964c48f2ec61f81345039d740",
-      "content_hash": "a68eaac8f672a51c91696aaedc80e010f3ac0d8a13df9d5af27a929c146b08dd",
+      "content_hash": "a233629e384b2bab2b783aaab7cc5e1891ba62ef3b8694ed74e92345fad7f2f2",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "70211d115142639aa8deaf5f6cda3db5eb59b38094e491c46a8cb292692f38be",
+      "content_hash": "d53dd3865d2417971594b9558abc8b10ffb75be102408137716d926eff253a45",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "9dc399ba9fc7426b7b08c77da550ccf283b94d3e60c545c17276338d70db631c",
+      "content_hash": "1c1ff57c12de43a971da3a18ac7aeb389f6bd02cc4d7ca85dc5a41bfa01a4368",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "66556ea106f4328a64df4200519ed06b492f45e2e3c5d5ec73a1a31773d68ffc",
+      "content_hash": "262d3e24bde6d33a18ed0edb03f769291fb2fbe6d26bd49bb91ee5afab39b487",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "a67f2726b69bc8e514b69f8fdbe13ad4f5bfd2d713c1aa0473a3e90cc8c11a0d",
-      "content_hash": "af1dc9455ac2a7dc6f47794dd1eaaaedb19ad1a49f9b0bf73868ddd5185c54a0",
+      "content_hash": "9c2fa9e1fdb221a1f8aeb583a289c33a3ea738e1267d5c25f4f747f0cadf0b80",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "c85e0b7537372ceaa31157d6ac09100e3b84b80ec610dd7e8156d06e2519db47",
+      "content_hash": "33a6e01657c97d4b7a7ad4a7a4c43ae2a24a93580e042f0674f9314aebfd4bfd",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "b47e3fa2c8ba89416f0ec1c4a31a616ecaf359b702e753c736258940070f72c4",
+      "content_hash": "b095107e7632665b74b0fc4ef98a085c0167b5ea4160e5e202cbe6a1b5937ecd",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "ac19340c4525bb31ce9a668ed463a81413a120f73283d92863ce089b24dca885",
+      "content_hash": "228c89aac79cfba25bad36c049c5693d348a977c6074316adfc2bc0bbd9cd824",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -408,7 +408,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -257,6 +257,13 @@ No legacy `globex` or `codex` namespace references in repo text sources
   "warn_count": 3,
   "failures": [],
   "warnings": ["Spec template stale for INTENT.md"],
+  "parallelism": 8,
+  "ci_prediction": {
+    "result": "pass|review|fail",
+    "confidence": "high|medium",
+    "reasons": [],
+    "recommendations": []
+  },
   "gate_timings": [
     { "name": "Workspace Preflight", "elapsed_ms": 123 },
     { "name": "Four Invariants", "elapsed_ms": 456 }
@@ -264,10 +271,15 @@ No legacy `globex` or `codex` namespace references in repo text sources
 }
 ```
 
+The tracked `.decapod/governance/validation.json` receipt preserves the
+warnings, failures, gate timings, available parallelism, and CI prediction
+from the successful run so an agent can inspect the proof artifact and act on
+actionable validation signals before publication.
+
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55`
+- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,109 +1,63 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "validation_01KY68KD0JFM1RYP05EDGM8AKP",
-  "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-  "task_id": "bugs_01ky67k6fw63bsj2",
-  "original_intent": "Produce proof artifacts for a repository validation completion.",
-  "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
-  "destination": "single PR",
-  "current_phase": "validation",
-  "next_transitions": [
-    "publish"
-  ],
+  "run_id": "run-986-987-20260723",
+  "intent_id": "intent:run-986-987-20260723",
+  "original_intent": "Solve GitHub Issues #986 and #987 in one PR",
+  "derived_intent": "Make decapod validate analyze validation.json for CI risk and use available CPU parallelism without losing bounded deterministic proof",
   "active_boundaries": [
-    "Repository validation and tracked proof artifacts"
+    "One Decapod repository PR; no direct .decapod store edits; isolated workspace only"
   ],
   "repo_scope": [
-    ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json"
+    "validation implementation, tests, proof artifacts, single GitHub PR"
   ],
   "inspected_files": [
-    "research/claims.md",
-    "src/core/workspace.rs",
-    "src/lib.rs",
+    ".decapod/generated/specs/VALIDATION.md",
+    "src/core/entrypoint_integrity.rs",
+    "src/core/validate.rs",
     "tests/validate_termination.rs"
   ],
-  "modified_files": [
-    ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json",
-    "research/claims.md",
-    "src/core/workspace.rs",
-    "src/lib.rs",
-    "tests/validate_termination.rs"
-  ],
-  "declared_commands": [
-    "cargo clippy --workspace --all-targets --offline -- -D warnings",
-    "cargo fmt --all",
-    "cargo test --test init_validate_green_field",
-    "cargo test --test trajectory_cli",
-    "cargo test --test validate_termination",
-    "cargo test --test workunit_publish_gate",
-    "decapod validate"
-  ],
-  "tool_calls": [
-    "decapod rpc --op specs.refresh",
-    "gh issue view 682",
-    "gh pr view 989"
-  ],
+  "modified_files": [],
+  "declared_commands": [],
+  "tool_calls": [],
   "checks": [
     {
-      "name": "cargo clippy --workspace --all-targets --offline -- -D warnings",
+      "name": "cargo_test_all_targets",
+      "status": "partial"
+    },
+    {
+      "name": "cargo_test_lib",
       "status": "passed"
     },
     {
-      "name": "cargo test --test init_validate_green_field",
-      "status": "passed"
-    },
-    {
-      "name": "cargo test --test trajectory_cli",
-      "status": "passed"
-    },
-    {
-      "name": "cargo test --test validate_termination",
-      "status": "passed"
-    },
-    {
-      "name": "cargo test --test workunit_publish_gate",
-      "status": "passed"
-    },
-    {
-      "name": "decapod validate",
+      "name": "validate_termination",
       "status": "passed"
     }
   ],
-  "evidence": [
-    "Issue #682 research claims and validation artifact lifecycle implemented",
-    "PR #989 stale trajectory custody reproduced and corrected",
-    "Validation receipt bound to current trajectory artifact hash",
-    "validation epoch ve_14f25174288f608f completed with zero failures",
-    "validation epoch ve_4b3aac4e7bc1dfdd completed with zero failures",
-    "validation epoch ve_75d0c7a0d9bc559f completed with zero failures"
-  ],
+  "evidence": [],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
-  "proof_status": "passed",
+  "proof_status": "partial",
   "verdicts": {
     "intent_alignment": "supported",
     "boundary_discipline": "supported",
     "shortcut_risk": "supported",
-    "completion_proof": "supported"
+    "completion_proof": "caution"
   },
-  "artifact_hash": "sha256:dd082ca0c02dab42d7fc7f4c2b300767068d79e02840ba3aa00b96806ad00c61",
+  "artifact_hash": "sha256:72e5209ffe14bcab29e3321bc3daedcd380004bfad63176bd0656b78c874c375",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP": {
-        "id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "raw_intent": "Produce proof artifacts for a repository validation completion.",
-        "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
+      "intent:run-986-987-20260723": {
+        "id": "intent:run-986-987-20260723",
+        "raw_intent": "Solve GitHub Issues #986 and #987 in one PR",
+        "refined_intent": "Make decapod validate analyze validation.json for CI risk and use available CPU parallelism without losing bounded deterministic proof",
         "acceptance_criteria": [],
         "constraints": [
-          ".decapod/governance/trajectory.json",
-          ".decapod/governance/validation.json"
+          "validation implementation, tests, proof artifacts, single GitHub PR"
         ],
         "assumptions": [],
         "boundaries": [
-          "Repository validation and tracked proof artifacts"
+          "One Decapod repository PR; no direct .decapod store edits; isolated workspace only"
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -116,199 +70,54 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
+        "intent_id": "intent:run-986-987-20260723",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
+        "intent_id": "intent:run-986-987-20260723",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
+        "intent_id": "intent:run-986-987-20260723",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
-      },
-      {
-        "sequence": 5,
-        "event_id": "event:5",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
-      },
-      {
-        "sequence": 6,
-        "event_id": "event:6",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
-      },
-      {
-        "sequence": 7,
-        "event_id": "event:7",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
-      },
-      {
-        "sequence": 8,
-        "event_id": "event:8",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
-      },
-      {
-        "sequence": 9,
-        "event_id": "event:9",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY68KD0JFM1RYP05EDGM8AKP"
+        "detail": "trajectory:run-986-987-20260723"
       }
     ],
     "trajectories": {
-      "validation_01KY68KD0JFM1RYP05EDGM8AKP": {
-        "id": "validation_01KY68KD0JFM1RYP05EDGM8AKP",
-        "intent_id": "intent:validation_01KY68KD0JFM1RYP05EDGM8AKP",
+      "run-986-987-20260723": {
+        "id": "run-986-987-20260723",
+        "intent_id": "intent:run-986-987-20260723",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "validation",
-            "command": "decapod validate",
+            "action": "trajectory.record",
             "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
+              "validation implementation, tests, proof artifacts, single GitHub PR"
             ],
             "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_14f25174288f608f completed with zero failures"
+              "src/core/validate.rs",
+              "src/core/entrypoint_integrity.rs",
+              "tests/validate_termination.rs",
+              ".decapod/generated/specs/VALIDATION.md"
             ],
             "proof_refs": [
-              "decapod validate"
+              "cargo_test_lib",
+              "validate_termination",
+              "cargo_test_all_targets"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
-          },
-          {
-            "sequence": 5,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_4b3aac4e7bc1dfdd completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:5"
-          },
-          {
-            "sequence": 6,
-            "action": "proof",
-            "tool": "gh issue view 682",
-            "command": "cargo fmt --all",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              "src/lib.rs",
-              "src/core/workspace.rs",
-              "tests/validate_termination.rs",
-              "research/claims.md",
-              "src/lib.rs",
-              "src/core/workspace.rs",
-              "tests/validate_termination.rs",
-              "research/claims.md",
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "Issue #682 research claims and validation artifact lifecycle implemented",
-              "PR #989 stale trajectory custody reproduced and corrected",
-              "Validation receipt bound to current trajectory artifact hash"
-            ],
-            "proof_refs": [
-              "cargo clippy --workspace --all-targets --offline -- -D warnings",
-              "cargo test --test validate_termination",
-              "cargo test --test init_validate_green_field",
-              "cargo test --test trajectory_cli",
-              "cargo test --test workunit_publish_gate",
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:6"
-          },
-          {
-            "sequence": 7,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_4b3aac4e7bc1dfdd completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:7"
-          },
-          {
-            "sequence": 8,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_4b3aac4e7bc1dfdd completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:8"
-          },
-          {
-            "sequence": 9,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_75d0c7a0d9bc559f completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:9"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 9
+    "next_sequence": 4
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -44,7 +44,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:4a291a90ac5c490ffac0c0dceae3c1648ffefc96df4906e06901dfff8aca8284",
+  "artifact_hash": "sha256:fe56a60670efbbb56a77dcdd43fa696c729cfec4e6896594f39369d42b437049",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -87,6 +87,13 @@
         "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR"
+      },
+      {
+        "sequence": 5,
+        "event_id": "event:5",
+        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR"
       }
     ],
     "trajectories": {
@@ -113,12 +120,31 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
+          },
+          {
+            "sequence": 5,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_7f6954920d025caf completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:5"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 4
+    "next_sequence": 5
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,63 +1,65 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "run-986-987-20260723",
-  "intent_id": "intent:run-986-987-20260723",
-  "original_intent": "Solve GitHub Issues #986 and #987 in one PR",
-  "derived_intent": "Make decapod validate analyze validation.json for CI risk and use available CPU parallelism without losing bounded deterministic proof",
+  "run_id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+  "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+  "task_id": "bugs_01ky82c1sz5wka9e",
+  "original_intent": "Produce proof artifacts for a repository validation completion.",
+  "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
+  "destination": "validation completion",
+  "current_phase": "validation",
+  "next_transitions": [
+    "publish"
+  ],
   "active_boundaries": [
-    "One Decapod repository PR; no direct .decapod store edits; isolated workspace only"
+    "Repository validation and tracked proof artifacts"
   ],
   "repo_scope": [
-    "validation implementation, tests, proof artifacts, single GitHub PR"
+    ".decapod/governance/trajectory.json",
+    ".decapod/governance/validation.json"
   ],
-  "inspected_files": [
-    ".decapod/generated/specs/VALIDATION.md",
-    "src/core/entrypoint_integrity.rs",
-    "src/core/validate.rs",
-    "tests/validate_termination.rs"
+  "inspected_files": [],
+  "modified_files": [
+    ".decapod/governance/trajectory.json",
+    ".decapod/governance/validation.json"
   ],
-  "modified_files": [],
-  "declared_commands": [],
+  "declared_commands": [
+    "decapod validate"
+  ],
   "tool_calls": [],
   "checks": [
     {
-      "name": "cargo_test_all_targets",
-      "status": "partial"
-    },
-    {
-      "name": "cargo_test_lib",
-      "status": "passed"
-    },
-    {
-      "name": "validate_termination",
+      "name": "decapod validate",
       "status": "passed"
     }
   ],
-  "evidence": [],
+  "evidence": [
+    "validation epoch ve_7f6954920d025caf completed with zero failures"
+  ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
-  "proof_status": "partial",
+  "proof_status": "passed",
   "verdicts": {
     "intent_alignment": "supported",
     "boundary_discipline": "supported",
     "shortcut_risk": "supported",
-    "completion_proof": "caution"
+    "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:72e5209ffe14bcab29e3321bc3daedcd380004bfad63176bd0656b78c874c375",
+  "artifact_hash": "sha256:4a291a90ac5c490ffac0c0dceae3c1648ffefc96df4906e06901dfff8aca8284",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:run-986-987-20260723": {
-        "id": "intent:run-986-987-20260723",
-        "raw_intent": "Solve GitHub Issues #986 and #987 in one PR",
-        "refined_intent": "Make decapod validate analyze validation.json for CI risk and use available CPU parallelism without losing bounded deterministic proof",
+      "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR": {
+        "id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "raw_intent": "Produce proof artifacts for a repository validation completion.",
+        "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
         "acceptance_criteria": [],
         "constraints": [
-          "validation implementation, tests, proof artifacts, single GitHub PR"
+          ".decapod/governance/trajectory.json",
+          ".decapod/governance/validation.json"
         ],
         "assumptions": [],
         "boundaries": [
-          "One Decapod repository PR; no direct .decapod store edits; isolated workspace only"
+          "Repository validation and tracked proof artifacts"
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -70,45 +72,44 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:run-986-987-20260723",
+        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:run-986-987-20260723",
+        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:run-986-987-20260723",
+        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:run-986-987-20260723"
+        "detail": "trajectory:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR"
       }
     ],
     "trajectories": {
-      "run-986-987-20260723": {
-        "id": "run-986-987-20260723",
-        "intent_id": "intent:run-986-987-20260723",
+      "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR": {
+        "id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "trajectory.record",
+            "action": "validation",
+            "command": "decapod validate",
             "scope": [
-              "validation implementation, tests, proof artifacts, single GitHub PR"
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
             ],
             "observations": [
-              "src/core/validate.rs",
-              "src/core/entrypoint_integrity.rs",
-              "tests/validate_termination.rs",
-              ".decapod/generated/specs/VALIDATION.md"
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_7f6954920d025caf completed with zero failures"
             ],
             "proof_refs": [
-              "cargo_test_lib",
-              "validate_termination",
-              "cargo_test_all_targets"
+              "decapod validate"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,36 +1,36 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.79.0",
-  "git_revision": "200cfc70c7fc36b484d015a160bc5ec2e6c03b21",
-  "repo_signal_fingerprint": "add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55",
-  "trajectory_run_id": "validation_01KY68KD0JFM1RYP05EDGM8AKP",
-  "trajectory_artifact_hash": "sha256:dd082ca0c02dab42d7fc7f4c2b300767068d79e02840ba3aa00b96806ad00c61",
+  "decapod_release": "0.79.1",
+  "git_revision": "37df7ba17bfb97964135afb7422625f9843745f2",
+  "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
+  "trajectory_run_id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+  "trajectory_artifact_hash": "sha256:4a291a90ac5c490ffac0c0dceae3c1648ffefc96df4906e06901dfff8aca8284",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_75d0c7a0d9bc559f",
-    "evaluator_identity": "decapod-validate@0.79.0",
-    "evaluator_set_hash": "sha256:6c39b49ce038fca960c307e50bf053fca8d0b104a94f1125aac901d6f09fb9b0",
-    "constitution_version": "embedded-docs@0.79.0",
-    "constitution_hash": "sha256:f373251db3adc961a144570e4d831c260a794996c02f4b3519d5539b504cfd6f",
+    "epoch_id": "ve_7f6954920d025caf",
+    "evaluator_identity": "decapod-validate@0.79.1",
+    "evaluator_set_hash": "sha256:75b92694fbe28be57bf3d6145952f1341fbd2504b4d9143d3fd0021c2191b849",
+    "constitution_version": "embedded-docs@0.79.1",
+    "constitution_hash": "sha256:31bdc253bcb0a7d2ce95b4324b91682848ede42e8f1b68155e11e26ccd5cea23",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:fa357efdffdf7f62c55d10f9ef679e6d65b4d30cda16636cec3962633ca20b6f",
-    "generated_specs_fingerprint": "add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55",
+    "generated_specs_manifest_hash": "sha256:6f4b28b0570a7ad0fd3e903a5377d253f3522d7d06d93f5f858d3844b587e48a",
+    "generated_specs_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:f373251db3adc961a144570e4d831c260a794996c02f4b3519d5539b504cfd6f",
-      "generated_spec:.decapod/generated/specs/ARCHITECTURE.md": "sha256:9dc399ba9fc7426b7b08c77da550ccf283b94d3e60c545c17276338d70db631c",
-      "generated_spec:.decapod/generated/specs/INTENT.md": "sha256:70211d115142639aa8deaf5f6cda3db5eb59b38094e491c46a8cb292692f38be",
-      "generated_spec:.decapod/generated/specs/INTERFACES.md": "sha256:66556ea106f4328a64df4200519ed06b492f45e2e3c5d5ec73a1a31773d68ffc",
-      "generated_spec:.decapod/generated/specs/OPERATIONS.md": "sha256:b47e3fa2c8ba89416f0ec1c4a31a616ecaf359b702e753c736258940070f72c4",
-      "generated_spec:.decapod/generated/specs/README.md": "sha256:a68eaac8f672a51c91696aaedc80e010f3ac0d8a13df9d5af27a929c146b08dd",
-      "generated_spec:.decapod/generated/specs/SECURITY.md": "sha256:ac19340c4525bb31ce9a668ed463a81413a120f73283d92863ce089b24dca885",
-      "generated_spec:.decapod/generated/specs/SEMANTICS.md": "sha256:c85e0b7537372ceaa31157d6ac09100e3b84b80ec610dd7e8156d06e2519db47",
-      "generated_spec:.decapod/generated/specs/VALIDATION.md": "sha256:af1dc9455ac2a7dc6f47794dd1eaaaedb19ad1a49f9b0bf73868ddd5185c54a0",
-      "generated_specs_fingerprint": "add97a3601417b9514fce3ec70f8a980db507cc1560b997cf03a12f1064c0f55",
-      "generated_specs_manifest": "sha256:fa357efdffdf7f62c55d10f9ef679e6d65b4d30cda16636cec3962633ca20b6f",
+      "constitution:core/DECAPOD": "sha256:31bdc253bcb0a7d2ce95b4324b91682848ede42e8f1b68155e11e26ccd5cea23",
+      "generated_spec:.decapod/generated/specs/ARCHITECTURE.md": "sha256:1c1ff57c12de43a971da3a18ac7aeb389f6bd02cc4d7ca85dc5a41bfa01a4368",
+      "generated_spec:.decapod/generated/specs/INTENT.md": "sha256:d53dd3865d2417971594b9558abc8b10ffb75be102408137716d926eff253a45",
+      "generated_spec:.decapod/generated/specs/INTERFACES.md": "sha256:262d3e24bde6d33a18ed0edb03f769291fb2fbe6d26bd49bb91ee5afab39b487",
+      "generated_spec:.decapod/generated/specs/OPERATIONS.md": "sha256:b095107e7632665b74b0fc4ef98a085c0167b5ea4160e5e202cbe6a1b5937ecd",
+      "generated_spec:.decapod/generated/specs/README.md": "sha256:a233629e384b2bab2b783aaab7cc5e1891ba62ef3b8694ed74e92345fad7f2f2",
+      "generated_spec:.decapod/generated/specs/SECURITY.md": "sha256:228c89aac79cfba25bad36c049c5693d348a977c6074316adfc2bc0bbd9cd824",
+      "generated_spec:.decapod/generated/specs/SEMANTICS.md": "sha256:33a6e01657c97d4b7a7ad4a7a4c43ae2a24a93580e042f0674f9314aebfd4bfd",
+      "generated_spec:.decapod/generated/specs/VALIDATION.md": "sha256:9c2fa9e1fdb221a1f8aeb583a289c33a3ea738e1267d5c25f4f747f0cadf0b80",
+      "generated_specs_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
+      "generated_specs_manifest": "sha256:6f4b28b0570a7ad0fd3e903a5377d253f3522d7d06d93f5f858d3844b587e48a",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,8 +39,242 @@
   "pass_count": 197,
   "fail_count": 0,
   "warn_count": 3,
-  "elapsed_ms": 45486,
+  "elapsed_ms": 44545,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
-  "receipt_hash": "sha256:b42e11195a8de2282f1d0bafde95f72006d618ee74fce43da01b4bb7a8b2c96a"
+  "failures": [],
+  "warnings": [
+    "Risk map missing (run `decapod riskmap init`)",
+    "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
+    "Watcher audit trail missing (run `decapod govern watcher run`)"
+  ],
+  "gate_timings": [
+    {
+      "name": "validate_federation_gates",
+      "elapsed_ms": 3406
+    },
+    {
+      "name": "validate_machine_contract",
+      "elapsed_ms": 576
+    },
+    {
+      "name": "validate_control_plane_contract",
+      "elapsed_ms": 201
+    },
+    {
+      "name": "validate_markdown_primitives_roundtrip_gate",
+      "elapsed_ms": 161
+    },
+    {
+      "name": "validate_schema_determinism",
+      "elapsed_ms": 90
+    },
+    {
+      "name": "validate_knowledge_integrity",
+      "elapsed_ms": 80
+    },
+    {
+      "name": "validate_canon_mutation",
+      "elapsed_ms": 76
+    },
+    {
+      "name": "validate_watcher_purity",
+      "elapsed_ms": 73
+    },
+    {
+      "name": "validate_risk_map_violations",
+      "elapsed_ms": 60
+    },
+    {
+      "name": "validate_no_legacy_namespaces",
+      "elapsed_ms": 43
+    },
+    {
+      "name": "validate_project_specs_docs",
+      "elapsed_ms": 39
+    },
+    {
+      "name": "validate_embedded_self_contained",
+      "elapsed_ms": 22
+    },
+    {
+      "name": "validate_repomap_determinism",
+      "elapsed_ms": 21
+    },
+    {
+      "name": "validate_obligations",
+      "elapsed_ms": 8
+    },
+    {
+      "name": "validate_generated_artifact_whitelist",
+      "elapsed_ms": 4
+    },
+    {
+      "name": "validate_health_purity",
+      "elapsed_ms": 4
+    },
+    {
+      "name": "validate_gatekeeper_gate",
+      "elapsed_ms": 3
+    },
+    {
+      "name": "validate_database_schema_versions",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_spec_drift",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_interface_contract_bootstrap",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_research_claims_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_heartbeat_invocation_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_entrypoint_invariants",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_repo_map",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_trajectory_artifacts_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_project_config_toml",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_project_scoped_state",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_validation_receipt_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsule_policy_contract",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_state_commit_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_docs_templates_bucket",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_workunit_manifests_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_watcher_audit",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lineage_hard_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lcm_immutability",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_coplayer_policy_tightening",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_root_dockerfile_seed_detection",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_archive_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_knowledge_promotions_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_recursive_improvement_passes_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_policy_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_risk_map",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_health_cache_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsules_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_eval_gate_if_required",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_internalization_artifacts_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lcm_rebuild_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_workspace_context",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_stale_workspaces",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_push_pr_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_tooling_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_plan_governed_execution_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_protected_branch",
+      "elapsed_ms": 0
+    }
+  ],
+  "parallelism": 8,
+  "ci_prediction": {
+    "result": "review",
+    "confidence": "medium",
+    "reasons": [
+      "Risk map missing (run `decapod riskmap init`)",
+      "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
+      "Watcher audit trail missing (run `decapod govern watcher run`)"
+    ],
+    "recommendations": [
+      "Review the reported validation warnings before relying on the CI result.",
+      "Use `decapod validate -v --format json` to inspect the affected gate output."
+    ]
+  },
+  "receipt_hash": "sha256:7f14c23523cda6d99d19b084e35b25c4b0628fac988d47fd53cffd7b8c51655e"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,10 +2,10 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.79.1",
-  "git_revision": "37df7ba17bfb97964135afb7422625f9843745f2",
+  "git_revision": "0378a9027ec461da15646e62257c3322b64e8343",
   "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
   "trajectory_run_id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
-  "trajectory_artifact_hash": "sha256:4a291a90ac5c490ffac0c0dceae3c1648ffefc96df4906e06901dfff8aca8284",
+  "trajectory_artifact_hash": "sha256:fe56a60670efbbb56a77dcdd43fa696c729cfec4e6896594f39369d42b437049",
   "validation_epoch": {
     "schema_version": "1.0.0",
     "epoch_id": "ve_7f6954920d025caf",
@@ -39,7 +39,7 @@
   "pass_count": 197,
   "fail_count": 0,
   "warn_count": 3,
-  "elapsed_ms": 44545,
+  "elapsed_ms": 43801,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -51,78 +51,82 @@
   "gate_timings": [
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 3406
+      "elapsed_ms": 2964
     },
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 576
+      "elapsed_ms": 599
     },
     {
       "name": "validate_control_plane_contract",
-      "elapsed_ms": 201
+      "elapsed_ms": 213
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 161
+      "elapsed_ms": 140
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 90
+      "elapsed_ms": 94
     },
     {
       "name": "validate_knowledge_integrity",
+      "elapsed_ms": 84
+    },
+    {
+      "name": "validate_watcher_purity",
       "elapsed_ms": 80
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 76
-    },
-    {
-      "name": "validate_watcher_purity",
-      "elapsed_ms": 73
+      "elapsed_ms": 77
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 60
+      "elapsed_ms": 69
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 43
+      "elapsed_ms": 49
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 39
-    },
-    {
-      "name": "validate_embedded_self_contained",
-      "elapsed_ms": 22
+      "elapsed_ms": 43
     },
     {
       "name": "validate_repomap_determinism",
-      "elapsed_ms": 21
+      "elapsed_ms": 22
     },
     {
-      "name": "validate_obligations",
-      "elapsed_ms": 8
+      "name": "validate_embedded_self_contained",
+      "elapsed_ms": 17
     },
     {
-      "name": "validate_generated_artifact_whitelist",
-      "elapsed_ms": 4
+      "name": "validate_research_claims_if_present",
+      "elapsed_ms": 9
     },
     {
       "name": "validate_health_purity",
-      "elapsed_ms": 4
+      "elapsed_ms": 7
+    },
+    {
+      "name": "validate_obligations",
+      "elapsed_ms": 6
     },
     {
       "name": "validate_gatekeeper_gate",
-      "elapsed_ms": 3
-    },
-    {
-      "name": "validate_database_schema_versions",
-      "elapsed_ms": 1
+      "elapsed_ms": 5
     },
     {
       "name": "validate_spec_drift",
+      "elapsed_ms": 2
+    },
+    {
+      "name": "validate_generated_artifact_whitelist",
+      "elapsed_ms": 2
+    },
+    {
+      "name": "validate_database_schema_versions",
       "elapsed_ms": 1
     },
     {
@@ -130,11 +134,23 @@
       "elapsed_ms": 1
     },
     {
-      "name": "validate_research_claims_if_present",
+      "name": "validate_risk_map",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lineage_hard_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_watcher_audit",
       "elapsed_ms": 0
     },
     {
       "name": "validate_heartbeat_invocation_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_validation_receipt_if_present",
       "elapsed_ms": 0
     },
     {
@@ -146,11 +162,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_knowledge_promotions_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_project_config_toml",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
@@ -158,7 +174,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_validation_receipt_if_present",
+      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
@@ -174,19 +190,23 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_internalization_artifacts_if_present",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_workunit_manifests_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_watcher_audit",
+      "name": "validate_archive_integrity",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_lineage_hard_gate",
+      "name": "validate_recursive_improvement_passes_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_lcm_immutability",
+      "name": "validate_context_capsules_if_present",
       "elapsed_ms": 0
     },
     {
@@ -198,23 +218,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_knowledge_promotions_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_recursive_improvement_passes_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_policy_integrity",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_risk_map",
+      "name": "validate_eval_gate_if_required",
       "elapsed_ms": 0
     },
     {
@@ -222,23 +226,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsules_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_eval_gate_if_required",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_internalization_artifacts_if_present",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_lcm_rebuild_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_git_workspace_context",
+      "name": "validate_lcm_immutability",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_policy_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_push_pr_gate",
       "elapsed_ms": 0
     },
     {
@@ -246,7 +246,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_git_push_pr_gate",
+      "name": "validate_git_workspace_context",
       "elapsed_ms": 0
     },
     {
@@ -276,5 +276,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:7f14c23523cda6d99d19b084e35b25c4b0628fac988d47fd53cffd7b8c51655e"
+  "receipt_hash": "sha256:50edd20a4705d292d92c3c3c14e5065a494e8698d66fc1fed2492a0052d25985"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.0 -->
-<!-- decapod-fingerprint: 92872fae034349a2760622dba85d4eb5f77e0250062c41bbeab36f231eb14bf5 -->
+<!-- decapod-release: 0.79.1 -->
+<!-- decapod-fingerprint: 100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.0 -->
-<!-- decapod-fingerprint: e77817639b6f483ad523d3fe7b8801d39d317afd59f0dfa67db9d95f110d38c4 -->
+<!-- decapod-release: 0.79.1 -->
+<!-- decapod-fingerprint: 5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.0 -->
-<!-- decapod-fingerprint: df8d38713abcb1f63f3737275e9c2ec736d40768dcca3380e0f482b1b15feed1 -->
+<!-- decapod-release: 0.79.1 -->
+<!-- decapod-fingerprint: d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.0 -->
-<!-- decapod-fingerprint: 2858a9403de3bf6aabdff3ed1be8a37c6988c3a6dc21d0bdbdca0d35051971dd -->
+<!-- decapod-release: 0.79.1 -->
+<!-- decapod-fingerprint: 45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/entrypoint_integrity.rs
+++ b/src/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.78.0 release manifest. Keep them immutable for the
+// These values are the v0.79.1 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "78fd39044c0a4c336b2e30de432be0840e82a300030b201f2eef74fe4119e4c2",
+        fingerprint: "100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "8e59a26939537f6619f9eff78d35171016c61230c777a39dc0eee07ee3c7c2a4",
+        fingerprint: "5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "aef276f8e2071f33a3fcf73e371a95b2c163dc9413960eaea199fce498383eb0",
+        fingerprint: "45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "c61cc5c681c5a9fd1a90f56971fec9b87cb0d2f6da8599974da678b5fab519b4",
+        fingerprint: "d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d",
     },
 ];
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -203,16 +203,20 @@ fn is_decapod_isolated_worktree(_main_root: &Path, repo_root: &Path) -> bool {
     }
 }
 
-/// Spawn a validation gate in a rayon scope with timing and error capture.
+/// Spawn a validation gate in a scoped thread with timing and error capture.
 ///
 /// Replaces ~10 lines of boilerplate per gate with a single invocation.
 macro_rules! gate {
     ($_scope:expr, $timings:expr, $ctx:expr, $name:literal, $body:expr) => {{
-        let start = Instant::now();
-        if let Err(e) = $body {
-            fail(&format!("gate error: {e}"), $ctx);
-        }
-        $timings.lock().unwrap().push(($name, start.elapsed()));
+        let ctx = $ctx;
+        let timings = $timings;
+        $_scope.spawn(move || {
+            let start = Instant::now();
+            if let Err(e) = $body {
+                fail(&format!("gate error: {e}"), ctx);
+            }
+            timings.lock().unwrap().push(($name, start.elapsed()));
+        });
     }};
 }
 
@@ -226,10 +230,18 @@ struct ValidationContext {
     repo_files_cache: Mutex<Vec<(PathBuf, Vec<PathBuf>)>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationGateTiming {
     pub name: String,
     pub elapsed_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationCiPrediction {
+    pub result: String,
+    pub confidence: String,
+    pub reasons: Vec<String>,
+    pub recommendations: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -245,6 +257,8 @@ pub struct ValidationReport {
     pub drift_findings: Vec<DriftFinding>,
     pub temporary_artifacts_cleaned: u32,
     pub gate_timings: Vec<ValidationGateTiming>,
+    pub parallelism: usize,
+    pub ci_prediction: ValidationCiPrediction,
 }
 
 pub const VALIDATION_RECEIPT_PATH: &str = ".decapod/governance/validation.json";
@@ -266,6 +280,16 @@ pub struct ValidationReceipt {
     pub elapsed_ms: u64,
     pub drift_findings: Vec<DriftFinding>,
     pub temporary_artifacts_cleaned: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failures: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_timings: Option<Vec<ValidationGateTiming>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallelism: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ci_prediction: Option<ValidationCiPrediction>,
     pub receipt_hash: String,
 }
 
@@ -332,6 +356,11 @@ pub fn build_validation_receipt(
         elapsed_ms: report.elapsed_ms,
         drift_findings: report.drift_findings.clone(),
         temporary_artifacts_cleaned: report.temporary_artifacts_cleaned,
+        failures: Some(report.failures.clone()),
+        warnings: Some(report.warnings.clone()),
+        gate_timings: Some(report.gate_timings.clone()),
+        parallelism: Some(report.parallelism),
+        ci_prediction: Some(report.ci_prediction.clone()),
         receipt_hash: String::new(),
     }
     .with_recomputed_hash()
@@ -6072,10 +6101,16 @@ pub fn run_validation(
         }
     }
 
-    // Run remaining gates in parallel for bounded wall-clock validation time.
+    // Run remaining gates concurrently for bounded wall-clock validation time.
+    // Each gate is independently timed and all shared findings are collected
+    // through the thread-safe validation context. The host's available
+    // parallelism is recorded in the proof report so agents can distinguish a
+    // parallel validation run from a sequential fallback.
+    let parallelism = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1);
     let timings: Mutex<Vec<(&str, Duration)>> = Mutex::new(Vec::new());
-    {
-        let _s = ();
+    std::thread::scope(|s| {
         let ctx = &ctx;
         let timings = &timings;
         let broker = broker_content.as_deref();
@@ -6461,15 +6496,19 @@ pub fn run_validation(
             "validate_plan_governed_execution_gate",
             validate_plan_governed_execution_gate(store, ctx, main_root)
         );
-    }
+    });
 
     let elapsed = total_start.elapsed();
     let validation_epoch = active_validation_epoch(working_root)?;
     let pass_count = ctx.pass_count.load(Ordering::Relaxed);
     let fail_count = ctx.fail_count.load(Ordering::Relaxed);
     let warn_count = ctx.warn_count.load(Ordering::Relaxed);
-    let fails = ctx.fails.lock().unwrap().clone();
-    let warns = ctx.warns.lock().unwrap().clone();
+    let mut fails = ctx.fails.lock().unwrap().clone();
+    let mut warns = ctx.warns.lock().unwrap().clone();
+    // Gate completion order is intentionally nondeterministic. Sort the
+    // collected messages before exposing them in JSON, receipts, or hashes.
+    fails.sort();
+    warns.sort();
     let mut drift_findings = ctx.drift_findings.lock().unwrap().clone();
     drift_findings.sort_by(|left, right| {
         (
@@ -6489,6 +6528,7 @@ pub fn run_validation(
     });
     let fail_total = (fails.len() as u32).max(fail_count);
     let warn_total = (warns.len() as u32).max(warn_count);
+    let ci_prediction = predict_ci_outcome(fail_total, warn_total, &fails, &warns);
     let mut gate_timings = timings.into_inner().unwrap();
     gate_timings.sort_by_key(|b| std::cmp::Reverse(b.1));
 
@@ -6510,7 +6550,49 @@ pub fn run_validation(
                 elapsed_ms: elapsed.as_millis() as u64,
             })
             .collect(),
+        parallelism,
+        ci_prediction,
     })
+}
+
+pub fn predict_ci_outcome(
+    fail_count: u32,
+    warn_count: u32,
+    failures: &[String],
+    warnings: &[String],
+) -> ValidationCiPrediction {
+    if fail_count > 0 {
+        return ValidationCiPrediction {
+            result: "fail".to_string(),
+            confidence: "high".to_string(),
+            reasons: failures.to_vec(),
+            recommendations: vec![
+                "Resolve the reported validation failures and rerun `decapod validate --format json`."
+                    .to_string(),
+            ],
+        };
+    }
+
+    if warn_count > 0 {
+        return ValidationCiPrediction {
+            result: "review".to_string(),
+            confidence: "medium".to_string(),
+            reasons: warnings.to_vec(),
+            recommendations: vec![
+                "Review the reported validation warnings before relying on the CI result."
+                    .to_string(),
+                "Use `decapod validate -v --format json` to inspect the affected gate output."
+                    .to_string(),
+            ],
+        };
+    }
+
+    ValidationCiPrediction {
+        result: "pass".to_string(),
+        confidence: "high".to_string(),
+        reasons: vec!["All validation gates completed without failures or warnings.".to_string()],
+        recommendations: vec![],
+    }
 }
 
 pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
@@ -6534,6 +6616,13 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
         "  {} {}",
         "epoch".bright_cyan(),
         report.validation_epoch.epoch_id.bright_white()
+    );
+    println!(
+        "  {} workers={} ci_prediction={} confidence={}",
+        "execution".bright_cyan(),
+        report.parallelism,
+        report.ci_prediction.result,
+        report.ci_prediction.confidence
     );
     println!(
         "  {} {}",
@@ -6622,6 +6711,14 @@ pub fn render_validation_report(report: &ValidationReport, verbose: bool) {
             "  {} {} hidden; use `-v` for warning details",
             "warnings".bright_yellow().bold(),
             report.warnings.len().to_string().bright_yellow()
+        );
+    }
+
+    if verbose && !report.ci_prediction.recommendations.is_empty() {
+        println!(
+            "  {} {}",
+            "recommendations".bright_blue().bold(),
+            output::preview_messages(&report.ci_prediction.recommendations, 10, 200)
         );
     }
 
@@ -6721,7 +6818,7 @@ fn validate_stale_workspaces(
 mod tests {
     use super::{
         SurfaceKind, ValidationContext, is_allowed_non_code_path, is_decapod_isolated_worktree,
-        is_non_code_path, strip_git_quotes, validate_git_workspace_context,
+        is_non_code_path, predict_ci_outcome, strip_git_quotes, validate_git_workspace_context,
         validate_root_dockerfile_seed_detection,
     };
     use super::{is_protected_git_branch, parse_ahead_behind_counts};
@@ -6826,6 +6923,27 @@ mod tests {
         assert_eq!(parse_ahead_behind_counts("3\t1\n"), Some((3, 1)));
         assert_eq!(parse_ahead_behind_counts("0 12"), Some((0, 12)));
         assert_eq!(parse_ahead_behind_counts("bad 12"), None);
+    }
+
+    #[test]
+    fn ci_prediction_preserves_actionable_validation_signals() {
+        let failures = vec!["gate failed".to_string()];
+        let warnings = vec!["review this warning".to_string()];
+
+        let failed = predict_ci_outcome(1, 1, &failures, &warnings);
+        assert_eq!(failed.result, "fail");
+        assert_eq!(failed.confidence, "high");
+        assert_eq!(failed.reasons, failures);
+        assert!(!failed.recommendations.is_empty());
+
+        let review = predict_ci_outcome(0, 1, &[], &warnings);
+        assert_eq!(review.result, "review");
+        assert_eq!(review.confidence, "medium");
+        assert_eq!(review.reasons, warnings);
+
+        let passing = predict_ci_outcome(0, 0, &[], &[]);
+        assert_eq!(passing.result, "pass");
+        assert_eq!(passing.confidence, "high");
     }
 
     #[test]

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -272,6 +272,13 @@ fn validate_json_reports_self_heal_and_structured_summary() {
     assert_eq!(payload["report"]["status"], "ok");
     assert!(payload["report"]["fail_count"].as_u64().unwrap_or(1) == 0);
     assert!(payload["report"]["gate_timings"].is_array());
+    assert!(payload["report"]["parallelism"].as_u64().unwrap_or(0) >= 1);
+    assert!(matches!(
+        payload["report"]["ci_prediction"]["result"].as_str(),
+        Some("pass" | "review")
+    ));
+    assert!(payload["report"]["ci_prediction"]["reasons"].is_array());
+    assert!(payload["report"]["ci_prediction"]["recommendations"].is_array());
     let epoch = &payload["report"]["validation_epoch"];
     assert_eq!(epoch["schema_version"], "1.0.0");
     let epoch_id = epoch["epoch_id"].as_str().expect("epoch_id");
@@ -294,6 +301,14 @@ fn validate_json_reports_self_heal_and_structured_summary() {
     assert_eq!(receipt["kind"], "validation_receipt");
     assert_eq!(receipt["decapod_release"], env!("CARGO_PKG_VERSION"));
     assert_eq!(receipt["status"], "ok");
+    assert!(receipt["warnings"].is_array());
+    assert!(receipt["failures"].is_array());
+    assert!(receipt["gate_timings"].is_array());
+    assert!(receipt["parallelism"].as_u64().unwrap_or(0) >= 1);
+    assert_eq!(
+        receipt["ci_prediction"]["result"],
+        payload["report"]["ci_prediction"]["result"]
+    );
     assert!(
         receipt["receipt_hash"]
             .as_str()


### PR DESCRIPTION
## Summary

Closes #986 and #987.

- Preserve validation failures, warnings, gate timings, available parallelism, and a structured CI prediction in the tracked validation receipt.
- Run independent validation gates concurrently with deterministic sorted findings and bounded scoped threads.
- Add actionable JSON/text recommendations and regression coverage.
- Refresh the v0.79.1 entrypoint manifest constants and living validation spec exposed by the validation run.

## Verification

- `cargo test --lib` (190 passed)
- `cargo test --test validate_termination` (11 passed)
- `DECAPOD_VALIDATE_SKIP_GIT_GATES=1 decapod validate --refresh-specs --format json` (status ok, fail_count 0, parallelism 8)

The full all-targets run also exposed the pre-existing `context_capsule_rpc` fixture failure during workspace setup; the changed validation and library suites pass.