### PR TITLE
feat: align Propodus wave 2 cloud command boundary

### DIFF
--- a/.decapod/governance/claims.json
+++ b/.decapod/governance/claims.json
@@ -11,7 +11,7 @@
     "status": "active",
     "created_at": "2026-07-22",
     "updated_at": "2026-07-25",
-    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025."
+    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025; wave-2 release-safe Propodus proof changes remain bounded to Decapod-owned client and CI surfaces."
   },
   "scope": {
     "product": "decapod",

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "title": "Propodus wave 2 review closure: truthful credential and CLI dogfood",
   "intent": "Revise PR #1036 to close the latest review gaps: make injected Propodus JWT credentials truthful and fail-fast, downgrade unbound repository identity claims, prove the production CLI dispatch with a mock Propodus transport, document explicit v1 governance limitations, and provide a repeatable dogfood runbook while preserving Propodus-owned auth policy.",
-  "state": "EXECUTING",
+  "state": "DONE",
   "todo_ids": [
     "cicd_01kydv7dsj7sayv4"
   ],
@@ -74,10 +74,10 @@
       "entry_gates": [],
       "exit_gates": [],
       "entered": true,
-      "completed": false,
+      "completed": true,
       "entered_at": "1785034186Z",
-      "completed_at": null
+      "completed_at": "1785035649Z"
     }
   ],
-  "updated_at": "1785034186Z"
+  "updated_at": "1785035649Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
-  "title": "Propodus phase 2: release-safe integration proof",
-  "intent": "Deliver a bounded second phase for the Decapod-owned Propodus boundary: exempt explicitly labeled release PRs from the governance-artifact diff gate, add a credential-gated live proof harness for the typed client, document its canonical repository isolation and failure taxonomy, and keep all default checks network-free while Propodus owns hosted authentication, authorization, deployment, and persistence.",
-  "state": "DONE",
+  "title": "Propodus phase 2 alignment: cloud command path and dogfood proof",
+  "intent": "Align PR #1036 with Decapod issues #1032-#1035 and #1037: activate explicit cloud todo storage through the typed Propodus adapter, derive and fail-closed on canonical GitHub repository identity, consume a machine-local Propodus bearer boundary without embedding service identity policy, and provide a protected command-level dogfood proof while preserving local offline defaults.",
+  "state": "EXECUTING",
   "todo_ids": [
     "cicd_01kydv7dsj7sayv4"
   ],
@@ -11,14 +11,18 @@
     "cargo test",
     "decapod validate"
   ],
-  "unknowns": [],
+  "unknowns": [
+    "Propodus #24 must provide the GitHub login/token exchange before Decapod can replace the legacy interactive login flow."
+  ],
   "human_questions": [],
   "stop_conditions": [],
   "unresolved_contradictions": [],
-  "deferred_questions": [],
+  "deferred_questions": [
+    "Propodus must expose an immutable repository identity field or authenticated resolver input before production cloud selection can require it."
+  ],
   "constraints": {
     "forbidden_paths": [],
-    "file_touch_budget": null
+    "file_touch_budget": 80
   },
   "phases": [
     {
@@ -53,7 +57,18 @@
       "completed": true,
       "entered_at": "1785023973Z",
       "completed_at": "1785025157Z"
+    },
+    {
+      "id": "propodus-phase-2-alignment",
+      "name": "Align cloud command path and dogfood proof",
+      "description": "Select the Propodus-backed todo store only for explicit cloud mode, verify canonical GitHub repository identity with an immutable runtime identity input, keep the Propodus bearer/session boundary thin, reject unsupported local fallback, and prove actual Decapod commands plus shared and unauthorized behavior through a protected opt-in live harness.",
+      "entry_gates": [],
+      "exit_gates": [],
+      "entered": true,
+      "completed": false,
+      "entered_at": "1785027089Z",
+      "completed_at": null
     }
   ],
-  "updated_at": "1785025157Z"
+  "updated_at": "1785027089Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "title": "Propodus phase 2: release-safe integration proof",
   "intent": "Deliver a bounded second phase for the Decapod-owned Propodus boundary: exempt explicitly labeled release PRs from the governance-artifact diff gate, add a credential-gated live proof harness for the typed client, document its canonical repository isolation and failure taxonomy, and keep all default checks network-free while Propodus owns hosted authentication, authorization, deployment, and persistence.",
-  "state": "APPROVED",
+  "state": "DONE",
   "todo_ids": [
     "cicd_01kydv7dsj7sayv4"
   ],
@@ -50,10 +50,10 @@
       "entry_gates": [],
       "exit_gates": [],
       "entered": true,
-      "completed": false,
+      "completed": true,
       "entered_at": "1785023973Z",
-      "completed_at": null
+      "completed_at": "1785025157Z"
     }
   ],
-  "updated_at": "1785024839Z"
+  "updated_at": "1785025157Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "title": "Propodus phase 2 alignment: cloud command path and dogfood proof",
   "intent": "Align PR #1036 with Decapod issues #1032-#1035 and #1037: activate explicit cloud todo storage through the typed Propodus adapter, derive and fail-closed on canonical GitHub repository identity, consume a machine-local Propodus bearer boundary without embedding service identity policy, and provide a protected command-level dogfood proof while preserving local offline defaults.",
-  "state": "EXECUTING",
+  "state": "DONE",
   "todo_ids": [
     "cicd_01kydv7dsj7sayv4"
   ],
@@ -11,14 +11,12 @@
     "cargo test",
     "decapod validate"
   ],
-  "unknowns": [
-    "Propodus #24 must provide the GitHub login/token exchange before Decapod can replace the legacy interactive login flow."
-  ],
+  "unknowns": [],
   "human_questions": [],
   "stop_conditions": [],
   "unresolved_contradictions": [],
   "deferred_questions": [
-    "Propodus must expose an immutable repository identity field or authenticated resolver input before production cloud selection can require it."
+    "Propodus issue #24 must expose the GitHub login/token exchange before Decapod can replace the legacy interactive login flow; this PR consumes only the machine bearer contract available in Propodus PR #31."
   ],
   "constraints": {
     "forbidden_paths": [],
@@ -65,10 +63,10 @@
       "entry_gates": [],
       "exit_gates": [],
       "entered": true,
-      "completed": false,
+      "completed": true,
       "entered_at": "1785027089Z",
-      "completed_at": null
+      "completed_at": "1785029250Z"
     }
   ],
-  "updated_at": "1785027089Z"
+  "updated_at": "1785029250Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
-  "title": "Propodus phase 2 alignment: cloud command path and dogfood proof",
-  "intent": "Align PR #1036 with Decapod issues #1032-#1035 and #1037: activate explicit cloud todo storage through the typed Propodus adapter, derive and fail-closed on canonical GitHub repository identity, consume a machine-local Propodus bearer boundary without embedding service identity policy, and provide a protected command-level dogfood proof while preserving local offline defaults.",
-  "state": "DONE",
+  "title": "Propodus wave 2 review closure: truthful credential and CLI dogfood",
+  "intent": "Revise PR #1036 to close the latest review gaps: make injected Propodus JWT credentials truthful and fail-fast, downgrade unbound repository identity claims, prove the production CLI dispatch with a mock Propodus transport, document explicit v1 governance limitations, and provide a repeatable dogfood runbook while preserving Propodus-owned auth policy.",
+  "state": "EXECUTING",
   "todo_ids": [
     "cicd_01kydv7dsj7sayv4"
   ],
@@ -16,7 +16,7 @@
   "stop_conditions": [],
   "unresolved_contradictions": [],
   "deferred_questions": [
-    "Propodus issue #24 must expose the GitHub login/token exchange before Decapod can replace the legacy interactive login flow; this PR consumes only the machine bearer contract available in Propodus PR #31."
+    "Propodus issue #24 must expose the GitHub login/token exchange before Decapod can provide an interactive compatible login; this PR must explicitly document injected-token dogfood instead."
   ],
   "constraints": {
     "forbidden_paths": [],
@@ -66,7 +66,18 @@
       "completed": true,
       "entered_at": "1785027089Z",
       "completed_at": "1785029250Z"
+    },
+    {
+      "id": "propodus-review-closure",
+      "name": "Close credential, identity, CLI, and dogfood review gaps",
+      "description": "Make cloud credentials truthful and fail-fast, retain only a temporary identity gate until Propodus binds immutable identity, prove the actual CLI boundary with an injected transport, document v1 unsupported proof semantics, and update the protected dogfood runbook.",
+      "entry_gates": [],
+      "exit_gates": [],
+      "entered": true,
+      "completed": false,
+      "entered_at": "1785034186Z",
+      "completed_at": null
     }
   ],
-  "updated_at": "1785029250Z"
+  "updated_at": "1785034186Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.0.0",
-  "title": "Propodus phase 1: governed local client boundary and proof",
-  "intent": "Deliver one coherent first phase for the propodus-labeled Decapod backlog: establish the versioned todo contract, machine-local bearer credential boundary, typed optional HTTP backend adapter/client, deterministic local fake-service proof, and living documentation while preserving local SQLite defaults and keeping hosted authentication, stable production deployment, and live integration as the next wave.",
-  "state": "DONE",
+  "title": "Propodus phase 2: release-safe integration proof",
+  "intent": "Deliver a bounded second phase for the Decapod-owned Propodus boundary: exempt explicitly labeled release PRs from the governance-artifact diff gate, add a credential-gated live proof harness for the typed client, document its canonical repository isolation and failure taxonomy, and keep all default checks network-free while Propodus owns hosted authentication, authorization, deployment, and persistence.",
+  "state": "APPROVED",
   "todo_ids": [
-    "feat_01kydm9j7phcvjyv"
+    "cicd_01kydv7dsj7sayv4"
   ],
   "proof_hooks": [
     "cargo fmt --check",
@@ -42,7 +42,18 @@
       "completed": true,
       "entered_at": "1785016815Z",
       "completed_at": "1785019855Z"
+    },
+    {
+      "id": "propodus-phase-2",
+      "name": "Deliver release-safe live proof boundary",
+      "description": "Exempt release-labeled PRs from the four-artifact CI gate and add a default-off, credential-gated live Propodus proof for health, list, create, claim, complete, and cross-repository authorization behavior.",
+      "entry_gates": [],
+      "exit_gates": [],
+      "entered": true,
+      "completed": false,
+      "entered_at": "1785023973Z",
+      "completed_at": null
     }
   ],
-  "updated_at": "1785019855Z"
+  "updated_at": "1785024839Z"
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,39 +1,61 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "validation_01KYDS9F1M2CG9SVWP17KWSZE0",
-  "intent_id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
-  "task_id": "code_01kyds",
-  "original_intent": "Produce proof artifacts for a repository validation completion.",
-  "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
-  "destination": "validation completion",
-  "current_phase": "validation",
-  "next_transitions": [
-    "publish"
-  ],
+  "run_id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+  "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+  "task_id": "cicd_01kydv7dsj7sayv4",
+  "original_intent": "Start Propodus wave 2 in Decapod v0.83.0 and solve issue #1022 within the same PR.",
+  "derived_intent": "Deliver release-labeled PR governance exemption, Decapod-side opt-in live Propodus proof, v0.83.0 generated projections, and explicit service-boundary documentation while leaving hosted Propodus auth, allowlisting, URL, and persistence to Propodus.",
+  "current_phase": "propodus-phase-2",
   "active_boundaries": [
-    "Repository validation and tracked proof artifacts"
+    "Decapod governance kernel, CI, typed Propodus client, tests, docs, and generated governance artifacts only; no payments, identity implementation, website, or Propodus deployment changes."
   ],
   "repo_scope": [
-    ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json"
+    "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
   ],
