### PR TITLE
feat: align backend contract for cloud onboarding

### DIFF
--- a/.decapod/config.toml
+++ b/.decapod/config.toml
@@ -22,6 +22,7 @@ primary_languages = ["Rust"]
 detected_surfaces = ["cargo"]
 external_tracker = false
 container_workspaces = true
+backend = "local"
 mode = "local"
 declared_capabilities = [
     "agent-helper",

--- a/.decapod/governance/claims.json
+++ b/.decapod/governance/claims.json
@@ -11,7 +11,7 @@
     "status": "active",
     "created_at": "2026-07-22",
     "updated_at": "2026-07-25",
-    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025; wave-2 release-safe Propodus proof changes remain bounded to Decapod-owned client and CI surfaces."
+    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025; wave-2 release-safe external-backend proof changes remain bounded to Decapod-owned client, configuration, onboarding, and CI surfaces."
   },
   "scope": {
     "product": "decapod",

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -77,7 +77,18 @@
       "completed": true,
       "entered_at": "1785034186Z",
       "completed_at": "1785035649Z"
+    },
+    {
+      "id": "propodus-phase-2-1040",
+      "name": "Advance provider-neutral cloud backend contract",
+      "description": "Preserve local-first governance and existing mode inputs while adding the non-breaking backend contract, provider-neutral onboarding/session seam, deterministic backend selection proof, and refreshed living specs for Issue #1040; defer provider implementation details and live deployment to the next wave.",
+      "entry_gates": [],
+      "exit_gates": [],
+      "entered": true,
+      "completed": false,
+      "entered_at": "1785041922Z",
+      "completed_at": null
     }
   ],
-  "updated_at": "1785035649Z"
+  "updated_at": "1785041922Z"
 }

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -85,10 +85,10 @@
       "entry_gates": [],
       "exit_gates": [],
       "entered": true,
-      "completed": false,
+      "completed": true,
       "entered_at": "1785041922Z",
-      "completed_at": null
+      "completed_at": "1785043828Z"
     }
   ],
-  "updated_at": "1785041922Z"
+  "updated_at": "1785043828Z"
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -34,6 +34,7 @@
   ],
   "evidence": [
     "validation epoch ve_93082d96f6119e30 completed with zero failures",
+    "validation epoch ve_d92d9efae5200aef completed with zero failures",
     "validation epoch ve_e25d59defedd0cb3 completed with zero failures"
   ],
   "shortcut_risk_signals": [],
@@ -45,7 +46,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:5e697e1b9be6d8ba8ef95fe17856aa9bd2722272216d408198bc559855473831",
+  "artifact_hash": "sha256:5cb0022061d65f608987e6da373cf14c928133b97ed8de76152d49ba5f4c4c23",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -95,6 +96,20 @@
         "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
