### PR TITLE
fix: scope validation temp artifacts to todo tasks

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.79.1
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.80.0
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.79.1
+ARG DECAPOD_VERSION=0.80.0
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784831710Z",
-  "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
+  "generated_at": "1784837968Z",
+  "repo_signal_fingerprint": "4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "adfe4aef8984fba70cfc21cc36beaa54fd639ac88ee68a92515a0ac95dea052b",
-  "decapod_release": "0.79.1",
+  "spec_input_hash": "36ab1acc98cee2b89575d4bd579c7c295a238672a1ebfe1865ee2d6c0a8076a2",
+  "decapod_release": "0.80.0",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "a9e1f83a7c0a28d2963262850e49af0a9761b5f5d8446df08f90fba49c38b36a",
-      "content_hash": "a9e1f83a7c0a28d2963262850e49af0a9761b5f5d8446df08f90fba49c38b36a",
-      "fingerprint": "100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0"
+      "template_hash": "3d62dc8272f7a9416cac7fdd50de8ab11215b4edce0358282d56b12b48911727",
+      "content_hash": "3d62dc8272f7a9416cac7fdd50de8ab11215b4edce0358282d56b12b48911727",
+      "fingerprint": "7eea13e398d7e4a899126603720422b4aeeba7628df9b3f09c93de2d3123fe3e"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "ec6751c36f33c5e7845c6554af66cebe1fa2374ba1dfcbf945887c2cdca96721",
-      "content_hash": "ec6751c36f33c5e7845c6554af66cebe1fa2374ba1dfcbf945887c2cdca96721",
-      "fingerprint": "5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9"
+      "template_hash": "9cc2c90b0977c8973df136fa5bb87b67056da7361310ace5233d4359a1ca4aba",
+      "content_hash": "9cc2c90b0977c8973df136fa5bb87b67056da7361310ace5233d4359a1ca4aba",
+      "fingerprint": "8bfb5f808286b651feef28b87f43287f4e40a06fef08463d538ed1380b5b65b7"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "451eb5868080c62c843637874e707f873178dcfd726a8472b1e7b50f81ff363b",
-      "content_hash": "451eb5868080c62c843637874e707f873178dcfd726a8472b1e7b50f81ff363b",
-      "fingerprint": "45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774"
+      "template_hash": "58d95bc2f07681b75ad87f660c605aa6eb4622cab33307136705b76d82038727",
+      "content_hash": "58d95bc2f07681b75ad87f660c605aa6eb4622cab33307136705b76d82038727",
+      "fingerprint": "6858c0ce03da5b9caf6445b88139099d8d914dc13dc56630ea56bff9a117adf0"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "0a534d8ee7c1687f711426aafdb24c4c997f484368bf10b3d4178f6a0838538a",
-      "content_hash": "0a534d8ee7c1687f711426aafdb24c4c997f484368bf10b3d4178f6a0838538a",
-      "fingerprint": "d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d"
+      "template_hash": "5c2bf31bcd898870edbfc067f33f68f8f32a3cf7452450e1926a61ce16ee7d72",
+      "content_hash": "5c2bf31bcd898870edbfc067f33f68f8f32a3cf7452450e1926a61ce16ee7d72",
+      "fingerprint": "11bd32c3bee8fa69f4ed03823f4f46b6a973e1fc5f20030960711ec5c3c90ae8"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "0b2c42ed97ae4f1637603c852e39cde761a5892964c48f2ec61f81345039d740",
-      "content_hash": "a233629e384b2bab2b783aaab7cc5e1891ba62ef3b8694ed74e92345fad7f2f2",
+      "content_hash": "a329410870c27a4728f21fd8472c5768251c564c13b9d0754e8aa96326858a58",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "d53dd3865d2417971594b9558abc8b10ffb75be102408137716d926eff253a45",
+      "content_hash": "9ad85343966fcf4bdbf84136978dd9e20373e877de96a5f864f6ce1a51a8c893",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "1c1ff57c12de43a971da3a18ac7aeb389f6bd02cc4d7ca85dc5a41bfa01a4368",
+      "content_hash": "2aec617f21b1885c6b8eed0724fed06383c1e903254aa8eb3d2d83d902d7c485",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "262d3e24bde6d33a18ed0edb03f769291fb2fbe6d26bd49bb91ee5afab39b487",
+      "content_hash": "68fada47cbf4e0307e38c6a8bb0608bd86471d4ea5abfa73625a4bc5716995d6",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "a67f2726b69bc8e514b69f8fdbe13ad4f5bfd2d713c1aa0473a3e90cc8c11a0d",
-      "content_hash": "9c2fa9e1fdb221a1f8aeb583a289c33a3ea738e1267d5c25f4f747f0cadf0b80",
+      "content_hash": "a54da63f92d65f1842f1d797b0af79ca8b8a4d187f2f9bcc18d405ea88036bb8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "33a6e01657c97d4b7a7ad4a7a4c43ae2a24a93580e042f0674f9314aebfd4bfd",
+      "content_hash": "7f0b24c3730073b86ed115d67b85a59ac8e65bc7f40d05ba99e877ebcef7323f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "b095107e7632665b74b0fc4ef98a085c0167b5ea4160e5e202cbe6a1b5937ecd",
+      "content_hash": "ca1a81a9832c493e9bb9dc03cffc116e42acce799908538dcf6a5acc677fff0f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "228c89aac79cfba25bad36c049c5693d348a977c6074316adfc2bc0bbd9cd824",
+      "content_hash": "c263b49b70f1e3abe7c28489704f69dc7efb8aea909ea4f56a3321ebb1cb0cd1",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -408,7 +408,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92`
+- Repository signal fingerprint: `4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
-  "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
-  "task_id": "bugs_01ky82c1sz5wka9e",
+  "run_id": "validation_01KY89XT966J34CQ2H2JJPX8T3",
+  "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
+  "task_id": "bugs_01ky84vzvhvz6fv0",
   "original_intent": "Produce proof artifacts for a repository validation completion.",
   "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
   "destination": "validation completion",