-  "inspected_files": [],
+  "inspected_files": [
+    ".github/workflows/ci.yml",
+    "docs/book/src/reference/propodus.md",
+    "src/decapod/core/propodus.rs",
+    "tests/propodus_contract.rs",
+    "tests/release_workflow_policy.rs"
+  ],
   "modified_files": [
-    ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json"
+    ".decapod/governance/claims.json",
+    ".github/workflows/ci.yml",
+    "docs/book/src/reference/propodus.md",
+    "src/decapod/core/entrypoint_integrity.rs",
+    "src/decapod/core/propodus.rs",
+    "tests/propodus_live.rs",
+    "tests/release_workflow_policy.rs"
   ],
   "declared_commands": [
-    "decapod validate"
+    "cargo clippy --locked --all-targets --all-features -- -D warnings",
+    "cargo fmt --all -- --check",
+    "cargo test --locked"
   ],
   "tool_calls": [],
   "checks": [
     {
-      "name": "decapod validate",
+      "name": "cargo_clippy",
+      "status": "passed"
+    },
+    {
+      "name": "cargo_fmt",
+      "status": "passed"
+    },
+    {
+      "name": "cargo_test",
+      "status": "passed"
+    },
+    {
+      "name": "focused_tests",
       "status": "passed"
     }
   ],
   "evidence": [
-    "validation epoch ve_38dc9244c3aaf167 completed with zero failures"
+    "entrypoint_release=0.83.0",
+    "issue_1022=release_label_gate",
+    "propodus_live=ignored_by_default_manual_protected"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -44,22 +66,21 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:20488f2ab467dacd1309505982818edc59501693d534ccca85a6733acbcfe3d7",
+  "artifact_hash": "sha256:b1dce5cb698b868c59840d69bfadf1bec128495023fd52e9ec66e8c4e54aa8d5",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0": {
-        "id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
-        "raw_intent": "Produce proof artifacts for a repository validation completion.",
-        "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
+      "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8": {
+        "id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "raw_intent": "Start Propodus wave 2 in Decapod v0.83.0 and solve issue #1022 within the same PR.",
+        "refined_intent": "Deliver release-labeled PR governance exemption, Decapod-side opt-in live Propodus proof, v0.83.0 generated projections, and explicit service-boundary documentation while leaving hosted Propodus auth, allowlisting, URL, and persistence to Propodus.",
         "acceptance_criteria": [],
         "constraints": [
-          ".decapod/governance/trajectory.json",
-          ".decapod/governance/validation.json"
+          "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
         ],
         "assumptions": [],
         "boundaries": [
-          "Repository validation and tracked proof artifacts"
+          "Decapod governance kernel, CI, typed Propodus client, tests, docs, and generated governance artifacts only; no payments, identity implementation, website, or Propodus deployment changes."
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -72,44 +93,58 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KYDS9F1M2CG9SVWP17KWSZE0"
+        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
       }
     ],
     "trajectories": {
-      "validation_01KYDS9F1M2CG9SVWP17KWSZE0": {
-        "id": "validation_01KYDS9F1M2CG9SVWP17KWSZE0",
-        "intent_id": "intent:validation_01KYDS9F1M2CG9SVWP17KWSZE0",
+      "01KYDVZ5AF1DPQYWDF2DJ4KBW8": {
+        "id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "validation",
-            "command": "decapod validate",
+            "action": "propodus-phase-2",
+            "command": "cargo fmt --all -- --check",
             "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
+              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
             ],
             "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_38dc9244c3aaf167 completed with zero failures"
+              ".github/workflows/ci.yml",
+              "src/decapod/core/propodus.rs",
+              "tests/release_workflow_policy.rs",
+              "tests/propodus_contract.rs",
+              "docs/book/src/reference/propodus.md",
+              ".github/workflows/ci.yml",
+              "src/decapod/core/propodus.rs",
+              "tests/release_workflow_policy.rs",
+              "tests/propodus_live.rs",
+              "docs/book/src/reference/propodus.md",
+              "src/decapod/core/entrypoint_integrity.rs",
+              ".decapod/governance/claims.json",
+              "issue_1022=release_label_gate",
+              "propodus_live=ignored_by_default_manual_protected",
+              "entrypoint_release=0.83.0"
             ],
             "proof_refs": [
-              "decapod validate"
+              "cargo_fmt",
+              "focused_tests",
+              "cargo_test",
+              "cargo_clippy"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -6,6 +6,9 @@
   "original_intent": "Start Propodus wave 2 in Decapod v0.83.0 and solve issue #1022 within the same PR.",
   "derived_intent": "Deliver release-labeled PR governance exemption, Decapod-side opt-in live Propodus proof, v0.83.0 generated projections, and explicit service-boundary documentation while leaving hosted Propodus auth, allowlisting, URL, and persistence to Propodus.",
   "current_phase": "propodus-phase-2",
+  "next_transitions": [
+    "publish"
+  ],
   "active_boundaries": [
     "Decapod governance kernel, CI, typed Propodus client, tests, docs, and generated governance artifacts only; no payments, identity implementation, website, or Propodus deployment changes."
   ],
@@ -21,6 +24,8 @@
   ],
   "modified_files": [
     ".decapod/governance/claims.json",
+    ".decapod/governance/trajectory.json",
+    ".decapod/governance/validation.json",
     ".github/workflows/ci.yml",
     "docs/book/src/reference/propodus.md",
     "src/decapod/core/entrypoint_integrity.rs",
@@ -31,7 +36,8 @@
   "declared_commands": [
     "cargo clippy --locked --all-targets --all-features -- -D warnings",
     "cargo fmt --all -- --check",
-    "cargo test --locked"
+    "cargo test --locked",
+    "decapod validate"
   ],
   "tool_calls": [],
   "checks": [
@@ -48,6 +54,14 @@
       "status": "passed"
     },
     {
+      "name": "decapod validate",
+      "status": "passed"
+    },
+    {
+      "name": "decapod_validate",
+      "status": "passed"
+    },
+    {
       "name": "focused_tests",
       "status": "passed"
     }
@@ -55,7 +69,11 @@
   "evidence": [
     "entrypoint_release=0.83.0",
     "issue_1022=release_label_gate",
-    "propodus_live=ignored_by_default_manual_protected"
+    "propodus_live=ignored_by_default_manual_protected",
+    "validation epoch ve_6ae38cd6df7733bc completed with zero failures",
+    "validation_pass_count=202",
+    "validation_receipt=.decapod/governance/validation.json",
+    "validation_warnings=6"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -66,7 +84,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:b1dce5cb698b868c59840d69bfadf1bec128495023fd52e9ec66e8c4e54aa8d5",
+  "artifact_hash": "sha256:f93fe07a69bb0f8b292ed3e71259ef1635429c46590386671a3eb6d9cce00de7",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -105,6 +123,20 @@
       {
         "sequence": 4,
         "event_id": "event:4",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
+      },
+      {
+        "sequence": 5,
+        "event_id": "event:5",
+        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
+      },
+      {
+        "sequence": 6,
+        "event_id": "event:6",
         "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
@@ -148,12 +180,47 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
+          },
+          {
+            "sequence": 5,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_6ae38cd6df7733bc completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:5"
+          },
+          {
+            "sequence": 6,
+            "action": "propodus-phase-2",
+            "scope": [
+              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+            ],
+            "observations": [
+              "validation_receipt=.decapod/governance/validation.json",
+              "validation_pass_count=202",
+              "validation_warnings=6"
+            ],
+            "proof_refs": [
+              "decapod_validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:6"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 4
+    "next_sequence": 6
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -5,6 +5,10 @@
   "task_id": "cicd_01kydv7dsj7sayv4",
   "original_intent": "Update PR #1036 to align Decapod issues #1032 through #1035 and #1037 with current Propodus PR #31 boundaries.",
   "derived_intent": "Activate explicit Propodus-backed todo commands, fail closed on verified canonical GitHub identity, and prove command-level shared and unauthorized behavior without moving Propodus-owned auth or policy into Decapod.",
+  "current_phase": "validation",
+  "next_transitions": [
+    "publish"
+  ],
   "active_boundaries": [
     "Decapod owns cloud composition, client credential boundary, repository identity resolution, typed errors, and proof orchestration; Propodus owns GitHub exchange, seat policy, persistence, deployment, and service allowlists."
   ],
@@ -19,13 +23,17 @@
     "tests/propodus_live.rs"
   ],
   "modified_files": [
+    ".decapod/governance/trajectory.json",
+    ".decapod/governance/validation.json",
     "src/decapod/core/propodus.rs",
     "src/decapod/core/repo_identity.rs",
     "src/decapod/core/todo.rs",
     "tests/cloud_command_path.rs",
     "tests/propodus_live.rs"
   ],
-  "declared_commands": [],
+  "declared_commands": [
+    "decapod validate"
+  ],
   "tool_calls": [],
   "checks": [
     {
@@ -37,7 +45,19 @@
       "status": "passed"
     },
     {
+      "name": "container_validate",
+      "status": "passed"
+    },
+    {
+      "name": "decapod validate",
+      "status": "passed"
+    },
+    {
       "name": "focused_tests",
+      "status": "passed"
+    },
+    {
+      "name": "pr_published",
       "status": "passed"
     },
     {
@@ -46,11 +66,14 @@
     }
   ],
   "evidence": [
-    "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs"
+    "container_validate=202 passed, 0 failed",
+    "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs",
+    "pr=https://github.com/DecapodLabs/decapod/pull/1036",
+    "validation epoch ve_384d6a144548fcff completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
-  "completion_claim": "PR #1036 implementation updated; final governed validation pending",
+  "completion_claim": "PR #1036 updated and published without merge; remaining Propodus issue #24 login exchange is explicitly deferred",
   "proof_status": "passed",
   "verdicts": {
     "intent_alignment": "supported",
@@ -58,7 +81,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:345c0f6e31e323cb32c5f30885eeeeb621f93116f3e8329fb08935c0f355f0a1",
+  "artifact_hash": "sha256:6243a08168792693bd35f16699adb3f8dad356834c98ab744f603cb6138e583a",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -104,6 +127,20 @@
       {
         "sequence": 5,
         "event_id": "event:5",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:wave2-propodus-1036-alignment"
+      },
+      {
+        "sequence": 6,
+        "event_id": "event:6",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:wave2-propodus-1036-alignment"
+      },
+      {
+        "sequence": 7,
+        "event_id": "event:7",
         "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:wave2-propodus-1036-alignment"
@@ -159,12 +196,47 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:5"
+          },
+          {
+            "sequence": 6,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_384d6a144548fcff completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:6"
+          },
+          {
+            "sequence": 7,
+            "action": "trajectory.record",
+            "scope": [
+              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+            ],
+            "observations": [
+              "container_validate=202 passed, 0 failed",
+              "pr=https://github.com/DecapodLabs/decapod/pull/1036"
+            ],
+            "proof_refs": [
+              "container_validate",
+              "pr_published"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:7"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 5
+    "next_sequence": 7
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -69,7 +69,8 @@
     "container_validate=202 passed, 0 failed",
     "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs",
     "pr=https://github.com/DecapodLabs/decapod/pull/1036",
-    "validation epoch ve_384d6a144548fcff completed with zero failures"
+    "validation epoch ve_384d6a144548fcff completed with zero failures",
+    "validation epoch ve_3ebfebc2881beebf completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -81,7 +82,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:6243a08168792693bd35f16699adb3f8dad356834c98ab744f603cb6138e583a",
+  "artifact_hash": "sha256:3948beb75fa329e261734945cd1b855fee77fa0b492c054c82274236e2de2bbc",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -141,6 +142,13 @@
       {
         "sequence": 7,
         "event_id": "event:7",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:wave2-propodus-1036-alignment"
+      },
+      {
+        "sequence": 8,
+        "event_id": "event:8",
         "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:wave2-propodus-1036-alignment"
@@ -231,12 +239,30 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:7"
+          },
+          {
+            "sequence": 8,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_3ebfebc2881beebf completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:8"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 7
+    "next_sequence": 8
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,82 +1,56 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
-  "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+  "run_id": "wave2-propodus-1036-alignment",
+  "intent_id": "intent:wave2-propodus-1036-alignment",
   "task_id": "cicd_01kydv7dsj7sayv4",
-  "original_intent": "Start Propodus wave 2 in Decapod v0.83.0 and solve issue #1022 within the same PR.",
-  "derived_intent": "Deliver release-labeled PR governance exemption, Decapod-side opt-in live Propodus proof, v0.83.0 generated projections, and explicit service-boundary documentation while leaving hosted Propodus auth, allowlisting, URL, and persistence to Propodus.",
-  "current_phase": "propodus-phase-2",
-  "next_transitions": [
-    "publish"
-  ],
+  "original_intent": "Update PR #1036 to align Decapod issues #1032 through #1035 and #1037 with current Propodus PR #31 boundaries.",
+  "derived_intent": "Activate explicit Propodus-backed todo commands, fail closed on verified canonical GitHub identity, and prove command-level shared and unauthorized behavior without moving Propodus-owned auth or policy into Decapod.",
   "active_boundaries": [
-    "Decapod governance kernel, CI, typed Propodus client, tests, docs, and generated governance artifacts only; no payments, identity implementation, website, or Propodus deployment changes."
+    "Decapod owns cloud composition, client credential boundary, repository identity resolution, typed errors, and proof orchestration; Propodus owns GitHub exchange, seat policy, persistence, deployment, and service allowlists."
   ],
   "repo_scope": [
-    "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+    "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
   ],
   "inspected_files": [
-    ".github/workflows/ci.yml",
-    "docs/book/src/reference/propodus.md",
     "src/decapod/core/propodus.rs",
-    "tests/propodus_contract.rs",
-    "tests/release_workflow_policy.rs"
+    "src/decapod/core/repo_identity.rs",
+    "src/decapod/core/todo.rs",
+    "tests/cloud_command_path.rs",
+    "tests/propodus_live.rs"
   ],
   "modified_files": [
-    ".decapod/governance/claims.json",
-    ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json",
-    ".github/workflows/ci.yml",
-    "docs/book/src/reference/propodus.md",
-    "src/decapod/core/entrypoint_integrity.rs",
     "src/decapod/core/propodus.rs",
-    "tests/propodus_live.rs",
-    "tests/release_workflow_policy.rs"
+    "src/decapod/core/repo_identity.rs",
+    "src/decapod/core/todo.rs",
+    "tests/cloud_command_path.rs",
+    "tests/propodus_live.rs"
   ],
-  "declared_commands": [
-    "cargo clippy --locked --all-targets --all-features -- -D warnings",
-    "cargo fmt --all -- --check",
-    "cargo test --locked",
-    "decapod validate"
-  ],
+  "declared_commands": [],
   "tool_calls": [],
   "checks": [
     {
-      "name": "cargo_clippy",
+      "name": "cargo_check",
       "status": "passed"
     },
     {
-      "name": "cargo_fmt",
-      "status": "passed"
-    },
-    {
-      "name": "cargo_test",
-      "status": "passed"
-    },
-    {
-      "name": "decapod validate",
-      "status": "passed"
-    },
-    {
-      "name": "decapod_validate",
+      "name": "clippy",
       "status": "passed"
     },
     {
       "name": "focused_tests",
       "status": "passed"
+    },
+    {
+      "name": "specs_refresh",
+      "status": "passed"
     }
   ],
   "evidence": [
-    "entrypoint_release=0.83.0",
-    "issue_1022=release_label_gate",
-    "propodus_live=ignored_by_default_manual_protected",
-    "validation epoch ve_6ae38cd6df7733bc completed with zero failures",
-    "validation_pass_count=202",
-    "validation_receipt=.decapod/governance/validation.json",
-    "validation_warnings=6"
+    "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
+  "completion_claim": "PR #1036 implementation updated; final governed validation pending",
   "proof_status": "passed",
   "verdicts": {
     "intent_alignment": "supported",
@@ -84,21 +58,21 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:f93fe07a69bb0f8b292ed3e71259ef1635429c46590386671a3eb6d9cce00de7",
+  "artifact_hash": "sha256:345c0f6e31e323cb32c5f30885eeeeb621f93116f3e8329fb08935c0f355f0a1",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8": {
-        "id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
-        "raw_intent": "Start Propodus wave 2 in Decapod v0.83.0 and solve issue #1022 within the same PR.",
-        "refined_intent": "Deliver release-labeled PR governance exemption, Decapod-side opt-in live Propodus proof, v0.83.0 generated projections, and explicit service-boundary documentation while leaving hosted Propodus auth, allowlisting, URL, and persistence to Propodus.",
+      "intent:wave2-propodus-1036-alignment": {
+        "id": "intent:wave2-propodus-1036-alignment",
+        "raw_intent": "Update PR #1036 to align Decapod issues #1032 through #1035 and #1037 with current Propodus PR #31 boundaries.",
+        "refined_intent": "Activate explicit Propodus-backed todo commands, fail closed on verified canonical GitHub identity, and prove command-level shared and unauthorized behavior without moving Propodus-owned auth or policy into Decapod.",
         "acceptance_criteria": [],
         "constraints": [
-          "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+          "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
         ],
         "assumptions": [],
         "boundaries": [
-          "Decapod governance kernel, CI, typed Propodus client, tests, docs, and generated governance artifacts only; no payments, identity implementation, website, or Propodus deployment changes."
+          "Decapod owns cloud composition, client credential boundary, repository identity resolution, typed errors, and proof orchestration; Propodus owns GitHub exchange, seat policy, persistence, deployment, and service allowlists."
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -111,116 +85,86 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
+        "detail": "trajectory:wave2-propodus-1036-alignment"
       },
       {
         "sequence": 5,
         "event_id": "event:5",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
-      },
-      {
-        "sequence": 6,
-        "event_id": "event:6",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:01KYDVZ5AF1DPQYWDF2DJ4KBW8"
+        "detail": "trajectory:wave2-propodus-1036-alignment"
       }
     ],
     "trajectories": {
-      "01KYDVZ5AF1DPQYWDF2DJ4KBW8": {
-        "id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
-        "intent_id": "intent:01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+      "wave2-propodus-1036-alignment": {
+        "id": "wave2-propodus-1036-alignment",
+        "intent_id": "intent:wave2-propodus-1036-alignment",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "propodus-phase-2",
-            "command": "cargo fmt --all -- --check",
+            "action": "trajectory.record",
             "scope": [
-              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
             ],
             "observations": [
-              ".github/workflows/ci.yml",
+              "src/decapod/core/todo.rs",
               "src/decapod/core/propodus.rs",
-              "tests/release_workflow_policy.rs",
-              "tests/propodus_contract.rs",
-              "docs/book/src/reference/propodus.md",
-              ".github/workflows/ci.yml",
-              "src/decapod/core/propodus.rs",
-              "tests/release_workflow_policy.rs",
-              "tests/propodus_live.rs",
-              "docs/book/src/reference/propodus.md",
-              "src/decapod/core/entrypoint_integrity.rs",
-              ".decapod/governance/claims.json",
-              "issue_1022=release_label_gate",
-              "propodus_live=ignored_by_default_manual_protected",
-              "entrypoint_release=0.83.0"
+              "src/decapod/core/repo_identity.rs",
+              "tests/cloud_command_path.rs",
+              "tests/propodus_live.rs"
             ],
             "proof_refs": [
-              "cargo_fmt",
+              "cargo_check",
               "focused_tests",
-              "cargo_test",
-              "cargo_clippy"
+              "clippy",
+              "specs_refresh"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
           },
           {
             "sequence": 5,
-            "action": "validation",
-            "command": "decapod validate",
+            "action": "trajectory.record",
             "scope": [
-              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
+              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
             ],
             "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_6ae38cd6df7733bc completed with zero failures"
+              "src/decapod/core/todo.rs",
+              "src/decapod/core/propodus.rs",
+              "src/decapod/core/repo_identity.rs",
+              "tests/cloud_command_path.rs",
+              "tests/propodus_live.rs",
+              "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs"
             ],
             "proof_refs": [
-              "decapod validate"
+              "cargo_check",
+              "focused_tests",
+              "clippy",
+              "specs_refresh"
             ],
             "validation_findings": [],
             "custody_event_id": "event:5"
-          },
-          {
-            "sequence": 6,
-            "action": "propodus-phase-2",
-            "scope": [
-              "DecapodLabs/decapod issue #1022 and wave-2 Propodus client proof surfaces related to #766/#1028; claims.json included in the publication bundle."
-            ],
-            "observations": [
-              "validation_receipt=.decapod/governance/validation.json",
-              "validation_pass_count=202",
-              "validation_warnings=6"
-            ],
-            "proof_refs": [
-              "decapod_validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:6"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 6
+    "next_sequence": 5
   }
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,13 +2,13 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.83.0",
-  "git_revision": "8f594db6110bf098f10cdf6dacf8118a50748c9f",
-  "repo_signal_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
-  "trajectory_run_id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
-  "trajectory_artifact_hash": "sha256:20af70d16e9395f7e932ac8c9745b6d81775f7baf59313183c0d5854c28fe3e8",
+  "git_revision": "80e5617557869ca681130ff9e50bcaea6a1dffcb",
+  "repo_signal_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
+  "trajectory_run_id": "wave2-propodus-1036-alignment",
+  "trajectory_artifact_hash": "sha256:beced49cd12cb4cdfcde61e539041f7f490d5cea03a568a1d15dbe090e5ea4cc",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_6ae38cd6df7733bc",
+    "epoch_id": "ve_384d6a144548fcff",
     "evaluator_identity": "decapod-validate@0.83.0",
     "evaluator_set_hash": "sha256:93c9e6132ec5fb2517597c679e6ba0ce80fecc73b3a48254f2265652807b0209",
     "constitution_version": "embedded-docs@0.83.0",
@@ -17,20 +17,20 @@
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:52c69cb53b544987919472a6198acf1bac55d20c15a7300d90a292f4313c045a",
-    "generated_specs_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
+    "generated_specs_manifest_hash": "sha256:61dbebc5aba05cccc608c951d987b4e65fdbe18ff4ab0e5c2c5c6fed4411e15a",
+    "generated_specs_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
     "material_hashes": {
       "constitution:core/DECAPOD": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:0d02940c9dcfd277f7a9f2fa1a0f9cd1f51386dba60403b9eb3d1e7a7ad99fff",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:bee60b33a416e5b1215f028c7ef976e9fde67b7d559a1c738451ae30067b495c",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:68cfc3769aa237fb69d101bc1b6e9337b746ed19d692fd65d7714eebc3f3e4d3",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:506b41822cf224e150edb659a566c06a78e75614ededfed388a561eda44af9c7",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:497b28739152e40807b48c2ce410e8e1846131abdd837c4f4d69de9feb24c6ab",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:442f35e235e59d7aefd38df27ffcf0797849e936dc03053f998bb124e1138ccd",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:6e296d9f4df04d3671c68d744a7cd333b3dfa178bd6bfb64b18ab1c5a391d4ec",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:f3d46da7e18b069371d74c57350652a0336408d31ab6276eabb30a8ef091f706",
-      "generated_specs_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
-      "generated_specs_manifest": "sha256:52c69cb53b544987919472a6198acf1bac55d20c15a7300d90a292f4313c045a",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:8d59e0e845bda1f2b3b8efc5b740de9e11bdeec1f913e5a55950d3d58a98f9a5",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:d46e6f06147069136b516d0c34f752bd9d4604d23d4b4d7e15130dd079677467",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:0705d8567f77a5355e4fea683ad87217cdcdf8974c03581d836494a6bf6d503d",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:42f7a39c4fa553cd6427e21b686dd8ed86de42c07e6fdd37a25b7806990f208a",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:9ed29636b7ee8e7b64900bf471dd844e464274c25d2d16e72fbb320e6ea12e15",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:8e34e67fcd02e9aca6daa774b69190d7a65c0870627418249882d4d6862d1f0b",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:b1cd8efc9fc20c0dcce60d92a91cc421aee2d0173f7bfa479d58497e3ea8411d",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:37c325d219232d8f563f312f425d6417e63723330bf8168ec79f1b7ec400f520",
+      "generated_specs_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
+      "generated_specs_manifest": "sha256:61dbebc5aba05cccc608c951d987b4e65fdbe18ff4ab0e5c2c5c6fed4411e15a",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,46 +39,42 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 6545,
+  "elapsed_ms": 3009,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
   "warnings": [
     "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
+    "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
     "Risk map missing (run `decapod riskmap init`)",
     "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
-    "Watcher audit trail missing (run `decapod govern watcher run`)",
-    "Workspace branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/cicd_01kydv7dsj7sayv4-wave2`."
+    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+    "Watcher audit trail missing (run `decapod govern watcher run`)"
   ],
   "gate_timings": [
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 3652
+      "elapsed_ms": 544
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 589
+      "elapsed_ms": 442
     },
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 120
+      "elapsed_ms": 113
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 96
-    },
-    {
-      "name": "validate_health_purity",
-      "elapsed_ms": 95
-    },
-    {
-      "name": "validate_knowledge_integrity",
-      "elapsed_ms": 44
+      "elapsed_ms": 92
     },
     {
       "name": "validate_canon_mutation",
       "elapsed_ms": 44
+    },
+    {
+      "name": "validate_knowledge_integrity",
+      "elapsed_ms": 43
     },
     {
       "name": "validate_watcher_purity",
@@ -90,23 +86,23 @@
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 32
+      "elapsed_ms": 31
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 18
+      "elapsed_ms": 17
     },
     {
       "name": "validate_git_workspace_context",
-      "elapsed_ms": 18
+      "elapsed_ms": 17
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 14
+      "elapsed_ms": 13
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 10
+      "elapsed_ms": 9
     },
     {
       "name": "validate_git_protected_branch",
@@ -125,12 +121,16 @@
       "elapsed_ms": 3
     },
     {
+      "name": "validate_health_purity",
+      "elapsed_ms": 3
+    },
+    {
       "name": "validate_gatekeeper_gate",
       "elapsed_ms": 2
     },
     {
       "name": "validate_generated_artifact_whitelist",
-      "elapsed_ms": 1
+      "elapsed_ms": 2
     },
     {
       "name": "validate_control_plane_contract",
@@ -142,7 +142,7 @@
     },
     {
       "name": "validate_database_schema_versions",
-      "elapsed_ms": 1
+      "elapsed_ms": 0
     },
     {
       "name": "validate_interface_contract_bootstrap",
@@ -157,11 +157,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_entrypoint_invariants",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_repo_map",
+      "name": "validate_entrypoint_invariants",
       "elapsed_ms": 0
     },
     {
@@ -169,7 +169,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_repo_map",
       "elapsed_ms": 0
     },
     {
@@ -197,7 +197,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
+      "name": "validate_recursive_improvement_passes_if_present",
       "elapsed_ms": 0
     },
     {
@@ -205,11 +205,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_workunit_manifests_if_present",
+      "name": "validate_archive_integrity",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_watcher_audit",
+      "name": "validate_workunit_manifests_if_present",
       "elapsed_ms": 0
     },
     {
@@ -221,19 +221,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_root_dockerfile_seed_detection",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_lcm_immutability",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_recursive_improvement_passes_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_context_capsules_if_present",
+      "name": "validate_watcher_audit",
       "elapsed_ms": 0
     },
     {
@@ -241,7 +229,23 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_lcm_immutability",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_root_dockerfile_seed_detection",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsules_if_present",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_knowledge_promotions_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_coplayer_policy_tightening",
       "elapsed_ms": 0
     },
     {
@@ -250,10 +254,6 @@
     },
     {
       "name": "validate_risk_map",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_coplayer_policy_tightening",
       "elapsed_ms": 0
     },
     {
@@ -271,16 +271,16 @@
     "confidence": "medium",
     "reasons": [
       "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
+      "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
       "Risk map missing (run `decapod riskmap init`)",
       "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
-      "Watcher audit trail missing (run `decapod govern watcher run`)",
-      "Workspace branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/cicd_01kydv7dsj7sayv4-wave2`."
+      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+      "Watcher audit trail missing (run `decapod govern watcher run`)"
     ],
     "recommendations": [
       "Review the reported validation warnings before relying on the CI result.",
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:40a02fb3077806ef30fabda9f7c3e61db09d25c8b71d07485697a390eea48143"
+  "receipt_hash": "sha256:ec4b88590e1a962535456c08f7c200b4fa5b04e30c41ec8fda1a4ae346043c16"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,36 +1,36 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.82.1",
-  "git_revision": "38e19e652b1bd6d1f43073acb0cc5c030d9341b0",
-  "repo_signal_fingerprint": "496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4",
-  "trajectory_run_id": "validation_01KYDS9F1M2CG9SVWP17KWSZE0",
-  "trajectory_artifact_hash": "sha256:20488f2ab467dacd1309505982818edc59501693d534ccca85a6733acbcfe3d7",
+  "decapod_release": "0.83.0",
+  "git_revision": "8f594db6110bf098f10cdf6dacf8118a50748c9f",
+  "repo_signal_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
+  "trajectory_run_id": "01KYDVZ5AF1DPQYWDF2DJ4KBW8",
+  "trajectory_artifact_hash": "sha256:20af70d16e9395f7e932ac8c9745b6d81775f7baf59313183c0d5854c28fe3e8",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_38dc9244c3aaf167",
-    "evaluator_identity": "decapod-validate@0.82.1",
-    "evaluator_set_hash": "sha256:cb0063e8cdebc313c391a3fc2de605a11c8e3eae110cbac6bfa986ec5052e137",
-    "constitution_version": "embedded-docs@0.82.1",
-    "constitution_hash": "sha256:17983eae69da5b2abe29dda34133fdecc8a06d79a28c4d0c80a17f4eb030d715",
+    "epoch_id": "ve_6ae38cd6df7733bc",
+    "evaluator_identity": "decapod-validate@0.83.0",
+    "evaluator_set_hash": "sha256:93c9e6132ec5fb2517597c679e6ba0ce80fecc73b3a48254f2265652807b0209",
+    "constitution_version": "embedded-docs@0.83.0",
+    "constitution_hash": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:f3c18676db884a1f71044395b1f05eb1a31fa79024744ad9636d1a381c86b45c",
-    "generated_specs_fingerprint": "496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4",
+    "generated_specs_manifest_hash": "sha256:52c69cb53b544987919472a6198acf1bac55d20c15a7300d90a292f4313c045a",
+    "generated_specs_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:17983eae69da5b2abe29dda34133fdecc8a06d79a28c4d0c80a17f4eb030d715",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:f854126a7c454de6edf503fa3ce381165f5756025fd66fdc89b821b93e7b23fa",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:de74b3512adc1021d596cfca6743e275301a4754b7c2ed34181a0592c1b8d0f3",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:617c5db81dcc09b66cd52507b84ecb615c26466ad3a32893d36c5e6f3d087005",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:9cc9c77816ed9f75c5d29c770064d2d37ac11866c35afbfd966cfea67f215cf1",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:5fa8a9007364ddbcbb20e68828056e255b406d4dd46036bd6086c735031c9623",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:457b17f9be1d6866f0255d78058be2006a8ca630d5aec1f08e2df5ea2a5f33fb",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:cb776aec1112c05f5518d4cb2b773ee6a4c8364895f1164eff43350ee5d77d63",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:ffe5feac7dbd6369ff2025f0b077237eecd5001ffe8e1628ee21081eed3f6c11",
-      "generated_specs_fingerprint": "496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4",
-      "generated_specs_manifest": "sha256:f3c18676db884a1f71044395b1f05eb1a31fa79024744ad9636d1a381c86b45c",
+      "constitution:core/DECAPOD": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:0d02940c9dcfd277f7a9f2fa1a0f9cd1f51386dba60403b9eb3d1e7a7ad99fff",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:bee60b33a416e5b1215f028c7ef976e9fde67b7d559a1c738451ae30067b495c",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:68cfc3769aa237fb69d101bc1b6e9337b746ed19d692fd65d7714eebc3f3e4d3",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:506b41822cf224e150edb659a566c06a78e75614ededfed388a561eda44af9c7",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:497b28739152e40807b48c2ce410e8e1846131abdd837c4f4d69de9feb24c6ab",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:442f35e235e59d7aefd38df27ffcf0797849e936dc03053f998bb124e1138ccd",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:6e296d9f4df04d3671c68d744a7cd333b3dfa178bd6bfb64b18ab1c5a391d4ec",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:f3d46da7e18b069371d74c57350652a0336408d31ab6276eabb30a8ef091f706",
+      "generated_specs_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
+      "generated_specs_manifest": "sha256:52c69cb53b544987919472a6198acf1bac55d20c15a7300d90a292f4313c045a",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,7 +39,7 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 67519,
+  "elapsed_ms": 6545,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -47,26 +47,30 @@
     "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
     "Risk map missing (run `decapod riskmap init`)",
     "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
     "Watcher audit trail missing (run `decapod govern watcher run`)",
-    "Workspace branch 'agent/unknown/todo-01kydm-1785016765-code-01kyds' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/todo-01kydm-1785016765-code-01kyds`."
+    "Workspace branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/cicd_01kydv7dsj7sayv4-wave2`."
   ],
   "gate_timings": [
     {
-      "name": "validate_federation_gates",
-      "elapsed_ms": 5741
+      "name": "validate_machine_contract",
+      "elapsed_ms": 3652
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 525
+      "elapsed_ms": 589
     },
     {
-      "name": "validate_machine_contract",
-      "elapsed_ms": 414
+      "name": "validate_federation_gates",
+      "elapsed_ms": 120
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 90
+      "elapsed_ms": 96
+    },
+    {
+      "name": "validate_health_purity",
+      "elapsed_ms": 95
     },
     {
       "name": "validate_knowledge_integrity",
@@ -74,15 +78,15 @@
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 42
+      "elapsed_ms": 44
     },
     {
       "name": "validate_watcher_purity",
-      "elapsed_ms": 41
+      "elapsed_ms": 43
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 36
+      "elapsed_ms": 37
     },
     {
       "name": "validate_schema_determinism",
@@ -98,23 +102,15 @@
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 13
+      "elapsed_ms": 14
+    },
+    {
+      "name": "validate_no_legacy_namespaces",
+      "elapsed_ms": 10
     },
     {
       "name": "validate_git_protected_branch",
       "elapsed_ms": 9
-    },
-    {
-      "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 8
-    },
-    {
-      "name": "validate_health_purity",
-      "elapsed_ms": 6
-    },
-    {
-      "name": "validate_plan_governed_execution_gate",
-      "elapsed_ms": 6
     },
     {
       "name": "validate_git_push_pr_gate",
@@ -123,6 +119,10 @@
     {
       "name": "validate_repomap_determinism",
       "elapsed_ms": 5
+    },
+    {
+      "name": "validate_plan_governed_execution_gate",
+      "elapsed_ms": 3
     },
     {
       "name": "validate_gatekeeper_gate",
@@ -169,11 +169,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_project_config_toml",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
@@ -189,7 +189,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
+      "name": "validate_context_capsule_policy_contract",
       "elapsed_ms": 0
     },
     {
@@ -197,7 +197,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsule_policy_contract",
+      "name": "validate_archive_integrity",
       "elapsed_ms": 0
     },
     {
@@ -217,11 +217,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_root_dockerfile_seed_detection",
+      "name": "validate_eval_gate_if_required",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_eval_gate_if_required",
+      "name": "validate_root_dockerfile_seed_detection",
       "elapsed_ms": 0
     },
     {
@@ -229,7 +229,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_health_cache_integrity",
+      "name": "validate_recursive_improvement_passes_if_present",
       "elapsed_ms": 0
     },
     {
@@ -237,15 +237,15 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_recursive_improvement_passes_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_internalization_artifacts_if_present",
+      "name": "validate_health_cache_integrity",
       "elapsed_ms": 0
     },
     {
       "name": "validate_knowledge_promotions_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_internalization_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
@@ -273,14 +273,14 @@
       "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
       "Risk map missing (run `decapod riskmap init`)",
       "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
       "Watcher audit trail missing (run `decapod govern watcher run`)",
-      "Workspace branch 'agent/unknown/todo-01kydm-1785016765-code-01kyds' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/todo-01kydm-1785016765-code-01kyds`."
+      "Workspace branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/cicd_01kydv7dsj7sayv4-wave2`."
     ],
     "recommendations": [
       "Review the reported validation warnings before relying on the CI result.",
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:a5a5dd3993666157f333558bc39ff014167637345d94183c2744c39b7f3746d8"
+  "receipt_hash": "sha256:40a02fb3077806ef30fabda9f7c3e61db09d25c8b71d07485697a390eea48143"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,13 +2,13 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.83.0",
-  "git_revision": "80e5617557869ca681130ff9e50bcaea6a1dffcb",
-  "repo_signal_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
+  "git_revision": "1341fac35b13976be5feb093325cb794691a6f4d",
+  "repo_signal_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
   "trajectory_run_id": "wave2-propodus-1036-alignment",
-  "trajectory_artifact_hash": "sha256:beced49cd12cb4cdfcde61e539041f7f490d5cea03a568a1d15dbe090e5ea4cc",
+  "trajectory_artifact_hash": "sha256:3948beb75fa329e261734945cd1b855fee77fa0b492c054c82274236e2de2bbc",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_384d6a144548fcff",
+    "epoch_id": "ve_3ebfebc2881beebf",
     "evaluator_identity": "decapod-validate@0.83.0",
     "evaluator_set_hash": "sha256:93c9e6132ec5fb2517597c679e6ba0ce80fecc73b3a48254f2265652807b0209",
     "constitution_version": "embedded-docs@0.83.0",
@@ -17,20 +17,20 @@
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:61dbebc5aba05cccc608c951d987b4e65fdbe18ff4ab0e5c2c5c6fed4411e15a",
-    "generated_specs_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
+    "generated_specs_manifest_hash": "sha256:0d136e5c4332a927e7cff69fceb7f2f313b5158f972cc1ba813c387323a398c7",
+    "generated_specs_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
     "material_hashes": {
       "constitution:core/DECAPOD": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:8d59e0e845bda1f2b3b8efc5b740de9e11bdeec1f913e5a55950d3d58a98f9a5",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:d46e6f06147069136b516d0c34f752bd9d4604d23d4b4d7e15130dd079677467",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:0705d8567f77a5355e4fea683ad87217cdcdf8974c03581d836494a6bf6d503d",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:42f7a39c4fa553cd6427e21b686dd8ed86de42c07e6fdd37a25b7806990f208a",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:9ed29636b7ee8e7b64900bf471dd844e464274c25d2d16e72fbb320e6ea12e15",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:8e34e67fcd02e9aca6daa774b69190d7a65c0870627418249882d4d6862d1f0b",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:b1cd8efc9fc20c0dcce60d92a91cc421aee2d0173f7bfa479d58497e3ea8411d",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:37c325d219232d8f563f312f425d6417e63723330bf8168ec79f1b7ec400f520",
-      "generated_specs_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
-      "generated_specs_manifest": "sha256:61dbebc5aba05cccc608c951d987b4e65fdbe18ff4ab0e5c2c5c6fed4411e15a",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:385cb0714b6f7e5efef1e69c5560754ceb5d5ad117f8803cf103f1d6bed5a2a3",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:ab60b4f659325448d61b99ce25d09c47aa42e6aeb02e29f0004ef4d4588917b8",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:c6e01067c9fe8b33b703e57535725d462b2e2a885c4884b0d9005d327082e34c",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:31a48021c3634d47cfc66d00374df4a5d25aaf812db675463a68b2907014369d",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:d4c89e6ebcd6e8726f6c52ad3c3b0d44141d930815727b007774d81a61b9ab95",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:74ca83a9f6f9eeafc260e444451dda89a55812fbcd2d0962899879c4301a40ec",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:43fc947cbf4a2b7a6e56a498d730be3325b50877fbe961c93d120a66e4c66866",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:3c69e879e3e4c1151b4dce9d4621915182fa2f5ab85e84991fa0c33fbd836f72",
+      "generated_specs_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
+      "generated_specs_manifest": "sha256:0d136e5c4332a927e7cff69fceb7f2f313b5158f972cc1ba813c387323a398c7",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,7 +39,7 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 3009,
+  "elapsed_ms": 63840,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -48,37 +48,37 @@
     "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
     "Risk map missing (run `decapod riskmap init`)",
     "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
     "Watcher audit trail missing (run `decapod govern watcher run`)"
   ],
   "gate_timings": [
     {
-      "name": "validate_machine_contract",
-      "elapsed_ms": 544
+      "name": "validate_federation_gates",
+      "elapsed_ms": 7640
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 442
+      "elapsed_ms": 452
     },
     {
-      "name": "validate_federation_gates",
-      "elapsed_ms": 113
+      "name": "validate_machine_contract",
+      "elapsed_ms": 384
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 92
-    },
-    {
-      "name": "validate_canon_mutation",
-      "elapsed_ms": 44
+      "elapsed_ms": 93
     },
     {
       "name": "validate_knowledge_integrity",
-      "elapsed_ms": 43
+      "elapsed_ms": 45
+    },
+    {
+      "name": "validate_canon_mutation",
+      "elapsed_ms": 45
     },
     {
       "name": "validate_watcher_purity",
-      "elapsed_ms": 43
+      "elapsed_ms": 44
     },
     {
       "name": "validate_risk_map_violations",
@@ -86,11 +86,11 @@
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 31
+      "elapsed_ms": 32
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 17
+      "elapsed_ms": 18
     },
     {
       "name": "validate_git_workspace_context",
@@ -98,7 +98,7 @@
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 13
+      "elapsed_ms": 14
     },
     {
       "name": "validate_no_legacy_namespaces",
@@ -133,11 +133,11 @@
       "elapsed_ms": 2
     },
     {
-      "name": "validate_control_plane_contract",
+      "name": "validate_obligations",
       "elapsed_ms": 1
     },
     {
-      "name": "validate_obligations",
+      "name": "validate_control_plane_contract",
       "elapsed_ms": 1
     },
     {
@@ -157,7 +157,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_validation_receipt_if_present",
       "elapsed_ms": 0
     },
     {
@@ -165,11 +165,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_validation_receipt_if_present",
+      "name": "validate_repo_map",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_repo_map",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
@@ -189,23 +189,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsule_policy_contract",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_docs_templates_bucket",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_recursive_improvement_passes_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_policy_integrity",
+      "name": "validate_context_capsule_policy_contract",
       "elapsed_ms": 0
     },
     {
       "name": "validate_archive_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_policy_integrity",
       "elapsed_ms": 0
     },
     {
@@ -217,15 +213,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_eval_gate_if_required",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_watcher_audit",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_health_cache_integrity",
       "elapsed_ms": 0
     },
     {
@@ -233,11 +221,27 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_context_capsules_if_present",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_root_dockerfile_seed_detection",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsules_if_present",
+      "name": "validate_recursive_improvement_passes_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_internalization_artifacts_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_eval_gate_if_required",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_health_cache_integrity",
       "elapsed_ms": 0
     },
     {
@@ -246,10 +250,6 @@
     },
     {
       "name": "validate_coplayer_policy_tightening",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_internalization_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
@@ -274,7 +274,7 @@
       "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
       "Risk map missing (run `decapod riskmap init`)",
       "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
       "Watcher audit trail missing (run `decapod govern watcher run`)"
     ],
     "recommendations": [
@@ -282,5 +282,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:ec4b88590e1a962535456c08f7c200b4fa5b04e30c41ec8fda1a4ae346043c16"
+  "receipt_hash": "sha256:09669572eb071cbd0dcd5c2d0c7667408c04dfbd9e10b1b84687558c260ee53e"
 }

--- a/.decapod/managed/Dockerfile.decapod
+++ b/.decapod/managed/Dockerfile.decapod
@@ -2,9 +2,9 @@
 # Path: .decapod/managed/Dockerfile.decapod
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.82.1-debian
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.83.0-debian
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.82.1
+ARG DECAPOD_VERSION=0.83.0
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785035220Z",
-  "repo_signal_fingerprint": "39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb",
+  "generated_at": "1785035728Z",
+  "repo_signal_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "19f5d509a87aa9d0d4db1cf5c5d7c35fce3b3ead1b83b98aef472c5eb46b3a6d",
-  "spec_input_hash": "1930c0f8944e00d0374eeb55a54373e60d1344a3d10f298095335610616915e3",
+  "spec_input_hash": "3198c4a9c7c62cafa7e58d73f6caf773b3a53c9682073f949221be835d13f598",
   "decapod_release": "0.83.0",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "e18542e47319e66324cf2659ad25b80a8c04925fe36fac9806fdabd0c04afeed",
+      "content_hash": "d4c89e6ebcd6e8726f6c52ad3c3b0d44141d930815727b007774d81a61b9ab95",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "701340de3b99149b05f0b4e3dcc3cbc6d1652f061a1e4a31d8155301b6daaf39",
+      "content_hash": "ab60b4f659325448d61b99ce25d09c47aa42e6aeb02e29f0004ef4d4588917b8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "587a9d6eb7260d83d4b9fb25951cec6dfb2effa1c465417d3c80d0459fa05173",
+      "content_hash": "385cb0714b6f7e5efef1e69c5560754ceb5d5ad117f8803cf103f1d6bed5a2a3",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "44620d19382fc54c7decd9c90239cfafef8fa08bec906de48c88ac96a69afd7f",
+      "content_hash": "c6e01067c9fe8b33b703e57535725d462b2e2a885c4884b0d9005d327082e34c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "b3ffc1212438b1671b4b4d50e93f881e96e2c2388c3d318f10af21da1db90fd0",
+      "content_hash": "3c69e879e3e4c1151b4dce9d4621915182fa2f5ab85e84991fa0c33fbd836f72",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "2bf3fd01d929db2db400a52d219c1fe73e5cd6fc2ad42d55ccffd2db7828581a",
+      "content_hash": "43fc947cbf4a2b7a6e56a498d730be3325b50877fbe961c93d120a66e4c66866",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "ce683c25ecdf5b903e836e6cad18402bd57fd016b6126cff41084888fa8608ce",
+      "content_hash": "31a48021c3634d47cfc66d00374df4a5d25aaf812db675463a68b2907014369d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "046705a8f5c819bccee84b88d8d88e28399d7301292b00fcdba6d5c6193fb895",
+      "content_hash": "74ca83a9f6f9eeafc260e444451dda89a55812fbcd2d0962899879c4301a40ec",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785024451Z",
-  "repo_signal_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
+  "generated_at": "1785028883Z",
+  "repo_signal_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "19f5d509a87aa9d0d4db1cf5c5d7c35fce3b3ead1b83b98aef472c5eb46b3a6d",
-  "spec_input_hash": "bf7262d75d9d2f5e488f42c7650517148d48584697192269a46a7add756e8979",
+  "spec_input_hash": "71c803a7d6af2b50db819bc04278dbbc56405f3a2196ae70223c91417c7c7627",
   "decapod_release": "0.83.0",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "497b28739152e40807b48c2ce410e8e1846131abdd837c4f4d69de9feb24c6ab",
+      "content_hash": "9ed29636b7ee8e7b64900bf471dd844e464274c25d2d16e72fbb320e6ea12e15",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "bee60b33a416e5b1215f028c7ef976e9fde67b7d559a1c738451ae30067b495c",
+      "content_hash": "d46e6f06147069136b516d0c34f752bd9d4604d23d4b4d7e15130dd079677467",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "0d02940c9dcfd277f7a9f2fa1a0f9cd1f51386dba60403b9eb3d1e7a7ad99fff",
+      "content_hash": "8d59e0e845bda1f2b3b8efc5b740de9e11bdeec1f913e5a55950d3d58a98f9a5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "68cfc3769aa237fb69d101bc1b6e9337b746ed19d692fd65d7714eebc3f3e4d3",
+      "content_hash": "0705d8567f77a5355e4fea683ad87217cdcdf8974c03581d836494a6bf6d503d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "f3d46da7e18b069371d74c57350652a0336408d31ab6276eabb30a8ef091f706",
+      "content_hash": "37c325d219232d8f563f312f425d6417e63723330bf8168ec79f1b7ec400f520",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "6e296d9f4df04d3671c68d744a7cd333b3dfa178bd6bfb64b18ab1c5a391d4ec",
+      "content_hash": "b1cd8efc9fc20c0dcce60d92a91cc421aee2d0173f7bfa479d58497e3ea8411d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "506b41822cf224e150edb659a566c06a78e75614ededfed388a561eda44af9c7",
+      "content_hash": "42f7a39c4fa553cd6427e21b686dd8ed86de42c07e6fdd37a25b7806990f208a",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "442f35e235e59d7aefd38df27ffcf0797849e936dc03053f998bb124e1138ccd",
+      "content_hash": "8e34e67fcd02e9aca6daa774b69190d7a65c0870627418249882d4d6862d1f0b",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785028883Z",
-  "repo_signal_fingerprint": "b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79",
+  "generated_at": "1785035220Z",
+  "repo_signal_fingerprint": "39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "19f5d509a87aa9d0d4db1cf5c5d7c35fce3b3ead1b83b98aef472c5eb46b3a6d",
-  "spec_input_hash": "71c803a7d6af2b50db819bc04278dbbc56405f3a2196ae70223c91417c7c7627",
+  "spec_input_hash": "1930c0f8944e00d0374eeb55a54373e60d1344a3d10f298095335610616915e3",
   "decapod_release": "0.83.0",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "9ed29636b7ee8e7b64900bf471dd844e464274c25d2d16e72fbb320e6ea12e15",
+      "content_hash": "e18542e47319e66324cf2659ad25b80a8c04925fe36fac9806fdabd0c04afeed",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "d46e6f06147069136b516d0c34f752bd9d4604d23d4b4d7e15130dd079677467",
+      "content_hash": "701340de3b99149b05f0b4e3dcc3cbc6d1652f061a1e4a31d8155301b6daaf39",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "8d59e0e845bda1f2b3b8efc5b740de9e11bdeec1f913e5a55950d3d58a98f9a5",
+      "content_hash": "587a9d6eb7260d83d4b9fb25951cec6dfb2effa1c465417d3c80d0459fa05173",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "0705d8567f77a5355e4fea683ad87217cdcdf8974c03581d836494a6bf6d503d",
+      "content_hash": "44620d19382fc54c7decd9c90239cfafef8fa08bec906de48c88ac96a69afd7f",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "37c325d219232d8f563f312f425d6417e63723330bf8168ec79f1b7ec400f520",
+      "content_hash": "b3ffc1212438b1671b4b4d50e93f881e96e2c2388c3d318f10af21da1db90fd0",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "b1cd8efc9fc20c0dcce60d92a91cc421aee2d0173f7bfa479d58497e3ea8411d",
+      "content_hash": "2bf3fd01d929db2db400a52d219c1fe73e5cd6fc2ad42d55ccffd2db7828581a",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "42f7a39c4fa553cd6427e21b686dd8ed86de42c07e6fdd37a25b7806990f208a",
+      "content_hash": "ce683c25ecdf5b903e836e6cad18402bd57fd016b6126cff41084888fa8608ce",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "8e34e67fcd02e9aca6daa774b69190d7a65c0870627418249882d4d6862d1f0b",
+      "content_hash": "046705a8f5c819bccee84b88d8d88e28399d7301292b00fcdba6d5c6193fb895",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785021010Z",
-  "repo_signal_fingerprint": "496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4",
+  "generated_at": "1785024451Z",
+  "repo_signal_fingerprint": "8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "19f5d509a87aa9d0d4db1cf5c5d7c35fce3b3ead1b83b98aef472c5eb46b3a6d",
-  "spec_input_hash": "bef7b1d8f885826ee7668a58ab5a34e9f3ba7ecf37fb44ec4014827105407c75",
-  "decapod_release": "0.82.1",
+  "spec_input_hash": "bf7262d75d9d2f5e488f42c7650517148d48584697192269a46a7add756e8979",
+  "decapod_release": "0.83.0",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "fb0e827ab838c525fa30552fe1d1a057a85c32599d74bda6b1a3d9c2167fc637",
-      "content_hash": "fb0e827ab838c525fa30552fe1d1a057a85c32599d74bda6b1a3d9c2167fc637",
-      "fingerprint": "d0fd2d97e7110240bbac3a83b1d44d7415924f5f69b521b556ce311180cb67b1"
+      "template_hash": "6c3cc1f8fb20e8cc96748b3a0ad4fce1b8218a6efd6d68bc739529ba1a6a755e",
+      "content_hash": "6c3cc1f8fb20e8cc96748b3a0ad4fce1b8218a6efd6d68bc739529ba1a6a755e",
+      "fingerprint": "ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "f736f5a17f7f435c562a1f57798d060ff3d8d3fd5b11be70ce93d0a69299babc",
-      "content_hash": "f736f5a17f7f435c562a1f57798d060ff3d8d3fd5b11be70ce93d0a69299babc",
-      "fingerprint": "1da08be69531c675ec1fd3c4f2fc48cf7f6b63e857363a42e1f1f898352e36fc"
+      "template_hash": "4699bf568e235b47e65eef6427d2e6616efcfa8dc3c994f25b02a9f4fa3e05d9",
+      "content_hash": "4699bf568e235b47e65eef6427d2e6616efcfa8dc3c994f25b02a9f4fa3e05d9",
+      "fingerprint": "e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "5a0881df6b5a121523593b2501b149fe1a19e38096cceedd5f3a50138a8f40f4",
-      "content_hash": "5a0881df6b5a121523593b2501b149fe1a19e38096cceedd5f3a50138a8f40f4",
-      "fingerprint": "90cdf59329eb640be87aace50eae6fe73c90e1d2900f0b3adc87390bd19f6fc1"
+      "template_hash": "da52bd25cd43db6ad7a0a091c506550d2ece19fba0af35e30bb3b2a97c894517",
+      "content_hash": "da52bd25cd43db6ad7a0a091c506550d2ece19fba0af35e30bb3b2a97c894517",
+      "fingerprint": "4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "1f5efb7b346496c89c9f234048cc6bf3deb4902b58b8790b94b051ff0c2f0f8f",
-      "content_hash": "1f5efb7b346496c89c9f234048cc6bf3deb4902b58b8790b94b051ff0c2f0f8f",
-      "fingerprint": "1addac8a84fe1630113100651a8929b4bf1917f36add1c0a03108be8bd8f4209"
+      "template_hash": "baf4dfe5155a679a1cc0e654c111f6171b048ad10532dacbc90691f7009eddf8",
+      "content_hash": "baf4dfe5155a679a1cc0e654c111f6171b048ad10532dacbc90691f7009eddf8",
+      "fingerprint": "a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782"
     }
   ],
   "files": [
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "5fa8a9007364ddbcbb20e68828056e255b406d4dd46036bd6086c735031c9623",
+      "content_hash": "497b28739152e40807b48c2ce410e8e1846131abdd837c4f4d69de9feb24c6ab",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "de74b3512adc1021d596cfca6743e275301a4754b7c2ed34181a0592c1b8d0f3",
+      "content_hash": "bee60b33a416e5b1215f028c7ef976e9fde67b7d559a1c738451ae30067b495c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
-      "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "f854126a7c454de6edf503fa3ce381165f5756025fd66fdc89b821b93e7b23fa",
+      "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
+      "content_hash": "0d02940c9dcfd277f7a9f2fa1a0f9cd1f51386dba60403b9eb3d1e7a7ad99fff",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "617c5db81dcc09b66cd52507b84ecb615c26466ad3a32893d36c5e6f3d087005",
+      "content_hash": "68cfc3769aa237fb69d101bc1b6e9337b746ed19d692fd65d7714eebc3f3e4d3",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "ffe5feac7dbd6369ff2025f0b077237eecd5001ffe8e1628ee21081eed3f6c11",
+      "content_hash": "f3d46da7e18b069371d74c57350652a0336408d31ab6276eabb30a8ef091f706",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "cb776aec1112c05f5518d4cb2b773ee6a4c8364895f1164eff43350ee5d77d63",
+      "content_hash": "6e296d9f4df04d3671c68d744a7cd333b3dfa178bd6bfb64b18ab1c5a391d4ec",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "9cc9c77816ed9f75c5d29c770064d2d37ac11866c35afbfd966cfea67f215cf1",
+      "content_hash": "506b41822cf224e150edb659a566c06a78e75614ededfed388a561eda44af9c7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "457b17f9be1d6866f0255d78058be2006a8ca630d5aec1f08e2df5ea2a5f33fb",
+      "content_hash": "442f35e235e59d7aefd38df27ffcf0797849e936dc03053f998bb124e1138ccd",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -398,7 +398,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -190,7 +190,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -415,7 +415,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -415,7 +415,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -415,7 +415,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -415,7 +415,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -221,7 +221,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -251,7 +251,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
-- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
+- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
+- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b332690b31f59535cb2fc3f0eb373d3e26fc10f13debe60d8efe2892e71dfd79`
+- Repository signal fingerprint: `39e50d2ef7b7dfeafb25de4dc9a08c350bc5e45ee706e149317bd57c73f544bb`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -279,7 +279,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `496fbd0a53c595453c2189ed60d9506dd1fb4195565fd4c03cb2655ff94892a4`
+- Repository signal fingerprint: `8d2cbfd7c360a068b5292064e11ac900f0eb8dac6fd3dcd8cf7e7364d92ec363`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (96 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       DECAPOD_PROPODUS_API_URL: ${{ secrets.DECAPOD_PROPODUS_API_URL }}
       DECAPOD_PROPODUS_ACCESS_TOKEN: ${{ secrets.DECAPOD_PROPODUS_ACCESS_TOKEN }}
       DECAPOD_PROPODUS_DISPOSABLE_REPO_ID: ${{ secrets.DECAPOD_PROPODUS_DISPOSABLE_REPO_ID }}
-      DECAPOD_GITHUB_REPOSITORY_ID: ${{ secrets.DECAPOD_GITHUB_REPOSITORY_ID }}
+      DECAPOD_PROPODUS_DOGFOOD: "1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,7 +100,7 @@ jobs:
       - name: Verify protected live-proof inputs
         run: |
           set -euo pipefail
-          for variable in DECAPOD_PROPODUS_API_URL DECAPOD_PROPODUS_ACCESS_TOKEN DECAPOD_PROPODUS_DISPOSABLE_REPO_ID DECAPOD_GITHUB_REPOSITORY_ID; do
+          for variable in DECAPOD_PROPODUS_API_URL DECAPOD_PROPODUS_ACCESS_TOKEN DECAPOD_PROPODUS_DISPOSABLE_REPO_ID DECAPOD_PROPODUS_DOGFOOD; do
             if [[ -z "${!variable:-}" ]]; then
               echo "Missing protected live-proof input: $variable"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       DECAPOD_PROPODUS_API_URL: ${{ secrets.DECAPOD_PROPODUS_API_URL }}
       DECAPOD_PROPODUS_ACCESS_TOKEN: ${{ secrets.DECAPOD_PROPODUS_ACCESS_TOKEN }}
       DECAPOD_PROPODUS_DISPOSABLE_REPO_ID: ${{ secrets.DECAPOD_PROPODUS_DISPOSABLE_REPO_ID }}
+      DECAPOD_GITHUB_REPOSITORY_ID: ${{ secrets.DECAPOD_GITHUB_REPOSITORY_ID }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -99,7 +100,7 @@ jobs:
       - name: Verify protected live-proof inputs
         run: |
           set -euo pipefail
-          for variable in DECAPOD_PROPODUS_API_URL DECAPOD_PROPODUS_ACCESS_TOKEN DECAPOD_PROPODUS_DISPOSABLE_REPO_ID; do
+          for variable in DECAPOD_PROPODUS_API_URL DECAPOD_PROPODUS_ACCESS_TOKEN DECAPOD_PROPODUS_DISPOSABLE_REPO_ID DECAPOD_GITHUB_REPOSITORY_ID; do
             if [[ -z "${!variable:-}" ]]; then
               echo "Missing protected live-proof input: $variable"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -43,7 +44,7 @@ jobs:
   governance-artifacts:
     name: Governance Artifacts (all four)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,6 +76,37 @@ jobs:
             exit 1
           fi
           echo "✅ All four governance artifacts are present and changed in the PR diff"
+
+  # PROPODUS LIVE PROOF: Manual, protected, and explicitly opt-in only.
+  propodus-live:
+    name: Propodus Live Contract Proof
+    runs-on: ubuntu-latest
+    environment: propodus-live
+    if: github.event_name == 'workflow_dispatch' && vars.DECAPOD_PROPODUS_LIVE == 'true'
+    env:
+      DECAPOD_PROPODUS_LIVE: "1"
+      DECAPOD_PROPODUS_API_URL: ${{ secrets.DECAPOD_PROPODUS_API_URL }}
+      DECAPOD_PROPODUS_ACCESS_TOKEN: ${{ secrets.DECAPOD_PROPODUS_ACCESS_TOKEN }}
+      DECAPOD_PROPODUS_DISPOSABLE_REPO_ID: ${{ secrets.DECAPOD_PROPODUS_DISPOSABLE_REPO_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.1
+      - name: Verify protected live-proof inputs
+        run: |
+          set -euo pipefail
+          for variable in DECAPOD_PROPODUS_API_URL DECAPOD_PROPODUS_ACCESS_TOKEN DECAPOD_PROPODUS_DISPOSABLE_REPO_ID; do
+            if [[ -z "${!variable:-}" ]]; then
+              echo "Missing protected live-proof input: $variable"
+              exit 1
+            fi
+          done
+      - name: Run opt-in live proof
+        run: cargo test --locked --test propodus_live -- --ignored --nocapture
 
   detect-migration-script-changes:
     name: Detect Migration Script Changes

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -19,7 +19,10 @@ jobs:
           path: ~/.cargo/bin/decapod
           key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
       - name: Install Decapod
-        run: cargo install --path . --locked --force
+        run: |
+          if ! command -v decapod &> /dev/null; then
+            cargo install decapod
+          fi
       - name: Decapod Validate
         env:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.82.1 -->
-<!-- decapod-fingerprint: d0fd2d97e7110240bbac3a83b1d44d7415924f5f69b521b556ce311180cb67b1 -->
+<!-- decapod-release: 0.83.0 -->
+<!-- decapod-fingerprint: ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.82.1 -->
-<!-- decapod-fingerprint: 1da08be69531c675ec1fd3c4f2fc48cf7f6b63e857363a42e1f1f898352e36fc -->
+<!-- decapod-release: 0.83.0 -->
+<!-- decapod-fingerprint: e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447 -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.82.1 -->
-<!-- decapod-fingerprint: 1addac8a84fe1630113100651a8929b4bf1917f36add1c0a03108be8bd8f4209 -->
+<!-- decapod-release: 0.83.0 -->
+<!-- decapod-fingerprint: a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.82.1 -->
-<!-- decapod-fingerprint: 90cdf59329eb640be87aace50eae6fe73c90e1d2900f0b3adc87390bd19f6fc1 -->
+<!-- decapod-release: 0.83.0 -->
+<!-- decapod-fingerprint: 4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/docs/book/src/reference/propodus.md
+++ b/docs/book/src/reference/propodus.md
@@ -20,6 +20,27 @@ The checked-in compatibility fixture is
 local `propodus_contract` test, which uses an injectable fake transport and
 never contacts Vercel, Neon, or production data.
 
+The opt-in live proof is `tests/propodus_live.rs`. Run it only with
+`DECAPOD_PROPODUS_LIVE=1`, `DECAPOD_PROPODUS_API_URL`,
+`DECAPOD_PROPODUS_ACCESS_TOKEN`, and a disposable
+`DECAPOD_PROPODUS_DISPOSABLE_REPO_ID`:
+
+```text
+DECAPOD_PROPODUS_LIVE=1 \
+DECAPOD_PROPODUS_API_URL=https://your-stable-propodus.example \
+DECAPOD_PROPODUS_ACCESS_TOKEN=... \
+DECAPOD_PROPODUS_DISPOSABLE_REPO_ID=DecapodLabs/propodus-live-deny \
+cargo test --test propodus_live -- --ignored --nocapture
+```
+
+The proof creates one uniquely named todo in the canonical repository,
+claims it, completes it, and verifies that the disposable repository receives
+`403 repository_not_authorized`. It does not delete the sentinel because the
+v1 client contract has no delete operation; remove it with Propodus operator
+tooling after the run. The test is ignored by default, and the CI job is
+manual, environment-protected, and gated by the `DECAPOD_PROPODUS_LIVE`
+repository variable.
+
 ## Credentials
 
 Credentials are never read from `.decapod/config.toml`. Lookup precedence is:
@@ -35,9 +56,10 @@ backend verification remains a Propodus deployment responsibility.
 
 ## Delivery boundary
 
-This phase provides the Decapod-side contract, credential lookup, typed client,
-storage adapter, and deterministic local proof. The following require the next
-wave and explicit deployment evidence: hosted authentication and repository
-allowlisting, a stable production alias, and an opt-in live integration proof.
-The client remains configurable so those deployment decisions do not become
-hardcoded repository assumptions.
+Wave 1 provided the Decapod-side contract, credential lookup, typed client,
+storage adapter, and deterministic local proof. Wave 2 adds the client health
+probe and a credential-gated live integration proof without moving hosted
+authentication, repository allowlisting, stable URL ownership, persistence, or
+deployment into Decapod. Those remain Propodus responsibilities. The client
+stays configurable so deployment decisions do not become hardcoded repository
+assumptions.

--- a/docs/book/src/reference/propodus.md
+++ b/docs/book/src/reference/propodus.md
@@ -27,16 +27,22 @@ that list, add, claim, and complete are routed through the backend-neutral
 `TodoStore` adapter. Unsupported local-only operations return an explicit
 error in cloud mode.
 
+The production-dispatch proof is `tests/cloud_cli_boundary.rs`; it uses a
+mock Propodus store factory and exercises the same `run_todo_cli` composition
+used by the binary. It proves config discovery, canonical-origin validation,
+credential preflight, list/add/get/show/claim/done routing, not-found behavior,
+and the absence of local SQLite initialization for cloud todo commands.
+
 The opt-in live proof is `tests/propodus_live.rs`. Run it only with
 `DECAPOD_PROPODUS_LIVE=1`, `DECAPOD_PROPODUS_API_URL`,
-`DECAPOD_PROPODUS_ACCESS_TOKEN`, `DECAPOD_GITHUB_REPOSITORY_ID`, and a
+`DECAPOD_PROPODUS_ACCESS_TOKEN`, `DECAPOD_PROPODUS_DOGFOOD=1`, and a
 disposable `DECAPOD_PROPODUS_DISPOSABLE_REPO_ID`:
 
 ```text
 DECAPOD_PROPODUS_LIVE=1 \
 DECAPOD_PROPODUS_API_URL=https://your-stable-propodus.example \
 DECAPOD_PROPODUS_ACCESS_TOKEN=... \
-DECAPOD_GITHUB_REPOSITORY_ID=... \
+DECAPOD_PROPODUS_DOGFOOD=1 \
 DECAPOD_PROPODUS_DISPOSABLE_REPO_ID=DecapodLabs/propodus-live-deny \
 cargo test --test propodus_live -- --ignored --nocapture
 ```
@@ -61,27 +67,61 @@ Credentials are never read from `.decapod/config.toml`. Lookup precedence is:
 
 1. an explicit client credential;
 2. `DECAPOD_ACCESS_TOKEN` for controlled development and CI use;
-3. the machine-local `session_token.json`.
+3. the machine-local `~/.local/share/decapod/session_token.json`.
 
-Use `decapod cloud status` to check availability without printing the token.
-Bearer tokens are sent only in the `Authorization` header. The current
-machine-local file is a credential boundary, not provider authentication proof;
-backend verification remains a Propodus responsibility. Propodus PR #31
-defines the active bearer contract as a GitHub-subject JWT with repository and
-seat authorization. Decapod can consume such a machine credential, but the
-GitHub login/token exchange remains deferred until Propodus issue #24 exposes
-that stable route; the legacy Auth0 device flow is not part of the active
-Propodus todo path.
+Use `decapod cloud status` to check whether a bearer is configured without
+printing the token. `decapod cloud login` fails fast with an explicit
+unsupported error; it no longer runs a legacy Auth0 device flow that could
+produce a token Propodus cannot accept. Bearer tokens are sent only in the
+`Authorization` header. Propodus PR #31 defines the active bearer contract as
+a JWT with its configured issuer/audience and a GitHub subject; Propodus owns
+those checks. Decapod only checks that a credential is present and reports a
+service 401/403 without logging the token. The GitHub login/token exchange
+remains deferred until Propodus issue #24 exposes its stable route.
+
+## Repeatable dogfood setup
+
+From a fresh checkout of the canonical repository:
+
+1. Run `decapod init --mode cloud --proof` and confirm `.decapod/config.toml`
+   contains `repo.mode = "cloud"`, `[cloud].enabled = true`, and the intended
+   Propodus `api_url`. The endpoint is selected only from this project config;
+   no service URL is inferred from credentials.
+2. Ensure `origin` is an unambiguous GitHub remote for
+   `DecapodLabs/decapod`. Forks and other remotes fail before any network
+   request.
+3. Set `DECAPOD_PROPODUS_DOGFOOD=1` as the explicit temporary dogfood gate.
+   This is a local opt-in marker, not an authenticated repository identity,
+   and is not sent to Propodus.
+4. Provision a Propodus-issued bearer JWT in `DECAPOD_ACCESS_TOKEN` or in
+   `~/.local/share/decapod/session_token.json`. The token must satisfy the
+   issuer, audience, GitHub-subject, repository-authorization, and seat rules
+   enforced by Propodus. Decapod cannot mint, refresh, revoke, or validate
+   those provider claims.
+5. Run `decapod todo list`, `add`, `get`, `show`, `claim`, or `done`. Missing
+   credentials, the dogfood gate, cloud config, or canonical remote produce a
+   preflight error; authentication, authorization, and transport failures do
+   not fall back to local SQLite.
 
 ## Repository identity
 
 Cloud dogfood is fail-closed to the canonical `DecapodLabs/decapod` origin.
-Decapod derives owner/name from `origin`, rejects non-GitHub, ambiguous, and
-fork remotes, and requires the immutable GitHub repository identity supplied by
-`DECAPOD_GITHUB_REPOSITORY_ID`. The project file's `cloud.repo_id` is not an
-authority to select another repository. Propodus currently authorizes the
-canonical name; the immutable value is retained at the Decapod identity
-boundary until the service contract exposes its final wire field.
+Decapod derives owner/name from `origin` and rejects non-GitHub, ambiguous, and
+fork remotes. The explicit `DECAPOD_PROPODUS_DOGFOOD=1` value is only a
+temporary local gate because Propodus has not yet published a wire contract
+binding an immutable GitHub repository ID to the request. The project file's
+`cloud.repo_id` is not an authority to select another repository.
+
+## v1 governance limits
+
+Propodus v1 supports repo-scoped list/create/claim/complete operations. `get`
+and `show` intentionally use list-and-filter because the v1 TodoStore contract
+has no repo-scoped get route; a missing item returns `status = "not_found"`.
+`todo done --validated` is intentionally rejected because v1 has no proof
+capture or verification-artifact contract. This is an explicit unsupported
+boundary, not full remote governance completion; a future proof-contract issue
+must define the service-side evidence model before Decapod can compose it;
+see [Decapod issue #1038](https://github.com/DecapodLabs/decapod/issues/1038).
 
 ## Delivery boundary
 

--- a/docs/book/src/reference/propodus.md
+++ b/docs/book/src/reference/propodus.md
@@ -2,6 +2,8 @@
 
 Propodus is an optional remote service boundary for repo-scoped todos. It is
 not compiled into Decapod and it does not replace local SQLite by default.
+`repo.mode = "cloud"` is an explicit opt-in: in that mode the todo commands
+use Propodus directly and never silently fall back to local SQLite.
 
 ## Contract v1
 
@@ -20,15 +22,21 @@ The checked-in compatibility fixture is
 local `propodus_contract` test, which uses an injectable fake transport and
 never contacts Vercel, Neon, or production data.
 
+The command boundary is covered by `tests/cloud_command_path.rs`, which proves
+that list, add, claim, and complete are routed through the backend-neutral
+`TodoStore` adapter. Unsupported local-only operations return an explicit
+error in cloud mode.
+
 The opt-in live proof is `tests/propodus_live.rs`. Run it only with
 `DECAPOD_PROPODUS_LIVE=1`, `DECAPOD_PROPODUS_API_URL`,
-`DECAPOD_PROPODUS_ACCESS_TOKEN`, and a disposable
-`DECAPOD_PROPODUS_DISPOSABLE_REPO_ID`:
+`DECAPOD_PROPODUS_ACCESS_TOKEN`, `DECAPOD_GITHUB_REPOSITORY_ID`, and a
+disposable `DECAPOD_PROPODUS_DISPOSABLE_REPO_ID`:
 
 ```text
 DECAPOD_PROPODUS_LIVE=1 \
 DECAPOD_PROPODUS_API_URL=https://your-stable-propodus.example \
 DECAPOD_PROPODUS_ACCESS_TOKEN=... \
+DECAPOD_GITHUB_REPOSITORY_ID=... \
 DECAPOD_PROPODUS_DISPOSABLE_REPO_ID=DecapodLabs/propodus-live-deny \
 cargo test --test propodus_live -- --ignored --nocapture
 ```
@@ -36,11 +44,13 @@ cargo test --test propodus_live -- --ignored --nocapture
 The proof creates one uniquely named todo in the canonical repository,
 claims it, completes it, and verifies that the disposable repository receives
 `403 repository_not_authorized`. It also verifies that an invalid bearer token
-is rejected with a 401 authentication failure. It does not delete the sentinel
-because the v1 client contract has no delete operation; remove it with Propodus
-operator tooling after the run. The test is ignored by default, and the CI job
-is manual, environment-protected, and gated by the `DECAPOD_PROPODUS_LIVE`
-repository variable.
+is rejected with a 401 authentication failure. The command-level proof also
+uses two Decapod agents to verify shared visibility and rejects a fork before
+any request is sent. It does not delete the sentinel because the v1 client
+contract has no delete operation; remove it with Propodus operator tooling
+after the run. The test is ignored by default, and the CI job is manual,
+environment-protected, and gated by the `DECAPOD_PROPODUS_LIVE` repository
+variable.
 
 Propodus also uses `403 organization_seat_required` when a valid GitHub bearer
 token lacks the required organization seat for the canonical repository.
@@ -51,22 +61,35 @@ Credentials are never read from `.decapod/config.toml`. Lookup precedence is:
 
 1. an explicit client credential;
 2. `DECAPOD_ACCESS_TOKEN` for controlled development and CI use;
-3. the machine-local `session_token.json` written by `decapod cloud login`.
+3. the machine-local `session_token.json`.
 
 Use `decapod cloud status` to check availability without printing the token.
 Bearer tokens are sent only in the `Authorization` header. The current
 machine-local file is a credential boundary, not provider authentication proof;
-backend verification remains a Propodus deployment responsibility. The current
-`decapod cloud login` flow is still the pre-Propodus Auth0 device flow; it does
-not yet mint the GitHub-subject Propodus JWT used by the live proof. That login
-exchange remains the scope of the future cloud-auth alignment.
+backend verification remains a Propodus responsibility. Propodus PR #31
+defines the active bearer contract as a GitHub-subject JWT with repository and
+seat authorization. Decapod can consume such a machine credential, but the
+GitHub login/token exchange remains deferred until Propodus issue #24 exposes
+that stable route; the legacy Auth0 device flow is not part of the active
+Propodus todo path.
+
+## Repository identity
+
+Cloud dogfood is fail-closed to the canonical `DecapodLabs/decapod` origin.
+Decapod derives owner/name from `origin`, rejects non-GitHub, ambiguous, and
+fork remotes, and requires the immutable GitHub repository identity supplied by
+`DECAPOD_GITHUB_REPOSITORY_ID`. The project file's `cloud.repo_id` is not an
+authority to select another repository. Propodus currently authorizes the
+canonical name; the immutable value is retained at the Decapod identity
+boundary until the service contract exposes its final wire field.
 
 ## Delivery boundary
 
 Wave 1 provided the Decapod-side contract, credential lookup, typed client,
-storage adapter, and deterministic local proof. Wave 2 adds the client health
-probe and a credential-gated live integration proof without moving hosted
+storage adapter, and deterministic local proof. Wave 2 now activates the
+explicit cloud todo command path, verified repository identity, adapter-level
+command proof, and protected command-level live proof without moving hosted
 authentication, repository allowlisting, stable URL ownership, persistence, or
 deployment into Decapod. Those remain Propodus responsibilities. The client
-stays configurable so deployment decisions do not become hardcoded repository
-assumptions.
+stays configurable so deployment decisions do not become hardcoded service
+policy.

--- a/docs/book/src/reference/propodus.md
+++ b/docs/book/src/reference/propodus.md
@@ -35,11 +35,15 @@ cargo test --test propodus_live -- --ignored --nocapture
 
 The proof creates one uniquely named todo in the canonical repository,
 claims it, completes it, and verifies that the disposable repository receives
-`403 repository_not_authorized`. It does not delete the sentinel because the
-v1 client contract has no delete operation; remove it with Propodus operator
-tooling after the run. The test is ignored by default, and the CI job is
-manual, environment-protected, and gated by the `DECAPOD_PROPODUS_LIVE`
+`403 repository_not_authorized`. It also verifies that an invalid bearer token
+is rejected with a 401 authentication failure. It does not delete the sentinel
+because the v1 client contract has no delete operation; remove it with Propodus
+operator tooling after the run. The test is ignored by default, and the CI job
+is manual, environment-protected, and gated by the `DECAPOD_PROPODUS_LIVE`
 repository variable.
+
+Propodus also uses `403 organization_seat_required` when a valid GitHub bearer
+token lacks the required organization seat for the canonical repository.
 
 ## Credentials
 
@@ -52,7 +56,10 @@ Credentials are never read from `.decapod/config.toml`. Lookup precedence is:
 Use `decapod cloud status` to check availability without printing the token.
 Bearer tokens are sent only in the `Authorization` header. The current
 machine-local file is a credential boundary, not provider authentication proof;
-backend verification remains a Propodus deployment responsibility.
+backend verification remains a Propodus deployment responsibility. The current
+`decapod cloud login` flow is still the pre-Propodus Auth0 device flow; it does
+not yet mint the GitHub-subject Propodus JWT used by the live proof. That login
+exchange remains the scope of the future cloud-auth alignment.
 
 ## Delivery boundary
 

--- a/src/decapod/core/auth.rs
+++ b/src/decapod/core/auth.rs
@@ -1,31 +1,10 @@
 use crate::core::ansi::AnsiExt;
 use crate::core::error::DecapodError;
-use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::time::{Duration, Instant};
 
-const AUTH0_DOMAIN: &str = "decapod.auth0.com";
-const AUTH0_CLIENT_ID: &str = "decapod-cli-client-id";
-const AUTH0_AUDIENCE: &str = "https://api.decapodlabs.com";
 pub const CLOUD_ACCESS_TOKEN_ENV: &str = "DECAPOD_ACCESS_TOKEN";
-
-#[derive(Deserialize, Debug)]
-struct DeviceCodeResponse {
-    device_code: String,
-    user_code: String,
-    verification_uri_complete: String,
-    expires_in: u64,
-    interval: u64,
-}
-
-#[derive(Deserialize, Debug)]
-struct TokenResponse {
-    access_token: Option<String>,
-    error: Option<String>,
-}
 
 fn machine_data_dir() -> Result<PathBuf, DecapodError> {
     if let Ok(data_home) = env::var("XDG_DATA_HOME") {
@@ -98,8 +77,7 @@ pub fn resolve_cloud_credential(
     }
 
     Err(DecapodError::SessionError(
-        "no cloud credential found; run `decapod cloud login` or set DECAPOD_ACCESS_TOKEN"
-            .to_string(),
+        "no Propodus bearer configured; set DECAPOD_ACCESS_TOKEN or provision the machine credential file at ~/.local/share/decapod/session_token.json (cloud login is unavailable until the Propodus GitHub exchange contract is published)".to_string(),
     ))
 }
 
@@ -136,72 +114,9 @@ pub fn load_cloud_credential(explicit: Option<&str>) -> Result<CloudCredential, 
 }
 
 pub fn perform_cloud_auth(_target_dir: &Path) -> Result<(), DecapodError> {
-    // Check if curl is available
-    if Command::new("curl").arg("--version").output().is_err() {
-        return Err(DecapodError::ValidationError(
-            "curl is required for cloud authentication. Please install curl and try again."
-                .to_string(),
-        ));
-    }
-
-    println!();
-    println!("◢ {}", "Cloud Authentication".bright_cyan().bold());
-    println!(
-        "  {}",
-        "Authenticating with Decapod Cloud. Credentials are stored outside this repository."
-            .bright_black()
-    );
-
-    let device_code_res = initiate_device_flow()?;
-
-    println!();
-    println!(
-        "  {}",
-        "1. Open the following URL in your browser:"
-            .bright_white()
-            .bold()
-    );
-    println!(
-        "     {}",
-        device_code_res.verification_uri_complete.bright_blue()
-    );
-    println!();
-    println!("  {}", "2. Ensure the code matches:".bright_white().bold());
-    println!("     {}", device_code_res.user_code.bright_green().bold());
-    println!();
-    println!("  {}", "Waiting for authentication...".bright_black());
-
-    let token = poll_for_token(&device_code_res)?;
-
-    let data_dir = machine_data_dir()?;
-    fs::create_dir_all(&data_dir).map_err(DecapodError::IoError)?;
-    let token_path = machine_session_token_path()?;
-
-    // Write token in JSON format
-    let token_json = serde_json::json!({
-        "token": token
-    });
-    let body = serde_json::to_string_pretty(&token_json)
-        .map_err(|e| DecapodError::ValidationError(format!("Failed to serialize token: {e}")))?;
-    fs::write(&token_path, body).map_err(DecapodError::IoError)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&token_path)
-            .map_err(DecapodError::IoError)?
-            .permissions();
-        perms.set_mode(0o600);
-        fs::set_permissions(&token_path, perms).map_err(DecapodError::IoError)?;
-    }
-
-    println!(
-        "{} {}",
-        "✓".bright_green().bold(),
-        "Cloud authentication successful. Session token saved.".bright_green()
-    );
-
-    Ok(())
+    Err(DecapodError::NotImplemented(
+        "Propodus-compatible GitHub login is not available in Decapod yet. Configure a Propodus-issued bearer JWT through DECAPOD_ACCESS_TOKEN or ~/.local/share/decapod/session_token.json; the Propodus service owns issuer, audience, GitHub-subject, refresh, and revocation checks.".to_string(),
+    ))
 }
 
 pub fn is_token_valid(_target_dir: &Path) -> bool {
@@ -241,94 +156,4 @@ pub fn get_cloud_auth_gate() -> Box<dyn CloudAuthGate> {
         return Box::new(InteractiveAuthGate);
     }
     Box::new(NoOpAuthGate)
-}
-
-fn initiate_device_flow() -> Result<DeviceCodeResponse, DecapodError> {
-    let url = format!("https://{AUTH0_DOMAIN}/oauth/device/code");
-    let body = format!(
-        "client_id={AUTH0_CLIENT_ID}&audience={AUTH0_AUDIENCE}&scope=openid profile email offline_access"
-    );
-
-    let output = Command::new("curl")
-        .args([
-            "-s",
-            "-X",
-            "POST",
-            &url,
-            "-H",
-            "content-type: application/x-www-form-urlencoded",
-            "-d",
-            &body,
-        ])
-        .output()
-        .map_err(|e| DecapodError::ValidationError(format!("Failed to execute curl: {e}")))?;
-
-    if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr);
-        return Err(DecapodError::ValidationError(format!(
-            "Auth0 device code request failed: {err}"
-        )));
-    }
-
-    serde_json::from_slice(&output.stdout).map_err(|e| {
-        DecapodError::ValidationError(format!(
-            "Failed to parse Auth0 response: {e}. Raw: {}",
-            String::from_utf8_lossy(&output.stdout)
-        ))
-    })
-}
-
-fn poll_for_token(device_code_res: &DeviceCodeResponse) -> Result<String, DecapodError> {
-    let url = format!("https://{AUTH0_DOMAIN}/oauth/token");
-    let body = format!(
-        "grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code={}&client_id={}",
-        device_code_res.device_code, AUTH0_CLIENT_ID
-    );
-
-    let start = Instant::now();
-    let expires_in = Duration::from_secs(device_code_res.expires_in);
-    let interval = Duration::from_secs(if device_code_res.interval == 0 {
-        5
-    } else {
-        device_code_res.interval
-    });
-
-    while start.elapsed() < expires_in {
-        std::thread::sleep(interval);
-
-        let output = Command::new("curl")
-            .args([
-                "-s",
-                "-X",
-                "POST",
-                &url,
-                "-H",
-                "content-type: application/x-www-form-urlencoded",
-                "-d",
-                &body,
-            ])
-            .output()
-            .map_err(|e| DecapodError::ValidationError(format!("Failed to execute curl: {e}")))?;
-
-        if output.status.success() {
-            let res: TokenResponse = serde_json::from_slice(&output.stdout).map_err(|e| {
-                DecapodError::ValidationError(format!("Failed to parse Auth0 token response: {e}"))
-            })?;
-
-            if let Some(token) = res.access_token {
-                return Ok(token);
-            }
-
-            if matches!(res.error.as_deref(), Some(err) if err != "authorization_pending") {
-                return Err(DecapodError::ValidationError(format!(
-                    "Auth0 error: {:?}",
-                    res.error
-                )));
-            }
-        }
-    }
-
-    Err(DecapodError::ValidationError(
-        "Authentication timed out.".to_string(),
-    ))
 }

--- a/src/decapod/core/entrypoint_integrity.rs
+++ b/src/decapod/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.82.1 release manifest. Keep them immutable for the
+// These values are the v0.83.0 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "d0fd2d97e7110240bbac3a83b1d44d7415924f5f69b521b556ce311180cb67b1",
+        fingerprint: "ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "1da08be69531c675ec1fd3c4f2fc48cf7f6b63e857363a42e1f1f898352e36fc",
+        fingerprint: "e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "90cdf59329eb640be87aace50eae6fe73c90e1d2900f0b3adc87390bd19f6fc1",
+        fingerprint: "4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "1addac8a84fe1630113100651a8929b4bf1917f36add1c0a03108be8bd8f4209",
+        fingerprint: "a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782",
     },
 ];
 

--- a/src/decapod/core/mod.rs
+++ b/src/decapod/core/mod.rs
@@ -40,6 +40,7 @@ pub mod pool;
 pub mod project_specs;
 pub mod proof;
 pub mod propodus;
+pub mod repo_identity;
 pub mod repomap;
 pub mod research_claims;
 pub mod rpc;

--- a/src/decapod/core/propodus.rs
+++ b/src/decapod/core/propodus.rs
@@ -6,6 +6,7 @@
 
 use crate::cli::CloudConfigSection;
 use crate::core::auth;
+use crate::core::repo_identity::RepositoryIdentity;
 use crate::core::storage::{Task as StorageTask, TodoStore};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -25,6 +26,7 @@ pub struct PropodusConfig {
     pub api_url: String,
     pub project_id: String,
     pub repo_id: String,
+    pub immutable_repo_id: Option<String>,
 }
 
 impl From<&CloudConfigSection> for PropodusConfig {
@@ -33,6 +35,7 @@ impl From<&CloudConfigSection> for PropodusConfig {
             api_url: config.api_url.clone(),
             project_id: config.project_id.clone(),
             repo_id: config.repo_id.clone(),
+            immutable_repo_id: None,
         }
     }
 }
@@ -238,6 +241,7 @@ impl std::error::Error for PropodusClientError {}
 pub struct PropodusClient<T = CurlTransport> {
     api_url: String,
     repo_id: String,
+    immutable_repo_id: Option<String>,
     credential: String,
     transport: T,
 }
@@ -247,6 +251,21 @@ impl PropodusClient<CurlTransport> {
         let credential = auth::load_cloud_credential(None)
             .map_err(|error| PropodusClientError::Authentication(error.to_string()))?;
         Self::with_transport(&config.into(), &credential.token, CurlTransport::default())
+    }
+
+    pub fn from_verified_cloud_config(
+        config: &CloudConfigSection,
+        identity: &RepositoryIdentity,
+    ) -> Result<Self, PropodusClientError> {
+        let credential = auth::load_cloud_credential(None)
+            .map_err(|error| PropodusClientError::Authentication(error.to_string()))?;
+        let config = PropodusConfig {
+            api_url: config.api_url.clone(),
+            project_id: config.project_id.clone(),
+            repo_id: identity.canonical_name.clone(),
+            immutable_repo_id: Some(identity.immutable_id.clone()),
+        };
+        Self::with_transport(&config, &credential.token, CurlTransport::default())
     }
 }
 
@@ -272,9 +291,16 @@ impl<T: PropodusTransport> PropodusClient<T> {
                 "a bearer credential is required".to_string(),
             ));
         }
+        let immutable_repo_id = config
+            .immutable_repo_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
         Ok(Self {
             api_url: api_url.to_string(),
             repo_id: config.repo_id.trim().to_string(),
+            immutable_repo_id,
             credential: credential.trim().to_string(),
             transport,
         })
@@ -282,6 +308,10 @@ impl<T: PropodusTransport> PropodusClient<T> {
 
     pub fn repo_id(&self) -> &str {
         &self.repo_id
+    }
+
+    pub fn immutable_repo_id(&self) -> Option<&str> {
+        self.immutable_repo_id.as_deref()
     }
 
     /// Verify that the configured Propodus endpoint is reachable and returns
@@ -353,15 +383,24 @@ impl<T: PropodusTransport> PropodusClient<T> {
         })
     }
 
-    pub fn claim_todo(&self, id: &str, actor: &str) -> Result<(), PropodusClientError> {
+    pub fn claim_todo(&self, id: &str, actor: &str) -> Result<PropodusTodo, PropodusClientError> {
         self.update_todo(id, PROPODUS_STATUS_IN_PROGRESS, actor)
     }
 
-    pub fn complete_todo(&self, id: &str, actor: &str) -> Result<(), PropodusClientError> {
+    pub fn complete_todo(
+        &self,
+        id: &str,
+        actor: &str,
+    ) -> Result<PropodusTodo, PropodusClientError> {
         self.update_todo(id, PROPODUS_STATUS_COMPLETED, actor)
     }
 
-    fn update_todo(&self, id: &str, status: &str, actor: &str) -> Result<(), PropodusClientError> {
+    fn update_todo(
+        &self,
+        id: &str,
+        status: &str,
+        actor: &str,
+    ) -> Result<PropodusTodo, PropodusClientError> {
         if id.trim().is_empty() || actor.trim().is_empty() {
             return Err(PropodusClientError::Validation(
                 "todo id and actor are required".to_string(),
@@ -382,7 +421,9 @@ impl<T: PropodusTransport> PropodusClient<T> {
         let response = self.send("PATCH", &url, Some(&body))?;
         let payload: PropodusMutationResponse = decode_json(&response.body)?;
         if payload.ok {
-            Ok(())
+            payload.todo.ok_or_else(|| {
+                PropodusClientError::Decode("successful update response omitted todo".to_string())
+            })
         } else {
             Err(payload
                 .error
@@ -436,16 +477,17 @@ impl<T: PropodusTransport> TodoStore for PropodusTodoStore<T> {
         task: StorageTask,
         actor: String,
         _intent: String,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StorageTask> {
         self.client
             .create_todo(&task.title, task.description.as_deref(), Some(&actor))
-            .map(|_| ())
+            .map(to_storage_task)
             .map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 
-    async fn claim_task(&self, id: &str, actor: String) -> anyhow::Result<()> {
+    async fn claim_task(&self, id: &str, actor: String) -> anyhow::Result<StorageTask> {
         self.client
             .claim_todo(id, &actor)
+            .map(to_storage_task)
             .map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 
@@ -454,9 +496,10 @@ impl<T: PropodusTransport> TodoStore for PropodusTodoStore<T> {
         id: &str,
         actor: String,
         _resolution: String,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<StorageTask> {
         self.client
             .complete_todo(id, &actor)
+            .map(to_storage_task)
             .map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 }

--- a/src/decapod/core/propodus.rs
+++ b/src/decapod/core/propodus.rs
@@ -26,7 +26,6 @@ pub struct PropodusConfig {
     pub api_url: String,
     pub project_id: String,
     pub repo_id: String,
-    pub immutable_repo_id: Option<String>,
 }
 
 impl From<&CloudConfigSection> for PropodusConfig {
@@ -35,7 +34,6 @@ impl From<&CloudConfigSection> for PropodusConfig {
             api_url: config.api_url.clone(),
             project_id: config.project_id.clone(),
             repo_id: config.repo_id.clone(),
-            immutable_repo_id: None,
         }
     }
 }
@@ -241,7 +239,6 @@ impl std::error::Error for PropodusClientError {}
 pub struct PropodusClient<T = CurlTransport> {
     api_url: String,
     repo_id: String,
-    immutable_repo_id: Option<String>,
     credential: String,
     transport: T,
 }
@@ -253,7 +250,7 @@ impl PropodusClient<CurlTransport> {
         Self::with_transport(&config.into(), &credential.token, CurlTransport::default())
     }
 
-    pub fn from_verified_cloud_config(
+    pub fn from_dogfood_cloud_config(
         config: &CloudConfigSection,
         identity: &RepositoryIdentity,
     ) -> Result<Self, PropodusClientError> {
@@ -263,7 +260,6 @@ impl PropodusClient<CurlTransport> {
             api_url: config.api_url.clone(),
             project_id: config.project_id.clone(),
             repo_id: identity.canonical_name.clone(),
-            immutable_repo_id: Some(identity.immutable_id.clone()),
         };
         Self::with_transport(&config, &credential.token, CurlTransport::default())
     }
@@ -291,16 +287,9 @@ impl<T: PropodusTransport> PropodusClient<T> {
                 "a bearer credential is required".to_string(),
             ));
         }
-        let immutable_repo_id = config
-            .immutable_repo_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
         Ok(Self {
             api_url: api_url.to_string(),
             repo_id: config.repo_id.trim().to_string(),
-            immutable_repo_id,
             credential: credential.trim().to_string(),
             transport,
         })
@@ -308,10 +297,6 @@ impl<T: PropodusTransport> PropodusClient<T> {
 
     pub fn repo_id(&self) -> &str {
         &self.repo_id
-    }
-
-    pub fn immutable_repo_id(&self) -> Option<&str> {
-        self.immutable_repo_id.as_deref()
     }
 
     /// Verify that the configured Propodus endpoint is reachable and returns

--- a/src/decapod/core/propodus.rs
+++ b/src/decapod/core/propodus.rs
@@ -284,6 +284,20 @@ impl<T: PropodusTransport> PropodusClient<T> {
         &self.repo_id
     }
 
+    /// Verify that the configured Propodus endpoint is reachable and returns
+    /// a successful health response. The endpoint owns the response schema;
+    /// the Decapod boundary only requires a successful HTTP status.
+    pub fn health_check(&self) -> Result<(), PropodusClientError> {
+        let url = format!("{}{}", self.api_url, PROPODUS_HEALTH_ROUTE);
+        let response = self.send("GET", &url, None)?;
+        if response.body.is_empty() {
+            return Err(PropodusClientError::Decode(
+                "Propodus health response was empty".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn list_todos(&self) -> Result<Vec<PropodusTodo>, PropodusClientError> {
         let url = format!(
             "{}{}?repo_id={}",

--- a/src/decapod/core/repo_identity.rs
+++ b/src/decapod/core/repo_identity.rs
@@ -1,10 +1,10 @@
-//! Verified GitHub repository identity for explicit Propodus cloud mode.
+//! Canonical GitHub repository gate for explicit Propodus cloud mode.
 //!
 //! The project file may describe a desired backend, but it must not be allowed
 //! to choose which repository slice receives cloud state. The active cloud
 //! path therefore derives the canonical owner/name from the Git remote and
-//! requires an immutable repository identifier from an authenticated resolver
-//! boundary.
+//! requires an explicit dogfood gate. The gate is a temporary local opt-in,
+//! not an authenticated immutable GitHub identity.
 
 use crate::core::error::DecapodError;
 use serde::{Deserialize, Serialize};
@@ -12,16 +12,18 @@ use std::path::Path;
 use std::process::Command;
 
 pub const DOGFOOD_REPOSITORY: &str = "DecapodLabs/decapod";
-pub const GITHUB_REPOSITORY_ID_ENV: &str = "DECAPOD_GITHUB_REPOSITORY_ID";
+/// Temporary local dogfood gate. It is not sent to Propodus or presented as
+/// authenticated repository identity until the service contract defines that
+/// binding.
+pub const PROPODUS_DOGFOOD_GATE_ENV: &str = "DECAPOD_PROPODUS_DOGFOOD";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryIdentity {
     pub canonical_name: String,
-    pub immutable_id: String,
     pub remote_url: String,
 }
 
-pub fn resolve_verified_repository_identity(
+pub fn resolve_dogfood_repository_identity(
     repo_root: &Path,
 ) -> Result<RepositoryIdentity, DecapodError> {
     let output = Command::new("git")
@@ -39,22 +41,24 @@ pub fn resolve_verified_repository_identity(
         ));
     }
     let remote_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let immutable_id = std::env::var(GITHUB_REPOSITORY_ID_ENV)
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            DecapodError::ValidationError(format!(
-                "cloud mode requires {GITHUB_REPOSITORY_ID_ENV} from an authenticated GitHub repository resolver"
-            ))
-        })?;
-
-    resolve_verified_repository_identity_from_remote(&remote_url, &immutable_id)
+    resolve_dogfood_repository_from_remote_with_gate(
+        &remote_url,
+        std::env::var(PROPODUS_DOGFOOD_GATE_ENV).ok().as_deref() == Some("1"),
+    )
 }
 
-pub fn resolve_verified_repository_identity_from_remote(
+pub fn resolve_dogfood_repository_from_remote(
     remote_url: &str,
-    immutable_id: &str,
+) -> Result<RepositoryIdentity, DecapodError> {
+    resolve_dogfood_repository_from_remote_with_gate(
+        remote_url,
+        std::env::var(PROPODUS_DOGFOOD_GATE_ENV).ok().as_deref() == Some("1"),
+    )
+}
+
+pub fn resolve_dogfood_repository_from_remote_with_gate(
+    remote_url: &str,
+    dogfood_gate_enabled: bool,
 ) -> Result<RepositoryIdentity, DecapodError> {
     let canonical_name = parse_github_repository(remote_url).ok_or_else(|| {
         DecapodError::ValidationError(format!(
@@ -66,15 +70,14 @@ pub fn resolve_verified_repository_identity_from_remote(
             "cloud dogfood is restricted to {DOGFOOD_REPOSITORY}; resolved {canonical_name}"
         )));
     }
-    if immutable_id.trim().is_empty() {
-        return Err(DecapodError::ValidationError(
-            "cloud mode requires a non-empty immutable GitHub repository identity".to_string(),
-        ));
+    if !dogfood_gate_enabled {
+        return Err(DecapodError::ValidationError(format!(
+            "cloud dogfood requires {PROPODUS_DOGFOOD_GATE_ENV}=1; this is a temporary explicit gate, not authenticated repository identity"
+        )));
     }
 
     Ok(RepositoryIdentity {
         canonical_name,
-        immutable_id: immutable_id.trim().to_string(),
         remote_url: remote_url.trim().to_string(),
     })
 }
@@ -98,7 +101,7 @@ pub fn parse_github_repository(remote_url: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_github_repository, resolve_verified_repository_identity_from_remote};
+    use super::parse_github_repository;
 
     #[test]
     fn parses_supported_github_remote_forms() {
@@ -126,29 +129,28 @@ mod tests {
     }
 
     #[test]
-    fn verified_identity_is_canonical_and_immutable() {
-        let identity = resolve_verified_repository_identity_from_remote(
+    fn dogfood_identity_is_canonical_and_explicitly_gated() {
+        let identity = super::resolve_dogfood_repository_from_remote_with_gate(
             "git@github.com:DecapodLabs/decapod.git",
-            "repo:123",
+            true,
         )
-        .expect("verified dogfood identity");
+        .expect("dogfood identity");
         assert_eq!(identity.canonical_name, "DecapodLabs/decapod");
-        assert_eq!(identity.immutable_id, "repo:123");
     }
 
     #[test]
-    fn verified_identity_rejects_other_repositories_and_missing_ids() {
+    fn dogfood_identity_rejects_other_repositories_and_missing_gate() {
         assert!(
-            resolve_verified_repository_identity_from_remote(
-                "git@github.com:DecapodLabs/propodus.git",
-                "repo:123",
+            super::resolve_dogfood_repository_from_remote_with_gate(
+                "git@github.com:DecapodLabs/decapod.git",
+                false,
             )
             .is_err()
         );
         assert!(
-            resolve_verified_repository_identity_from_remote(
-                "git@github.com:DecapodLabs/decapod.git",
-                " ",
+            super::resolve_dogfood_repository_from_remote_with_gate(
+                "git@github.com:DecapodLabs/propodus.git",
+                true,
             )
             .is_err()
         );

--- a/src/decapod/core/repo_identity.rs
+++ b/src/decapod/core/repo_identity.rs
@@ -1,0 +1,156 @@
+//! Verified GitHub repository identity for explicit Propodus cloud mode.
+//!
+//! The project file may describe a desired backend, but it must not be allowed
+//! to choose which repository slice receives cloud state. The active cloud
+//! path therefore derives the canonical owner/name from the Git remote and
+//! requires an immutable repository identifier from an authenticated resolver
+//! boundary.
+
+use crate::core::error::DecapodError;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Command;
+
+pub const DOGFOOD_REPOSITORY: &str = "DecapodLabs/decapod";
+pub const GITHUB_REPOSITORY_ID_ENV: &str = "DECAPOD_GITHUB_REPOSITORY_ID";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryIdentity {
+    pub canonical_name: String,
+    pub immutable_id: String,
+    pub remote_url: String,
+}
+
+pub fn resolve_verified_repository_identity(
+    repo_root: &Path,
+) -> Result<RepositoryIdentity, DecapodError> {
+    let output = Command::new("git")
+        .current_dir(repo_root)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .map_err(|error| {
+            DecapodError::ValidationError(format!(
+                "unable to resolve the GitHub repository remote: {error}"
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(DecapodError::ValidationError(
+            "cloud mode requires a configured origin Git remote".to_string(),
+        ));
+    }
+    let remote_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let immutable_id = std::env::var(GITHUB_REPOSITORY_ID_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            DecapodError::ValidationError(format!(
+                "cloud mode requires {GITHUB_REPOSITORY_ID_ENV} from an authenticated GitHub repository resolver"
+            ))
+        })?;
+
+    resolve_verified_repository_identity_from_remote(&remote_url, &immutable_id)
+}
+
+pub fn resolve_verified_repository_identity_from_remote(
+    remote_url: &str,
+    immutable_id: &str,
+) -> Result<RepositoryIdentity, DecapodError> {
+    let canonical_name = parse_github_repository(remote_url).ok_or_else(|| {
+        DecapodError::ValidationError(format!(
+            "cloud mode requires a GitHub origin remote; got unsupported remote `{remote_url}`"
+        ))
+    })?;
+    if canonical_name != DOGFOOD_REPOSITORY {
+        return Err(DecapodError::ValidationError(format!(
+            "cloud dogfood is restricted to {DOGFOOD_REPOSITORY}; resolved {canonical_name}"
+        )));
+    }
+    if immutable_id.trim().is_empty() {
+        return Err(DecapodError::ValidationError(
+            "cloud mode requires a non-empty immutable GitHub repository identity".to_string(),
+        ));
+    }
+
+    Ok(RepositoryIdentity {
+        canonical_name,
+        immutable_id: immutable_id.trim().to_string(),
+        remote_url: remote_url.trim().to_string(),
+    })
+}
+
+pub fn parse_github_repository(remote_url: &str) -> Option<String> {
+    let value = remote_url.trim().trim_end_matches('/');
+    let path = value
+        .strip_prefix("git@github.com:")
+        .or_else(|| value.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| value.strip_prefix("https://github.com/"))
+        .or_else(|| value.strip_prefix("http://github.com/"))?;
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let mut parts = path.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_github_repository, resolve_verified_repository_identity_from_remote};
+
+    #[test]
+    fn parses_supported_github_remote_forms() {
+        for remote in [
+            "git@github.com:DecapodLabs/decapod.git",
+            "ssh://git@github.com/DecapodLabs/decapod.git",
+            "https://github.com/DecapodLabs/decapod",
+        ] {
+            assert_eq!(
+                parse_github_repository(remote).as_deref(),
+                Some("DecapodLabs/decapod")
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_github_and_ambiguous_remotes() {
+        for remote in [
+            "git@gitlab.com:DecapodLabs/decapod.git",
+            "https://github.com/DecapodLabs/decapod/issues",
+            "https://github.com/DecapodLabs/decapod/fork.git",
+        ] {
+            assert!(parse_github_repository(remote).is_none());
+        }
+    }
+
+    #[test]
+    fn verified_identity_is_canonical_and_immutable() {
+        let identity = resolve_verified_repository_identity_from_remote(
+            "git@github.com:DecapodLabs/decapod.git",
+            "repo:123",
+        )
+        .expect("verified dogfood identity");
+        assert_eq!(identity.canonical_name, "DecapodLabs/decapod");
+        assert_eq!(identity.immutable_id, "repo:123");
+    }
+
+    #[test]
+    fn verified_identity_rejects_other_repositories_and_missing_ids() {
+        assert!(
+            resolve_verified_repository_identity_from_remote(
+                "git@github.com:DecapodLabs/propodus.git",
+                "repo:123",
+            )
+            .is_err()
+        );
+        assert!(
+            resolve_verified_repository_identity_from_remote(
+                "git@github.com:DecapodLabs/decapod.git",
+                " ",
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/decapod/core/storage.rs
+++ b/src/decapod/core/storage.rs
@@ -58,9 +58,9 @@ pub struct Decision {
 #[async_trait]
 pub trait TodoStore: Send + Sync {
     async fn list_tasks(&self) -> Result<Vec<Task>>;
-    async fn add_task(&self, task: Task, actor: String, intent: String) -> Result<()>;
-    async fn claim_task(&self, id: &str, actor: String) -> Result<()>;
-    async fn complete_task(&self, id: &str, actor: String, resolution: String) -> Result<()>;
+    async fn add_task(&self, task: Task, actor: String, intent: String) -> Result<Task>;
+    async fn claim_task(&self, id: &str, actor: String) -> Result<Task>;
+    async fn complete_task(&self, id: &str, actor: String, resolution: String) -> Result<Task>;
 }
 
 #[async_trait]

--- a/src/decapod/core/todo.rs
+++ b/src/decapod/core/todo.rs
@@ -1,7 +1,11 @@
+use crate::cli::{BackendType, CloudConfigSection, DecapodProjectConfig};
 use crate::core::broker::DbBroker;
 use crate::core::error;
 use crate::core::external_action::{self, ExternalCapability};
+use crate::core::propodus::{PropodusClient, PropodusTodoStore};
+use crate::core::repo_identity::{RepositoryIdentity, resolve_verified_repository_identity};
 use crate::core::schemas; // Import the new schemas module
+use crate::core::storage::{Task as StorageTask, TodoStore};
 use crate::core::store::Store;
 use crate::core::work_claim;
 use crate::plugins::aptitude;
@@ -4771,8 +4775,317 @@ fn summarize_claim_container_error(err: &str) -> String {
         .collect()
 }
 
+fn cloud_runtime(
+    root: &Path,
+) -> Result<Option<(CloudConfigSection, RepositoryIdentity)>, error::DecapodError> {
+    let project_root = crate::core::store::find_decapod_project_root(
+        &env::current_dir().map_err(error::DecapodError::IoError)?,
+    )
+    .unwrap_or_else(|_| {
+        root.parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| root.to_path_buf())
+    });
+    let config = DecapodProjectConfig::load(&project_root)?;
+    if config.repo.mode != BackendType::Cloud {
+        return Ok(None);
+    }
+    let cloud = config.cloud.ok_or_else(|| {
+        error::DecapodError::Config(
+            "repo.mode=cloud requires an enabled [cloud] configuration".to_string(),
+        )
+    })?;
+    if !cloud.enabled {
+        return Err(error::DecapodError::Config(
+            "repo.mode=cloud requires cloud.enabled=true".to_string(),
+        ));
+    }
+    if cloud.provider != "vercel" {
+        return Err(error::DecapodError::Config(format!(
+            "unsupported cloud provider `{}` for the Propodus todo path",
+            cloud.provider
+        )));
+    }
+    let identity = resolve_verified_repository_identity(&project_root)?;
+    Ok(Some((cloud, identity)))
+}
+
+fn cloud_error(error: anyhow::Error) -> error::DecapodError {
+    error::DecapodError::ValidationError(format!("Propodus cloud todo operation failed: {error}"))
+}
+
+fn cloud_task_from_command(
+    title: &str,
+    description: &str,
+    priority: &str,
+    tags: &str,
+    scope: &str,
+    dir: Option<&String>,
+    repo_id: &str,
+) -> StorageTask {
+    let now = chrono::Utc::now();
+    StorageTask {
+        id: String::new(),
+        repo_id: repo_id.to_string(),
+        hash: String::new(),
+        title: title.trim().to_string(),
+        description: (!description.trim().is_empty()).then(|| description.to_string()),
+        status: "pending".to_string(),
+        assignee: None,
+        scope: if scope.trim().is_empty() {
+            "repo".to_string()
+        } else {
+            scope.trim().to_string()
+        },
+        dir_path: dir.map(|value| value.to_string()).unwrap_or_default(),
+        priority: priority.to_string(),
+        category: String::new(),
+        tags: tags
+            .split(',')
+            .map(str::trim)
+            .filter(|tag| !tag.is_empty())
+            .map(str::to_string)
+            .collect(),
+        created_at: now,
+        updated_at: now,
+        version: 1,
+    }
+}
+
+fn cloud_status_matches(requested: &str, actual: &str) -> bool {
+    match requested {
+        "open" => actual == "pending",
+        "done" => actual == "completed",
+        "all" => true,
+        value => value == actual,
+    }
+}
+
+fn run_cloud_todo_command(
+    root: &Path,
+    command: &TodoCommand,
+    config: &CloudConfigSection,
+    identity: &RepositoryIdentity,
+) -> Result<JsonValue, error::DecapodError> {
+    let client = PropodusClient::from_verified_cloud_config(config, identity)
+        .map_err(|error| error::DecapodError::ValidationError(error.to_string()))?;
+    let store = PropodusTodoStore::new(client);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error::DecapodError::ValidationError(error.to_string()))?;
+    runtime.block_on(run_cloud_todo_command_with_store_async(
+        root,
+        command,
+        &store,
+        &identity.canonical_name,
+    ))
+}
+
+async fn run_cloud_todo_command_with_store_async(
+    root: &Path,
+    command: &TodoCommand,
+    store: &dyn TodoStore,
+    repo_id: &str,
+) -> Result<JsonValue, error::DecapodError> {
+    let actor = env::var("DECAPOD_AGENT_ID").unwrap_or_else(|_| "unknown".to_string());
+    let result = match command {
+        TodoCommand::List {
+            status,
+            scope,
+            tags,
+            title_search,
+            dir,
+        } => {
+            let mut items = store.list_tasks().await.map_err(cloud_error)?;
+            items.retain(|task| {
+                cloud_status_matches(status, &task.status)
+                    && scope.as_deref().is_none_or(|value| value == task.scope)
+                    && tags
+                        .as_deref()
+                        .is_none_or(|value| task.tags.iter().any(|tag| tag == value))
+                    && title_search.as_deref().is_none_or(|value| {
+                        task.title.to_lowercase().contains(&value.to_lowercase())
+                    })
+                    && dir.as_deref().is_none_or(|value| task.dir_path == *value)
+            });
+            serde_json::json!({
+                "ts": now_iso(),
+                "cmd": "todo.list",
+                "status": "ok",
+                "root": root.to_string_lossy(),
+                "backend": "propodus",
+                "items": items,
+            })
+        }
+        TodoCommand::Add {
+            title,
+            description,
+            priority,
+            tags,
+            scope,
+            dir,
+            ..
+        } => {
+            let task = cloud_task_from_command(
+                title,
+                description,
+                priority,
+                tags,
+                scope,
+                dir.as_ref(),
+                repo_id,
+            );
+            let task = store
+                .add_task(
+                    task,
+                    actor.clone(),
+                    format!("intent:todo.add:{}", crate::core::ulid::new_ulid()),
+                )
+                .await
+                .map_err(cloud_error)?;
+            serde_json::json!({
+                "ts": now_iso(),
+                "cmd": "todo.add",
+                "status": "ok",
+                "root": root.to_string_lossy(),
+                "backend": "propodus",
+                "id": task.id,
+                "item": task,
+            })
+        }
+        TodoCommand::Get { id } => cloud_get_task(root, store, id).await?,
+        TodoCommand::Show { id, id_positional } => {
+            let task_id = resolve_task_id_arg(id, id_positional, "todo show")?;
+            cloud_get_task(root, store, &task_id).await?
+        }
+        TodoCommand::Claim { id, .. } => {
+            let task = store.claim_task(id, actor).await.map_err(cloud_error)?;
+            serde_json::json!({
+                "ts": now_iso(),
+                "cmd": "todo.claim",
+                "status": "ok",
+                "root": root.to_string_lossy(),
+                "backend": "propodus",
+                "id": id,
+                "item": task,
+            })
+        }
+        TodoCommand::Done {
+            id,
+            id_positional,
+            validated,
+            ..
+        } => {
+            if *validated {
+                return Err(error::DecapodError::NotImplemented(
+                    "cloud todo proof capture is not part of the Propodus v1 contract; complete the remote task first, then run a remote proof workflow".to_string(),
+                ));
+            }
+            let task_id = resolve_task_id_arg(id, id_positional, "todo done")?;
+            let task = store
+                .complete_task(&task_id, actor, String::new())
+                .await
+                .map_err(cloud_error)?;
+            serde_json::json!({
+                "ts": now_iso(),
+                "cmd": "todo.done",
+                "status": "ok",
+                "root": root.to_string_lossy(),
+                "backend": "propodus",
+                "id": task_id,
+                "item": task,
+            })
+        }
+        _ => {
+            return Err(error::DecapodError::NotImplemented(
+                "this todo operation is not in the Propodus v1 contract; cloud mode never falls back to local SQLite".to_string(),
+            ));
+        }
+    };
+    Ok(result)
+}
+
+pub fn run_cloud_todo_command_with_store(
+    root: &Path,
+    command: &TodoCommand,
+    store: &dyn TodoStore,
+) -> Result<JsonValue, error::DecapodError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| error::DecapodError::ValidationError(error.to_string()))?;
+    runtime.block_on(run_cloud_todo_command_with_store_async(
+        root,
+        command,
+        store,
+        crate::core::repo_identity::DOGFOOD_REPOSITORY,
+    ))
+}
+
+async fn cloud_get_task(
+    root: &Path,
+    store: &dyn TodoStore,
+    id: &str,
+) -> Result<JsonValue, error::DecapodError> {
+    let item = store
+        .list_tasks()
+        .await
+        .map_err(cloud_error)?
+        .into_iter()
+        .find(|task| task.id == id);
+    Ok(serde_json::json!({
+        "ts": now_iso(),
+        "cmd": "todo.get",
+        "status": if item.is_some() { "ok" } else { "not_found" },
+        "root": root.to_string_lossy(),
+        "backend": "propodus",
+        "item": item,
+    }))
+}
+
 pub fn run_todo_cli(store: &Store, cli: TodoCli) -> Result<(), error::DecapodError> {
     let root = &store.root;
+    if let Some((cloud, identity)) = cloud_runtime(root)? {
+        let out = run_cloud_todo_command(root, &cli.command, &cloud, &identity)?;
+        match cli.format {
+            OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&out).unwrap()),
+            OutputFormat::Text => {
+                if matches!(cli.command, TodoCommand::List { .. }) {
+                    let items = out
+                        .get("items")
+                        .and_then(JsonValue::as_array)
+                        .cloned()
+                        .unwrap_or_default();
+                    if items.is_empty() {
+                        println!("No tasks found.");
+                    } else {
+                        println!("Cloud tasks (root: {}):", root.display());
+                        for item in items {
+                            println!(
+                                "- {} [{}|{}|{}] {}",
+                                item.get("id").and_then(JsonValue::as_str).unwrap_or("?"),
+                                item.get("status")
+                                    .and_then(JsonValue::as_str)
+                                    .unwrap_or("?"),
+                                item.get("priority")
+                                    .and_then(JsonValue::as_str)
+                                    .unwrap_or("?"),
+                                item.get("scope")
+                                    .and_then(JsonValue::as_str)
+                                    .unwrap_or("repo"),
+                                item.get("title").and_then(JsonValue::as_str).unwrap_or("")
+                            );
+                        }
+                    }
+                } else {
+                    println!("{}", serde_json::to_string(&out).unwrap());
+                }
+            }
+        }
+        return Ok(());
+    }
     let out = match &cli.command {
         TodoCommand::Add { .. } => add_task(root, &cli.command)?,
         TodoCommand::List {

--- a/src/decapod/core/todo.rs
+++ b/src/decapod/core/todo.rs
@@ -3,7 +3,7 @@ use crate::core::broker::DbBroker;
 use crate::core::error;
 use crate::core::external_action::{self, ExternalCapability};
 use crate::core::propodus::{PropodusClient, PropodusTodoStore};
-use crate::core::repo_identity::{RepositoryIdentity, resolve_verified_repository_identity};
+use crate::core::repo_identity::{RepositoryIdentity, resolve_dogfood_repository_identity};
 use crate::core::schemas; // Import the new schemas module
 use crate::core::storage::{Task as StorageTask, TodoStore};
 use crate::core::store::Store;
@@ -4778,15 +4778,15 @@ fn summarize_claim_container_error(err: &str) -> String {
 fn cloud_runtime(
     root: &Path,
 ) -> Result<Option<(CloudConfigSection, RepositoryIdentity)>, error::DecapodError> {
-    let project_root = crate::core::store::find_decapod_project_root(
-        &env::current_dir().map_err(error::DecapodError::IoError)?,
-    )
-    .unwrap_or_else(|_| {
-        root.parent()
-            .and_then(Path::parent)
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| root.to_path_buf())
-    });
+    let project_root = root
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            error::DecapodError::Config(
+                "unable to resolve the project root for cloud todo configuration".to_string(),
+            )
+        })?;
     let config = DecapodProjectConfig::load(&project_root)?;
     if config.repo.mode != BackendType::Cloud {
         return Ok(None);
@@ -4807,12 +4807,37 @@ fn cloud_runtime(
             cloud.provider
         )));
     }
-    let identity = resolve_verified_repository_identity(&project_root)?;
+    let identity = resolve_dogfood_repository_identity(&project_root)?;
     Ok(Some((cloud, identity)))
 }
 
 fn cloud_error(error: anyhow::Error) -> error::DecapodError {
     error::DecapodError::ValidationError(format!("Propodus cloud todo operation failed: {error}"))
+}
+
+pub trait CloudTodoStoreFactory {
+    fn build(
+        &self,
+        config: &CloudConfigSection,
+        identity: &RepositoryIdentity,
+    ) -> Result<Box<dyn TodoStore>, error::DecapodError>;
+}
+
+struct PropodusCloudTodoStoreFactory;
+
+impl CloudTodoStoreFactory for PropodusCloudTodoStoreFactory {
+    fn build(
+        &self,
+        config: &CloudConfigSection,
+        identity: &RepositoryIdentity,
+    ) -> Result<Box<dyn TodoStore>, error::DecapodError> {
+        let client = PropodusClient::from_dogfood_cloud_config(config, identity).map_err(|error| {
+            error::DecapodError::ValidationError(format!(
+                "Propodus credential/configuration preflight failed: {error}. Configure a Propodus-issued bearer through DECAPOD_ACCESS_TOKEN or the machine credential file; Decapod does not mint provider tokens."
+            ))
+        })?;
+        Ok(Box::new(PropodusTodoStore::new(client)))
+    }
 }
 
 fn cloud_task_from_command(
@@ -4862,15 +4887,14 @@ fn cloud_status_matches(requested: &str, actual: &str) -> bool {
     }
 }
 
-fn run_cloud_todo_command(
+fn run_cloud_todo_command_with_factory<F: CloudTodoStoreFactory>(
     root: &Path,
     command: &TodoCommand,
     config: &CloudConfigSection,
     identity: &RepositoryIdentity,
+    factory: &F,
 ) -> Result<JsonValue, error::DecapodError> {
-    let client = PropodusClient::from_verified_cloud_config(config, identity)
-        .map_err(|error| error::DecapodError::ValidationError(error.to_string()))?;
-    let store = PropodusTodoStore::new(client);
+    let store = factory.build(config, identity)?;
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -4878,7 +4902,7 @@ fn run_cloud_todo_command(
     runtime.block_on(run_cloud_todo_command_with_store_async(
         root,
         command,
-        &store,
+        store.as_ref(),
         &identity.canonical_name,
     ))
 }
@@ -4980,7 +5004,7 @@ async fn run_cloud_todo_command_with_store_async(
         } => {
             if *validated {
                 return Err(error::DecapodError::NotImplemented(
-                    "cloud todo proof capture is not part of the Propodus v1 contract; complete the remote task first, then run a remote proof workflow".to_string(),
+                    "cloud todo --validated is intentionally unsupported in Propodus v1: the service has no proof-capture contract. Complete the remote task first, then run a separate local/remote proof workflow; see docs/book/src/reference/propodus.md".to_string(),
                 ));
             }
             let task_id = resolve_task_id_arg(id, id_positional, "todo done")?;
@@ -5046,9 +5070,18 @@ async fn cloud_get_task(
 }
 
 pub fn run_todo_cli(store: &Store, cli: TodoCli) -> Result<(), error::DecapodError> {
+    run_todo_cli_with_cloud_factory(store, cli, &PropodusCloudTodoStoreFactory)
+}
+
+pub fn run_todo_cli_with_cloud_factory<F: CloudTodoStoreFactory>(
+    store: &Store,
+    cli: TodoCli,
+    factory: &F,
+) -> Result<(), error::DecapodError> {
     let root = &store.root;
     if let Some((cloud, identity)) = cloud_runtime(root)? {
-        let out = run_cloud_todo_command(root, &cli.command, &cloud, &identity)?;
+        let out =
+            run_cloud_todo_command_with_factory(root, &cli.command, &cloud, &identity, factory)?;
         match cli.format {
             OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&out).unwrap()),
             OutputFormat::Text => {

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -1436,9 +1436,9 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
             .as_deref()
             .is_some_and(|provider| provider != "decapod");
     repo.external_tracker = tracker_is_external;
-    // #688 adds the cloud opt-in boundary only. Fresh init config must keep
-    // local storage canonical until a later sync feature explicitly changes it.
-    repo.mode = crate::cli::BackendType::Local;
+    // Explicit cloud mode is an active backend selection. Local remains the
+    // default when the caller does not opt in.
+    repo.mode = init.mode.clone();
 
     let mut entrypoints = Vec::new();
     let no_entrypoint_flags = !init.claude && !init.gemini && !init.cdx_ep && !init.agents;
@@ -1704,7 +1704,7 @@ fn enrich_repo_context_interactive(
     } else {
         crate::cli::BackendType::Local
     };
-    repo.mode = crate::cli::BackendType::Local;
+    repo.mode = init.mode.clone();
 
     let enable_ci = prompt_yes_no("Scaffold GitHub Action for decapod validate?", init.ci)?;
     init.ci = enable_ci;

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -7,6 +7,7 @@
 //! docs and constitution documents, not in Rust source comments.
 
 pub(crate) mod cli;
+pub use cli::CloudConfigSection;
 pub mod constitution;
 pub mod core;
 pub(crate) mod plan_governance;
@@ -145,7 +146,10 @@ fn run_cloud_command(cloud_cli: CloudCli) -> Result<(), error::DecapodError> {
         CloudCommand::Login => auth::perform_cloud_auth(&std::env::current_dir()?),
         CloudCommand::Status => match auth::load_cloud_credential(None) {
             Ok(credential) => {
-                println!("cloud credential available ({:?})", credential.source);
+                println!(
+                    "Propodus bearer configured ({:?}); issuer, audience, GitHub subject, repository, and seat claims are validated by Propodus",
+                    credential.source
+                );
                 Ok(())
             }
             Err(error::DecapodError::SessionError(message)) => {
@@ -2234,9 +2238,12 @@ pub fn run() -> Result<(), error::DecapodError> {
             // For other commands, ensure .decapod exists in the GOVERNANCE root
             let decapod_root_path = governance_root.join(".decapod");
             store_root = decapod_root_path.join("data");
-            std::fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
+            let cloud_todo_command = is_cloud_todo_command(&cli.command, &workspace_root)?;
+            if !cloud_todo_command {
+                std::fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
+            }
 
-            if should_route_via_group_broker(&cli.command, &argv) {
+            if !cloud_todo_command && should_route_via_group_broker(&cli.command, &argv) {
                 match core::group_broker::maybe_route_mutation(&store_root, &argv) {
                     Err(e) => {
                         if !core::group_broker::is_internal_invocation() {
@@ -2263,22 +2270,24 @@ pub fn run() -> Result<(), error::DecapodError> {
 
             // Check for version/schema changes and run protected migrations if needed.
             // Backups are auto-created in .decapod/data only when schema upgrades are pending.
-            let migration_result =
-                migration::check_and_migrate_with_backup(&decapod_root_path, |data_root| {
-                    subsystems::initialize_all_dbs(data_root)
-                });
-            match migration_result {
-                Ok(()) => {}
-                Err(e) if is_validate_cmd => {
-                    let normalized = normalize_validate_error(e);
-                    return Err(attach_validate_diagnostic_if_enabled(
-                        normalized,
-                        &workspace_root,
-                        0,
-                        validate_timeout_secs(),
-                    ));
+            if !cloud_todo_command {
+                let migration_result =
+                    migration::check_and_migrate_with_backup(&decapod_root_path, |data_root| {
+                        subsystems::initialize_all_dbs(data_root)
+                    });
+                match migration_result {
+                    Ok(()) => {}
+                    Err(e) if is_validate_cmd => {
+                        let normalized = normalize_validate_error(e);
+                        return Err(attach_validate_diagnostic_if_enabled(
+                            normalized,
+                            &workspace_root,
+                            0,
+                            validate_timeout_secs(),
+                        ));
+                    }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
             }
 
             // Best-effort hygiene: routinely scrub stale git worktree metadata/config.
@@ -2294,7 +2303,8 @@ pub fn run() -> Result<(), error::DecapodError> {
                 root: store_root.clone(),
             };
 
-            if should_auto_clock_in(&cli.command)
+            if !cloud_todo_command
+                && should_auto_clock_in(&cli.command)
                 && let Err(e) =
                     retry_transient_sqlite(|| todo::clock_in_agent_presence(&project_store), 4)
             {
@@ -2460,6 +2470,17 @@ fn should_auto_clock_in(command: &Command) -> bool {
         | Command::System(_) => false,
         _ => true,
     }
+}
+
+fn is_cloud_todo_command(
+    command: &Command,
+    workspace_root: &Path,
+) -> Result<bool, error::DecapodError> {
+    if !matches!(command, Command::Todo(_)) {
+        return Ok(false);
+    }
+    Ok(load_project_config_if_present(workspace_root)?
+        .is_some_and(|config| config.repo.mode == crate::cli::BackendType::Cloud))
 }
 
 fn command_requires_worktree(command: &Command) -> bool {

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -1,6 +1,20 @@
 use std::process::Command;
 use tempfile::TempDir;
 
+fn git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn test_cloud_opt_in_fails_closed_without_verified_remote() {
     let tmp = TempDir::new().expect("tempdir");
@@ -85,5 +99,65 @@ fn test_cloud_init_records_opt_in_without_auth_or_repo_credentials() {
             .iter()
             .any(|write| write["table"] == "todos" && write["operation"] == "claim/complete"),
         "registration should model the repo-scoped todo lifecycle"
+    );
+}
+
+#[test]
+fn cloud_cli_preflight_does_not_initialize_local_sqlite() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--mode", "cloud", "--force", "--proof"])
+        .current_dir(&dir)
+        .output()
+        .expect("decapod init");
+    assert!(init_out.status.success());
+    git(
+        &dir,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:DecapodLabs/decapod.git",
+        ],
+    );
+
+    let data_home = TempDir::new().expect("credential data home");
+    let list_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["todo", "list", "--format", "json"])
+        .current_dir(&dir)
+        .env("DECAPOD_PROPODUS_DOGFOOD", "1")
+        .env_remove("DECAPOD_ACCESS_TOKEN")
+        .env("XDG_DATA_HOME", data_home.path())
+        .output()
+        .expect("cloud list");
+    assert!(!list_out.status.success());
+    let error = String::from_utf8_lossy(&list_out.stderr);
+    assert!(
+        error.contains("Propodus credential/configuration preflight failed")
+            && error.contains("DECAPOD_ACCESS_TOKEN"),
+        "unexpected credential preflight error: {error}"
+    );
+    assert!(
+        !dir.join(".decapod/data/todo.db").exists(),
+        "cloud credential preflight must not initialize local SQLite"
+    );
+}
+
+#[test]
+fn cloud_login_fails_fast_until_propodus_exchange_exists() {
+    let tmp = TempDir::new().expect("tempdir");
+    let data_home = TempDir::new().expect("credential data home");
+    let login_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["cloud", "login"])
+        .current_dir(tmp.path())
+        .env("XDG_DATA_HOME", data_home.path())
+        .output()
+        .expect("cloud login");
+    assert!(!login_out.status.success());
+    let error = String::from_utf8_lossy(&login_out.stderr);
+    assert!(
+        error.contains("Propodus-compatible GitHub login is not available"),
+        "unexpected login error: {error}"
     );
 }

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 #[test]
-fn test_cloud_opt_in_keeps_local_state_usable() {
+fn test_cloud_opt_in_fails_closed_without_verified_remote() {
     let tmp = TempDir::new().expect("tempdir");
     let dir = tmp.path().to_path_buf();
 
@@ -18,71 +18,20 @@ fn test_cloud_opt_in_keeps_local_state_usable() {
         String::from_utf8_lossy(&init_out.stderr)
     );
 
-    let title = format!(
-        "Test local task with cloud opt-in {}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis()
-    );
-
     let add_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["todo", "add", &title, "--format", "json"])
+        .args(["todo", "add", "must not fall back", "--format", "json"])
         .current_dir(&dir)
         .output()
         .expect("todo add");
 
     assert!(
-        add_out.status.success(),
-        "todo add failed: {}",
-        String::from_utf8_lossy(&add_out.stderr)
+        !add_out.status.success(),
+        "cloud mode must not use local SQLite"
     );
-
-    let add_json: serde_json::Value =
-        serde_json::from_slice(&add_out.stdout).expect("parse todo add json");
-    let task_id = add_json["id"].as_str().expect("task id").to_string();
-
-    let list_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["todo", "list", "--format", "json"])
-        .current_dir(&dir)
-        .output()
-        .expect("todo list");
-
+    let error = String::from_utf8_lossy(&add_out.stderr);
     assert!(
-        list_out.status.success(),
-        "todo list failed: {}",
-        String::from_utf8_lossy(&list_out.stderr)
-    );
-
-    let list_stdout = String::from_utf8_lossy(&list_out.stdout);
-    assert!(
-        list_stdout.contains(&title),
-        "Task '{}' not found in list output after cloud opt-in: {}",
-        title,
-        list_stdout
-    );
-    assert!(
-        list_stdout.contains(&task_id),
-        "Cloud task ID '{}' not found in list output",
-        task_id
-    );
-
-    let get_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
-        .args(["todo", "get", "--id", &task_id, "--format", "json"])
-        .current_dir(&dir)
-        .output()
-        .expect("todo get");
-
-    assert!(
-        get_out.status.success(),
-        "todo get failed: {}",
-        String::from_utf8_lossy(&get_out.stderr)
-    );
-
-    let get_stdout = String::from_utf8_lossy(&get_out.stdout);
-    assert!(
-        get_stdout.contains(&title),
-        "Task get did not return expected title"
+        error.contains("origin Git remote"),
+        "unexpected error: {error}"
     );
 }
 
@@ -112,7 +61,7 @@ fn test_cloud_init_records_opt_in_without_auth_or_repo_credentials() {
     assert!(config.contains("experimental = true"));
     assert!(config.contains("provider = \"vercel\""));
     assert!(config.contains("api_url = \"https://decapod-cloud.vercel.app\""));
-    assert!(config.contains("mode = \"local\""));
+    assert!(config.contains("mode = \"cloud\""));
     assert!(!config.contains("SUPABASE"));
     assert!(!config.contains("supabase"));
     assert!(!config.contains("token"));

--- a/tests/cloud_cli_boundary.rs
+++ b/tests/cloud_cli_boundary.rs
@@ -1,0 +1,272 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use clap::Parser;
+use decapod::CloudConfigSection;
+use decapod::core::error::DecapodError;
+use decapod::core::repo_identity::RepositoryIdentity;
+use decapod::core::storage::{Task, TodoStore};
+use decapod::core::store::{Store, StoreKind};
+use decapod::core::todo::{CloudTodoStoreFactory, TodoCli, run_todo_cli_with_cloud_factory};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+
+#[derive(Clone, Default)]
+struct MockPropodusStore {
+    calls: Arc<Mutex<Vec<String>>>,
+    tasks: Arc<Mutex<Vec<Task>>>,
+}
+
+impl MockPropodusStore {
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("calls lock").clone()
+    }
+}
+
+#[async_trait]
+impl TodoStore for MockPropodusStore {
+    async fn list_tasks(&self) -> Result<Vec<Task>> {
+        self.calls.lock().expect("calls lock").push("list".into());
+        Ok(self.tasks.lock().expect("tasks lock").clone())
+    }
+
+    async fn add_task(&self, mut task: Task, _actor: String, _intent: String) -> Result<Task> {
+        self.calls.lock().expect("calls lock").push("add".into());
+        task.id = "cloud-cli-1".into();
+        self.tasks.lock().expect("tasks lock").push(task.clone());
+        Ok(task)
+    }
+
+    async fn claim_task(&self, id: &str, _actor: String) -> Result<Task> {
+        self.calls.lock().expect("calls lock").push("claim".into());
+        let mut tasks = self.tasks.lock().expect("tasks lock");
+        let task = tasks.iter_mut().find(|task| task.id == id).expect("task");
+        task.assignee = Some("cli-agent".into());
+        Ok(task.clone())
+    }
+
+    async fn complete_task(&self, id: &str, _actor: String, _resolution: String) -> Result<Task> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push("complete".into());
+        let mut tasks = self.tasks.lock().expect("tasks lock");
+        let task = tasks.iter_mut().find(|task| task.id == id).expect("task");
+        task.status = "completed".into();
+        Ok(task.clone())
+    }
+}
+
+#[derive(Clone)]
+struct MockFactory {
+    store: MockPropodusStore,
+    builds: Arc<Mutex<usize>>,
+}
+
+impl CloudTodoStoreFactory for MockFactory {
+    fn build(
+        &self,
+        config: &CloudConfigSection,
+        identity: &RepositoryIdentity,
+    ) -> Result<Box<dyn TodoStore>, DecapodError> {
+        assert_eq!(config.provider, "vercel");
+        assert_eq!(identity.canonical_name, "DecapodLabs/decapod");
+        *self.builds.lock().expect("builds lock") += 1;
+        Ok(Box::new(self.store.clone()))
+    }
+}
+
+struct FailingStore;
+
+#[async_trait]
+impl TodoStore for FailingStore {
+    async fn list_tasks(&self) -> Result<Vec<Task>> {
+        Err(anyhow::anyhow!("transport failure from fake Propodus"))
+    }
+
+    async fn add_task(&self, _task: Task, _actor: String, _intent: String) -> Result<Task> {
+        Err(anyhow::anyhow!("transport failure from fake Propodus"))
+    }
+
+    async fn claim_task(&self, _id: &str, _actor: String) -> Result<Task> {
+        Err(anyhow::anyhow!("transport failure from fake Propodus"))
+    }
+
+    async fn complete_task(&self, _id: &str, _actor: String, _resolution: String) -> Result<Task> {
+        Err(anyhow::anyhow!("transport failure from fake Propodus"))
+    }
+}
+
+struct FailingFactory;
+
+impl CloudTodoStoreFactory for FailingFactory {
+    fn build(
+        &self,
+        _config: &CloudConfigSection,
+        _identity: &RepositoryIdentity,
+    ) -> Result<Box<dyn TodoStore>, DecapodError> {
+        Ok(Box::new(FailingStore))
+    }
+}
+
+fn parse_todo(args: &[&str]) -> TodoCli {
+    let mut argv = vec!["todo".to_string()];
+    argv.extend(args.iter().map(|arg| (*arg).to_string()));
+    TodoCli::try_parse_from(argv).expect("parse todo CLI")
+}
+
+fn git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn cloud_project() -> TempDir {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let init = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--mode", "cloud", "--force", "--proof"])
+        .current_dir(project.path())
+        .output()
+        .expect("init cloud project");
+    assert!(
+        init.status.success(),
+        "cloud init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    git(
+        project.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:DecapodLabs/decapod.git",
+        ],
+    );
+    project
+}
+
+#[test]
+fn production_cli_dispatch_uses_remote_store_and_never_local_sqlite() {
+    let project = cloud_project();
+    let data_root = project.path().join(".decapod/data");
+    let todo_db = data_root.join("todo.db");
+    assert!(!todo_db.exists(), "test starts without local todo SQLite");
+    // This integration test invokes the same env-gated production resolver as
+    // the binary. Tests in this file run serially to keep the process-global
+    // dogfood marker isolated.
+    unsafe { std::env::set_var("DECAPOD_PROPODUS_DOGFOOD", "1") };
+
+    let store = MockPropodusStore::default();
+    let factory = MockFactory {
+        store: store.clone(),
+        builds: Arc::new(Mutex::new(0)),
+    };
+    let decapod_store = Store {
+        kind: StoreKind::Repo,
+        root: data_root,
+    };
+
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["list", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud list");
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["add", "CLI boundary task", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud add");
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["get", "--id", "cloud-cli-1", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud get");
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["show", "cloud-cli-1", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud show");
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["claim", "--id", "cloud-cli-1", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud claim");
+    run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["done", "--id", "cloud-cli-1", "--format", "json"]),
+        &factory,
+    )
+    .expect("cloud done");
+    let missing = run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["get", "--id", "missing", "--format", "json"]),
+        &factory,
+    );
+    assert!(
+        missing.is_ok(),
+        "v1 get must report not_found in its output"
+    );
+
+    assert_eq!(
+        store.calls(),
+        ["list", "add", "list", "list", "claim", "complete", "list"]
+    );
+    assert_eq!(*factory.builds.lock().expect("builds lock"), 7);
+    assert!(
+        !todo_db.exists(),
+        "cloud CLI must not initialize local todo SQLite"
+    );
+
+    let transport_error = run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["list", "--format", "json"]),
+        &FailingFactory,
+    )
+    .expect_err("transport failure must remain an error");
+    assert!(
+        transport_error
+            .to_string()
+            .contains("Propodus cloud todo operation failed"),
+        "unexpected transport error: {transport_error}"
+    );
+    assert!(
+        !todo_db.exists(),
+        "transport failure must not fall back to SQLite"
+    );
+
+    git(
+        project.path(),
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:someone/decapod.git",
+        ],
+    );
+    let fork_error = run_todo_cli_with_cloud_factory(
+        &decapod_store,
+        parse_todo(&["list", "--format", "json"]),
+        &factory,
+    )
+    .expect_err("fork must fail before factory/network");
+    assert!(
+        fork_error
+            .to_string()
+            .contains("restricted to DecapodLabs/decapod")
+    );
+    assert_eq!(*factory.builds.lock().expect("builds lock"), 7);
+    unsafe { std::env::remove_var("DECAPOD_PROPODUS_DOGFOOD") };
+}

--- a/tests/cloud_command_path.rs
+++ b/tests/cloud_command_path.rs
@@ -1,0 +1,115 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use decapod::core::storage::{Task, TodoStore};
+use decapod::core::todo::{ClaimMode, TodoCommand, run_cloud_todo_command_with_store};
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+
+#[derive(Clone, Default)]
+struct RecordingStore {
+    calls: Arc<Mutex<Vec<String>>>,
+    tasks: Arc<Mutex<Vec<Task>>>,
+}
+
+impl RecordingStore {
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("calls lock").clone()
+    }
+}
+
+#[async_trait]
+impl TodoStore for RecordingStore {
+    async fn list_tasks(&self) -> Result<Vec<Task>> {
+        self.calls.lock().expect("calls lock").push("list".into());
+        Ok(self.tasks.lock().expect("tasks lock").clone())
+    }
+
+    async fn add_task(&self, mut task: Task, _actor: String, _intent: String) -> Result<Task> {
+        self.calls.lock().expect("calls lock").push("add".into());
+        task.id = "cloud-1".to_string();
+        self.tasks.lock().expect("tasks lock").push(task.clone());
+        Ok(task)
+    }
+
+    async fn claim_task(&self, id: &str, _actor: String) -> Result<Task> {
+        self.calls.lock().expect("calls lock").push("claim".into());
+        let mut tasks = self.tasks.lock().expect("tasks lock");
+        let task = tasks.iter_mut().find(|task| task.id == id).expect("task");
+        task.assignee = Some("agent-two".to_string());
+        Ok(task.clone())
+    }
+
+    async fn complete_task(&self, id: &str, _actor: String, _resolution: String) -> Result<Task> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push("complete".into());
+        let mut tasks = self.tasks.lock().expect("tasks lock");
+        let task = tasks.iter_mut().find(|task| task.id == id).expect("task");
+        task.status = "completed".to_string();
+        Ok(task.clone())
+    }
+}
+
+#[test]
+fn active_cloud_commands_use_the_storage_adapter_without_local_fallback() {
+    let root = tempdir().expect("tempdir");
+    let store = RecordingStore::default();
+
+    run_cloud_todo_command_with_store(
+        root.path(),
+        &TodoCommand::Add {
+            title: "shared cloud task".into(),
+            description: String::new(),
+            priority: "medium".into(),
+            tags: String::new(),
+            owner: String::new(),
+            due: None,
+            r#ref: String::new(),
+            scope: String::new(),
+            dir: None,
+            depends_on: String::new(),
+            blocks: String::new(),
+            parent: None,
+            one_shot: 0,
+        },
+        &store,
+    )
+    .expect("cloud add");
+
+    run_cloud_todo_command_with_store(
+        root.path(),
+        &TodoCommand::List {
+            status: "open".into(),
+            scope: None,
+            tags: None,
+            title_search: None,
+            dir: None,
+        },
+        &store,
+    )
+    .expect("cloud list");
+    run_cloud_todo_command_with_store(
+        root.path(),
+        &TodoCommand::Claim {
+            id: "cloud-1".into(),
+            agent: Some("agent-two".into()),
+            mode: ClaimMode::Shared,
+        },
+        &store,
+    )
+    .expect("cloud claim");
+    run_cloud_todo_command_with_store(
+        root.path(),
+        &TodoCommand::Done {
+            id: Some("cloud-1".into()),
+            id_positional: None,
+            validated: false,
+            artifact: vec![],
+        },
+        &store,
+    )
+    .expect("cloud complete");
+
+    assert_eq!(store.calls(), ["add", "list", "claim", "complete"]);
+}

--- a/tests/fixtures/propodus/todo-contract-v1.json
+++ b/tests/fixtures/propodus/todo-contract-v1.json
@@ -31,6 +31,7 @@
     {"status": 400, "code": "validation_error"},
     {"status": 401, "code": "authentication_required"},
     {"status": 403, "code": "repository_not_authorized"},
+    {"status": 403, "code": "organization_seat_required"},
     {"status": 404, "code": "todo_not_found"},
     {"status": 409, "code": "todo_conflict"}
   ]

--- a/tests/init_config_behavior.rs
+++ b/tests/init_config_behavior.rs
@@ -108,8 +108,8 @@ fn init_with_backend_cloud_saves_to_config() {
         "cloud API URL should use the Vercel backend default: {config}"
     );
     assert!(
-        config.contains("mode = \"local\""),
-        "cloud opt-in must not switch storage away from local by default: {config}"
+        config.contains("mode = \"cloud\""),
+        "explicit cloud opt-in must activate cloud todo routing: {config}"
     );
     assert!(
         !config.contains("supabase") && !config.contains("token") && !config.contains("secret"),

--- a/tests/propodus_contract.rs
+++ b/tests/propodus_contract.rs
@@ -55,6 +55,7 @@ fn config() -> PropodusConfig {
         api_url: "https://propodus.example.test".to_string(),
         project_id: "test-project".to_string(),
         repo_id: "DecapodLabs/decapod".to_string(),
+        immutable_repo_id: Some("github:repo:123".to_string()),
     }
 }
 

--- a/tests/propodus_contract.rs
+++ b/tests/propodus_contract.rs
@@ -55,7 +55,6 @@ fn config() -> PropodusConfig {
         api_url: "https://propodus.example.test".to_string(),
         project_id: "test-project".to_string(),
         repo_id: "DecapodLabs/decapod".to_string(),
-        immutable_repo_id: Some("github:repo:123".to_string()),
     }
 }
 

--- a/tests/propodus_contract.rs
+++ b/tests/propodus_contract.rs
@@ -177,6 +177,7 @@ fn failure_statuses_remain_distinct_and_do_not_decode_as_success() {
     let cases = [
         (401, "authentication_required", "Authentication"),
         (403, "repository_not_authorized", "Service"),
+        (403, "organization_seat_required", "Service"),
         (404, "todo_not_found", "NotFound"),
         (409, "todo_conflict", "Conflict"),
     ];

--- a/tests/propodus_live.rs
+++ b/tests/propodus_live.rs
@@ -55,6 +55,23 @@ fn live_propodus_contract_proves_canonical_scope_and_mutations() {
         .complete_todo(&todo.id, "decapod-live-proof")
         .expect("canonical repository complete");
 
+    let invalid_client = PropodusClient::with_transport(
+        &PropodusConfig {
+            repo_id: CANONICAL_REPO_ID.to_string(),
+            ..config.clone()
+        },
+        "not-a-valid-propodus-token",
+        CurlTransport::default(),
+    )
+    .expect("invalid-token proof client configuration");
+    assert!(
+        matches!(
+            invalid_client.list_todos(),
+            Err(PropodusClientError::Authentication(_))
+        ),
+        "Propodus must reject an invalid bearer token with 401 authentication failure"
+    );
+
     let unauthorized_config = PropodusConfig {
         repo_id: disposable_repo_id,
         ..config

--- a/tests/propodus_live.rs
+++ b/tests/propodus_live.rs
@@ -1,11 +1,58 @@
 use decapod::core::propodus::{CurlTransport, PropodusClient, PropodusClientError, PropodusConfig};
 use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::tempdir;
 
 const CANONICAL_REPO_ID: &str = "DecapodLabs/decapod";
 
 fn required_env(name: &str) -> String {
     env::var(name).unwrap_or_else(|_| panic!("{name} is required for the live proof"))
+}
+
+fn run_decapod(
+    dir: &Path,
+    args: &[&str],
+    agent: &str,
+    token: &str,
+    repo_id: &str,
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(args)
+        .current_dir(dir)
+        .env("DECAPOD_AGENT_ID", agent)
+        .env("DECAPOD_ACCESS_TOKEN", token)
+        .env("DECAPOD_GITHUB_REPOSITORY_ID", repo_id)
+        .output()
+        .expect("run decapod command")
+}
+
+fn prepare_cloud_repo(dir: &Path, api_url: &str, remote: &str) {
+    let init = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--mode", "cloud", "--force", "--proof"])
+        .current_dir(dir)
+        .output()
+        .expect("initialize cloud proof repository");
+    assert!(
+        init.status.success(),
+        "cloud init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let remote_result = Command::new("git")
+        .args(["remote", "add", "origin", remote])
+        .current_dir(dir)
+        .output()
+        .expect("configure proof remote");
+    assert!(remote_result.status.success());
+    let config_path = dir.join(".decapod/config.toml");
+    let config = fs::read_to_string(&config_path).expect("read cloud config");
+    fs::write(
+        config_path,
+        config.replace("https://decapod-cloud.vercel.app", api_url),
+    )
+    .expect("write proof API URL");
 }
 
 #[test]
@@ -29,6 +76,7 @@ fn live_propodus_contract_proves_canonical_scope_and_mutations() {
         api_url,
         project_id: "decapod-live-proof".to_string(),
         repo_id: CANONICAL_REPO_ID.to_string(),
+        immutable_repo_id: Some(required_env("DECAPOD_GITHUB_REPOSITORY_ID")),
     };
     let client = PropodusClient::with_transport(&config, &credential, CurlTransport::default())
         .expect("live Propodus client configuration");
@@ -86,4 +134,97 @@ fn live_propodus_contract_proves_canonical_scope_and_mutations() {
         Err(error) => panic!("expected 403 repository_not_authorized, got {error}"),
         Ok(_) => panic!("unprovisioned repository unexpectedly returned todo data"),
     }
+}
+
+#[test]
+#[ignore = "requires DECAPOD_PROPODUS_LIVE=1 and protected Propodus inputs"]
+fn live_decapod_cloud_commands_share_state_and_reject_forks() {
+    assert_eq!(
+        env::var("DECAPOD_PROPODUS_LIVE").as_deref(),
+        Ok("1"),
+        "set DECAPOD_PROPODUS_LIVE=1 to opt into the live proof"
+    );
+    let api_url = required_env("DECAPOD_PROPODUS_API_URL");
+    let credential = required_env("DECAPOD_PROPODUS_ACCESS_TOKEN");
+    let immutable_repo_id = required_env("DECAPOD_GITHUB_REPOSITORY_ID");
+
+    let canonical = tempdir().expect("canonical proof repository");
+    prepare_cloud_repo(
+        canonical.path(),
+        &api_url,
+        "git@github.com:DecapodLabs/decapod.git",
+    );
+    let title = format!(
+        "Decapod command dogfood proof {}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    );
+    let add = run_decapod(
+        canonical.path(),
+        &["todo", "add", &title, "--format", "json"],
+        "decapod-live-agent-one",
+        &credential,
+        &immutable_repo_id,
+    );
+    assert!(
+        add.status.success(),
+        "cloud add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let add_json: serde_json::Value = serde_json::from_slice(&add.stdout).expect("add JSON");
+    let task_id = add_json["id"].as_str().expect("cloud task ID").to_string();
+
+    for args in [
+        vec!["todo", "claim", "--id", task_id.as_str()],
+        vec!["todo", "done", "--id", task_id.as_str()],
+    ] {
+        let output = run_decapod(
+            canonical.path(),
+            &args,
+            "decapod-live-agent-one",
+            &credential,
+            &immutable_repo_id,
+        );
+        assert!(
+            output.status.success(),
+            "cloud lifecycle command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let second_agent_list = run_decapod(
+        canonical.path(),
+        &["todo", "list", "--status", "all", "--format", "json"],
+        "decapod-live-agent-two",
+        &credential,
+        &immutable_repo_id,
+    );
+    assert!(second_agent_list.status.success());
+    let list = String::from_utf8_lossy(&second_agent_list.stdout);
+    assert!(
+        list.contains(&task_id),
+        "second agent cannot see shared task: {list}"
+    );
+    assert!(
+        list.contains(&title),
+        "second agent cannot see task title: {list}"
+    );
+
+    let fork = tempdir().expect("fork proof repository");
+    prepare_cloud_repo(fork.path(), &api_url, "git@github.com:someone/decapod.git");
+    let fork_list = run_decapod(
+        fork.path(),
+        &["todo", "list", "--format", "json"],
+        "decapod-live-fork-agent",
+        &credential,
+        &immutable_repo_id,
+    );
+    assert!(!fork_list.status.success(), "forks must fail closed");
+    let fork_error = String::from_utf8_lossy(&fork_list.stderr);
+    assert!(
+        fork_error.contains("restricted to DecapodLabs/decapod"),
+        "unexpected fork rejection: {fork_error}"
+    );
 }

--- a/tests/propodus_live.rs
+++ b/tests/propodus_live.rs
@@ -12,19 +12,13 @@ fn required_env(name: &str) -> String {
     env::var(name).unwrap_or_else(|_| panic!("{name} is required for the live proof"))
 }
 
-fn run_decapod(
-    dir: &Path,
-    args: &[&str],
-    agent: &str,
-    token: &str,
-    repo_id: &str,
-) -> std::process::Output {
+fn run_decapod(dir: &Path, args: &[&str], agent: &str, token: &str) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_decapod"))
         .args(args)
         .current_dir(dir)
         .env("DECAPOD_AGENT_ID", agent)
         .env("DECAPOD_ACCESS_TOKEN", token)
-        .env("DECAPOD_GITHUB_REPOSITORY_ID", repo_id)
+        .env("DECAPOD_PROPODUS_DOGFOOD", "1")
         .output()
         .expect("run decapod command")
 }
@@ -76,7 +70,6 @@ fn live_propodus_contract_proves_canonical_scope_and_mutations() {
         api_url,
         project_id: "decapod-live-proof".to_string(),
         repo_id: CANONICAL_REPO_ID.to_string(),
-        immutable_repo_id: Some(required_env("DECAPOD_GITHUB_REPOSITORY_ID")),
     };
     let client = PropodusClient::with_transport(&config, &credential, CurlTransport::default())
         .expect("live Propodus client configuration");
@@ -146,7 +139,6 @@ fn live_decapod_cloud_commands_share_state_and_reject_forks() {
     );
     let api_url = required_env("DECAPOD_PROPODUS_API_URL");
     let credential = required_env("DECAPOD_PROPODUS_ACCESS_TOKEN");
-    let immutable_repo_id = required_env("DECAPOD_GITHUB_REPOSITORY_ID");
 
     let canonical = tempdir().expect("canonical proof repository");
     prepare_cloud_repo(
@@ -166,7 +158,6 @@ fn live_decapod_cloud_commands_share_state_and_reject_forks() {
         &["todo", "add", &title, "--format", "json"],
         "decapod-live-agent-one",
         &credential,
-        &immutable_repo_id,
     );
     assert!(
         add.status.success(),
@@ -185,7 +176,6 @@ fn live_decapod_cloud_commands_share_state_and_reject_forks() {
             &args,
             "decapod-live-agent-one",
             &credential,
-            &immutable_repo_id,
         );
         assert!(
             output.status.success(),
@@ -199,7 +189,6 @@ fn live_decapod_cloud_commands_share_state_and_reject_forks() {
         &["todo", "list", "--status", "all", "--format", "json"],
         "decapod-live-agent-two",
         &credential,
-        &immutable_repo_id,
     );
     assert!(second_agent_list.status.success());
     let list = String::from_utf8_lossy(&second_agent_list.stdout);
@@ -219,7 +208,6 @@ fn live_decapod_cloud_commands_share_state_and_reject_forks() {
         &["todo", "list", "--format", "json"],
         "decapod-live-fork-agent",
         &credential,
-        &immutable_repo_id,
     );
     assert!(!fork_list.status.success(), "forks must fail closed");
     let fork_error = String::from_utf8_lossy(&fork_list.stderr);

--- a/tests/propodus_live.rs
+++ b/tests/propodus_live.rs
@@ -1,0 +1,72 @@
+use decapod::core::propodus::{CurlTransport, PropodusClient, PropodusClientError, PropodusConfig};
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CANONICAL_REPO_ID: &str = "DecapodLabs/decapod";
+
+fn required_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("{name} is required for the live proof"))
+}
+
+#[test]
+#[ignore = "requires DECAPOD_PROPODUS_LIVE=1 and protected Propodus inputs"]
+fn live_propodus_contract_proves_canonical_scope_and_mutations() {
+    assert_eq!(
+        env::var("DECAPOD_PROPODUS_LIVE").as_deref(),
+        Ok("1"),
+        "set DECAPOD_PROPODUS_LIVE=1 to opt into the live proof"
+    );
+
+    let api_url = required_env("DECAPOD_PROPODUS_API_URL");
+    let credential = required_env("DECAPOD_PROPODUS_ACCESS_TOKEN");
+    let disposable_repo_id = required_env("DECAPOD_PROPODUS_DISPOSABLE_REPO_ID");
+    assert_ne!(
+        disposable_repo_id, CANONICAL_REPO_ID,
+        "the disposable repository identifier must not be the canonical repository"
+    );
+
+    let config = PropodusConfig {
+        api_url,
+        project_id: "decapod-live-proof".to_string(),
+        repo_id: CANONICAL_REPO_ID.to_string(),
+    };
+    let client = PropodusClient::with_transport(&config, &credential, CurlTransport::default())
+        .expect("live Propodus client configuration");
+
+    client.health_check().expect("Propodus health check");
+    client.list_todos().expect("canonical repository list");
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let todo = client
+        .create_todo(
+            &format!("Decapod live contract proof {nonce}"),
+            Some("Completed by the explicit live proof; safe to remove with service tooling."),
+            Some("decapod-live-proof"),
+        )
+        .expect("canonical repository create");
+    assert_eq!(todo.repo_id, CANONICAL_REPO_ID);
+    client
+        .claim_todo(&todo.id, "decapod-live-proof")
+        .expect("canonical repository claim");
+    client
+        .complete_todo(&todo.id, "decapod-live-proof")
+        .expect("canonical repository complete");
+
+    let unauthorized_config = PropodusConfig {
+        repo_id: disposable_repo_id,
+        ..config
+    };
+    let unauthorized =
+        PropodusClient::with_transport(&unauthorized_config, &credential, CurlTransport::default())
+            .expect("disposable repository client configuration");
+    match unauthorized.list_todos() {
+        Err(PropodusClientError::Service {
+            status: 403, code, ..
+        }) => assert_eq!(code, "repository_not_authorized"),
+        Err(error) => panic!("expected 403 repository_not_authorized, got {error}"),
+        Ok(_) => panic!("unprovisioned repository unexpectedly returned todo data"),
+    }
+}

--- a/tests/release_workflow_policy.rs
+++ b/tests/release_workflow_policy.rs
@@ -176,3 +176,32 @@ fn public_release_surface_has_no_private_propodus_dependency() {
         );
     }
 }
+
+#[test]
+fn governance_artifact_gate_skips_release_labeled_prs() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workflow =
+        fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read CI workflow");
+
+    assert!(
+        workflow.contains("governance-artifacts:"),
+        "CI must retain the governance artifact job"
+    );
+    assert!(
+        workflow.contains(
+            "if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'release')"
+        ),
+        "release-labeled PRs must not be forced to carry the four governance artifacts"
+    );
+    for artifact in [
+        ".decapod/governance/claims.json",
+        ".decapod/governance/trajectory.json",
+        ".decapod/governance/validation.json",
+        ".decapod/governance/plan.json",
+    ] {
+        assert!(
+            workflow.contains(artifact),
+            "the regular governance gate must continue checking {artifact}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Updates PR #1036 for Decapod issues #1032, #1033, #1034, #1035, and #1037 without merging it.

- `repo.mode = "cloud"` now reaches the real `decapod todo` CLI dispatch for list/add/get/show/claim/done through the typed Propodus adapter; cloud mode never initializes or silently falls back to local SQLite.
- Cloud preflight requires the canonical `DecapodLabs/decapod` origin and explicit `DECAPOD_PROPODUS_DOGFOOD=1`; this is documented as a temporary dogfood gate, not authenticated immutable repository identity, and it is not sent to Propodus.
- Decapod now consumes only a Propodus-issued bearer from `DECAPOD_ACCESS_TOKEN` or the machine credential file. The incompatible Auth0 device flow is removed; `cloud login` fails fast until Propodus issue #24 publishes the stable GitHub exchange.
- Propodus owns issuer, audience, GitHub-subject, repository authorization, organization-seat, refresh, and revocation policy. Decapod does not own provider auth, identity implementation, payments, deployment, or service allowlisting.
- The production CLI boundary is covered with an injectable store factory, including no-local-SQLite assertions, transport-error no-fallback behavior, and fork rejection before factory/network use.
- Generated living specs, `claims.json`, `trajectory.json`, `validation.json`, and `plan.json` are refreshed and included in the PR diff.

## Boundary and follow-up

Propodus PR #31 is the current bearer/JWT contract consumed by this change. The interactive GitHub login/token exchange remains a Propodus-owned dependency under issue #24.

Cloud `todo get` and `todo show` use list-and-filter because the current Propodus v1 contract has no repo-scoped get route. Cloud `todo done --validated` is explicitly rejected because Propodus v1 has no proof-capture contract; Decapod issue #1038 tracks the future alignment.

This PR closes #1022 and advances the Decapod-owned portions of #1032-#1035 and #1037. Remaining provider-owned work stays in Propodus.

## Proof

- `cargo fmt --all -- --check`
- `cargo check --locked`
- Focused cloud/Propodus contract tests: 9 passed
- Full Rust suite: the new cloud tests and documentation-alignment tests passed; one parallel temporary-fixture race in `entrypoint_correctness` was reproduced as an isolated pass
- Container-backed `decapod validate --format json`: 202 passed, 0 failed
- Live proof remains ignored, manual, environment-protected, and requires protected non-secret inputs. No credentials are stored in the repository or logs.