+      },
+      {
+        "sequence": 6,
+        "event_id": "event:6",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
+      },
+      {
+        "sequence": 7,
+        "event_id": "event:7",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
       }
     ],
     "trajectories": {
@@ -140,12 +155,50 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:5"
+          },
+          {
+            "sequence": 6,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_d92d9efae5200aef completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:6"
+          },
+          {
+            "sequence": 7,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_e25d59defedd0cb3 completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:7"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 5
+    "next_sequence": 7
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -33,7 +33,8 @@
     }
   ],
   "evidence": [
-    "validation epoch ve_93082d96f6119e30 completed with zero failures"
+    "validation epoch ve_93082d96f6119e30 completed with zero failures",
+    "validation epoch ve_e25d59defedd0cb3 completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -44,7 +45,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:4bf9dd18535c9e57e96e11e6d1233c0f2419fb1fbf1cd75f6b923b0b62165625",
+  "artifact_hash": "sha256:5e697e1b9be6d8ba8ef95fe17856aa9bd2722272216d408198bc559855473831",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -87,6 +88,13 @@
         "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
+      },
+      {
+        "sequence": 5,
+        "event_id": "event:5",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
       }
     ],
     "trajectories": {
@@ -113,12 +121,31 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
+          },
+          {
+            "sequence": 5,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_e25d59defedd0cb3 completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:5"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 4
+    "next_sequence": 5
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,35 +1,26 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "wave2-propodus-1036-alignment",
-  "intent_id": "intent:wave2-propodus-1036-alignment",
-  "task_id": "cicd_01kydv7dsj7sayv4",
-  "original_intent": "Update PR #1036 to align Decapod issues #1032 through #1035 and #1037 with current Propodus PR #31 boundaries.",
-  "derived_intent": "Activate explicit Propodus-backed todo commands, fail closed on verified canonical GitHub identity, and prove command-level shared and unauthorized behavior without moving Propodus-owned auth or policy into Decapod.",
+  "run_id": "validation_01KYEDQTT5WZDBA25ACH62YDDV",
+  "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
+  "task_id": "bend_01kyecfw7jcfytnk",
+  "original_intent": "Produce proof artifacts for a repository validation completion.",
+  "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
+  "destination": "validation completion",
   "current_phase": "validation",
   "next_transitions": [
     "publish"
   ],
   "active_boundaries": [
-    "Decapod owns cloud composition, client credential boundary, repository identity resolution, typed errors, and proof orchestration; Propodus owns GitHub exchange, seat policy, persistence, deployment, and service allowlists."
+    "Repository validation and tracked proof artifacts"
   ],
   "repo_scope": [
-    "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+    ".decapod/governance/trajectory.json",
+    ".decapod/governance/validation.json"
   ],
-  "inspected_files": [
-    "src/decapod/core/propodus.rs",
-    "src/decapod/core/repo_identity.rs",
-    "src/decapod/core/todo.rs",
-    "tests/cloud_command_path.rs",
-    "tests/propodus_live.rs"
-  ],
+  "inspected_files": [],
   "modified_files": [
     ".decapod/governance/trajectory.json",
-    ".decapod/governance/validation.json",
-    "src/decapod/core/propodus.rs",
-    "src/decapod/core/repo_identity.rs",
-    "src/decapod/core/todo.rs",
-    "tests/cloud_command_path.rs",
-    "tests/propodus_live.rs"
+    ".decapod/governance/validation.json"
   ],
   "declared_commands": [
     "decapod validate"
@@ -37,44 +28,15 @@
   "tool_calls": [],
   "checks": [
     {
-      "name": "cargo_check",
-      "status": "passed"
-    },
-    {
-      "name": "clippy",
-      "status": "passed"
-    },
-    {
-      "name": "container_validate",
-      "status": "passed"
-    },
-    {
       "name": "decapod validate",
-      "status": "passed"
-    },
-    {
-      "name": "focused_tests",
-      "status": "passed"
-    },
-    {
-      "name": "pr_published",
-      "status": "passed"
-    },
-    {
-      "name": "specs_refresh",
       "status": "passed"
     }
   ],
   "evidence": [
-    "container_validate=202 passed, 0 failed",
-    "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs",
-    "pr=https://github.com/DecapodLabs/decapod/pull/1036",
-    "validation epoch ve_384d6a144548fcff completed with zero failures",
-    "validation epoch ve_3ebfebc2881beebf completed with zero failures"
+    "validation epoch ve_93082d96f6119e30 completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
-  "completion_claim": "PR #1036 updated and published without merge; remaining Propodus issue #24 login exchange is explicitly deferred",
   "proof_status": "passed",
   "verdicts": {
     "intent_alignment": "supported",
@@ -82,21 +44,22 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:3948beb75fa329e261734945cd1b855fee77fa0b492c054c82274236e2de2bbc",
+  "artifact_hash": "sha256:4bf9dd18535c9e57e96e11e6d1233c0f2419fb1fbf1cd75f6b923b0b62165625",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:wave2-propodus-1036-alignment": {
-        "id": "intent:wave2-propodus-1036-alignment",
-        "raw_intent": "Update PR #1036 to align Decapod issues #1032 through #1035 and #1037 with current Propodus PR #31 boundaries.",
-        "refined_intent": "Activate explicit Propodus-backed todo commands, fail closed on verified canonical GitHub identity, and prove command-level shared and unauthorized behavior without moving Propodus-owned auth or policy into Decapod.",
+      "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV": {
+        "id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
+        "raw_intent": "Produce proof artifacts for a repository validation completion.",
+        "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
         "acceptance_criteria": [],
         "constraints": [
-          "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+          ".decapod/governance/trajectory.json",
+          ".decapod/governance/validation.json"
         ],
         "assumptions": [],
         "boundaries": [
-          "Decapod owns cloud composition, client credential boundary, repository identity resolution, typed errors, and proof orchestration; Propodus owns GitHub exchange, seat policy, persistence, deployment, and service allowlists."
+          "Repository validation and tracked proof artifacts"
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -109,160 +72,53 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:wave2-propodus-1036-alignment"
-      },
-      {
-        "sequence": 5,
-        "event_id": "event:5",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:wave2-propodus-1036-alignment"
-      },
-      {
-        "sequence": 6,
-        "event_id": "event:6",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:wave2-propodus-1036-alignment"
-      },
-      {
-        "sequence": 7,
-        "event_id": "event:7",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:wave2-propodus-1036-alignment"
-      },
-      {
-        "sequence": 8,
-        "event_id": "event:8",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:wave2-propodus-1036-alignment"
+        "detail": "trajectory:validation_01KYEDQTT5WZDBA25ACH62YDDV"
       }
     ],
     "trajectories": {
-      "wave2-propodus-1036-alignment": {
-        "id": "wave2-propodus-1036-alignment",
-        "intent_id": "intent:wave2-propodus-1036-alignment",
+      "validation_01KYEDQTT5WZDBA25ACH62YDDV": {
+        "id": "validation_01KYEDQTT5WZDBA25ACH62YDDV",
+        "intent_id": "intent:validation_01KYEDQTT5WZDBA25ACH62YDDV",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "trajectory.record",
+            "action": "validation",
+            "command": "decapod validate",
             "scope": [
-              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
             ],
             "observations": [
-              "src/decapod/core/todo.rs",
-              "src/decapod/core/propodus.rs",
-              "src/decapod/core/repo_identity.rs",
-              "tests/cloud_command_path.rs",
-              "tests/propodus_live.rs"
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_93082d96f6119e30 completed with zero failures"
             ],
             "proof_refs": [
-              "cargo_check",
-              "focused_tests",
-              "clippy",
-              "specs_refresh"
+              "decapod validate"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
-          },
-          {
-            "sequence": 5,
-            "action": "trajectory.record",
-            "scope": [
-              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
-            ],
-            "observations": [
-              "src/decapod/core/todo.rs",
-              "src/decapod/core/propodus.rs",
-              "src/decapod/core/repo_identity.rs",
-              "tests/cloud_command_path.rs",
-              "tests/propodus_live.rs",
-              "focused_tests=tests/cloud_backend_storage.rs,tests/cloud_command_path.rs,tests/init_config_behavior.rs,tests/propodus_contract.rs"
-            ],
-            "proof_refs": [
-              "cargo_check",
-              "focused_tests",
-              "clippy",
-              "specs_refresh"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:5"
-          },
-          {
-            "sequence": 6,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_384d6a144548fcff completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:6"
-          },
-          {
-            "sequence": 7,
-            "action": "trajectory.record",
-            "scope": [
-              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
-            ],
-            "observations": [
-              "container_validate=202 passed, 0 failed",
-              "pr=https://github.com/DecapodLabs/decapod/pull/1036"
-            ],
-            "proof_refs": [
-              "container_validate",
-              "pr_published"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:7"
-          },
-          {
-            "sequence": 8,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              "PR #1036 source, tests, workflow, docs, generated specs, and governance artifacts"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_3ebfebc2881beebf completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:8"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 8
+    "next_sequence": 4
   }
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,36 +1,36 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.83.0",
-  "git_revision": "1341fac35b13976be5feb093325cb794691a6f4d",
-  "repo_signal_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
-  "trajectory_run_id": "wave2-propodus-1036-alignment",
-  "trajectory_artifact_hash": "sha256:3948beb75fa329e261734945cd1b855fee77fa0b492c054c82274236e2de2bbc",
+  "decapod_release": "0.83.1",
+  "git_revision": "76faf5e6986f144c5184dde0edb241100b69b2f8",
+  "repo_signal_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
+  "trajectory_run_id": "validation_01KYEDQTT5WZDBA25ACH62YDDV",
+  "trajectory_artifact_hash": "sha256:4bf9dd18535c9e57e96e11e6d1233c0f2419fb1fbf1cd75f6b923b0b62165625",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_3ebfebc2881beebf",
-    "evaluator_identity": "decapod-validate@0.83.0",
-    "evaluator_set_hash": "sha256:93c9e6132ec5fb2517597c679e6ba0ce80fecc73b3a48254f2265652807b0209",
-    "constitution_version": "embedded-docs@0.83.0",
-    "constitution_hash": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
+    "epoch_id": "ve_93082d96f6119e30",
+    "evaluator_identity": "decapod-validate@0.83.1",
+    "evaluator_set_hash": "sha256:db8b2eb82af0f3828cd85b898b1eb67529714b92a0b232119abfe89afc390d78",
+    "constitution_version": "embedded-docs@0.83.1",
+    "constitution_hash": "sha256:e829cd3d2c38f135f6d025596a232ede88e7e2f2f9119a80286946fa35423fa8",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:0d136e5c4332a927e7cff69fceb7f2f313b5158f972cc1ba813c387323a398c7",
-    "generated_specs_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
+    "generated_specs_manifest_hash": "sha256:ee9d47e38e77d56d3da37ef21cb99baddc77a963db0a8c9602d842239490c7f3",
+    "generated_specs_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:047063e0d91b6d1a6b13c59d4700d7d67ef7668cbc6da06eaf61c57eda16dd78",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:385cb0714b6f7e5efef1e69c5560754ceb5d5ad117f8803cf103f1d6bed5a2a3",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:ab60b4f659325448d61b99ce25d09c47aa42e6aeb02e29f0004ef4d4588917b8",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:c6e01067c9fe8b33b703e57535725d462b2e2a885c4884b0d9005d327082e34c",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:31a48021c3634d47cfc66d00374df4a5d25aaf812db675463a68b2907014369d",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:d4c89e6ebcd6e8726f6c52ad3c3b0d44141d930815727b007774d81a61b9ab95",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:74ca83a9f6f9eeafc260e444451dda89a55812fbcd2d0962899879c4301a40ec",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:43fc947cbf4a2b7a6e56a498d730be3325b50877fbe961c93d120a66e4c66866",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:3c69e879e3e4c1151b4dce9d4621915182fa2f5ab85e84991fa0c33fbd836f72",
-      "generated_specs_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
-      "generated_specs_manifest": "sha256:0d136e5c4332a927e7cff69fceb7f2f313b5158f972cc1ba813c387323a398c7",
+      "constitution:core/DECAPOD": "sha256:e829cd3d2c38f135f6d025596a232ede88e7e2f2f9119a80286946fa35423fa8",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:59b2a154669a4c73b42386bab2fe3543f746dd97897c687b51d413e32bf1620e",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:76334ac2cce3b5263919de5fc09e3bfa22a0e7bc17d6e3782da076fa0fc524ea",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:a9bf6092ed60a657c8d800d4f0ea5a9ed7fb52a2499d652b72981b4de9de186c",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:673568721fd8ff790e2bbd9a774b15be46e4184b9085da0f4ad63f795885ecf7",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:2423b154e9c5122390583ddddd090a5a1fc827bf3e7e8e142412ae91d76ea5ee",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:348b8cc7d6291819df0f326fa0e3db40080cc467e26759dfdf44cce6cb1ab3bc",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:92c87dc874f3705eb10114252b258e7866e6c584af23193ffe10b0f90a289d5c",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:de86e0b50120997f54a6efaac7c0ffab82392da35cb27928cfed0074874db479",
+      "generated_specs_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
+      "generated_specs_manifest": "sha256:ee9d47e38e77d56d3da37ef21cb99baddc77a963db0a8c9602d842239490c7f3",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,78 +39,82 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 63840,
+  "elapsed_ms": 60518,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
   "warnings": [
     "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
-    "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
     "Risk map missing (run `decapod riskmap init`)",
     "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
-    "Watcher audit trail missing (run `decapod govern watcher run`)"
+    "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bend-01kyecfw7jcfytnk-01kyecg3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+    "Watcher audit trail missing (run `decapod govern watcher run`)",
+    "Workspace branch 'agent/bend_01kyecfw7jcfytnk/issue-1040-backend-alignment' has unpushed commits or does not exist on origin. Run `git push origin agent/bend_01kyecfw7jcfytnk/issue-1040-backend-alignment`."
   ],
   "gate_timings": [
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 7640
+      "elapsed_ms": 5786
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 452
+      "elapsed_ms": 1526
     },
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 384
+      "elapsed_ms": 511
+    },
+    {
+      "name": "validate_control_plane_contract",
+      "elapsed_ms": 187
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 93
+      "elapsed_ms": 107
     },
     {
       "name": "validate_knowledge_integrity",
-      "elapsed_ms": 45
+      "elapsed_ms": 72
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 45
+      "elapsed_ms": 72
     },
     {
       "name": "validate_watcher_purity",
-      "elapsed_ms": 44
+      "elapsed_ms": 67
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 37
+      "elapsed_ms": 56
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 32
-    },
-    {
-      "name": "validate_project_specs_docs",
-      "elapsed_ms": 18
+      "elapsed_ms": 45
     },
     {
       "name": "validate_git_workspace_context",
-      "elapsed_ms": 17
+      "elapsed_ms": 40
+    },
+    {
+      "name": "validate_project_specs_docs",
+      "elapsed_ms": 19
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 14
+      "elapsed_ms": 15
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 9
+      "elapsed_ms": 10
     },
     {
       "name": "validate_git_protected_branch",
-      "elapsed_ms": 9
+      "elapsed_ms": 10
     },
     {
       "name": "validate_git_push_pr_gate",
-      "elapsed_ms": 6
+      "elapsed_ms": 7
     },
     {
       "name": "validate_repomap_determinism",
@@ -137,12 +141,8 @@
       "elapsed_ms": 1
     },
     {
-      "name": "validate_control_plane_contract",
-      "elapsed_ms": 1
-    },
-    {
       "name": "validate_database_schema_versions",
-      "elapsed_ms": 0
+      "elapsed_ms": 1
     },
     {
       "name": "validate_interface_contract_bootstrap",
@@ -157,19 +157,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_validation_receipt_if_present",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_entrypoint_invariants",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_repo_map",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_validation_receipt_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_repo_map",
       "elapsed_ms": 0
     },
     {
@@ -189,19 +189,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_docs_templates_bucket",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_context_capsule_policy_contract",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
+      "name": "validate_docs_templates_bucket",
       "elapsed_ms": 0
     },
     {
       "name": "validate_policy_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_archive_integrity",
       "elapsed_ms": 0
     },
     {
@@ -221,15 +221,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsules_if_present",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_root_dockerfile_seed_detection",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_recursive_improvement_passes_if_present",
+      "name": "validate_coplayer_policy_tightening",
       "elapsed_ms": 0
     },
     {
@@ -237,7 +233,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_eval_gate_if_required",
+      "name": "validate_context_capsules_if_present",
       "elapsed_ms": 0
     },
     {
@@ -249,7 +245,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_coplayer_policy_tightening",
+      "name": "validate_recursive_improvement_passes_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_eval_gate_if_required",
       "elapsed_ms": 0
     },
     {
@@ -271,16 +271,16 @@
     "confidence": "medium",
     "reasons": [
       "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
-      "No open pull request found on GitHub for branch 'agent/unknown/cicd_01kydv7dsj7sayv4-wave2'. Create a pull request to submit changes.",
       "Risk map missing (run `decapod riskmap init`)",
       "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
-      "Watcher audit trail missing (run `decapod govern watcher run`)"
+      "Stale workspaces preserved for explicit review: /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (dirty_workspace: workspace contains tracked or untracked changes; preserve or review them before rerunning with --force), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /home/arx/src/decapod/.decapod/workspaces/agent-unknown-bend-01kyecfw7jcfytnk-01kyecg3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
+      "Watcher audit trail missing (run `decapod govern watcher run`)",
+      "Workspace branch 'agent/bend_01kyecfw7jcfytnk/issue-1040-backend-alignment' has unpushed commits or does not exist on origin. Run `git push origin agent/bend_01kyecfw7jcfytnk/issue-1040-backend-alignment`."
     ],
     "recommendations": [
       "Review the reported validation warnings before relying on the CI result.",
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:09669572eb071cbd0dcd5c2d0c7667408c04dfbd9e10b1b84687558c260ee53e"
+  "receipt_hash": "sha256:9670ca6790e1ab08be0f7213bd39391bddd85f27a79eed484a55a9f94647ef22"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,10 +2,10 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.83.1",
-  "git_revision": "3e06916e5b16386aba671f9ee391d6196d188e41",
+  "git_revision": "ae6e457bc12cfde9053094635257d2f226d99528",
   "repo_signal_fingerprint": "aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0",
   "trajectory_run_id": "validation_01KYEDQTT5WZDBA25ACH62YDDV",
-  "trajectory_artifact_hash": "sha256:5e697e1b9be6d8ba8ef95fe17856aa9bd2722272216d408198bc559855473831",
+  "trajectory_artifact_hash": "sha256:5cb0022061d65f608987e6da373cf14c928133b97ed8de76152d49ba5f4c4c23",
   "validation_epoch": {
     "schema_version": "1.0.0",
     "epoch_id": "ve_e25d59defedd0cb3",
@@ -39,7 +39,7 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 63815,
+  "elapsed_ms": 59761,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -54,19 +54,19 @@
   "gate_timings": [
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 5900
+      "elapsed_ms": 6215
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 1544
+      "elapsed_ms": 1526
     },
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 437
+      "elapsed_ms": 495
     },
     {
       "name": "validate_control_plane_contract",
-      "elapsed_ms": 187
+      "elapsed_ms": 179
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
@@ -74,19 +74,19 @@
     },
     {
       "name": "validate_knowledge_integrity",
-      "elapsed_ms": 74
+      "elapsed_ms": 75
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 73
+      "elapsed_ms": 72
     },
     {
       "name": "validate_watcher_purity",
-      "elapsed_ms": 68
+      "elapsed_ms": 67
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 57
+      "elapsed_ms": 56
     },
     {
       "name": "validate_schema_determinism",
@@ -110,7 +110,7 @@
     },
     {
       "name": "validate_git_protected_branch",
-      "elapsed_ms": 10
+      "elapsed_ms": 11
     },
     {
       "name": "validate_git_push_pr_gate",
@@ -153,11 +153,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_entrypoint_invariants",
+      "name": "validate_heartbeat_invocation_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_heartbeat_invocation_gate",
+      "name": "validate_entrypoint_invariants",
       "elapsed_ms": 0
     },
     {
@@ -169,19 +169,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_project_config_toml",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_spec_drift",
+      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
       "name": "validate_project_scoped_state",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_spec_drift",
       "elapsed_ms": 0
     },
     {
@@ -217,6 +217,10 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_eval_gate_if_required",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_lcm_immutability",
       "elapsed_ms": 0
     },
@@ -233,11 +237,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsules_if_present",
+      "name": "validate_health_cache_integrity",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_health_cache_integrity",
+      "name": "validate_context_capsules_if_present",
       "elapsed_ms": 0
     },
     {
@@ -249,19 +253,15 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_eval_gate_if_required",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_risk_map",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_tooling_gate",
+      "name": "validate_lcm_rebuild_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_lcm_rebuild_gate",
+      "name": "validate_tooling_gate",
       "elapsed_ms": 0
     }
   ],
@@ -282,5 +282,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:10ec80b57d6c829e928d1fafb9549e9efa562e3086c7c57188412939cc47fa56"
+  "receipt_hash": "sha256:afb46c9c199be78036fed6398dfddc1072d599055cd85ee15e55bff977551cf5"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,13 +2,13 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.83.1",
-  "git_revision": "76faf5e6986f144c5184dde0edb241100b69b2f8",
-  "repo_signal_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
+  "git_revision": "3e06916e5b16386aba671f9ee391d6196d188e41",
+  "repo_signal_fingerprint": "aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0",
   "trajectory_run_id": "validation_01KYEDQTT5WZDBA25ACH62YDDV",
-  "trajectory_artifact_hash": "sha256:4bf9dd18535c9e57e96e11e6d1233c0f2419fb1fbf1cd75f6b923b0b62165625",
+  "trajectory_artifact_hash": "sha256:5e697e1b9be6d8ba8ef95fe17856aa9bd2722272216d408198bc559855473831",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_93082d96f6119e30",
+    "epoch_id": "ve_e25d59defedd0cb3",
     "evaluator_identity": "decapod-validate@0.83.1",
     "evaluator_set_hash": "sha256:db8b2eb82af0f3828cd85b898b1eb67529714b92a0b232119abfe89afc390d78",
     "constitution_version": "embedded-docs@0.83.1",
@@ -17,20 +17,20 @@
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:ee9d47e38e77d56d3da37ef21cb99baddc77a963db0a8c9602d842239490c7f3",
-    "generated_specs_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
+    "generated_specs_manifest_hash": "sha256:d5b018e64ac5af9bbe241b411f5ada26c8c2cf848a84b410d04161630976cca7",
+    "generated_specs_fingerprint": "aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0",
     "material_hashes": {
       "constitution:core/DECAPOD": "sha256:e829cd3d2c38f135f6d025596a232ede88e7e2f2f9119a80286946fa35423fa8",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:59b2a154669a4c73b42386bab2fe3543f746dd97897c687b51d413e32bf1620e",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:76334ac2cce3b5263919de5fc09e3bfa22a0e7bc17d6e3782da076fa0fc524ea",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:a9bf6092ed60a657c8d800d4f0ea5a9ed7fb52a2499d652b72981b4de9de186c",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:673568721fd8ff790e2bbd9a774b15be46e4184b9085da0f4ad63f795885ecf7",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:2423b154e9c5122390583ddddd090a5a1fc827bf3e7e8e142412ae91d76ea5ee",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:348b8cc7d6291819df0f326fa0e3db40080cc467e26759dfdf44cce6cb1ab3bc",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:92c87dc874f3705eb10114252b258e7866e6c584af23193ffe10b0f90a289d5c",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:de86e0b50120997f54a6efaac7c0ffab82392da35cb27928cfed0074874db479",
-      "generated_specs_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
-      "generated_specs_manifest": "sha256:ee9d47e38e77d56d3da37ef21cb99baddc77a963db0a8c9602d842239490c7f3",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:0580beef9e0011cd2331f39e7165b483d23bcb3cc8aeb27a823a4c7dbd67355b",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:eb4b02cdb354318c26882ecaa57f9d4dea85e6dd9947b2448c7d8c7e15e53648",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:ebb067c5200dbfa8a56b5c7fcdfaa40fd80ff7c9610d5bb9c0a4f7bf5d4251eb",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:13f1e06b33dbb64513a7bebe1efd263453bda1a6d1c89fdea4cda4ebd4694260",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:949bc4d8135d6e023ce6e7a2f521d0fa32bb2d1fa45662cf8c0a9d5928aead7d",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:c4cf31fa682c0095a580c1698fc97231c99bfab5cbe447ffce634cce91999461",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:0b277df98905238fc567ac1a426a946f7c6570823b1dd4582cf46936e1289538",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:b47d916f28adf0df62dc3a3a482b3a895c6793577a6d03af0cfcb92477635fff",
+      "generated_specs_fingerprint": "aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0",
+      "generated_specs_manifest": "sha256:d5b018e64ac5af9bbe241b411f5ada26c8c2cf848a84b410d04161630976cca7",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
@@ -39,7 +39,7 @@
   "pass_count": 202,
   "fail_count": 0,
   "warn_count": 6,
-  "elapsed_ms": 60518,
+  "elapsed_ms": 63815,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
@@ -54,15 +54,15 @@
   "gate_timings": [
     {
       "name": "validate_federation_gates",
-      "elapsed_ms": 5786
+      "elapsed_ms": 5900
     },
     {
       "name": "validate_stale_workspaces",
-      "elapsed_ms": 1526
+      "elapsed_ms": 1544
     },
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 511
+      "elapsed_ms": 437
     },
     {
       "name": "validate_control_plane_contract",
@@ -70,27 +70,27 @@
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 107
+      "elapsed_ms": 109
     },
     {
       "name": "validate_knowledge_integrity",
-      "elapsed_ms": 72
+      "elapsed_ms": 74
     },
     {
       "name": "validate_canon_mutation",
-      "elapsed_ms": 72
+      "elapsed_ms": 73
     },
     {
       "name": "validate_watcher_purity",
-      "elapsed_ms": 67
+      "elapsed_ms": 68
     },
     {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 56
+      "elapsed_ms": 57
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 45
+      "elapsed_ms": 43
     },
     {
       "name": "validate_git_workspace_context",
@@ -106,7 +106,7 @@
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 10
+      "elapsed_ms": 11
     },
     {
       "name": "validate_git_protected_branch",
@@ -153,15 +153,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_heartbeat_invocation_gate",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_entrypoint_invariants",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
+      "name": "validate_heartbeat_invocation_gate",
       "elapsed_ms": 0
     },
     {
@@ -177,11 +173,15 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_project_scoped_state",
+      "name": "validate_trajectory_artifacts_if_present",
       "elapsed_ms": 0
     },
     {
       "name": "validate_spec_drift",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_project_scoped_state",
       "elapsed_ms": 0
     },
     {
@@ -197,11 +197,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_policy_integrity",
+      "name": "validate_archive_integrity",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
+      "name": "validate_policy_integrity",
       "elapsed_ms": 0
     },
     {
@@ -257,11 +257,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_lcm_rebuild_gate",
+      "name": "validate_tooling_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_tooling_gate",
+      "name": "validate_lcm_rebuild_gate",
       "elapsed_ms": 0
     }
   ],
@@ -282,5 +282,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:9670ca6790e1ab08be0f7213bd39391bddd85f27a79eed484a55a9f94647ef22"
+  "receipt_hash": "sha256:10ec80b57d6c829e928d1fafb9549e9efa562e3086c7c57188412939cc47fa56"
 }

--- a/.decapod/managed/Dockerfile.decapod
+++ b/.decapod/managed/Dockerfile.decapod
@@ -2,9 +2,9 @@
 # Path: .decapod/managed/Dockerfile.decapod
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.83.0-debian
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.83.1-debian
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.83.0
+ARG DECAPOD_VERSION=0.83.1
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785035728Z",
-  "repo_signal_fingerprint": "da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3",
+  "generated_at": "1785042897Z",
+  "repo_signal_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -16,82 +16,82 @@
     "scheduled-jobs"
   ],
   "capability_definition_version": "1.0.0",
-  "config_input_hash": "19f5d509a87aa9d0d4db1cf5c5d7c35fce3b3ead1b83b98aef472c5eb46b3a6d",
-  "spec_input_hash": "3198c4a9c7c62cafa7e58d73f6caf773b3a53c9682073f949221be835d13f598",
-  "decapod_release": "0.83.0",
+  "config_input_hash": "c0d5657ed32f79b59bd4cff700e00cf5eda445508715de9df048fbe7a7a24812",
+  "spec_input_hash": "fb29301e2b00da1b9fe552a80a179bca81ba2fceaf741f63aaf0a324ff320b39",
+  "decapod_release": "0.83.1",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "6c3cc1f8fb20e8cc96748b3a0ad4fce1b8218a6efd6d68bc739529ba1a6a755e",
-      "content_hash": "6c3cc1f8fb20e8cc96748b3a0ad4fce1b8218a6efd6d68bc739529ba1a6a755e",
-      "fingerprint": "ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b"
+      "template_hash": "ae90f8007b6021ed7acf6bc1204f6047696602663a1fbd054c8679a22c4de092",
+      "content_hash": "ae90f8007b6021ed7acf6bc1204f6047696602663a1fbd054c8679a22c4de092",
+      "fingerprint": "1a6aca6018c5611b082762b5ba2a0a73901a2014e23b1b492b3b0cf3b8034ced"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "4699bf568e235b47e65eef6427d2e6616efcfa8dc3c994f25b02a9f4fa3e05d9",
-      "content_hash": "4699bf568e235b47e65eef6427d2e6616efcfa8dc3c994f25b02a9f4fa3e05d9",
-      "fingerprint": "e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447"
+      "template_hash": "e49a661b7f8c95c036ac7c0037616585095493dcdc7c4d0930d2c644fd7445d4",
+      "content_hash": "e49a661b7f8c95c036ac7c0037616585095493dcdc7c4d0930d2c644fd7445d4",
+      "fingerprint": "c340241bb7ac59f6f03223ddb3a6cbf7ae1580a0eb2ac9a7e4b0cb80aa4de4dd"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "da52bd25cd43db6ad7a0a091c506550d2ece19fba0af35e30bb3b2a97c894517",
-      "content_hash": "da52bd25cd43db6ad7a0a091c506550d2ece19fba0af35e30bb3b2a97c894517",
-      "fingerprint": "4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a"
+      "template_hash": "0e52327b6f312840ae3f808c5dfae734c9b9d80f092e5283bd3d2ced534bde61",
+      "content_hash": "0e52327b6f312840ae3f808c5dfae734c9b9d80f092e5283bd3d2ced534bde61",
+      "fingerprint": "e52700d6c69d7f73d358e81cdcc2c9e8a07d5cd70cba24f56a6faf90e0644966"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "baf4dfe5155a679a1cc0e654c111f6171b048ad10532dacbc90691f7009eddf8",
-      "content_hash": "baf4dfe5155a679a1cc0e654c111f6171b048ad10532dacbc90691f7009eddf8",
-      "fingerprint": "a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782"
+      "template_hash": "8d687f1edcb7e5e1ce25aa1bb4d3b9f9ef47bd7fe2d716d4bf59cbdfc9d2bab9",
+      "content_hash": "8d687f1edcb7e5e1ce25aa1bb4d3b9f9ef47bd7fe2d716d4bf59cbdfc9d2bab9",
+      "fingerprint": "d11d38cbf7e71ef3decac61284d880d442120dc4ff8a865e37f9eed90f3a7e6f"
     }
   ],
   "files": [
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "d4c89e6ebcd6e8726f6c52ad3c3b0d44141d930815727b007774d81a61b9ab95",
+      "content_hash": "2423b154e9c5122390583ddddd090a5a1fc827bf3e7e8e142412ae91d76ea5ee",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ab60b4f659325448d61b99ce25d09c47aa42e6aeb02e29f0004ef4d4588917b8",
+      "content_hash": "76334ac2cce3b5263919de5fc09e3bfa22a0e7bc17d6e3782da076fa0fc524ea",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
-      "template_hash": "f81224214db72e367670029174b0b69cf21ea2240d14ba936257324f2a9449d7",
-      "content_hash": "385cb0714b6f7e5efef1e69c5560754ceb5d5ad117f8803cf103f1d6bed5a2a3",
+      "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
+      "content_hash": "59b2a154669a4c73b42386bab2fe3543f746dd97897c687b51d413e32bf1620e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "c6e01067c9fe8b33b703e57535725d462b2e2a885c4884b0d9005d327082e34c",
+      "content_hash": "a9bf6092ed60a657c8d800d4f0ea5a9ed7fb52a2499d652b72981b4de9de186c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "3c69e879e3e4c1151b4dce9d4621915182fa2f5ab85e84991fa0c33fbd836f72",
+      "content_hash": "de86e0b50120997f54a6efaac7c0ffab82392da35cb27928cfed0074874db479",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "43fc947cbf4a2b7a6e56a498d730be3325b50877fbe961c93d120a66e4c66866",
+      "content_hash": "92c87dc874f3705eb10114252b258e7866e6c584af23193ffe10b0f90a289d5c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "31a48021c3634d47cfc66d00374df4a5d25aaf812db675463a68b2907014369d",
+      "content_hash": "673568721fd8ff790e2bbd9a774b15be46e4184b9085da0f4ad63f795885ecf7",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "74ca83a9f6f9eeafc260e444451dda89a55812fbcd2d0962899879c4301a40ec",
+      "content_hash": "348b8cc7d6291819df0f326fa0e3db40080cc467e26759dfdf44cce6cb1ab3bc",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785042897Z",
-  "repo_signal_fingerprint": "b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b",
+  "generated_at": "1785043719Z",
+  "repo_signal_fingerprint": "aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,7 +17,7 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "c0d5657ed32f79b59bd4cff700e00cf5eda445508715de9df048fbe7a7a24812",
-  "spec_input_hash": "fb29301e2b00da1b9fe552a80a179bca81ba2fceaf741f63aaf0a324ff320b39",
+  "spec_input_hash": "1e0e7659dd181fefc023dce8ebf126c174ea18897a267a8bea9e57241bc1a210",
   "decapod_release": "0.83.1",
   "entrypoints": [
     {
@@ -49,49 +49,49 @@
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "2423b154e9c5122390583ddddd090a5a1fc827bf3e7e8e142412ae91d76ea5ee",
+      "content_hash": "949bc4d8135d6e023ce6e7a2f521d0fa32bb2d1fa45662cf8c0a9d5928aead7d",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "76334ac2cce3b5263919de5fc09e3bfa22a0e7bc17d6e3782da076fa0fc524ea",
+      "content_hash": "eb4b02cdb354318c26882ecaa57f9d4dea85e6dd9947b2448c7d8c7e15e53648",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "59b2a154669a4c73b42386bab2fe3543f746dd97897c687b51d413e32bf1620e",
+      "content_hash": "0580beef9e0011cd2331f39e7165b483d23bcb3cc8aeb27a823a4c7dbd67355b",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "a9bf6092ed60a657c8d800d4f0ea5a9ed7fb52a2499d652b72981b4de9de186c",
+      "content_hash": "ebb067c5200dbfa8a56b5c7fcdfaa40fd80ff7c9610d5bb9c0a4f7bf5d4251eb",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "de86e0b50120997f54a6efaac7c0ffab82392da35cb27928cfed0074874db479",
+      "content_hash": "b47d916f28adf0df62dc3a3a482b3a895c6793577a6d03af0cfcb92477635fff",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "92c87dc874f3705eb10114252b258e7866e6c584af23193ffe10b0f90a289d5c",
+      "content_hash": "0b277df98905238fc567ac1a426a946f7c6570823b1dd4582cf46936e1289538",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "673568721fd8ff790e2bbd9a774b15be46e4184b9085da0f4ad63f795885ecf7",
+      "content_hash": "13f1e06b33dbb64513a7bebe1efd263453bda1a6d1c89fdea4cda4ebd4694260",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "348b8cc7d6291819df0f326fa0e3db40080cc467e26759dfdf44cce6cb1ab3bc",
+      "content_hash": "c4cf31fa682c0095a580c1698fc97231c99bfab5cbe447ffce634cce91999461",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -403,7 +403,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -48,6 +48,11 @@ Persistent state is proven by the configured `[repo.migration_validation]` comma
 - **Config**: `.decapod/config.toml` (schema_version 1.0.0)
 - **Generated**: `.decapod/managed/{specs,context,policy,artifacts}`
 
+### Backend Selection and External Onboarding
+`[repo].backend` is the canonical storage/runtime selection. A legacy `[repo].mode` is accepted only for compatibility when `backend` is absent. The effective backend is resolved before command dispatch, so an explicit cloud selection cannot fall through to local todo SQLite. Governance plans, claims, trajectories, validation records, and specification JSON retain local ownership in both backend modes.
+
+The external session boundary is provider-neutral. Decapod accepts a machine-local session result or a bounded one-time HTTPS onboarding handoff; it does not mint, persist, or print access/refresh credentials. Headless callers receive a safe URL/resume instruction and a bounded state rather than an interactive prompt.
+
 ## Architecture Map
 ```
 src/
@@ -398,7 +403,7 @@ Verification and artifact emission:
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -197,7 +197,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -59,6 +59,13 @@ Decapod is a Rust CLI project that implements a governance runtime for AI agents
 - **State**: `.decapod/data/*.db` + `.decapod/data/*.jsonl` event logs
 - **Generated artifacts**: `.decapod/managed/{specs,context,policy,artifacts,artifacts/provenance,artifacts/custody}`
 
+## Backend and Cloud Boundary
+- `repo.backend = "local" | "cloud"` is the canonical persisted backend selector.
+- Existing `repo.mode` values remain readable as a compatibility input; when both are present, `repo.backend` wins.
+- Local governance artifacts remain authoritative in both backends: plans, claims, trajectories, validation receipts, and specification JSON stay in `.decapod/`.
+- Explicit cloud selection fails closed when its external session or adapter contract is unavailable; it never silently falls back to local todo SQLite.
+- Browser onboarding is an external, one-time handoff. Decapod may carry a bounded HTTPS URL and provider-neutral pending/authorized/canceled/expired/failed/uncertain state, but never stores raw credentials in repository configuration.
+
 ## Product View
 ```mermaid
 flowchart LR
@@ -190,7 +197,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -423,7 +423,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -25,6 +25,14 @@ Generated interface specs include:
 
 `.decapod/config.toml` may declare `repo.declared_capabilities` as a sorted, deduplicated list. The legacy `repo.capabilities` spelling remains readable for compatibility. Capability declarations shape context and generated specifications but do not grant external-action permissions by themselves; runtime authorization remains governed by the action capability and session/policy checks.
 
+### Repository Backend Contract
+The canonical repository configuration is `repo.backend = "local" | "cloud"`. `repo.mode` remains a readable legacy input for existing projects; if both fields exist, `backend` is authoritative. New initialization and documentation use `backend` while retaining the legacy field for older readers.
+
+Cloud selection does not move local governance state. Plans, claims, trajectories, validation receipts, and specification JSON remain local `.decapod/` artifacts. Todo operations that require an external backend fail closed when the session or adapter is unavailable; they do not fall back to local SQLite.
+
+### External Onboarding Handoff
+The `CloudOnboardingHandoff` contract carries only a trusted HTTPS `bootstrap_url`, bounded `expires_at`, `poll_after_seconds`, and provider-neutral state (`pending`, `authorized`, `canceled`, `expired`, `failed`, or `uncertain`). The URL may be opened automatically in an interactive terminal or printed with a resume instruction in a headless terminal. Raw access/refresh credentials are outside this repository contract.
+
 ### Core Commands (Agent-Facing)
 
 | Command | Purpose | Key Flags | Output |
@@ -415,7 +423,7 @@ Agents declare needed capabilities via `assurance.evaluate` params; interlocks b
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -211,7 +211,7 @@ cd /tmp/smoke-test && decapod activate && decapod todo add "Smoke test" && decap
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -58,7 +58,7 @@ Run `decapod validate --refresh-specs` to regenerate scaffold sections from curr
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -227,7 +227,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -59,6 +59,12 @@ flowchart LR
 - **Token Lifetime**: N/A (direct CLI invocation)
 - **Elevation**: `sudo`/`doas` required for `workspace ensure --container`
 
+### External Cloud Session Boundary
+- Decapod consumes a provider-issued machine session; it does not implement external identity, authorization policy, or session issuance.
+- Onboarding handoffs are one-time HTTPS URLs with an explicit expiration and provider-neutral state.
+- Repository configuration contains backend selection and non-secret endpoint metadata only; raw access/refresh credentials remain outside the repository.
+- Headless flows print a safe resume instruction and fail closed when no valid session exists.
+
 ## Authorization
 
 ### Role Model
@@ -221,7 +227,7 @@ Completion evidence export carries canonical records, source revision bindings, 
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -257,7 +257,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -98,6 +98,12 @@ stateDiagram-v2
 | Obligation status derived, never asserted | Data | `obligation verify` computes from deps/proofs/commit |
 | Session required for mutations | Auth | Broker rejects mutating ops without valid session |
 | Capability-gated external actions | Security | Every `git`/`docker`/`cargo` call declares capability |
+
+### Cloud Onboarding Handoff
+- `pending -> authorized` only after the external provider reports a completed handoff.
+- `pending -> canceled | expired | failed | uncertain` remains visible to the caller and never authorizes local fallback.
+- `authorized` yields a machine-local session boundary; credentials are not copied into `.decapod/config.toml` or printed in command output.
+- A missing, expired, or revoked session causes a bounded onboarding/resume instruction and the selected cloud operation fails closed.
 | No secrets in config.toml | Security | `validate` config gate rejects forbidden keys |
 | Specs manifest tracks template drift | Governance | `validate` specs gate fails on stale template_hash |
 | Ordered phase completion | Governance | Phase transitions reject out-of-order, concurrent, or incomplete execution |## Event Sourcing Schema
@@ -251,7 +257,7 @@ Error codes stable within major version (0.x may add codes; 1.0+ semver).
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -211,11 +211,15 @@ Whitelisted tracked paths:
 | `.decapod/config.toml` exists | Warn |
 | `schema_version = "1.0.0"` | Fail |
 | Has `[repo]` and `[init]` tables | Fail |
+| `repo.backend` is local or cloud when present | Fail |
+| Legacy `repo.mode` is accepted only when `repo.backend` is absent | Fail |
 | `repo.product_summary` non-empty | Fail |
 | `repo.architecture_direction` non-empty | Fail |
 | `repo.done_criteria` non-empty | Warn |
 | No cloud secrets in config | Fail |
 | Cloud opt-in: experimental + provider + api_url | Fail if enabled but incomplete |
+
+Cloud command proof must also demonstrate that canonical `repo.backend` selection wins over a conflicting legacy `repo.mode`, missing external session state fails closed, and no local `todo.db` is created as a fallback.
 
 ### Project Specs Architecture Gate
 | Check | Failure Mode |
@@ -279,7 +283,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `da1fab632fe6eed26a5ec8c54740931c5c64db065f9fd086ca290afc8111d4f3`
+- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -283,7 +283,7 @@ actionable validation signals before publication.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `b9d64eb5b34aeb08bbf2ef73e32ffdfbb68cfbccc927ba057344704d81a0335b`
+- Repository signal fingerprint: `aef45298529360ab3a760375c208c47076affb050574776345fde8d32580b7d0`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.83.0 -->
-<!-- decapod-fingerprint: ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b -->
+<!-- decapod-release: 0.83.1 -->
+<!-- decapod-fingerprint: 1a6aca6018c5611b082762b5ba2a0a73901a2014e23b1b492b3b0cf3b8034ced -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.83.0 -->
-<!-- decapod-fingerprint: e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447 -->
+<!-- decapod-release: 0.83.1 -->
+<!-- decapod-fingerprint: c340241bb7ac59f6f03223ddb3a6cbf7ae1580a0eb2ac9a7e4b0cb80aa4de4dd -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.83.0 -->
-<!-- decapod-fingerprint: a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782 -->
+<!-- decapod-release: 0.83.1 -->
+<!-- decapod-fingerprint: d11d38cbf7e71ef3decac61284d880d442120dc4ff8a865e37f9eed90f3a7e6f -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.83.0 -->
-<!-- decapod-fingerprint: 4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a -->
+<!-- decapod-release: 0.83.1 -->
+<!-- decapod-fingerprint: e52700d6c69d7f73d358e81cdcc2c9e8a07d5cd70cba24f56a6faf90e0644966 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/decapod/cli.rs
+++ b/src/decapod/cli.rs
@@ -417,12 +417,18 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BackendType {
     #[default]
     Local,
     Cloud,
+}
+
+impl BackendType {
+    pub fn is_cloud(self) -> bool {
+        matches!(self, Self::Cloud)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
@@ -584,6 +590,11 @@ pub struct RepoContext {
     pub external_tracker: bool,
     #[serde(default = "default_container_workspaces_true")]
     pub container_workspaces: bool,
+    /// Canonical repository backend selection. The legacy `mode` field remains
+    /// accepted for compatibility and is used only when this field is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<BackendType>,
+    /// Legacy backend selector retained as a read-compatible input.
     #[serde(default)]
     pub mode: BackendType,
     #[serde(
@@ -595,6 +606,20 @@ pub struct RepoContext {
     pub capabilities: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration_validation: Option<MigrationValidationConfig>,
+}
+
+impl RepoContext {
+    /// Resolve the canonical backend while accepting pre-backend config files.
+    pub fn effective_backend(&self) -> BackendType {
+        self.backend.unwrap_or(self.mode)
+    }
+
+    /// Set the canonical backend and keep the legacy field coherent for older
+    /// readers that still inspect `repo.mode` directly.
+    pub fn set_backend(&mut self, backend: BackendType) {
+        self.backend = Some(backend);
+        self.mode = backend;
+    }
 }
 
 /// Human-governed executable proof for the persistent-state capability.
@@ -1793,4 +1818,30 @@ pub(crate) struct DemoCli {
     /// Demo to run: interlock
     #[clap(long, default_value = "interlock")]
     pub demo: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendType, RepoContext};
+
+    #[test]
+    fn backend_field_takes_precedence_over_legacy_mode() {
+        let mut context = RepoContext {
+            mode: BackendType::Cloud,
+            ..RepoContext::default()
+        };
+        assert_eq!(context.effective_backend(), BackendType::Cloud);
+
+        context.backend = Some(BackendType::Local);
+        assert_eq!(context.effective_backend(), BackendType::Local);
+    }
+
+    #[test]
+    fn setting_backend_keeps_legacy_mode_readers_coherent() {
+        let mut context = RepoContext::default();
+        context.set_backend(BackendType::Cloud);
+        assert_eq!(context.backend, Some(BackendType::Cloud));
+        assert_eq!(context.mode, BackendType::Cloud);
+        assert_eq!(context.effective_backend(), BackendType::Cloud);
+    }
 }

--- a/src/decapod/core/broker.rs
+++ b/src/decapod/core/broker.rs
@@ -88,7 +88,7 @@ impl DbBroker {
         let project_root =
             find_decapod_project_root(&self.root).unwrap_or_else(|_| self.root.clone());
         if let Ok(config) = crate::cli::DecapodProjectConfig::load(&project_root) {
-            return config.repo.mode == crate::cli::BackendType::Cloud;
+            return config.repo.effective_backend().is_cloud();
         }
         false
     }

--- a/src/decapod/core/cloud_backend.rs
+++ b/src/decapod/core/cloud_backend.rs
@@ -9,6 +9,80 @@ pub const PUBLIC_CLOUD_BACKEND_UNAVAILABLE: &str = "Cloud todo persistence is no
 pub const PROPODUS_TODO_ROUTE_SUMMARY: &str =
     "GET /api/health; GET /api/todos?repo_id=<repo>; POST /api/todos; PATCH /api/todos?id=<todo>";
 
+/// Provider-neutral states returned while an external onboarding handoff is
+/// being completed. Decapod does not interpret provider identity or policy
+/// claims; it only carries this bounded state to the CLI/session boundary.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudOnboardingState {
+    Pending,
+    Authorized,
+    Canceled,
+    Expired,
+    Failed,
+    Uncertain,
+}
+
+/// A trusted, one-time browser handoff that can also be printed for a
+/// headless terminal. The URL is intentionally not persisted in repository
+/// configuration and this contract carries no access or refresh credential.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CloudOnboardingHandoff {
+    pub bootstrap_url: String,
+    pub expires_at: String,
+    pub poll_after_seconds: u64,
+    pub state: CloudOnboardingState,
+}
+
+impl CloudOnboardingHandoff {
+    pub const DEFAULT_POLL_AFTER_SECONDS: u64 = 2;
+
+    pub fn new(bootstrap_url: &str, expires_at: &str) -> Result<Self, DecapodError> {
+        let bootstrap_url = bootstrap_url.trim();
+        let authority = bootstrap_url
+            .strip_prefix("https://")
+            .and_then(|value| value.split('/').next())
+            .unwrap_or_default();
+        let lower_url = bootstrap_url.to_ascii_lowercase();
+        if !bootstrap_url.starts_with("https://")
+            || bootstrap_url.chars().any(char::is_control)
+            || bootstrap_url.chars().any(char::is_whitespace)
+            || authority.contains('@')
+            || lower_url.contains("access_token=")
+            || lower_url.contains("refresh_token=")
+            || lower_url.contains("session_token=")
+        {
+            return Err(DecapodError::ValidationError(
+                "cloud onboarding handoff must be a trusted HTTPS URL without embedded credentials"
+                    .to_string(),
+            ));
+        }
+        let expires_at = expires_at.trim();
+        if expires_at.is_empty()
+            || expires_at.chars().any(char::is_control)
+            || expires_at.chars().any(char::is_whitespace)
+        {
+            return Err(DecapodError::ValidationError(
+                "cloud onboarding handoff requires a bounded expiration timestamp".to_string(),
+            ));
+        }
+        Ok(Self {
+            bootstrap_url: bootstrap_url.to_string(),
+            expires_at: expires_at.to_string(),
+            poll_after_seconds: Self::DEFAULT_POLL_AFTER_SECONDS,
+            state: CloudOnboardingState::Pending,
+        })
+    }
+
+    /// Safe terminal guidance for interactive and headless callers.
+    pub fn terminal_instruction(&self) -> String {
+        format!(
+            "Open this one-time cloud onboarding URL, then resume the command: {} (expires {})",
+            self.bootstrap_url, self.expires_at
+        )
+    }
+}
+
 pub fn unavailable_error() -> DecapodError {
     DecapodError::NotImplemented(PUBLIC_CLOUD_BACKEND_UNAVAILABLE.to_string())
 }
@@ -94,4 +168,42 @@ pub fn write_mock_init_registration(
     })?;
     fs::write(&path, bytes).map_err(DecapodError::IoError)?;
     Ok(Some(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CloudOnboardingHandoff, CloudOnboardingState};
+
+    #[test]
+    fn onboarding_handoff_is_provider_neutral_and_headless_safe() {
+        let handoff = CloudOnboardingHandoff::new(
+            "https://cloud.example.test/onboard/one-time",
+            "2030-01-01T00:00:00Z",
+        )
+        .expect("valid handoff");
+
+        assert_eq!(handoff.state, CloudOnboardingState::Pending);
+        assert_eq!(handoff.poll_after_seconds, 2);
+        assert!(handoff.terminal_instruction().contains("one-time"));
+        assert!(!handoff.terminal_instruction().contains("token"));
+    }
+
+    #[test]
+    fn onboarding_handoff_rejects_untrusted_or_unbounded_values() {
+        assert!(
+            CloudOnboardingHandoff::new(
+                "http://cloud.example.test/onboard",
+                "2030-01-01T00:00:00Z",
+            )
+            .is_err()
+        );
+        assert!(
+            CloudOnboardingHandoff::new(
+                "https://cloud.example.test/onboard?access_token=raw",
+                "2030-01-01T00:00:00Z",
+            )
+            .is_err()
+        );
+        assert!(CloudOnboardingHandoff::new("https://cloud.example.test/onboard", "",).is_err());
+    }
 }

--- a/src/decapod/core/entrypoint_integrity.rs
+++ b/src/decapod/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.83.0 release manifest. Keep them immutable for the
+// These values are the v0.83.1 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "ccd2edd2fb9ddfcd7a7c6be8d1a489161ebe207e3c80f1d67bdf6e31dce9364b",
+        fingerprint: "1a6aca6018c5611b082762b5ba2a0a73901a2014e23b1b492b3b0cf3b8034ced",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "e2a748a1e1a36d3c6931a3ec3aff3e96f342fd5f7acc269e1e47ec32d6453447",
+        fingerprint: "c340241bb7ac59f6f03223ddb3a6cbf7ae1580a0eb2ac9a7e4b0cb80aa4de4dd",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "4a53beea8823dd6ae076f6548d704969fc2d2797ad297d3256990a96403b315a",
+        fingerprint: "e52700d6c69d7f73d358e81cdcc2c9e8a07d5cd70cba24f56a6faf90e0644966",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "a6304b4efdee9cb73b8bb06bdda652c08041b89de02c8bd4063a75b7a42ce782",
+        fingerprint: "d11d38cbf7e71ef3decac61284d880d442120dc4ff8a865e37f9eed90f3a7e6f",
     },
 ];
 

--- a/src/decapod/core/todo.rs
+++ b/src/decapod/core/todo.rs
@@ -1,4 +1,4 @@
-use crate::cli::{BackendType, CloudConfigSection, DecapodProjectConfig};
+use crate::cli::{CloudConfigSection, DecapodProjectConfig};
 use crate::core::broker::DbBroker;
 use crate::core::error;
 use crate::core::external_action::{self, ExternalCapability};
@@ -4788,17 +4788,17 @@ fn cloud_runtime(
             )
         })?;
     let config = DecapodProjectConfig::load(&project_root)?;
-    if config.repo.mode != BackendType::Cloud {
+    if !config.repo.effective_backend().is_cloud() {
         return Ok(None);
     }
     let cloud = config.cloud.ok_or_else(|| {
         error::DecapodError::Config(
-            "repo.mode=cloud requires an enabled [cloud] configuration".to_string(),
+            "repo.backend=cloud requires an enabled [cloud] configuration".to_string(),
         )
     })?;
     if !cloud.enabled {
         return Err(error::DecapodError::Config(
-            "repo.mode=cloud requires cloud.enabled=true".to_string(),
+            "repo.backend=cloud requires cloud.enabled=true".to_string(),
         ));
     }
     if cloud.provider != "vercel" {

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -508,9 +508,9 @@ fn apply_repo_context_env_overrides(ctx: &mut RepoContext) {
     }
     if let Ok(v) = std::env::var("DECAPOD_INIT_BACKEND") {
         if v.eq_ignore_ascii_case("cloud") {
-            ctx.mode = crate::cli::BackendType::Cloud;
+            ctx.set_backend(crate::cli::BackendType::Cloud);
         } else {
-            ctx.mode = crate::cli::BackendType::Local;
+            ctx.set_backend(crate::cli::BackendType::Local);
         }
     }
     dedupe_sorted(&mut ctx.primary_languages);
@@ -573,7 +573,7 @@ fn apply_repo_context_cli_overrides(ctx: &mut RepoContext, init_with: &InitWithC
             .collect();
     }
     ctx.container_workspaces = init_with.container_workspaces;
-    ctx.mode = init_with.mode.clone();
+    ctx.set_backend(init_with.mode);
     dedupe_sorted(&mut ctx.primary_languages);
     dedupe_sorted(&mut ctx.detected_surfaces);
     ctx.capabilities.sort();
@@ -1418,7 +1418,7 @@ fn init_with_from_config(
             .map(|proof| format!("{}={}", proof.name, proof.command))
             .collect(),
         mode: if config.cloud.as_ref().map(|c| c.enabled).unwrap_or(false)
-            || config.repo.mode == crate::cli::BackendType::Cloud
+            || config.repo.effective_backend().is_cloud()
         {
             crate::cli::BackendType::Cloud
         } else {
@@ -1430,8 +1430,7 @@ fn init_with_from_config(
 }
 
 fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjectConfig {
-    let cloud_enabled =
-        init.mode == crate::cli::BackendType::Cloud || repo.mode == crate::cli::BackendType::Cloud;
+    let cloud_enabled = init.mode.is_cloud() || repo.effective_backend().is_cloud();
     let mut repo = repo;
     let external_tracker = repo.external_tracker;
     let tracker_is_external = external_tracker
@@ -1442,7 +1441,7 @@ fn config_from_init_with(init: &InitWithCli, repo: RepoContext) -> DecapodProjec
     repo.external_tracker = tracker_is_external;
     // Explicit cloud mode is an active backend selection. Local remains the
     // default when the caller does not opt in.
-    repo.mode = init.mode.clone();
+    repo.set_backend(init.mode);
 
     let mut entrypoints = Vec::new();
     let no_entrypoint_flags = !init.claude && !init.gemini && !init.cdx_ep && !init.agents;
@@ -1708,7 +1707,7 @@ fn enrich_repo_context_interactive(
     } else {
         crate::cli::BackendType::Local
     };
-    repo.mode = init.mode.clone();
+    repo.set_backend(init.mode);
 
     let enable_ci = prompt_yes_no("Scaffold GitHub Action for decapod validate?", init.ci)?;
     init.ci = enable_ci;
@@ -2149,9 +2148,7 @@ pub fn run() -> Result<(), error::DecapodError> {
             }
             apply_repo_context_env_overrides(&mut repo_ctx);
             apply_repo_context_cli_overrides(&mut repo_ctx, &init_with);
-            if repo_ctx.mode == crate::cli::BackendType::Cloud
-                && init_with.mode == crate::cli::BackendType::Local
-            {
+            if repo_ctx.effective_backend().is_cloud() && !init_with.mode.is_cloud() {
                 init_with.mode = crate::cli::BackendType::Cloud;
             }
             apply_substrate_adoption(&mut repo_ctx, &init_target);
@@ -2480,7 +2477,7 @@ fn is_cloud_todo_command(
         return Ok(false);
     }
     Ok(load_project_config_if_present(workspace_root)?
-        .is_some_and(|config| config.repo.mode == crate::cli::BackendType::Cloud))
+        .is_some_and(|config| config.repo.effective_backend().is_cloud()))
 }
 
 fn command_requires_worktree(command: &Command) -> bool {
@@ -5350,7 +5347,7 @@ fn run_validate_command(
 
     // Ensure cloud authentication if using cloud backend
     if crate::cli::DecapodProjectConfig::load(governance_root)
-        .map(|config| config.repo.mode == crate::cli::BackendType::Cloud)
+        .map(|config| config.repo.effective_backend().is_cloud())
         .unwrap_or(false)
     {
         let auth_gate = crate::core::auth::get_cloud_auth_gate();

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -2117,7 +2117,7 @@ pub fn run() -> Result<(), error::DecapodError> {
                             tracker_url: init_group.tracker_url.clone(),
                             declared_context_sources: init_group.declared_context_sources.clone(),
                             proof_commands: init_group.proof_commands.clone(),
-                            mode: init_group.mode.clone(),
+                            mode: init_group.mode,
                             git: init_group.git,
                             no_git: init_group.no_git,
                         }

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -75,6 +75,7 @@ fn test_cloud_init_records_opt_in_without_auth_or_repo_credentials() {
     assert!(config.contains("experimental = true"));
     assert!(config.contains("provider = \"vercel\""));
     assert!(config.contains("api_url = \"https://decapod-cloud.vercel.app\""));
+    assert!(config.contains("backend = \"cloud\""));
     assert!(config.contains("mode = \"cloud\""));
     assert!(!config.contains("SUPABASE"));
     assert!(!config.contains("supabase"));
@@ -141,6 +142,58 @@ fn cloud_cli_preflight_does_not_initialize_local_sqlite() {
     assert!(
         !dir.join(".decapod/data/todo.db").exists(),
         "cloud credential preflight must not initialize local SQLite"
+    );
+}
+
+#[test]
+fn canonical_backend_selection_overrides_legacy_mode_without_local_fallback() {
+    let tmp = TempDir::new().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    let init_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["init", "--mode", "cloud", "--force", "--proof"])
+        .current_dir(&dir)
+        .output()
+        .expect("decapod init");
+    assert!(init_out.status.success());
+    let config_path = dir.join(".decapod/config.toml");
+    let config = std::fs::read_to_string(&config_path).expect("config");
+    assert!(config.contains("backend = \"cloud\""));
+    std::fs::write(
+        config_path,
+        config.replace("mode = \"cloud\"", "mode = \"local\""),
+    )
+    .expect("rewrite legacy compatibility field");
+
+    git(
+        &dir,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:DecapodLabs/decapod.git",
+        ],
+    );
+    let data_home = TempDir::new().expect("credential data home");
+    let list_out = Command::new(env!("CARGO_BIN_EXE_decapod"))
+        .args(["todo", "list", "--format", "json"])
+        .current_dir(&dir)
+        .env("DECAPOD_PROPODUS_DOGFOOD", "1")
+        .env_remove("DECAPOD_ACCESS_TOKEN")
+        .env("XDG_DATA_HOME", data_home.path())
+        .output()
+        .expect("cloud todo list");
+
+    assert!(
+        !list_out.status.success(),
+        "missing cloud session must fail closed"
+    );
+    assert!(
+        String::from_utf8_lossy(&list_out.stderr).contains("credential")
+            || String::from_utf8_lossy(&list_out.stdout).contains("credential")
+    );
+    assert!(
+        !dir.join(".decapod/data/todo.db").exists(),
+        "backend selection must not fall back to local SQLite"
     );
 }
 


### PR DESCRIPTION
## Summary

Refs #1040.

- Adds canonical `repo.backend` configuration while preserving read compatibility for existing `mode` values and keeping both fields coherent for local configuration.
- Adds a typed, provider-neutral cloud onboarding handoff contract with HTTPS, bounded-expiry, credential-free safety checks.
- Keeps local governance artifacts authoritative and makes canonical backend selection fail closed without falling back to local SQLite state.
- Adds backend-selection and onboarding contract proof, refreshes the living specs, and updates the release-bound entrypoint manifest for the current toolchain.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked` (203 unit tests pass; the existing parallel entrypoint fixture is race-sensitive, and its failing case passes in isolation with `--test-threads=1`)
- `cargo test --locked --test cloud_backend_storage`
- `cargo test --locked --lib backend_field_takes_precedence_over_legacy_mode`
- `cargo test --locked --lib onboarding_handoff`
- `target/debug/decapod validate --format json` (0 failures; review warnings are historical/environmental hygiene signals)

This is a non-breaking contract-alignment slice. Actual hosted deployment and provider-specific session implementation remain future work.
