### PR TITLE
Refactor: fold selective tests into decapod qa

### DIFF
--- a/.decapod/generated/Dockerfile
+++ b/.decapod/generated/Dockerfile
@@ -2,9 +2,9 @@
 # Path: .decapod/generated/Dockerfile
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.80.1
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.80.2
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.80.1
+ARG DECAPOD_VERSION=0.80.2
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784850482Z",
-  "repo_signal_fingerprint": "0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194",
+  "generated_at": "1784850907Z",
+  "repo_signal_fingerprint": "a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "61cd81d06e42d9f4b7287d7a92853b3701259686353f46538d0e97b63c246642",
+  "spec_input_hash": "a80d5c9ed67c2d2b2f80e6d1ad7bab5f22db875bea4dc5dac361e833dfe26b5e",
   "decapod_release": "0.80.2",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "0b2c42ed97ae4f1637603c852e39cde761a5892964c48f2ec61f81345039d740",
-      "content_hash": "430c1beec0d813e9f7433229ea70601f755b846acb789c061ed48a5176faf1dc",
+      "content_hash": "48d0f3366870b08556486ee9800ec0851241ac75918ab45266c010257a70b948",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "b4a65b2935a3fad971800e9bee7b9baf75616f39bf2086578f4a1869f395df6b",
+      "content_hash": "f91a1aed89ef66b5d5790c0b710d9fb682acee704c00e31a78de672b11e0f7c0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "66a64ced9bcdfa78ece106d2470caeff226b15a0758d495e66a9490757fcfadb",
+      "content_hash": "0ef8fdae08a51748911a48216f63d947ce5f1465c8aaf8b328601cadb1be4be4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "6896d3aa3351159f8f45691ed745449a0c19b87f7cdd64f6aa4a8e46da3e4aed",
+      "content_hash": "a0a6fa8bac7772a753e7a4bd04b43dd7760670d4b4c8256168cf059d22b0040e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "a67f2726b69bc8e514b69f8fdbe13ad4f5bfd2d713c1aa0473a3e90cc8c11a0d",
-      "content_hash": "1daf268938777d488ef0aa5f6066888e4ffcf1ec6c57eb42b2be887df8747ff7",
+      "content_hash": "bc2ce65a46f8008dcf74f944c966aacd31b2fafbbed4749d367b24016ba4d4cf",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "9b3de52fc5705c7063da501e0ba82f0cb5c9a93f94445394e374c702b12156f8",
+      "content_hash": "ef089e0f6c8ea4a93cd6446cf50c576b61a48c217a312fec9a640de4c56d483c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "32071a9796c422d48c8bc3a5afa604c4551dc4ad6cf1ece823d2dd0d514a6729",
+      "content_hash": "07e3f65cc2158d27ccb26e78ee34fbde3474fc57bb319c396a2efd91fdc8aca9",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "bad20f7711c6dcd24397e399e4a165d782e8d3ac7f805d138f9ebbdee21a4975",
+      "content_hash": "ba8b7625f8ee47d34838a732563dc7b3e6977db06a81d1317f0dca3def44c0c5",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784848765Z",
-  "repo_signal_fingerprint": "a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76",
+  "generated_at": "1784850482Z",
+  "repo_signal_fingerprint": "0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "b7332be7264fb7da5ba1f3b656d53fd60861ff0b1f8979bb4314c05e392e0276",
-  "decapod_release": "0.80.1",
+  "spec_input_hash": "61cd81d06e42d9f4b7287d7a92853b3701259686353f46538d0e97b63c246642",
+  "decapod_release": "0.80.2",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "9322545e28da9b1a90fd3830d5de148c90bb1ad6af6201eacca5e98eb5775822",
-      "content_hash": "9322545e28da9b1a90fd3830d5de148c90bb1ad6af6201eacca5e98eb5775822",
-      "fingerprint": "4f3ea3cb9493ccfacba6bbb02fb87a67653675e9f2c1865bf127013290080a7c"
+      "template_hash": "bfc5e5d182414a8ad8abbf895f82e8f0d31d21ca848b75bccf31f8ad0a671ab7",
+      "content_hash": "bfc5e5d182414a8ad8abbf895f82e8f0d31d21ca848b75bccf31f8ad0a671ab7",
+      "fingerprint": "af849e8e04a7b1533285dddfac052b221c60e51d1ea7a6fddbfba961f3433851"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "6fbe7c6a43713d000835a69c8d9f4461e49fb8f00d7be119e1a9db930f023b83",
-      "content_hash": "6fbe7c6a43713d000835a69c8d9f4461e49fb8f00d7be119e1a9db930f023b83",
-      "fingerprint": "557c3bfc731c72863e34e77a73d0770c319b10fd25f57823327cb8348ca06d22"
+      "template_hash": "877703d8adf35afa5f6bee7f3482306b7484f6bc446d7b0376a8042a2d73ebb1",
+      "content_hash": "877703d8adf35afa5f6bee7f3482306b7484f6bc446d7b0376a8042a2d73ebb1",
+      "fingerprint": "53850acd075192f0a89cd9660635e2daf57ac0d02b82213086ffc103314c717f"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "8807e6a52ef9536aff257b8fdafa6110eddd8e498dc32de784be4aa27240a938",
-      "content_hash": "8807e6a52ef9536aff257b8fdafa6110eddd8e498dc32de784be4aa27240a938",
-      "fingerprint": "4c391fe1fdc2f3c821d027c85f1b6028dd6bdb474d4859e4f70fc57810af6b3f"
+      "template_hash": "f4a9d8a3654016b428fc7dead5bcdd1dbac472d76f109561d8de283331ecdc39",
+      "content_hash": "f4a9d8a3654016b428fc7dead5bcdd1dbac472d76f109561d8de283331ecdc39",
+      "fingerprint": "2dd2fb43f09a90b586cff93c560199ff39a2515430d10e21a7ae0b67cb3d3dab"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "d56b0f543ad9d2d7c9513d20e40f338f169f8801acf86ff4c7cd151b2a450e0c",
-      "content_hash": "d56b0f543ad9d2d7c9513d20e40f338f169f8801acf86ff4c7cd151b2a450e0c",
-      "fingerprint": "3266d46c0f7aad465c4600b07b67da2655d485f629d22fdbb76b202284cfff20"
+      "template_hash": "a1b85150621bef42cefd51e66991ec3cb6b985e46ac9e24cd59e3c2abda84950",
+      "content_hash": "a1b85150621bef42cefd51e66991ec3cb6b985e46ac9e24cd59e3c2abda84950",
+      "fingerprint": "f103572b76b036899ffb08f40524e0173aee69dc7e00aa9db9bff6debc2d08cc"
     }
   ],
   "files": [
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "0b2c42ed97ae4f1637603c852e39cde761a5892964c48f2ec61f81345039d740",
-      "content_hash": "40be9c82d1992f3afa447f8066229308b7f8e999569a12ec7f92ecd96439cef8",
+      "content_hash": "430c1beec0d813e9f7433229ea70601f755b846acb789c061ed48a5176faf1dc",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ce5245b97222b632032bfafc93c9f4a6b30ae2540a04f03be4110fe9e7b6881c",
+      "content_hash": "b4a65b2935a3fad971800e9bee7b9baf75616f39bf2086578f4a1869f395df6b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "c2eeff1690c34cb890c41e96ab8725b13825117efb21a67b67e71c09e4410991",
+      "content_hash": "66a64ced9bcdfa78ece106d2470caeff226b15a0758d495e66a9490757fcfadb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "e5110246d86f2a53549e3fc0b14fc0344d7a89dd9ca3a1db3915b61a62250a71",
+      "content_hash": "6896d3aa3351159f8f45691ed745449a0c19b87f7cdd64f6aa4a8e46da3e4aed",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "a67f2726b69bc8e514b69f8fdbe13ad4f5bfd2d713c1aa0473a3e90cc8c11a0d",
-      "content_hash": "2c954bdd48ef80ba8f74fcb028efb32b415dfcf6fb1bbc752174d48c4cbd2e23",
+      "content_hash": "1daf268938777d488ef0aa5f6066888e4ffcf1ec6c57eb42b2be887df8747ff7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "0600d58d3777d9865d963858f2f1413e1745651d6fa773921df2a8bd49b342d6",
+      "content_hash": "9b3de52fc5705c7063da501e0ba82f0cb5c9a93f94445394e374c702b12156f8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "4cbf672ed62dddf8ab2a470bc5d12a1a71cd4e6be686fe3e4e45ea139aca33d4",
+      "content_hash": "32071a9796c422d48c8bc3a5afa604c4551dc4ad6cf1ece823d2dd0d514a6729",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "8e0858fc45cefa1470ebcee9b227a8541a2e1a0aead1e94ebd0f8d94ed761c21",
+      "content_hash": "bad20f7711c6dcd24397e399e4a165d782e8d3ac7f805d138f9ebbdee21a4975",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/.manifest.json
+++ b/.decapod/generated/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1784850907Z",
-  "repo_signal_fingerprint": "a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a",
+  "generated_at": "1784851480Z",
+  "repo_signal_fingerprint": "969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "884bc4a795be741206109c0af2d45bc3ba63b019585c96985b2458c605f55320",
-  "spec_input_hash": "a80d5c9ed67c2d2b2f80e6d1ad7bab5f22db875bea4dc5dac361e833dfe26b5e",
+  "spec_input_hash": "270a8423997f1e4b82fb4827ac6affb58f1e4a486a8483a08686a6f2bb9cffe8",
   "decapod_release": "0.80.2",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/generated/specs/README.md",
       "template_hash": "0b2c42ed97ae4f1637603c852e39cde761a5892964c48f2ec61f81345039d740",
-      "content_hash": "48d0f3366870b08556486ee9800ec0851241ac75918ab45266c010257a70b948",
+      "content_hash": "e988590c81cfab6e85489c63c9de672dc2156cd07c8fd60d12248b24c375f71a",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "f91a1aed89ef66b5d5790c0b710d9fb682acee704c00e31a78de672b11e0f7c0",
+      "content_hash": "df17fe22d44ebc0e3a56bbf5f3d3889a182316b1a8f8f8548dda6cc4b2f3c034",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "0ef8fdae08a51748911a48216f63d947ce5f1465c8aaf8b328601cadb1be4be4",
+      "content_hash": "d2d972377a5f10370bc1ee0a3f08453c66950b663ef8275569f04b5c7c890cb5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "a0a6fa8bac7772a753e7a4bd04b43dd7760670d4b4c8256168cf059d22b0040e",
+      "content_hash": "00c7d97fb5696e964b900eb38cb7ef84ca2febd7953721829a081920521a7b95",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/VALIDATION.md",
       "template_hash": "a67f2726b69bc8e514b69f8fdbe13ad4f5bfd2d713c1aa0473a3e90cc8c11a0d",
-      "content_hash": "bc2ce65a46f8008dcf74f944c966aacd31b2fafbbed4749d367b24016ba4d4cf",
+      "content_hash": "71095d846d976faf7a17df9b4f17a3bcc426eaa8e615b4e91096d5ef2a2a1088",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "ef089e0f6c8ea4a93cd6446cf50c576b61a48c217a312fec9a640de4c56d483c",
+      "content_hash": "614a6062310192754023b34ef684255148fb5cb629fa22be819172bb3528f067",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "07e3f65cc2158d27ccb26e78ee34fbde3474fc57bb319c396a2efd91fdc8aca9",
+      "content_hash": "0ab62a6346fc3d928841abd87cf1402026b54ad179ac6137ef66494f5362c4f4",
       "fingerprint": ""
     },
     {
       "path": ".decapod/generated/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "ba8b7625f8ee47d34838a732563dc7b3e6977db06a81d1317f0dca3def44c0c5",
+      "content_hash": "d16c3f7b6470a75ae3829240a92bd37491c5a69aed5aead4f74352cb816b77d2",
       "fingerprint": ""
     }
   ]

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/ARCHITECTURE.md
+++ b/.decapod/generated/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTENT.md
+++ b/.decapod/generated/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -408,7 +408,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -408,7 +408,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/INTERFACES.md
+++ b/.decapod/generated/specs/INTERFACES.md
@@ -408,7 +408,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/OPERATIONS.md
+++ b/.decapod/generated/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/README.md
+++ b/.decapod/generated/specs/README.md
@@ -56,7 +56,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SECURITY.md
+++ b/.decapod/generated/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/SEMANTICS.md
+++ b/.decapod/generated/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a1cc93c8a9c89d892402121971a7b1e9d88314dd3d98261a72131dc3a551fa76`
+- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
+- Repository signal fingerprint: `969692735b78d645601572827c9c883720221f54897132667c5d6643abe0fa37`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/generated/specs/VALIDATION.md
+++ b/.decapod/generated/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `0b8204d35a0a4347b8dcc4bd939f3f229d6ab4cbbfe8b8f55bdcec2f71eeb194`
+- Repository signal fingerprint: `a3e5404ec1eb17df6b77c19af61f08157c9a6b3a06fdd779822b2b7ad01e6c2a`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (94 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,59 +1,61 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "run_issue991",
-  "intent_id": "intent:run_issue991",
-  "task_id": "bugs_01ky8j73f1h4rg98",
-  "original_intent": "Solve GitHub Issue #991 by restructuring the Rust source tree so src/main.rs is the only root source file.",
-  "derived_intent": "Move the library/runtime hierarchy under src/decapod, repair all build/test/path breaks, and publish the migration.",
-  "destination": "published PR #1005",
+  "run_id": "issue-990-20260723",
+  "intent_id": "intent:issue-990-20260723",
+  "task_id": "bugs_01ky8n4t2314wp63",
+  "original_intent": "Solve GitHub Issue #990 by consolidating the selective_tests crate into the existing Decapod source hierarchy.",
+  "derived_intent": "Move selective test planning and execution into the decapod qa command, remove the standalone Cargo and Bazel targets, align CI selectors, and add CLI coverage.",
+  "destination": "Publish a reviewable GitHub PR linked to Issue #990.",
   "current_phase": "proof",
   "next_transitions": [
-    "review"
+    "proof",
+    "publish"
   ],
   "active_boundaries": [
-    "Cargo.toml,src/**,tests/**,docs/**,root entrypoints,.decapod/generated/Dockerfile,.decapod/generated/specs/**",
-    "src/**"
+    "src/decapod/**,src/bin/selective-test.rs,Cargo.toml,BUILD.bazel,.github/workflows/ci.yml,tests/**,generated governance artifacts"
   ],
   "repo_scope": [
-    "Cargo.toml,src/**,tests/**,docs/**,.decapod/generated/specs/**",
-    "Issue #991 source layout plus Issue #1001 release-bound generated artifacts"
+    "Issue #990 selective test consolidation"
   ],
   "inspected_files": [
-    ".decapod/generated/Dockerfile",
+    ".github/workflows/ci.yml",
+    "BUILD.bazel",
     "Cargo.toml",
-    "src/decapod/core/entrypoint_integrity.rs",
-    "src/decapod/core/scaffold.rs",
-    "src/decapod/plugins/container.rs"
+    "src/bin/selective-test.rs",
+    "src/decapod/cli.rs",
+    "src/decapod/lib.rs",
+    "src/decapod/plugins/mod.rs"
   ],
   "modified_files": [
-    ".decapod/generated/Dockerfile",
-    ".decapod/generated/specs/.manifest.json",
-    "AGENTS.md",
-    "CLAUDE.md",
-    "CODEX.md",
-    "GEMINI.md",
-    "src/decapod/core/entrypoint_integrity.rs"
+    ".github/workflows/ci.yml",
+    "BUILD.bazel",
+    "Cargo.toml",
+    "src/decapod/cli.rs",
+    "src/decapod/core/entrypoint_integrity.rs",
+    "src/decapod/lib.rs",
+    "src/decapod/plugins/mod.rs",
+    "src/decapod/plugins/selective_test.rs",
+    "tests/cli_contract_enforcement.rs"
   ],
   "declared_commands": [
     "cargo check --all-targets",
-    "cargo test --lib core::entrypoint_integrity -- --test-threads=1",
-    "cargo test --test entrypoint_correctness -- --test-threads=1",
-    "decapod rpc --op specs.refresh",
-    "decapod validate --format json",
-    "git diff --check"
+    "cargo fmt --all -- --check",
+    "cargo test --lib plugins::selective_test -- --test-threads=1",
+    "cargo test --test cli_contract_enforcement -- --test-threads=1",
+    "cargo test --test entrypoint_correctness -- --test-threads=1"
   ],
   "tool_calls": [],
   "checks": [
     {
-      "name": "cargo_check",
+      "name": "cli_contract_tests",
       "status": "passed"
     },
     {
-      "name": "decapod_validate",
-      "status": "partial"
+      "name": "compile",
+      "status": "passed"
     },
     {
-      "name": "entrypoint_correctness_tests",
+      "name": "diff_check",
       "status": "passed"
     },
     {
@@ -61,42 +63,41 @@
       "status": "passed"
     },
     {
-      "name": "git_diff_check",
+      "name": "format",
+      "status": "passed"
+    },
+    {
+      "name": "selective_unit_tests",
       "status": "passed"
     }
   ],
   "evidence": [
-    "Decapod 0.80.1 generated fingerprints and Dockerfile header",
-    "Issue #1001 release alignment in this PR",
-    "PR #1005"
+    "Focused tests and all-target compilation passed in the isolated workspace; CLI help exposes qa selective-test and --reflex; generated Decapod artifacts were refreshed by Decapod."
   ],
   "shortcut_risk_signals": [],
-  "unresolved_assumptions": [
-    "Unrelated claimed-but-unverified TODO hooks remain outside this PR scope"
-  ],
-  "completion_claim": "Issue #1001 release-bound Dockerfile, entrypoints, compiled manifest, and specs attestation aligned to Decapod 0.80.1; remaining validation failures are external governance gates.",
-  "proof_status": "partial",
+  "unresolved_assumptions": [],
+  "proof_status": "passed",
   "verdicts": {
     "intent_alignment": "supported",
     "boundary_discipline": "supported",
     "shortcut_risk": "supported",
-    "completion_proof": "caution"
+    "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:67ec89d9eb250508e4797310b4f72c8fb715f0a0237e8acfa47d39444f692d7e",
+  "artifact_hash": "sha256:5c04ee4bd1bbb3e9559cb13832a275e0153c3a111158d398a245af8103e6de1d",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:run_issue991": {
-        "id": "intent:run_issue991",
-        "raw_intent": "Solve GitHub Issue #991 by restructuring the Rust source tree so src/main.rs is the only root source file.",
-        "refined_intent": "Move the library/runtime hierarchy under src/decapod, repair all build/test/path breaks, and publish the migration.",
+      "intent:issue-990-20260723": {
+        "id": "intent:issue-990-20260723",
+        "raw_intent": "Solve GitHub Issue #990 by consolidating the selective_tests crate into the existing Decapod source hierarchy.",
+        "refined_intent": "Move selective test planning and execution into the decapod qa command, remove the standalone Cargo and Bazel targets, align CI selectors, and add CLI coverage.",
         "acceptance_criteria": [],
         "constraints": [
-          "Cargo.toml,src/**,tests/**,docs/**,.decapod/generated/specs/**"
+          "Issue #990 selective test consolidation"
         ],
         "assumptions": [],
         "boundaries": [
-          "src/**"
+          "src/decapod/**,src/bin/selective-test.rs,Cargo.toml,BUILD.bazel,.github/workflows/ci.yml,tests/**,generated governance artifacts"
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -109,63 +110,64 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:run_issue991",
+        "intent_id": "intent:issue-990-20260723",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:run_issue991",
+        "intent_id": "intent:issue-990-20260723",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:run_issue991",
+        "intent_id": "intent:issue-990-20260723",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:run_issue991"
+        "detail": "trajectory:issue-990-20260723"
       }
     ],
     "trajectories": {
-      "run_issue991": {
-        "id": "run_issue991",
-        "intent_id": "intent:run_issue991",
+      "issue-990-20260723": {
+        "id": "issue-990-20260723",
+        "intent_id": "intent:issue-990-20260723",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
             "action": "proof",
-            "command": "decapod validate --format json",
+            "command": "cargo fmt --all -- --check",
             "scope": [
-              "Cargo.toml,src/**,tests/**,docs/**,.decapod/generated/specs/**"
+              "Issue #990 selective test consolidation"
             ],
             "observations": [
+              "src/bin/selective-test.rs",
+              "src/decapod/cli.rs",
+              "src/decapod/lib.rs",
+              "src/decapod/plugins/mod.rs",
+              ".github/workflows/ci.yml",
               "Cargo.toml",
+              "BUILD.bazel",
+              "src/decapod/plugins/selective_test.rs",
+              "src/decapod/cli.rs",
+              "src/decapod/lib.rs",
+              "src/decapod/plugins/mod.rs",
               "src/decapod/core/entrypoint_integrity.rs",
-              "src/decapod/core/scaffold.rs",
-              "src/decapod/plugins/container.rs",
-              ".decapod/generated/Dockerfile",
-              "src/decapod/core/entrypoint_integrity.rs",
-              "AGENTS.md",
-              "CLAUDE.md",
-              "GEMINI.md",
-              "CODEX.md",
-              ".decapod/generated/Dockerfile",
-              ".decapod/generated/specs/.manifest.json",
-              "PR #1005",
-              "Issue #1001 release alignment in this PR",
-              "Decapod 0.80.1 generated fingerprints and Dockerfile header"
+              ".github/workflows/ci.yml",
+              "Cargo.toml",
+              "BUILD.bazel",
+              "tests/cli_contract_enforcement.rs",
+              "Focused tests and all-target compilation passed in the isolated workspace; CLI help exposes qa selective-test and --reflex; generated Decapod artifacts were refreshed by Decapod."
             ],
             "proof_refs": [
-              "decapod_validate",
+              "format",
+              "compile",
+              "selective_unit_tests",
+              "cli_contract_tests",
               "entrypoint_integrity_tests",
-              "entrypoint_correctness_tests",
-              "cargo_check",
-              "git_diff_check"
+              "diff_check"
             ],
-            "validation_findings": [
-              "Unrelated claimed-but-unverified TODO hooks remain outside this PR scope"
-            ],
+            "validation_findings": [],
             "custody_event_id": "event:4"
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           git fetch --no-tags --prune origin "$base_ref"
           changed_files="$(git diff --name-only "origin/$base_ref"...HEAD)"
           echo "$changed_files"
-          if echo "$changed_files" | grep -qE '^src/core/sql/.*\.sql$'; then
+          if echo "$changed_files" | grep -qE '^src/decapod/core/sql/.*\.sql$'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -285,18 +285,18 @@ jobs:
 
           case "${{ matrix.target }}" in
             core)
-              if echo "$CHANGED" | grep -qE 'src/core/(todo|validate|workspace|workunit|obligation|docs|capsule|rpc|migration|gateway)'; then
+              if echo "$CHANGED" | grep -qE 'src/decapod/core/(todo|validate|workspace|workunit|obligation|docs|capsule|rpc|migration|gateway)'; then
                 bazelisk test //:todo_enforcement --test_arg=--test-threads=4
                 bazelisk test //:validate_termination --test_arg=--test-threads=4
                 bazelisk test //:workspace_interlock --test_arg=--test-threads=4
                 bazelisk test //:workunit_cli --test_arg=--test-threads=4
                 bazelisk test //:context_capsule_cli --test_arg=--test-threads=4
-              elif echo "$CHANGED" | grep -qE 'src/core/'; then
+              elif echo "$CHANGED" | grep -qE 'src/decapod/core/'; then
                 bazelisk test //:entrypoint_correctness --test_arg=--test-threads=4
               fi
               ;;
             plugins)
-              if echo "$CHANGED" | grep -qE 'src/plugins/'; then
+              if echo "$CHANGED" | grep -qE 'src/decapod/plugins/'; then
                 bazelisk test //:plugins_todo_tests --test_arg=--test-threads=4
                 bazelisk test //:plugins_policy_tests --test_arg=--test-threads=4
                 bazelisk test //:plugins_health_tests --test_arg=--test-threads=4
@@ -308,7 +308,7 @@ jobs:
               fi
               ;;
             cli)
-              if echo "$CHANGED" | grep -qE 'src/(cli|lib|main)'; then
+              if echo "$CHANGED" | grep -qE 'src/(decapod/(cli|lib)|main)'; then
                 bazelisk test //:cli_contract_enforcement --test_arg=--test-threads=4
                 bazelisk test //:entrypoint_correctness --test_arg=--test-threads=4
                 bazelisk test //:cli_contracts --test_arg=--test-threads=4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.80.1 -->
-<!-- decapod-fingerprint: 4f3ea3cb9493ccfacba6bbb02fb87a67653675e9f2c1865bf127013290080a7c -->
+<!-- decapod-release: 0.80.2 -->
+<!-- decapod-fingerprint: af849e8e04a7b1533285dddfac052b221c60e51d1ea7a6fddbfba961f3433851 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,16 +57,6 @@ rust_binary(
     proc_macro_deps = all_crate_deps(proc_macro = True),
 )
 
-rust_binary(
-    name = "selective-test",
-    srcs = ["src/bin/selective-test.rs"],
-    edition = "2024",
-    deps = [
-        ":decapod_lib",
-    ] + all_crate_deps(normal = True),
-    proc_macro_deps = all_crate_deps(proc_macro = True),
-)
-
 rust_test(
     name = "core_tests",
     srcs = ["tests/core/core.rs"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.80.1 -->
-<!-- decapod-fingerprint: 557c3bfc731c72863e34e77a73d0770c319b10fd25f57823327cb8348ca06d22 -->
+<!-- decapod-release: 0.80.2 -->
+<!-- decapod-fingerprint: 53850acd075192f0a89cd9660635e2daf57ac0d02b82213086ffc103314c717f -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.80.1 -->
-<!-- decapod-fingerprint: 3266d46c0f7aad465c4600b07b67da2655d485f629d22fdbb76b202284cfff20 -->
+<!-- decapod-release: 0.80.2 -->
+<!-- decapod-fingerprint: f103572b76b036899ffb08f40524e0173aee69dc7e00aa9db9bff6debc2d08cc -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,6 @@ path = "src/decapod/lib.rs"
 name = "decapod"
 path = "src/main.rs"
 
-[[bin]]
-name = "selective-test"
-path = "src/bin/selective-test.rs"
-
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.80.1 -->
-<!-- decapod-fingerprint: 4c391fe1fdc2f3c821d027c85f1b6028dd6bdb474d4859e4f70fc57810af6b3f -->
+<!-- decapod-release: 0.80.2 -->
+<!-- decapod-fingerprint: 2dd2fb43f09a90b586cff93c560199ff39a2515430d10e21a7ae0b67cb3d3dab -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/decapod/cli.rs
+++ b/src/decapod/cli.rs
@@ -6,7 +6,7 @@ use crate::core::{constitution_cli, docs_cli, flight_recorder, obligation, todo,
 use crate::plan_governance;
 use crate::plugins::{
     aptitude, container, cron, decide, doctor, eval, federation, health, internalize, lcm, map_ops,
-    policy, primitives, reflex, verify, workflow,
+    policy, primitives, reflex, selective_test, verify, workflow,
 };
 
 use clap::{Parser, Subcommand};
@@ -1222,6 +1222,9 @@ pub(crate) enum QaCommand {
 
     /// Run gatling regression test across all CLI code paths
     Gatling(crate::plugins::gatling::GatlingCli),
+
+    /// Run only the integration tests affected by changed files.
+    SelectiveTest(selective_test::SelectiveTestCli),
 
     /// Variance-aware evaluation artifacts and promotion gates
     Eval(Box<eval::EvalCli>),

--- a/src/decapod/core/entrypoint_integrity.rs
+++ b/src/decapod/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.80.1 release manifest. Keep them immutable for the
+// These values are the v0.80.2 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "4f3ea3cb9493ccfacba6bbb02fb87a67653675e9f2c1865bf127013290080a7c",
+        fingerprint: "af849e8e04a7b1533285dddfac052b221c60e51d1ea7a6fddbfba961f3433851",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "557c3bfc731c72863e34e77a73d0770c319b10fd25f57823327cb8348ca06d22",
+        fingerprint: "53850acd075192f0a89cd9660635e2daf57ac0d02b82213086ffc103314c717f",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "4c391fe1fdc2f3c821d027c85f1b6028dd6bdb474d4859e4f70fc57810af6b3f",
+        fingerprint: "2dd2fb43f09a90b586cff93c560199ff39a2515430d10e21a7ae0b67cb3d3dab",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "3266d46c0f7aad465c4600b07b67da2655d485f629d22fdbb76b202284cfff20",
+        fingerprint: "f103572b76b036899ffb08f40524e0173aee69dc7e00aa9db9bff6debc2d08cc",
     },
 ];
 

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -7354,6 +7354,9 @@ fn run_qa_command(
             all,
         } => run_check(crate_description, commands, all)?,
         QaCommand::Gatling(ref gatling_cli) => plugins::gatling::run_gatling_cli(gatling_cli)?,
+        QaCommand::SelectiveTest(selective_test_cli) => {
+            plugins::selective_test::run_selective_test_cli(selective_test_cli)?;
+        }
         QaCommand::Eval(eval_cli) => {
             eval::run_eval_cli(project_store, *eval_cli)?;
         }

--- a/src/decapod/plugins/mod.rs
+++ b/src/decapod/plugins/mod.rs
@@ -19,6 +19,7 @@ pub mod map_ops;
 pub mod policy;
 pub mod primitives;
 pub mod reflex;
+pub mod selective_test;
 pub mod verify;
 pub mod watcher;
 pub mod workflow;

--- a/src/decapod/plugins/selective_test.rs
+++ b/src/decapod/plugins/selective_test.rs
@@ -1,11 +1,12 @@
-use clap::Parser;
+//! Selective test planning and execution for the `decapod qa` command.
+
+use crate::core::error::DecapodError;
+use clap::Args;
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
-#[derive(Parser, Debug)]
-#[command(name = "selective-test")]
-#[command(about = "Selective test automation: runs tests against changed files only")]
-struct Args {
+#[derive(Args, Debug)]
+pub struct SelectiveTestCli {
     #[arg(help = "Files to test (comma or space separated)")]
     files: Option<String>,
 
@@ -14,6 +15,42 @@ struct Args {
 
     #[arg(long, help = "Run in reflex mode (post-commit hook style)")]
     reflex: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_comma_and_space_separated_paths() {
+        assert_eq!(
+            get_changed_files_from_arg("src/main.rs, tests/cli.rs Cargo.toml"),
+            vec![
+                "src/main.rs".to_string(),
+                "tests/cli.rs".to_string(),
+                "Cargo.toml".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn maps_current_source_layout_to_existing_test_targets() {
+        let mut tests_to_run = HashMap::new();
+        add_tests_for_file("src/decapod/core/todo.rs", &mut tests_to_run);
+        add_tests_for_file("src/decapod/plugins/selective_test.rs", &mut tests_to_run);
+
+        assert!(tests_to_run.contains_key("todo_enforcement"));
+        assert!(tests_to_run.contains_key("todo_rebuild_compat"));
+        assert!(tests_to_run.contains_key("cli_contract_enforcement"));
+        assert!(!tests_to_run.contains_key("plugins_selective_test_tests"));
+    }
+
+    #[test]
+    fn ignores_generated_and_fixture_paths() {
+        assert!(is_ignored_path(".decapod/generated/specs/README.md"));
+        assert!(is_ignored_path("tests/fixtures/repo/file.txt"));
+        assert!(!is_ignored_path("src/decapod/lib.rs"));
+    }
 }
 
 fn get_changed_files() -> Vec<String> {
@@ -28,17 +65,19 @@ fn get_changed_files() -> Vec<String> {
         Some(out) => out
             .lines()
             .filter_map(|line| {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 2 {
-                    let status = parts[0];
-                    if status
-                        .chars()
-                        .any(|c| matches!(c, 'M' | 'A' | 'D' | 'R' | 'C'))
-                    {
-                        return Some(parts[1].to_string());
-                    }
+                let status = line.get(..2)?;
+                if !status
+                    .chars()
+                    .any(|c| matches!(c, 'M' | 'A' | 'D' | 'R' | 'C' | '?'))
+                {
+                    return None;
                 }
-                None
+                let path = line.get(3..)?.trim();
+                let path = path
+                    .split_once(" -> ")
+                    .map(|(_, destination)| destination)
+                    .unwrap_or(path);
+                (!path.is_empty()).then(|| path.to_string())
             })
             .collect(),
         None => Vec::new(),
@@ -113,6 +152,9 @@ fn add_tests_for_file(file: &str, tests_to_run: &mut HashMap<String, bool>) {
             tests_to_run.insert("init_validate_green_field".to_string(), true);
         }
         "src/decapod/cli.rs" => {
+            tests_to_run.insert("cli_contract_enforcement".to_string(), true);
+        }
+        "src/decapod/plugins/selective_test.rs" => {
             tests_to_run.insert("cli_contract_enforcement".to_string(), true);
         }
         s if s.starts_with("src/decapod/plugins/") => {
@@ -236,6 +278,12 @@ fn run_reflex_mode(changed_files: &[String]) -> bool {
                     failed = true;
                 }
             }
+            "src/decapod/plugins/selective_test.rs" => {
+                println!("Testing: selective-test CLI contracts");
+                if !run_cargo_test("cli_contract_enforcement", "2") {
+                    failed = true;
+                }
+            }
             s if s.starts_with("src/decapod/plugins/") => {
                 if let Some(rest) = s.strip_prefix("src/decapod/plugins/") {
                     let plugin_name = rest.strip_suffix(".rs").unwrap_or(rest);
@@ -285,9 +333,7 @@ fn all_tests() -> Vec<&'static str> {
     ]
 }
 
-fn main() {
-    let args = Args::parse();
-
+pub fn run_selective_test_cli(args: SelectiveTestCli) -> Result<(), DecapodError> {
     let changed_files: Vec<String> = if args.reflex {
         get_changed_files()
     } else if args.all {
@@ -314,12 +360,13 @@ fn main() {
     if args.reflex {
         let failed = run_reflex_mode(&changed_files);
         if failed {
-            println!("✗ Some tests failed");
-            std::process::exit(1);
+            return Err(DecapodError::ValidationError(
+                "Some reflex-selective tests failed".to_string(),
+            ));
         } else {
             println!("✓ All affected tests passed");
         }
-        return;
+        return Ok(());
     }
 
     let mut tests_to_run: HashMap<String, bool> = HashMap::new();
@@ -343,7 +390,8 @@ fn main() {
     }
 
     println!("\n=== Tests to run ===");
-    let targets: Vec<String> = tests_to_run.keys().cloned().collect();
+    let mut targets: Vec<String> = tests_to_run.keys().cloned().collect();
+    targets.sort();
     println!("Target: {}", targets.join(" "));
 
     println!("\n=== Running selective tests ===");
@@ -356,9 +404,11 @@ fn main() {
     }
 
     if failed {
-        println!("\n=== Some selective tests failed ===");
-        std::process::exit(1);
+        Err(DecapodError::ValidationError(
+            "Some selective tests failed".to_string(),
+        ))
     } else {
         println!("\n=== All selective tests passed ===");
+        Ok(())
     }
 }

--- a/src/decapod/plugins/selective_test.rs
+++ b/src/decapod/plugins/selective_test.rs
@@ -17,42 +17,6 @@ pub struct SelectiveTestCli {
     reflex: bool,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_comma_and_space_separated_paths() {
-        assert_eq!(
-            get_changed_files_from_arg("src/main.rs, tests/cli.rs Cargo.toml"),
-            vec![
-                "src/main.rs".to_string(),
-                "tests/cli.rs".to_string(),
-                "Cargo.toml".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn maps_current_source_layout_to_existing_test_targets() {
-        let mut tests_to_run = HashMap::new();
-        add_tests_for_file("src/decapod/core/todo.rs", &mut tests_to_run);
-        add_tests_for_file("src/decapod/plugins/selective_test.rs", &mut tests_to_run);
-
-        assert!(tests_to_run.contains_key("todo_enforcement"));
-        assert!(tests_to_run.contains_key("todo_rebuild_compat"));
-        assert!(tests_to_run.contains_key("cli_contract_enforcement"));
-        assert!(!tests_to_run.contains_key("plugins_selective_test_tests"));
-    }
-
-    #[test]
-    fn ignores_generated_and_fixture_paths() {
-        assert!(is_ignored_path(".decapod/generated/specs/README.md"));
-        assert!(is_ignored_path("tests/fixtures/repo/file.txt"));
-        assert!(!is_ignored_path("src/decapod/lib.rs"));
-    }
-}
-
 fn get_changed_files() -> Vec<String> {
     let output = Command::new("git")
         .args(["status", "--porcelain"])
@@ -410,5 +374,41 @@ pub fn run_selective_test_cli(args: SelectiveTestCli) -> Result<(), DecapodError
     } else {
         println!("\n=== All selective tests passed ===");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_comma_and_space_separated_paths() {
+        assert_eq!(
+            get_changed_files_from_arg("src/main.rs, tests/cli.rs Cargo.toml"),
+            vec![
+                "src/main.rs".to_string(),
+                "tests/cli.rs".to_string(),
+                "Cargo.toml".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn maps_current_source_layout_to_existing_test_targets() {
+        let mut tests_to_run = HashMap::new();
+        add_tests_for_file("src/decapod/core/todo.rs", &mut tests_to_run);
+        add_tests_for_file("src/decapod/plugins/selective_test.rs", &mut tests_to_run);
+
+        assert!(tests_to_run.contains_key("todo_enforcement"));
+        assert!(tests_to_run.contains_key("todo_rebuild_compat"));
+        assert!(tests_to_run.contains_key("cli_contract_enforcement"));
+        assert!(!tests_to_run.contains_key("plugins_selective_test_tests"));
+    }
+
+    #[test]
+    fn ignores_generated_and_fixture_paths() {
+        assert!(is_ignored_path(".decapod/generated/specs/README.md"));
+        assert!(is_ignored_path("tests/fixtures/repo/file.txt"));
+        assert!(!is_ignored_path("src/decapod/lib.rs"));
     }
 }

--- a/tests/cli_contract_enforcement.rs
+++ b/tests/cli_contract_enforcement.rs
@@ -172,6 +172,25 @@ fn test_workspace_command_structure() {
 }
 
 #[test]
+fn test_selective_test_command_structure() {
+    let (_tmp, dir) = setup_repo();
+
+    let help = run_decapod(dir, &["qa", "selective-test", "--help"]);
+    assert!(
+        help.status.success(),
+        "qa selective-test help should succeed: {}",
+        String::from_utf8_lossy(&help.stderr)
+    );
+
+    let output = String::from_utf8_lossy(&help.stdout);
+    assert!(
+        output.contains("Run only the integration tests affected by changed files")
+            && output.contains("--reflex"),
+        "qa selective-test should expose its selective and reflex modes: {output}"
+    );
+}
+
+#[test]
 fn test_todo_command_structure() {
     let (_tmp, dir) = setup_repo();
 


### PR DESCRIPTION
## Summary

- Move selective test planning and execution into the existing decapod qa command hierarchy.
- Remove the standalone Cargo and Bazel selective-test targets.
- Correct CI selectors for the current src/decapod layout.
- Add CLI contract and selective-runner unit coverage.
- Refresh Decapod v0.80.2 generated entrypoint and spec attestations.

## Proof

- cargo fmt --all -- --check
- cargo check --all-targets
- cargo test --lib plugins::selective_test -- --test-threads=1
- cargo test --test cli_contract_enforcement -- --test-threads=1
- cargo test --test entrypoint_correctness -- --test-threads=1
- git diff --check

Closes #990