@@ -33,7 +33,8 @@
     }
   ],
   "evidence": [
-    "validation epoch ve_7f6954920d025caf completed with zero failures"
+    "validation epoch ve_a49d9019f59ab63d completed with zero failures",
+    "validation epoch ve_b31eb04d2982fc0c completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -44,12 +45,12 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:fe56a60670efbbb56a77dcdd43fa696c729cfec4e6896594f39369d42b437049",
+  "artifact_hash": "sha256:3bc63c1a6814ba769c26922843f4d9b39b4506084f0a553657a489bb3133de3a",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR": {
-        "id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+      "intent:validation_01KY89XT966J34CQ2H2JJPX8T3": {
+        "id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "raw_intent": "Produce proof artifacts for a repository validation completion.",
         "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
         "acceptance_criteria": [],
@@ -72,34 +73,34 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR"
+        "detail": "trajectory:validation_01KY89XT966J34CQ2H2JJPX8T3"
       },
       {
         "sequence": 5,
         "event_id": "event:5",
-        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+        "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR"
+        "detail": "trajectory:validation_01KY89XT966J34CQ2H2JJPX8T3"
       }
     ],
     "trajectories": {
-      "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR": {
-        "id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
-        "intent_id": "intent:validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
+      "validation_01KY89XT966J34CQ2H2JJPX8T3": {
+        "id": "validation_01KY89XT966J34CQ2H2JJPX8T3",
+        "intent_id": "intent:validation_01KY89XT966J34CQ2H2JJPX8T3",
         "evidence_only": true,
         "steps": [
           {
@@ -113,7 +114,7 @@
             "observations": [
               ".decapod/governance/trajectory.json",
               ".decapod/governance/validation.json",
-              "validation epoch ve_7f6954920d025caf completed with zero failures"
+              "validation epoch ve_b31eb04d2982fc0c completed with zero failures"
             ],
             "proof_refs": [
               "decapod validate"
@@ -132,7 +133,7 @@
             "observations": [
               ".decapod/governance/trajectory.json",
               ".decapod/governance/validation.json",
-              "validation epoch ve_7f6954920d025caf completed with zero failures"
+              "validation epoch ve_a49d9019f59ab63d completed with zero failures"
             ],
             "proof_refs": [
               "decapod validate"

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,36 +1,36 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.79.1",
-  "git_revision": "0378a9027ec461da15646e62257c3322b64e8343",
-  "repo_signal_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
-  "trajectory_run_id": "validation_01KY8471HB5ZH9FJZ9ZD27Z9DR",
-  "trajectory_artifact_hash": "sha256:fe56a60670efbbb56a77dcdd43fa696c729cfec4e6896594f39369d42b437049",
+  "decapod_release": "0.80.0",
+  "git_revision": "eea323f044e345bdecafa64ba0a51c78ae220a9b",
+  "repo_signal_fingerprint": "4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473",
+  "trajectory_run_id": "validation_01KY89XT966J34CQ2H2JJPX8T3",
+  "trajectory_artifact_hash": "sha256:3bc63c1a6814ba769c26922843f4d9b39b4506084f0a553657a489bb3133de3a",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_7f6954920d025caf",
-    "evaluator_identity": "decapod-validate@0.79.1",
-    "evaluator_set_hash": "sha256:75b92694fbe28be57bf3d6145952f1341fbd2504b4d9143d3fd0021c2191b849",
-    "constitution_version": "embedded-docs@0.79.1",
-    "constitution_hash": "sha256:31bdc253bcb0a7d2ce95b4324b91682848ede42e8f1b68155e11e26ccd5cea23",
+    "epoch_id": "ve_a49d9019f59ab63d",
+    "evaluator_identity": "decapod-validate@0.80.0",
+    "evaluator_set_hash": "sha256:93bcb1a0a023f7f25899ecb5b9c0284fad65deadcdd38d0212ae52438285d6b2",
+    "constitution_version": "embedded-docs@0.80.0",
+    "constitution_hash": "sha256:53a744d0e075f8235b36efd19cfa32f290639dd97e4a88c2775bcdbde8764ce6",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:6f4b28b0570a7ad0fd3e903a5377d253f3522d7d06d93f5f858d3844b587e48a",
-    "generated_specs_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
+    "generated_specs_manifest_hash": "sha256:3c5d6d7e9628eb0226441dd7099321d80d0f3cb81677fae7799a90efb196445b",
+    "generated_specs_fingerprint": "4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:31bdc253bcb0a7d2ce95b4324b91682848ede42e8f1b68155e11e26ccd5cea23",
-      "generated_spec:.decapod/generated/specs/ARCHITECTURE.md": "sha256:1c1ff57c12de43a971da3a18ac7aeb389f6bd02cc4d7ca85dc5a41bfa01a4368",
-      "generated_spec:.decapod/generated/specs/INTENT.md": "sha256:d53dd3865d2417971594b9558abc8b10ffb75be102408137716d926eff253a45",
-      "generated_spec:.decapod/generated/specs/INTERFACES.md": "sha256:262d3e24bde6d33a18ed0edb03f769291fb2fbe6d26bd49bb91ee5afab39b487",
-      "generated_spec:.decapod/generated/specs/OPERATIONS.md": "sha256:b095107e7632665b74b0fc4ef98a085c0167b5ea4160e5e202cbe6a1b5937ecd",
-      "generated_spec:.decapod/generated/specs/README.md": "sha256:a233629e384b2bab2b783aaab7cc5e1891ba62ef3b8694ed74e92345fad7f2f2",
-      "generated_spec:.decapod/generated/specs/SECURITY.md": "sha256:228c89aac79cfba25bad36c049c5693d348a977c6074316adfc2bc0bbd9cd824",
-      "generated_spec:.decapod/generated/specs/SEMANTICS.md": "sha256:33a6e01657c97d4b7a7ad4a7a4c43ae2a24a93580e042f0674f9314aebfd4bfd",
-      "generated_spec:.decapod/generated/specs/VALIDATION.md": "sha256:9c2fa9e1fdb221a1f8aeb583a289c33a3ea738e1267d5c25f4f747f0cadf0b80",
-      "generated_specs_fingerprint": "406d0d4fa85d579c37104a1ec8d743383718c554e8d8fb3ae911b85439993c92",
-      "generated_specs_manifest": "sha256:6f4b28b0570a7ad0fd3e903a5377d253f3522d7d06d93f5f858d3844b587e48a",
+      "constitution:core/DECAPOD": "sha256:53a744d0e075f8235b36efd19cfa32f290639dd97e4a88c2775bcdbde8764ce6",
+      "generated_spec:.decapod/generated/specs/ARCHITECTURE.md": "sha256:2aec617f21b1885c6b8eed0724fed06383c1e903254aa8eb3d2d83d902d7c485",
+      "generated_spec:.decapod/generated/specs/INTENT.md": "sha256:9ad85343966fcf4bdbf84136978dd9e20373e877de96a5f864f6ce1a51a8c893",
+      "generated_spec:.decapod/generated/specs/INTERFACES.md": "sha256:68fada47cbf4e0307e38c6a8bb0608bd86471d4ea5abfa73625a4bc5716995d6",
+      "generated_spec:.decapod/generated/specs/OPERATIONS.md": "sha256:ca1a81a9832c493e9bb9dc03cffc116e42acce799908538dcf6a5acc677fff0f",
+      "generated_spec:.decapod/generated/specs/README.md": "sha256:a329410870c27a4728f21fd8472c5768251c564c13b9d0754e8aa96326858a58",
+      "generated_spec:.decapod/generated/specs/SECURITY.md": "sha256:c263b49b70f1e3abe7c28489704f69dc7efb8aea909ea4f56a3321ebb1cb0cd1",
+      "generated_spec:.decapod/generated/specs/SEMANTICS.md": "sha256:7f0b24c3730073b86ed115d67b85a59ac8e65bc7f40d05ba99e877ebcef7323f",
+      "generated_spec:.decapod/generated/specs/VALIDATION.md": "sha256:a54da63f92d65f1842f1d797b0af79ca8b8a4d187f2f9bcc18d405ea88036bb8",
+      "generated_specs_fingerprint": "4d612a069a3bf8fa28928683edbea7003b9992fe5148416a17d31f134cc5a473",
+      "generated_specs_manifest": "sha256:3c5d6d7e9628eb0226441dd7099321d80d0f3cb81677fae7799a90efb196445b",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,7 +39,7 @@
   "pass_count": 197,
   "fail_count": 0,
   "warn_count": 3,
-  "elapsed_ms": 43801,
+  "elapsed_ms": 47666,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -51,130 +51,114 @@
   "gate_timings": [
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 2964
-    },
-    {
-      "name": "validate_machine_contract",
-      "elapsed_ms": 599
-    },
-    {
-      "name": "validate_control_plane_contract",
-      "elapsed_ms": 213
-    },
-    {
-      "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 140
-    },
-    {
-      "name": "validate_schema_determinism",
-      "elapsed_ms": 94
+      "elapsed_ms": 3491
     },
     {
       "name": "validate_knowledge_integrity",
-      "elapsed_ms": 84
-    },
-    {
-      "name": "validate_watcher_purity",
-      "elapsed_ms": 80
+      "elapsed_ms": 937
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 77
+      "elapsed_ms": 899
+    },
+    {
+      "name": "validate_watcher_purity",
+      "elapsed_ms": 843
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 69
+      "elapsed_ms": 835
     },
     {
-      "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 49
+      "name": "validate_machine_contract",
+      "elapsed_ms": 684
+    },
+    {
+      "name": "validate_markdown_primitives_roundtrip_gate",
+      "elapsed_ms": 363
+    },
+    {
+      "name": "validate_schema_determinism",
+      "elapsed_ms": 348
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 43
+      "elapsed_ms": 322
     },
     {
-      "name": "validate_repomap_determinism",
-      "elapsed_ms": 22
+      "name": "validate_control_plane_contract",
+      "elapsed_ms": 301
+    },
+    {
+      "name": "validate_no_legacy_namespaces",
+      "elapsed_ms": 205
     },
     {
       "name": "validate_embedded_self_contained",
+      "elapsed_ms": 199
+    },
+    {
+      "name": "validate_repomap_determinism",
+      "elapsed_ms": 40
+    },
+    {
+      "name": "validate_health_purity",
       "elapsed_ms": 17
     },
     {
       "name": "validate_research_claims_if_present",
-      "elapsed_ms": 9
-    },
-    {
-      "name": "validate_health_purity",
-      "elapsed_ms": 7
-    },
-    {
-      "name": "validate_obligations",
-      "elapsed_ms": 6
+      "elapsed_ms": 12
     },
     {
       "name": "validate_gatekeeper_gate",
-      "elapsed_ms": 5
+      "elapsed_ms": 10
     },
     {
-      "name": "validate_spec_drift",
-      "elapsed_ms": 2
-    },
-    {
-      "name": "validate_generated_artifact_whitelist",
-      "elapsed_ms": 2
-    },
-    {
-      "name": "validate_database_schema_versions",
-      "elapsed_ms": 1
-    },
-    {
-      "name": "validate_interface_contract_bootstrap",
-      "elapsed_ms": 1
-    },
-    {
-      "name": "validate_risk_map",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_lineage_hard_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_watcher_audit",
-      "elapsed_ms": 0
+      "name": "validate_obligations",
+      "elapsed_ms": 7
     },
     {
       "name": "validate_heartbeat_invocation_gate",
-      "elapsed_ms": 0
+      "elapsed_ms": 7
     },
     {
-      "name": "validate_validation_receipt_if_present",
-      "elapsed_ms": 0
+      "name": "validate_generated_artifact_whitelist",
+      "elapsed_ms": 4
     },
     {
       "name": "validate_entrypoint_invariants",
-      "elapsed_ms": 0
+      "elapsed_ms": 4
+    },
+    {
+      "name": "validate_database_schema_versions",
+      "elapsed_ms": 4
+    },
+    {
+      "name": "validate_interface_contract_bootstrap",
+      "elapsed_ms": 3
+    },
+    {
+      "name": "validate_spec_drift",
+      "elapsed_ms": 3
+    },
+    {
+      "name": "validate_validation_receipt_if_present",
+      "elapsed_ms": 2
     },
     {
       "name": "validate_repo_map",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_knowledge_promotions_if_present",
-      "elapsed_ms": 0
+      "elapsed_ms": 1
     },
     {
       "name": "validate_trajectory_artifacts_if_present",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
       "name": "validate_project_scoped_state",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
@@ -194,19 +178,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_workunit_manifests_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_archive_integrity",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_recursive_improvement_passes_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_context_capsules_if_present",
+      "name": "validate_eval_gate_if_required",
       "elapsed_ms": 0
     },
     {
@@ -214,23 +186,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_root_dockerfile_seed_detection",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_eval_gate_if_required",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_health_cache_integrity",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_lcm_rebuild_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_lcm_immutability",
+      "name": "validate_lineage_hard_gate",
       "elapsed_ms": 0
     },
     {
@@ -238,7 +194,63 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_knowledge_promotions_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsules_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_health_cache_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_risk_map",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_root_dockerfile_seed_detection",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_watcher_audit",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lcm_immutability",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_workunit_manifests_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_protected_branch",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_recursive_improvement_passes_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_archive_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_tooling_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lcm_rebuild_gate",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_git_push_pr_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_plan_governed_execution_gate",
       "elapsed_ms": 0
     },
     {
@@ -247,18 +259,6 @@
     },
     {
       "name": "validate_git_workspace_context",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_tooling_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_plan_governed_execution_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_git_protected_branch",
       "elapsed_ms": 0
     }
   ],
@@ -276,5 +276,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:50edd20a4705d292d92c3c3c14e5065a494e8698d66fc1fed2492a0052d25985"
+  "receipt_hash": "sha256:51b1317bf2e8fd658f943dd78593118e5abb4ba6a22493962cefd31d7b0243dc"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.1 -->
-<!-- decapod-fingerprint: 100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0 -->
+<!-- decapod-release: 0.80.0 -->
+<!-- decapod-fingerprint: 7eea13e398d7e4a899126603720422b4aeeba7628df9b3f09c93de2d3123fe3e -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.1 -->
-<!-- decapod-fingerprint: 5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9 -->
+<!-- decapod-release: 0.80.0 -->
+<!-- decapod-fingerprint: 8bfb5f808286b651feef28b87f43287f4e40a06fef08463d538ed1380b5b65b7 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.1 -->
-<!-- decapod-fingerprint: d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d -->
+<!-- decapod-release: 0.80.0 -->
+<!-- decapod-fingerprint: 11bd32c3bee8fa69f4ed03823f4f46b6a973e1fc5f20030960711ec5c3c90ae8 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.79.1 -->
-<!-- decapod-fingerprint: 45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774 -->
+<!-- decapod-release: 0.80.0 -->
+<!-- decapod-fingerprint: 6858c0ce03da5b9caf6445b88139099d8d914dc13dc56630ea56bff9a117adf0 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/core/entrypoint_integrity.rs
+++ b/src/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.79.1 release manifest. Keep them immutable for the
+// These values are the v0.80.0 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "100b122803018de15a055df5dfb47476a9d19e36fc3df761a323d7d08ec95fd0",
+        fingerprint: "7eea13e398d7e4a899126603720422b4aeeba7628df9b3f09c93de2d3123fe3e",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "5956c56567d02e45b015eb6583d9b6d8d6b0b554169a17410115ffd63890eca9",
+        fingerprint: "8bfb5f808286b651feef28b87f43287f4e40a06fef08463d538ed1380b5b65b7",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "45276c81e9cfc327c9c5ef4037a9779571f093cffcdbdc300df6e2cadafa9774",
+        fingerprint: "6858c0ce03da5b9caf6445b88139099d8d914dc13dc56630ea56bff9a117adf0",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "d17805e7669d12d6bc99cefce672572f99ae0000f0ac13bab0e33e9fe3c4541d",
+        fingerprint: "11bd32c3bee8fa69f4ed03823f4f46b6a973e1fc5f20030960711ec5c3c90ae8",
     },
 ];
 

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -376,21 +376,27 @@ pub fn register_validation_temp_path(path: PathBuf) {
     validation_temp_paths().lock().unwrap().push(path);
 }
 
-/// Remove only temporary directories created by this process's validation run.
+/// Remove only temporary directories registered by this process's validation run.
 ///
 /// Validation intentionally does not scan or mutate arbitrary `/tmp` entries.
-/// Cleanup is invoked by the bounded runner only after every gate passes.
+/// Cleanup is best-effort across every registered path so one stale path cannot
+/// prevent the remaining validation artifacts from being removed.
 pub fn cleanup_validation_temp_paths() -> Result<u32, error::DecapodError> {
     let paths = std::mem::take(&mut *validation_temp_paths().lock().unwrap());
     let mut cleaned = 0;
+    let mut first_error = None;
     for path in paths {
         match fs::remove_dir_all(&path) {
             Ok(()) => cleaned += 1,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error::DecapodError::IoError(error)),
+            Err(error) => {
+                if first_error.is_none() {
+                    first_error = Some(error::DecapodError::IoError(error));
+                }
+            }
         }
     }
-    Ok(cleaned)
+    first_error.map_or(Ok(cleaned), Err)
 }
 
 impl ValidationContext {

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -373,14 +373,81 @@ fn validation_temp_paths() -> &'static Mutex<Vec<PathBuf>> {
 }
 
 pub fn register_validation_temp_path(path: PathBuf) {
-    validation_temp_paths().lock().unwrap().push(path);
+    let mut paths = validation_temp_paths().lock().unwrap();
+    if !paths.iter().any(|registered| registered == &path) {
+        paths.push(path);
+    }
 }
 
-/// Remove only temporary directories registered by this process's validation run.
+fn sanitize_validation_task_id(task_id: &str) -> String {
+    let sanitized: String = task_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let sanitized = sanitized.trim_matches('-');
+    if sanitized.is_empty() {
+        "todo-unassigned".to_string()
+    } else {
+        sanitized.to_string()
+    }
+}
+
+fn validation_task_id(workspace_root: &Path) -> String {
+    let explicit = ["DECAPOD_TASK_ID"].iter().find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    });
+
+    if let Some(task_id) = explicit {
+        return sanitize_validation_task_id(&task_id);
+    }
+
+    if let Ok(status) = workspace::get_workspace_status(workspace_root) {
+        if let Some(task_id) = workspace::extract_task_ids_from_branch(&status.git.current_branch)
+            .into_iter()
+            .next()
+        {
+            return sanitize_validation_task_id(&task_id);
+        }
+    }
+
+    "todo-unassigned".to_string()
+}
+
+/// Return the task-owned temporary directory for this validation workspace.
+///
+/// The task ID is part of the path by contract. Legacy unscoped `/tmp`
+/// validation directories are intentionally not discovered or mutated.
+pub fn create_validation_temp_path(
+    workspace_root: &Path,
+    kind: &str,
+) -> Result<PathBuf, error::DecapodError> {
+    let task_root = std::env::temp_dir()
+        .join("decapod_validate")
+        .join(validation_task_id(workspace_root));
+    fs::create_dir_all(&task_root).map_err(error::DecapodError::IoError)?;
+    register_validation_temp_path(task_root);
+
+    let path = std::env::temp_dir()
+        .join("decapod_validate")
+        .join(validation_task_id(workspace_root))
+        .join(format!("{kind}_{}", crate::core::ulid::new_ulid()));
+    fs::create_dir_all(&path).map_err(error::DecapodError::IoError)?;
+    Ok(path)
+}
+
+/// Remove only task-owned directories registered by this process's validation run.
 ///
 /// Validation intentionally does not scan or mutate arbitrary `/tmp` entries.
-/// Cleanup is best-effort across every registered path so one stale path cannot
-/// prevent the remaining validation artifacts from being removed.
+/// Callers invoke this only after a green validation result; failed runs retain
+/// their task-scoped artifacts for diagnosis and a later green retry.
 pub fn cleanup_validation_temp_paths() -> Result<u32, error::DecapodError> {
     let paths = std::mem::take(&mut *validation_temp_paths().lock().unwrap());
     let mut cleaned = 0;
@@ -667,14 +734,12 @@ fn fetch_tasks_fingerprint(db_path: &Path) -> Result<String, error::DecapodError
     Ok(serde_json::to_string(&out).unwrap())
 }
 
-fn validate_user_store_blank_slate(ctx: &ValidationContext) -> Result<(), error::DecapodError> {
+fn validate_user_store_blank_slate(
+    ctx: &ValidationContext,
+    working_root: &Path,
+) -> Result<(), error::DecapodError> {
     info("Store: user (blank-slate semantics)");
-    let tmp_root = std::env::temp_dir().join(format!(
-        "decapod_validate_user_{}",
-        crate::core::ulid::new_ulid()
-    ));
-    fs::create_dir_all(&tmp_root).map_err(error::DecapodError::IoError)?;
-    register_validation_temp_path(tmp_root.clone());
+    let tmp_root = create_validation_temp_path(working_root, "user")?;
 
     todo::initialize_todo_db(&tmp_root)?;
     let db_path = tmp_root.join("todo.db");
@@ -694,7 +759,7 @@ fn validate_user_store_blank_slate(ctx: &ValidationContext) -> Result<(), error:
 fn validate_repo_store_dogfood(
     store: &Store,
     ctx: &ValidationContext,
-    _working_root: &Path,
+    working_root: &Path,
 ) -> Result<(), error::DecapodError> {
     info("Store: repo (dogfood backlog semantics)");
 
@@ -736,12 +801,7 @@ fn validate_repo_store_dogfood(
         );
     }
 
-    let tmp_root = std::env::temp_dir().join(format!(
-        "decapod_validate_repo_{}",
-        crate::core::ulid::new_ulid()
-    ));
-    fs::create_dir_all(&tmp_root).map_err(error::DecapodError::IoError)?;
-    register_validation_temp_path(tmp_root.clone());
+    let tmp_root = create_validation_temp_path(working_root, "repo")?;
     let tmp_db = tmp_root.join("todo.db");
     let _events = todo::rebuild_db_from_events(&events, &tmp_db)?;
 
@@ -6097,12 +6157,12 @@ pub fn run_validation(
     match store.kind {
         StoreKind::User => {
             let start = Instant::now();
-            validate_user_store_blank_slate(&ctx)?;
+            validate_user_store_blank_slate(&ctx, working_root)?;
             let _ = start;
         }
         StoreKind::Repo => {
             let start = Instant::now();
-            validate_repo_store_dogfood(store, &ctx, main_root)?;
+            validate_repo_store_dogfood(store, &ctx, working_root)?;
             let _ = start;
         }
     }

--- a/src/core/validate.rs
+++ b/src/core/validate.rs
@@ -409,13 +409,12 @@ fn validation_task_id(workspace_root: &Path) -> String {
         return sanitize_validation_task_id(&task_id);
     }
 
-    if let Ok(status) = workspace::get_workspace_status(workspace_root) {
-        if let Some(task_id) = workspace::extract_task_ids_from_branch(&status.git.current_branch)
+    if let Ok(status) = workspace::get_workspace_status(workspace_root)
+        && let Some(task_id) = workspace::extract_task_ids_from_branch(&status.git.current_branch)
             .into_iter()
             .next()
-        {
-            return sanitize_validation_task_id(&task_id);
-        }
+    {
+        return sanitize_validation_task_id(&task_id);
     }
 
     "todo-unassigned".to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5648,6 +5648,19 @@ fn run_validate_command(
         auth_gate.check_and_trigger(governance_root)?;
     }
 
+    // Cleanup must also cover setup/healing errors that happen before the
+    // bounded worker starts. The worker and timeout branches handle normal
+    // validation completion; this guard covers every remaining return path.
+    struct ValidationTempCleanupGuard;
+    impl Drop for ValidationTempCleanupGuard {
+        fn drop(&mut self) {
+            if let Err(error) = validate::cleanup_validation_temp_paths() {
+                eprintln!("warning: validation temporary-artifact cleanup failed: {error}");
+            }
+        }
+    }
+    let _temp_cleanup_guard = ValidationTempCleanupGuard;
+
     let store = match validate_cli.store.as_str() {
         "user" => {
             // User store uses a temp directory for blank-slate validation
@@ -5959,7 +5972,8 @@ fn run_validation_bounded(
 ) -> Result<validate::ValidationReport, error::DecapodError> {
     let timeout_secs = validate_timeout_secs();
     let started = std::time::Instant::now();
-    let (tx, rx) = mpsc::channel();
+    let (tx, rx) =
+        mpsc::channel::<(Result<validate::ValidationReport, error::DecapodError>, u32)>();
     let store_cloned = store.clone();
     let g_root = governance_root.to_path_buf();
     let w_root = workspace_root.to_path_buf();
@@ -6000,17 +6014,31 @@ fn run_validation_bounded(
                 false,
             );
         }
-        let _ = tx.send(result);
+        let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
+        let _ = tx.send((result, cleaned));
     });
 
-    let result = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
-        Ok(result) => result.map_err(normalize_validate_error),
-        Err(mpsc::RecvTimeoutError::Timeout) => Err(error::DecapodError::ValidationError(format!(
-            "VALIDATE_TIMEOUT_OR_LOCK: validate exceeded timeout ({timeout_secs}s). Terminated to preserve proof-gate liveness."
-        ))),
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(error::DecapodError::ValidationError(
-            "VALIDATE_TIMEOUT_OR_LOCK: validate worker disconnected unexpectedly.".to_string(),
-        )),
+    let (result, cleaned) = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok((result, cleaned)) => (result.map_err(normalize_validate_error), cleaned),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
+            (
+                Err(error::DecapodError::ValidationError(format!(
+                    "VALIDATE_TIMEOUT_OR_LOCK: validate exceeded timeout ({timeout_secs}s). Terminated to preserve proof-gate liveness."
+                ))),
+                cleaned,
+            )
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
+            (
+                Err(error::DecapodError::ValidationError(
+                    "VALIDATE_TIMEOUT_OR_LOCK: validate worker disconnected unexpectedly."
+                        .to_string(),
+                )),
+                cleaned,
+            )
+        }
     };
     let result = result.map_err(|err| {
         attach_validate_diagnostic_if_enabled(
@@ -6021,10 +6049,12 @@ fn run_validation_bounded(
         )
     });
     match result {
-        Ok(mut report) if report.fail_count == 0 => {
-            report.temporary_artifacts_cleaned = validate::cleanup_validation_temp_paths()?;
-            record_validation_proof(workspace_root, &report)?;
-            write_validation_receipt(workspace_root, &report)?;
+        Ok(mut report) => {
+            report.temporary_artifacts_cleaned = cleaned;
+            if report.fail_count == 0 {
+                record_validation_proof(workspace_root, &report)?;
+                write_validation_receipt(workspace_root, &report)?;
+            }
             Ok(report)
         }
         other => other,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5648,28 +5648,10 @@ fn run_validate_command(
         auth_gate.check_and_trigger(governance_root)?;
     }
 
-    // Cleanup must also cover setup/healing errors that happen before the
-    // bounded worker starts. The worker and timeout branches handle normal
-    // validation completion; this guard covers every remaining return path.
-    struct ValidationTempCleanupGuard;
-    impl Drop for ValidationTempCleanupGuard {
-        fn drop(&mut self) {
-            if let Err(error) = validate::cleanup_validation_temp_paths() {
-                eprintln!("warning: validation temporary-artifact cleanup failed: {error}");
-            }
-        }
-    }
-    let _temp_cleanup_guard = ValidationTempCleanupGuard;
-
     let store = match validate_cli.store.as_str() {
         "user" => {
             // User store uses a temp directory for blank-slate validation
-            let tmp_root = std::env::temp_dir().join(format!(
-                "decapod_validate_user_{}",
-                crate::core::ulid::new_ulid()
-            ));
-            std::fs::create_dir_all(&tmp_root).map_err(error::DecapodError::IoError)?;
-            validate::register_validation_temp_path(tmp_root.clone());
+            let tmp_root = validate::create_validation_temp_path(workspace_root, "user")?;
             Store {
                 kind: StoreKind::User,
                 root: tmp_root,
@@ -5972,8 +5954,7 @@ fn run_validation_bounded(
 ) -> Result<validate::ValidationReport, error::DecapodError> {
     let timeout_secs = validate_timeout_secs();
     let started = std::time::Instant::now();
-    let (tx, rx) =
-        mpsc::channel::<(Result<validate::ValidationReport, error::DecapodError>, u32)>();
+    let (tx, rx) = mpsc::channel::<Result<validate::ValidationReport, error::DecapodError>>();
     let store_cloned = store.clone();
     let g_root = governance_root.to_path_buf();
     let w_root = workspace_root.to_path_buf();
@@ -6014,31 +5995,17 @@ fn run_validation_bounded(
                 false,
             );
         }
-        let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
-        let _ = tx.send((result, cleaned));
+        let _ = tx.send(result);
     });
 
-    let (result, cleaned) = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
-        Ok((result, cleaned)) => (result.map_err(normalize_validate_error), cleaned),
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
-            (
-                Err(error::DecapodError::ValidationError(format!(
-                    "VALIDATE_TIMEOUT_OR_LOCK: validate exceeded timeout ({timeout_secs}s). Terminated to preserve proof-gate liveness."
-                ))),
-                cleaned,
-            )
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            let cleaned = validate::cleanup_validation_temp_paths().unwrap_or_default();
-            (
-                Err(error::DecapodError::ValidationError(
-                    "VALIDATE_TIMEOUT_OR_LOCK: validate worker disconnected unexpectedly."
-                        .to_string(),
-                )),
-                cleaned,
-            )
-        }
+    let result = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok(result) => result.map_err(normalize_validate_error),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(error::DecapodError::ValidationError(format!(
+            "VALIDATE_TIMEOUT_OR_LOCK: validate exceeded timeout ({timeout_secs}s). Terminated to preserve proof-gate liveness."
+        ))),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(error::DecapodError::ValidationError(
+            "VALIDATE_TIMEOUT_OR_LOCK: validate worker disconnected unexpectedly.".to_string(),
+        )),
     };
     let result = result.map_err(|err| {
         attach_validate_diagnostic_if_enabled(
@@ -6049,12 +6016,10 @@ fn run_validation_bounded(
         )
     });
     match result {
-        Ok(mut report) => {
-            report.temporary_artifacts_cleaned = cleaned;
-            if report.fail_count == 0 {
-                record_validation_proof(workspace_root, &report)?;
-                write_validation_receipt(workspace_root, &report)?;
-            }
+        Ok(mut report) if report.fail_count == 0 => {
+            report.temporary_artifacts_cleaned = validate::cleanup_validation_temp_paths()?;
+            record_validation_proof(workspace_root, &report)?;
+            write_validation_receipt(workspace_root, &report)?;
             Ok(report)
         }
         other => other,

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -1,5 +1,6 @@
 use rusqlite::Connection;
 use serde_json::Value;
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -73,6 +74,19 @@ fn setup_repo() -> (TempDir, PathBuf, String) {
     (tmp, dir, password)
 }
 
+fn validation_temp_dirs() -> BTreeSet<PathBuf> {
+    fs::read_dir(std::env::temp_dir())
+        .expect("read system temp directory")
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            let name = path.file_name()?.to_string_lossy();
+            (name.starts_with("decapod_validate_repo_")
+                || name.starts_with("decapod_validate_user_"))
+            .then_some(path)
+        })
+        .collect()
+}
+
 #[test]
 fn successful_validation_cleans_only_its_temporary_artifacts() {
     let (_tmp, dir, password) = setup_repo();
@@ -116,6 +130,7 @@ fn successful_validation_cleans_only_its_temporary_artifacts() {
 #[test]
 fn validate_terminates_with_typed_error_under_db_contention() {
     let (_tmp, dir, password) = setup_repo();
+    let temp_before = validation_temp_dirs();
     let db_path = dir.join(".decapod").join("data").join("todo.db");
     assert!(db_path.exists(), "todo db should exist before lock test");
 
@@ -153,6 +168,13 @@ fn validate_terminates_with_typed_error_under_db_contention() {
     );
 
     conn.execute_batch("ROLLBACK;").expect("release lock");
+
+    let temp_after = validation_temp_dirs();
+    assert_eq!(
+        temp_after.difference(&temp_before).count(),
+        0,
+        "failed validation must clean its owned temporary directories"
+    );
 }
 
 #[test]

--- a/tests/validate_termination.rs
+++ b/tests/validate_termination.rs
@@ -1,7 +1,8 @@
 use rusqlite::Connection;
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::hash_map::DefaultHasher;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
@@ -12,6 +13,11 @@ fn run_decapod(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> std::process
     cmd.current_dir(dir).args(args);
     for (k, v) in envs {
         cmd.env(k, v);
+    }
+    if !envs.iter().any(|(key, _)| *key == "DECAPOD_TASK_ID") {
+        let mut hasher = DefaultHasher::new();
+        dir.hash(&mut hasher);
+        cmd.env("DECAPOD_TASK_ID", format!("test_{:016x}", hasher.finish()));
     }
     cmd.output().expect("run decapod")
 }
@@ -74,15 +80,18 @@ fn setup_repo() -> (TempDir, PathBuf, String) {
     (tmp, dir, password)
 }
 
-fn validation_temp_dirs() -> BTreeSet<PathBuf> {
-    fs::read_dir(std::env::temp_dir())
-        .expect("read system temp directory")
+fn validation_task_dir(task_id: &str) -> PathBuf {
+    std::env::temp_dir().join("decapod_validate").join(task_id)
+}
+
+fn validation_temp_dirs() -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(std::env::temp_dir().join("decapod_validate")) else {
+        return Vec::new();
+    };
+    entries
         .filter_map(|entry| {
             let path = entry.ok()?.path();
-            let name = path.file_name()?.to_string_lossy();
-            (name.starts_with("decapod_validate_repo_")
-                || name.starts_with("decapod_validate_user_"))
-            .then_some(path)
+            path.is_dir().then_some(path)
         })
         .collect()
 }
@@ -90,10 +99,8 @@ fn validation_temp_dirs() -> BTreeSet<PathBuf> {
 #[test]
 fn successful_validation_cleans_only_its_temporary_artifacts() {
     let (_tmp, dir, password) = setup_repo();
-    let unowned = std::env::temp_dir().join(format!(
-        "decapod_validate_user_unowned_{}",
-        std::process::id()
-    ));
+    let unowned =
+        std::env::temp_dir().join(format!("decapod_validate_unowned_{}", std::process::id()));
     fs::create_dir_all(&unowned).expect("create unowned validation-shaped temp directory");
     let validate = run_decapod(
         &dir,
@@ -116,7 +123,7 @@ fn successful_validation_cleans_only_its_temporary_artifacts() {
         payload["report"]["temporary_artifacts_cleaned"]
             .as_u64()
             .unwrap_or_default()
-            >= 2,
+            >= 1,
         "successful validation should report cleanup of its user-store temp dirs: {payload}"
     );
 
@@ -130,6 +137,7 @@ fn successful_validation_cleans_only_its_temporary_artifacts() {
 #[test]
 fn validate_terminates_with_typed_error_under_db_contention() {
     let (_tmp, dir, password) = setup_repo();
+    let task_id = format!("test_validation_cleanup_{}", std::process::id());
     let temp_before = validation_temp_dirs();
     let db_path = dir.join(".decapod").join("data").join("todo.db");
     assert!(db_path.exists(), "todo db should exist before lock test");
@@ -147,6 +155,7 @@ fn validate_terminates_with_typed_error_under_db_contention() {
             ("DECAPOD_SESSION_PASSWORD", &password),
             ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
             ("DECAPOD_VALIDATE_TIMEOUT_SECS", "2"),
+            ("DECAPOD_TASK_ID", &task_id),
         ],
     );
     let elapsed = start.elapsed();
@@ -170,10 +179,32 @@ fn validate_terminates_with_typed_error_under_db_contention() {
     conn.execute_batch("ROLLBACK;").expect("release lock");
 
     let temp_after = validation_temp_dirs();
-    assert_eq!(
-        temp_after.difference(&temp_before).count(),
-        0,
-        "failed validation must clean its owned temporary directories"
+    assert!(
+        temp_after
+            .iter()
+            .filter(|path| !temp_before.contains(path))
+            .all(|path| path == &validation_task_dir(&task_id)),
+        "failed validation must not create an unscoped temporary directory"
+    );
+
+    let green = run_decapod(
+        &dir,
+        &["validate"],
+        &[
+            ("DECAPOD_AGENT_ID", "unknown"),
+            ("DECAPOD_SESSION_PASSWORD", &password),
+            ("DECAPOD_VALIDATE_SKIP_GIT_GATES", "1"),
+            ("DECAPOD_TASK_ID", &task_id),
+        ],
+    );
+    assert!(
+        green.status.success(),
+        "green validation should remove prior task-scoped artifacts: {}",
+        String::from_utf8_lossy(&green.stderr)
+    );
+    assert!(
+        !validation_task_dir(&task_id).exists(),
+        "green validation should remove the entire todo-scoped directory"
     );
 }
 


### PR DESCRIPTION
## Summary

- Create validation temporary artifacts only under `/tmp/decapod_validate/<todo-id>/...`.
- Retain task-scoped artifacts after failed, timed-out, or early validation exits for diagnosis.
- Remove the registered todo directory only after validation is green.
- Never scan or mutate legacy unscoped `/tmp/decapod*` directories.
- Deduplicate task-root cleanup registration and cover the lifecycle with regression tests.
- Refresh Decapod v0.80.0 entrypoint fingerprints, version-bound generated artifacts, specs manifest, and validation proof.

## Tests and validation

- `cargo test --test validate_termination` — 11 passed.
- `cargo test --lib` — 190 passed.
- `cargo clippy --all-targets -- -D warnings` — passed.
- Decapod v0.80.0 validation — 197 passed, 0 failures, 3 review warnings for missing risk map, hygiene-only spec drift, and watcher audit trail.
