### PR TITLE
fix: make backend=cloud session acquisition seamless

### DIFF
--- a/.decapod/governance/claims.json
+++ b/.decapod/governance/claims.json
@@ -10,8 +10,8 @@
     "source_issue": "https://github.com/DecapodLabs/decapod/issues/682",
     "status": "active",
     "created_at": "2026-07-22",
-    "updated_at": "2026-07-27",
-    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025; the v0.85.0 cloud auto-login work for #1077 remains bounded to Decapod-owned backend composition, machine-local session reuse/refresh, repository identity, and CI surfaces while Propodus retains hosted authorization and persistence policy. One-time human GitHub approval, live protected todo behavior, and cross-system acceptance remain explicitly unproven follow-ups."
+    "updated_at": "2026-07-28",
+    "change_policy": "Claims are changed only through an issue-scoped review that preserves the baseline, Decapod condition, failure modes, measurements, proof gate, open questions, and evidence status. Governance artifact generation and publication inventory are tracked under issue #1025; the v0.85.0 cloud auto-login work for #1077 remains bounded to Decapod-owned backend composition, machine-local session reuse/refresh, repository identity, and CI surfaces while Propodus retains hosted authorization and persistence policy. One-time human GitHub approval, live protected todo behavior, and cross-system acceptance remain explicitly unproven follow-ups. The #1100/#1101/#1102 session lifecycle proof now covers local-session-first custody, machine-session reuse/refresh, pending-flow deduplication, one-time exchange persistence, and secret-free failure handling; deployment-provided live proof remains a protected follow-up."
   },
   "scope": {
     "product": "decapod",

--- a/.decapod/governance/plan.json
+++ b/.decapod/governance/plan.json
@@ -1,19 +1,25 @@
 {
   "schema_version": "1.0.0",
-  "title": "README uplift: sharpen Decapod's governance-kernel positioning per Issue #1050",
-  "intent": "Update README.md to position Decapod as a repo-native governance kernel, per the acceptance criteria and implementation notes in Issue #1050.",
-  "state": "APPROVED",
-  "todo_ids": [],
+  "title": "Finish backend=cloud session lifecycle (#1100/#1101/#1102)",
+  "intent": "Make decapod session acquire establish local custody first, then reuse or refresh the machine-local Propodus session and complete one-time onboarding without repository credentials or local SQLite fallback.",
+  "state": "DONE",
+  "todo_ids": [
+    "bend_01kyktj9m6ftb44j"
+  ],
   "proof_hooks": [
-    "decapod validate",
-    "decapod capabilities --format json | jq ' .capabilities[] | select(.name==\"governance-kernel\")'",
-    "wc -w README.md"
+    "cargo test --lib propodus",
+    "cargo test --test cloud_backend_storage",
+    "cargo fmt --all -- --check",
+    "CLIPPY_CONF_DIR=.config cargo clippy --all-targets --all-features -- -D warnings",
+    "decapod validate --refresh-specs --projections"
   ],
   "unknowns": [],
   "human_questions": [],
   "stop_conditions": [],
   "unresolved_contradictions": [],
-  "deferred_questions": [],
+  "deferred_questions": [
+    "Run the existing ignored propodus_live proof through the protected GitHub environment with deployment-provided secrets; local implementation and redaction proof are complete."
+  ],
   "constraints": {
     "forbidden_paths": [
       ".decapod/data"
@@ -21,5 +27,5 @@
     "file_touch_budget": 40
   },
   "phases": [],
-  "updated_at": "1785175266Z"
+  "updated_at": "1785227881Z"
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,84 +1,145 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "validation_01KYJ6FZ2B16B9GH14Q0848YDA",
-  "intent_id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
-  "original_intent": "Produce proof artifacts for a repository validation completion.",
-  "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
-  "current_phase": "validation",
+  "run_id": "01KYKVSESSION1071",
+  "intent_id": "intent:01KYKVSESSION1071",
+  "task_id": "bend_01kyktj9m6ftb44j",
+  "original_intent": "Finish Decapod backend=cloud session lifecycle with seamless local custody and Propodus machine-session reuse",
+  "derived_intent": "Move local session acquisition ahead of cloud preflight, preserve distinct cloud session custody, and prove reuse/refresh/redaction without local SQLite fallback",
+  "current_phase": "publication",
   "next_transitions": [
+    "commit and publish focused PR",
+    "complete validated todo and publish focused PR",
+    "inspect issue contracts and current auth/session tests",
     "publish"
   ],
   "active_boundaries": [
-    "Repository validation and tracked proof artifacts"
+    "Work only in Decapod; do not modify Propodus; preserve root and unrelated dirty state"
   ],
   "repo_scope": [
-    "decapod"
+    "src/decapod auth/session/Propodus client and deterministic tests/specs"
   ],
   "inspected_files": [
-    ".decapod/config.toml",
-    ".decapod/governance/claims.json",
+    "src/decapod/core/auth.rs",
+    "src/decapod/core/entrypoint_integrity.rs",
+    "src/decapod/core/error.rs",
+    "src/decapod/core/propodus.rs",
+    "src/decapod/lib.rs",
+    "tests/cloud_backend_storage.rs",
+    "tests/propodus_contract.rs"
+  ],
+  "modified_files": [
     ".decapod/governance/plan.json",
     ".decapod/governance/trajectory.json",
     ".decapod/governance/validation.json",
-    "src/decapod/cli.rs",
-    "src/decapod/lib.rs"
+    ".decapod/managed/specs",
+    "src/decapod/core/auth.rs",
+    "src/decapod/core/entrypoint_integrity.rs",
+    "src/decapod/core/error.rs",
+    "src/decapod/core/propodus.rs",
+    "src/decapod/lib.rs",
+    "tests/cloud_backend_storage.rs"
   ],
-  "modified_files": [],
-  "declared_commands": [],
+  "declared_commands": [
+    "CLIPPY_CONF_DIR=.config cargo clippy --all-targets --all-features -- -D warnings",
+    "cargo fmt --all -- --check",
+    "cargo test --locked -- --test-threads=1",
+    "decapod qa check --all",
+    "decapod release check",
+    "decapod validate",
+    "decapod validate --projections --format json"
+  ],
   "tool_calls": [],
   "checks": [
     {
-      "name": "container_workspace",
-      "status": "failed"
+      "name": "artifact_inventory",
+      "status": "passed"
+    },
+    {
+      "name": "claims_ledger",
+      "status": "passed"
+    },
+    {
+      "name": "clippy",
+      "status": "passed"
     },
     {
       "name": "decapod validate",
-      "status": "failed"
-    },
-    {
-      "name": "governance_alignment",
       "status": "passed"
     },
     {
-      "name": "specs_freshness",
+      "name": "decapod_validate",
       "status": "passed"
     },
     {
-      "name": "trajectory_schema",
+      "name": "default_full_tests",
+      "status": "partial"
+    },
+    {
+      "name": "focused_tests",
       "status": "passed"
     },
     {
-      "name": "validation_schema",
+      "name": "format",
+      "status": "passed"
+    },
+    {
+      "name": "protected_propodus_proof",
+      "status": "unavailable"
+    },
+    {
+      "name": "qa_check",
+      "status": "passed"
+    },
+    {
+      "name": "release_check",
+      "status": "passed"
+    },
+    {
+      "name": "serialized_full_tests",
+      "status": "passed"
+    },
+    {
+      "name": "targeted_secret_scan",
       "status": "passed"
     }
   ],
   "evidence": [
-    "Ran decapod validate; container workspace not available in this environment; specs refreshed via decapod rpc --op specs.refresh; trajectory and validation schemas verified"
+    "All deterministic cloud/session tests use synthetic credentials and fake transports; protected live proof reads deployment environment only and remains ignored by default.",
+    "All four required governance artifacts are present and staged; PR-diff inventory will be rechecked after commit.",
+    "Focused session/auth and cloud backend tests pass; serialized full suite passed all feature and governance tests except an existing release-source-tree test policy failure in pre-existing source modules during the default run.",
+    "Protected live Propodus proof was not run because deployment-provided secrets were unavailable.",
+    "decapod validate --projections reported status ok, 199 gates passed, zero failures, four existing hygiene warnings.",
+    "validation epoch ve_32f036e0a69734a3 completed with zero failures",
+    "validation epoch ve_4d1a663bbebccf3b completed with zero failures"
   ],
-  "shortcut_risk_signals": [],
-  "unresolved_assumptions": [],
-  "proof_status": "failed",
+  "shortcut_risk_signals": [
+    "Protected live provider proof unavailable locally; not claimed."
+  ],
+  "unresolved_assumptions": [
+    "No Propodus changes are in scope; provider contract is treated as existing and sufficient."
+  ],
+  "proof_status": "partial",
   "verdicts": {
     "intent_alignment": "supported",
     "boundary_discipline": "supported",
-    "shortcut_risk": "supported",
-    "completion_proof": "unsupported"
+    "shortcut_risk": "caution",
+    "completion_proof": "caution"
   },
-  "artifact_hash": "sha256:90708ac75ec867c9233f3394235d1234c582dac6d50b180a9346630f85be6914",
+  "artifact_hash": "sha256:8dfede0546786ba4492acb0c18dc6cfde4d10674a074df3fe99eb4ab1f052ce1",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA": {
-        "id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
-        "raw_intent": "Produce proof artifacts for a repository validation completion.",
-        "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
+      "intent:01KYKVSESSION1071": {
+        "id": "intent:01KYKVSESSION1071",
+        "raw_intent": "Finish Decapod backend=cloud session lifecycle with seamless local custody and Propodus machine-session reuse",
+        "refined_intent": "Move local session acquisition ahead of cloud preflight, preserve distinct cloud session custody, and prove reuse/refresh/redaction without local SQLite fallback",
         "acceptance_criteria": [],
         "constraints": [
-          "decapod"
+          "src/decapod auth/session/Propodus client and deterministic tests/specs"
         ],
         "assumptions": [],
         "boundaries": [
-          "Repository validation and tracked proof artifacts"
+          "Work only in Decapod; do not modify Propodus; preserve root and unrelated dirty state"
         ],
         "out_of_scope": [],
         "proof_requirements": [],
@@ -91,61 +152,155 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
+        "intent_id": "intent:01KYKVSESSION1071",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
+        "intent_id": "intent:01KYKVSESSION1071",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
+        "intent_id": "intent:01KYKVSESSION1071",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KYJ6FZ2B16B9GH14Q0848YDA"
+        "detail": "trajectory:01KYKVSESSION1071"
+      },
+      {
+        "sequence": 5,
+        "event_id": "event:5",
+        "intent_id": "intent:01KYKVSESSION1071",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:01KYKVSESSION1071"
+      },
+      {
+        "sequence": 6,
+        "event_id": "event:6",
+        "intent_id": "intent:01KYKVSESSION1071",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:01KYKVSESSION1071"
+      },
+      {
+        "sequence": 7,
+        "event_id": "event:7",
+        "intent_id": "intent:01KYKVSESSION1071",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:01KYKVSESSION1071"
       }
     ],
     "trajectories": {
-      "validation_01KYJ6FZ2B16B9GH14Q0848YDA": {
-        "id": "validation_01KYJ6FZ2B16B9GH14Q0848YDA",
-        "intent_id": "intent:validation_01KYJ6FZ2B16B9GH14Q0848YDA",
+      "01KYKVSESSION1071": {
+        "id": "01KYKVSESSION1071",
+        "intent_id": "intent:01KYKVSESSION1071",
         "evidence_only": true,
         "steps": [
           {
             "sequence": 4,
-            "action": "trajectory.record",
+            "action": "validation",
+            "command": "decapod validate",
             "scope": [
-              "decapod"
+              "src/decapod auth/session/Propodus client and deterministic tests/specs"
             ],
             "observations": [
               ".decapod/governance/trajectory.json",
               ".decapod/governance/validation.json",
-              ".decapod/governance/claims.json",
-              ".decapod/governance/plan.json",
-              "src/decapod/cli.rs",
-              "src/decapod/lib.rs",
-              ".decapod/config.toml",
-              "Ran decapod validate; container workspace not available in this environment; specs refreshed via decapod rpc --op specs.refresh; trajectory and validation schemas verified"
+              "validation epoch ve_4d1a663bbebccf3b completed with zero failures"
             ],
             "proof_refs": [
-              "decapod validate",
-              "container_workspace",
-              "specs_freshness",
-              "trajectory_schema",
-              "validation_schema",
-              "governance_alignment"
+              "decapod validate"
             ],
             "validation_findings": [],
             "custody_event_id": "event:4"
+          },
+          {
+            "sequence": 5,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              "src/decapod auth/session/Propodus client and deterministic tests/specs"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_32f036e0a69734a3 completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:5"
+          },
+          {
+            "sequence": 6,
+            "action": "verification",
+            "command": "cargo fmt --all -- --check",
+            "scope": [
+              "src/decapod auth/session/Propodus client and deterministic tests/specs"
+            ],
+            "observations": [
+              "src/decapod/lib.rs",
+              "src/decapod/core/auth.rs",
+              "src/decapod/core/error.rs",
+              "src/decapod/core/propodus.rs",
+              "src/decapod/core/entrypoint_integrity.rs",
+              "tests/cloud_backend_storage.rs",
+              "tests/propodus_contract.rs",
+              "src/decapod/lib.rs",
+              "src/decapod/core/auth.rs",
+              "src/decapod/core/error.rs",
+              "src/decapod/core/propodus.rs",
+              "src/decapod/core/entrypoint_integrity.rs",
+              "tests/cloud_backend_storage.rs",
+              ".decapod/managed/specs",
+              ".decapod/governance/plan.json",
+              ".decapod/governance/validation.json",
+              ".decapod/governance/trajectory.json",
+              "Focused session/auth and cloud backend tests pass; serialized full suite passed all feature and governance tests except an existing release-source-tree test policy failure in pre-existing source modules during the default run.",
+              "decapod validate --projections reported status ok, 199 gates passed, zero failures, four existing hygiene warnings.",
+              "Protected live Propodus proof was not run because deployment-provided secrets were unavailable."
+            ],
+            "proof_refs": [
+              "format",
+              "focused_tests",
+              "serialized_full_tests",
+              "default_full_tests",
+              "clippy",
+              "decapod_validate",
+              "qa_check",
+              "release_check",
+              "protected_propodus_proof"
+            ],
+            "validation_findings": [
+              "Protected live provider proof unavailable locally; not claimed.",
+              "No Propodus changes are in scope; provider contract is treated as existing and sufficient."
+            ],
+            "custody_event_id": "event:6"
+          },
+          {
+            "sequence": 7,
+            "action": "publication",
+            "scope": [
+              "src/decapod auth/session/Propodus client and deterministic tests/specs"
+            ],
+            "observations": [
+              "All deterministic cloud/session tests use synthetic credentials and fake transports; protected live proof reads deployment environment only and remains ignored by default.",
+              "All four required governance artifacts are present and staged; PR-diff inventory will be rechecked after commit."
+            ],
+            "proof_refs": [
+              "claims_ledger",
+              "artifact_inventory",
+              "targeted_secret_scan"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:7"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 4
+    "next_sequence": 7
   }
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,124 +1,98 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.86.0",
-  "git_revision": "b0cd8418a8fcdf8e1c4660605647b4bc0e114045",
-  "repo_signal_fingerprint": "29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d",
-  "trajectory_run_id": "validation_01KYJ6FZ2B16B9GH14Q0848YDA",
-  "trajectory_artifact_hash": "sha256:90708ac75ec867c9233f3394235d1234c582dac6d50b180a9346630f85be6914",
+  "decapod_release": "0.86.2",
+  "git_revision": "def52a98a2fdade3e85fcda9d600e70ebb1cea8d",
+  "repo_signal_fingerprint": "2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b",
+  "trajectory_run_id": "01KYKVSESSION1071",
+  "trajectory_artifact_hash": "sha256:556e556afc3cf421be2a3f3cf87c4d189c69cecd528730231b8bdd15b3c5edab",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_436623949a60e125",
-    "evaluator_identity": "decapod-validate@0.86.0",
-    "evaluator_set_hash": "sha256:645e4661b2ba37224d8c4cfb80fd2a809a166fdd063612f1f3291d2dd20f1515",
-    "constitution_version": "embedded-docs@0.86.0",
-    "constitution_hash": "sha256:5de668bfc8882af0f52099fec78efd5663cbd3252c4275f8e57d937c7252d4e7",
+    "epoch_id": "ve_32f036e0a69734a3",
+    "evaluator_identity": "decapod-validate@0.86.2",
+    "evaluator_set_hash": "sha256:d733ccf8bc3a64661eb3ff80ab4309051d1c5c1b5460beb7f5d39fdf63cc3dd5",
+    "constitution_version": "embedded-docs@0.86.2",
+    "constitution_hash": "sha256:7729aac4966092fa60e12d72c4f630dc565f65c54dcc8155e207f3d3aae50b03",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:f0999443feb3d0d4fed004d4fabd11a7eee68351a953b3dcf7194edb998e9f86",
-    "generated_specs_fingerprint": "29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d",
+    "generated_specs_manifest_hash": "sha256:aec4fd8ad13b0dd11687f0a36c7567f8f5f3b02de21c80ef17002d020e7db5b2",
+    "generated_specs_fingerprint": "2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:5de668bfc8882af0f52099fec78efd5663cbd3252c4275f8e57d937c7252d4e7",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:acbdb383c2b60b5f68a3df624849093116f09cc1d3ae0fd5d39747237c861bb6",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:ac720c91566a3161935b5d3d56a43ecb0d81e6622979e6acf4369b8eb1b9b677",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:da380ebb0b50834835a2437a2ecb40064fb6847a7ac186535ff35dca8c0407e8",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:7d8533c9908953107d6e692e42c14471c5ef5388922596818e3c594ca181b861",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:c43e588ab9eca0a2eaa6d9f56069bcc8f54482fcf46e88fb260b18e404e085f8",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:f4fcbe98c3b3ecb45f9f44867cb26e36c8ee3ccae43f3d5de81470da23d9d488",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:78568b9279efa3d11a4bb6e49460bfca42a1894f53699f000421b4005a8aec72",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:55117e9fe0a73d8543a7cda7600b25e6f85b6aeecd06bb05060627ba535224cf",
-      "generated_specs_fingerprint": "29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d",
-      "generated_specs_manifest": "sha256:f0999443feb3d0d4fed004d4fabd11a7eee68351a953b3dcf7194edb998e9f86",
+      "constitution:core/DECAPOD": "sha256:7729aac4966092fa60e12d72c4f630dc565f65c54dcc8155e207f3d3aae50b03",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:fd0842afe8d4e696f089aef6b2a2f1c89b13778874840f6a803be416db6be194",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:9b8c61d3c3fababb257672eb840cda650bd358f52fb1b69833841b1e879e1b5e",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:713d3c099f4b3935e54ee6289e9c213df1c48cc763e4218897ce5d4ce6c84f06",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:e579070af84c3a5b8ba5b5bebfd8527782081243f826eddc5a9a162713c7c1be",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:2e243f4f9e5091c421e1abac86f785c9556a6fcbb0c127463eb5b9563c4ddb6c",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:47e769e5204a20740344945a46f61f02edbce308023420561152d430a76e15d6",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:48bafe92adbaa51b304e290ca538d509f2b39f69531e7990003a430a8e364ef5",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:371e4101c7360bdb9cfb13603ead861c74e8786a005ca371fd606d74228ab3d5",
+      "generated_specs_fingerprint": "2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b",
+      "generated_specs_manifest": "sha256:aec4fd8ad13b0dd11687f0a36c7567f8f5f3b02de21c80ef17002d020e7db5b2",
       "proof_rubric": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
       "validation_profile": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f"
     }
   },
   "status": "ok",
-  "pass_count": 203,
+  "pass_count": 199,
   "fail_count": 0,
-  "warn_count": 6,
-  "elapsed_ms": 3425,
+  "warn_count": 4,
+  "elapsed_ms": 2047,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 1,
   "failures": [],
   "warnings": [
-    "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
     "Risk map missing (run `decapod riskmap init`)",
     "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-    "Stale workspaces preserved for explicit review: /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxae-agent-unknown-apis-01kxaebbt848yje8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxaf-agent-bugs_01kxaf1tav0n6yj9-issue-846 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxk7-agent-unknown-code_01kxk7qsxqy87nk1 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxk9-agent-unknown-bugs_01kxk92eec5zvxc2-ghcr-public (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkc-agent-unknown-bugs_01kxkck8zrmnx1kq (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkj-agent-unknown-feat_01kxkjck9v1rr88b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkp-agent-unknown-bugs_01kxkpp9aaxfz78a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkr-agent-unknown-bugs_01kxkrccbppg1f3m (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkx-agent-unknown-code_01kxkxnmcphhqd5p-validation-recovery (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxms-agent-feat_01kxmsqgv10yjqzx-issue-861-provenance (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxms-plus-1-agent-feat_01kxmx3gk6ywny5r-issue-861-portable-evidence (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxmz-plus-2-agent-unknown-activation-conformance-bugs_01kxmzncx6aenszn (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxp0-agent-feat_01kxp0h02pnjjby0-issue-909-entrypoint-fingerprints (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky1f-agent-unknown-bugs-01ky1f00y7vpd2se-issue-804 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky5t-agent-unknown-bugs_01ky5t1t5drxd2q4-issue-686-work-claims (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67-agent-unknown-todo-01ky67-1784768051 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67-plus-1-agent-bugs-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-agent-unknown-todo-01ky82-1784829686 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-agent-unknown-todo-01ky82-1784829765 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-plus-1-agent-bugs_01ky82c1sz5wka9e-validation-986-987 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-plus-1-agent-unknown-bugs_01ky8n4t2314wp63-issue990 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-plus-1-agent-unknown-bugs_01ky8qy7yt8nn1x9-issues-995-1002-1004 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bend-01kyecfw7jcfytnk-01kyecg3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyenjm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyenp3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyensh (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kyen-agent-unknown-feat_01kyenj71ap51saz-cloud-cutover (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/feat-readme-1050 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01kyh1qpc0f7gej7-01kyh1qw (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01kyh1qpc0f7gej7-01kyh1rh (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01kyh3rmg1c6z9xe-01kyh3rt (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kyh3-plus-1-agent-bugs_01kyh3rmg1c6z9xe-auto-login (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
     "Watcher audit trail missing (run `decapod govern watcher run`)",
-    "Workspace branch 'agent/unknown/code_01kyj63vg7abpjva' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/code_01kyj63vg7abpjva`."
+    "[federation.rebuild_determinism] DB diverged from event replay. Current: 488 nodes/488 sources/399 edges. Rebuilt: 1 nodes/1 sources/0 edges. Run: decapod data federation rebuild"
   ],
   "gate_timings": [
     {
-      "name": "validate_stale_workspaces",
-      "elapsed_ms": 1152
-    },
-    {
       "name": "validate_machine_contract",
-      "elapsed_ms": 535
+      "elapsed_ms": 436
     },
     {
-      "name": "validate_federation_gates",
-      "elapsed_ms": 70
+      "name": "validate_control_plane_contract",
+      "elapsed_ms": 248
     },
     {
-      "name": "validate_canon_mutation",
-      "elapsed_ms": 51
-    },
-    {
-      "name": "validate_knowledge_integrity",
-      "elapsed_ms": 50
-    },
-    {
-      "name": "validate_watcher_purity",
-      "elapsed_ms": 49
-    },
-    {
-      "name": "validate_git_workspace_context",
-      "elapsed_ms": 43
-    },
-    {
-      "name": "validate_risk_map_violations",
-      "elapsed_ms": 41
+      "name": "validate_projection_consistency",
+      "elapsed_ms": 239
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 31
+      "elapsed_ms": 44
+    },
+    {
+      "name": "validate_federation_gates",
+      "elapsed_ms": 39
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 17
+      "elapsed_ms": 18
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 13
-    },
-    {
-      "name": "validate_git_protected_branch",
-      "elapsed_ms": 10
+      "elapsed_ms": 14
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 9
-    },
-    {
-      "name": "validate_git_push_pr_gate",
-      "elapsed_ms": 7
+      "elapsed_ms": 12
     },
     {
       "name": "validate_repomap_determinism",
       "elapsed_ms": 5
     },
     {
-      "name": "validate_plan_governed_execution_gate",
+      "name": "validate_markdown_primitives_roundtrip_gate",
       "elapsed_ms": 3
     },
     {
       "name": "validate_health_purity",
-      "elapsed_ms": 3
+      "elapsed_ms": 2
     },
     {
       "name": "validate_gatekeeper_gate",
@@ -129,10 +103,6 @@
       "elapsed_ms": 2
     },
     {
-      "name": "validate_control_plane_contract",
-      "elapsed_ms": 1
-    },
-    {
       "name": "validate_obligations",
       "elapsed_ms": 1
     },
@@ -141,7 +111,15 @@
       "elapsed_ms": 1
     },
     {
-      "name": "validate_interface_contract_bootstrap",
+      "name": "validate_knowledge_integrity",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_canon_mutation",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_watcher_purity",
       "elapsed_ms": 0
     },
     {
@@ -149,7 +127,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_validation_receipt_if_present",
+      "name": "validate_interface_contract_bootstrap",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_risk_map_violations",
       "elapsed_ms": 0
     },
     {
@@ -165,15 +147,15 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_trajectory_artifacts_if_present",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_markdown_primitives_roundtrip_gate",
+      "name": "validate_trajectory_artifacts_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_validation_receipt_if_present",
       "elapsed_ms": 0
     },
     {
@@ -193,23 +175,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_archive_integrity",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_docs_templates_bucket",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_policy_integrity",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_workunit_manifests_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_lineage_hard_gate",
       "elapsed_ms": 0
     },
     {
@@ -226,6 +196,18 @@
     },
     {
       "name": "validate_root_dockerfile_seed_detection",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_lineage_hard_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_archive_integrity",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_policy_integrity",
       "elapsed_ms": 0
     },
     {
@@ -249,11 +231,19 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_coplayer_policy_tightening",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_workspace_context",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_risk_map",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_coplayer_policy_tightening",
+      "name": "validate_tooling_gate",
       "elapsed_ms": 0
     },
     {
@@ -261,7 +251,19 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_tooling_gate",
+      "name": "validate_plan_governed_execution_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_stale_workspaces",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_protected_branch",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_git_push_pr_gate",
       "elapsed_ms": 0
     }
   ],
@@ -270,17 +272,15 @@
     "result": "review",
     "confidence": "medium",
     "reasons": [
-      "Audit log contains 1 potential crash divergence(s); historical pending entries detected. Run `decapod data broker verify` for details.",
       "Risk map missing (run `decapod riskmap init`)",
       "Spec markdown drift checks are hygiene-only. Use validate_machine_contract for authoritative governance.",
-      "Stale workspaces preserved for explicit review: /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxae-agent-unknown-apis-01kxaebbt848yje8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxaf-agent-bugs_01kxaf1tav0n6yj9-issue-846 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxk7-agent-unknown-code_01kxk7qsxqy87nk1 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxk9-agent-unknown-bugs_01kxk92eec5zvxc2-ghcr-public (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkc-agent-unknown-bugs_01kxkck8zrmnx1kq (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkj-agent-unknown-feat_01kxkjck9v1rr88b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkp-agent-unknown-bugs_01kxkpp9aaxfz78a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkr-agent-unknown-bugs_01kxkrccbppg1f3m (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxkx-agent-unknown-code_01kxkxnmcphhqd5p-validation-recovery (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxms-agent-feat_01kxmsqgv10yjqzx-issue-861-provenance (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxms-plus-1-agent-feat_01kxmx3gk6ywny5r-issue-861-portable-evidence (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxmz-plus-2-agent-unknown-activation-conformance-bugs_01kxmzncx6aenszn (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kxp0-agent-feat_01kxp0h02pnjjby0-issue-909-entrypoint-fingerprints (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky1f-agent-unknown-bugs-01ky1f00y7vpd2se-issue-804 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky3shjf622scgy-01ky3shr (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01ky5c74ep1pbghf-01ky5c7a (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky5eebkhm8e5z2-01ky5eej (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-test-01ky5pw11545p7n2-01ky5pw4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5t1t5drxd2q4-01ky5t20 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky5t-agent-unknown-bugs_01ky5t1t5drxd2q4-issue-686-work-claims (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky5zjk7b64v1cj-01ky5zjs (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky5z-agent-unknown-bugs_01ky5zjk7b64v1cj-issue-685-trajectories (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61dg (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01ky61da989s5har-01ky61gz (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky62-agent-feat_01ky62wzjy7cm1gv-issue-679-custody (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67-agent-unknown-todo-01ky67-1784768051 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky67k6fw63bsj2-01ky67kj (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67-plus-1-agent-bugs-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky67k6fw63bsj2-issue-682-validation-artifacts (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-agent-unknown-todo-01ky82-1784829686 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-agent-unknown-todo-01ky82-1784829765 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky82c1sz5wka9e-01ky82c7 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky82-plus-1-agent-bugs_01ky82c1sz5wka9e-validation-986-987 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84w8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky84zp (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky8533 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky84vzvhvz6fv0-01ky858f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8j79 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8j73f1h4rg98-01ky8jb0 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-agent-unknown-bugs-01ky8j-issue991 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n50 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8n4t2314wp63-01ky8n8k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-plus-1-agent-unknown-bugs_01ky8n4t2314wp63-issue990 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01ky8j-plus-1-agent-unknown-bugs_01ky8qy7yt8nn1x9-issues-995-1002-1004 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky8vzzgg651154-01ky8w08 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01ky931vvhw2wkfg-01ky9322 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky97k3bsgywdtt-01ky97k8 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f49 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01ky9f3ztz3n1x7m-01ky9f7t (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydm9q (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmd6 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kydm9j7phcvjyv-01kydmgm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydv7k (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvb4 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydvef (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kydy9b (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-cicd-01kydv7dsj7sayv4-01kye57f (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bend-01kyecfw7jcfytnk-01kyecg3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyenjm (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyenp3 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-feat-01kyenj71ap51saz-01kyensh (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kyen-agent-unknown-feat_01kyenj71ap51saz-cloud-cutover (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/feat-readme-1050 (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01kyh1qpc0f7gej7-01kyh1qw (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-code-01kyh1qpc0f7gej7-01kyh1rh (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/agent-unknown-bugs-01kyh3rmg1c6z9xe-01kyh3rt (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files), /workspace/src/decapod/.decapod/workspaces/unknown-todo-01kyh3-plus-1-agent-bugs_01kyh3rmg1c6z9xe-auto-login (unregistered_workspace: workspace directory is not registered with git; inspect it and rerun with --force only after preserving any needed files)",
       "Watcher audit trail missing (run `decapod govern watcher run`)",
-      "Workspace branch 'agent/unknown/code_01kyj63vg7abpjva' has unpushed commits or does not exist on origin. Run `git push origin agent/unknown/code_01kyj63vg7abpjva`."
+      "[federation.rebuild_determinism] DB diverged from event replay. Current: 488 nodes/488 sources/399 edges. Rebuilt: 1 nodes/1 sources/0 edges. Run: decapod data federation rebuild"
     ],
     "recommendations": [
       "Review the reported validation warnings before relying on the CI result.",
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:0b1fb1fde1a5b72009384357669405e07053a8649fa71ad8cbc6f964b2d704f2"
+  "receipt_hash": "sha256:a470796087fe62e61ebc0f57b6305ace75223445126a9296ca29ec3f08565227"
 }

--- a/.decapod/managed/Dockerfile.decapod
+++ b/.decapod/managed/Dockerfile.decapod
@@ -2,9 +2,9 @@
 # Path: .decapod/managed/Dockerfile.decapod
 # Managed seed: Decapod maintains the image/version header; agents may
 # mutate project-specific packages and commands in workspace branches.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.85.0-debian
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.86.2-debian
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.85.0
+ARG DECAPOD_VERSION=0.86.2
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v3",
-  "generated_at": "1785170582Z",
-  "repo_signal_fingerprint": "29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d",
+  "generated_at": "1785226872Z",
+  "repo_signal_fingerprint": "2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "8d09a6ab4f6034d39463e02c4c8530704b92bd227a6e6831bc63bb59b6ad55cc",
-  "spec_input_hash": "7d6bcf030e9c75f316efb91a31defb54d2bc959054299e5326ed6d0730cb7f5d",
-  "decapod_release": "0.86.0",
+  "spec_input_hash": "a3c1b275db28f5fc6dffd8e5570b6ceee0ab59a4db09b661d46c3a3d0b11dbfb",
+  "decapod_release": "0.86.2",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "006b690a8f378ffdebb70de33d4f68d703f003d939d92dd232df905b8141a0da",
-      "content_hash": "006b690a8f378ffdebb70de33d4f68d703f003d939d92dd232df905b8141a0da",
-      "fingerprint": "5ed40e31f7809cacc8d649422a3861a3b5ffd14a6b36211f233cd1c53439ae09"
+      "template_hash": "c0ae1635330acd0641ee5be3224b9adc1f87d02e0129f8501eace424776a82e8",
+      "content_hash": "c0ae1635330acd0641ee5be3224b9adc1f87d02e0129f8501eace424776a82e8",
+      "fingerprint": "776d7696f5579c5188091323d94fcb1fff0a1f3cb9cf692d00de934ef06c1915"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "7b1411f5143a0269c2836c8b5e6969a44dcded81bc44ab0cbc2885bf5a814112",
-      "content_hash": "7b1411f5143a0269c2836c8b5e6969a44dcded81bc44ab0cbc2885bf5a814112",
-      "fingerprint": "a87ab96b237b15f3690b92464bef3dd6d88b0df149e2cf4cf9d2844e6d78d31f"
+      "template_hash": "1a593a48fa082436f2f4ea3b579d67ed9ec37c6db02c528f271e53e538139bdd",
+      "content_hash": "1a593a48fa082436f2f4ea3b579d67ed9ec37c6db02c528f271e53e538139bdd",
+      "fingerprint": "ee5ad891871fc9e76265288fd2fe90c39b8bef52e7732d171953b705edb8b90d"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "80c473151e214ea3b7c255da762325e5acc860121654f3f31bb822f789ea2629",
-      "content_hash": "80c473151e214ea3b7c255da762325e5acc860121654f3f31bb822f789ea2629",
-      "fingerprint": "d0c632e45105641484c29838e27964c336850ae819ff81dc43126e6eb94ce823"
+      "template_hash": "5da8af5e10ab075c36da5961f6b56c806432494cd434dc43751d354715ca624f",
+      "content_hash": "5da8af5e10ab075c36da5961f6b56c806432494cd434dc43751d354715ca624f",
+      "fingerprint": "777afd971370e9116098c70836946a05fab951412600e7da718ae1e7e5539c34"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "3b924b1b456ee1123f1c1cd9b6bd43064b0f515cb62e2967faec0908fda98141",
-      "content_hash": "3b924b1b456ee1123f1c1cd9b6bd43064b0f515cb62e2967faec0908fda98141",
-      "fingerprint": "4c8de5f5f223767fbcbbfdccb50079555683d9e63b7450401e573a454f10325f"
+      "template_hash": "168e96679d789e121586ee8b0be9de8e7f2ec611cb900a247c6f531f6b97e393",
+      "content_hash": "168e96679d789e121586ee8b0be9de8e7f2ec611cb900a247c6f531f6b97e393",
+      "fingerprint": "e32646bb33972e6d0b21f4b6fd0fa2bfe4b6eab68f71d572be86ea7453630910"
     }
   ],
   "files": [
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "6957cf384fae78bcc966182ee914b88230c0cbaea909b7b406c53bece8bbfe6c",
-      "content_hash": "c43e588ab9eca0a2eaa6d9f56069bcc8f54482fcf46e88fb260b18e404e085f8",
+      "content_hash": "2e243f4f9e5091c421e1abac86f785c9556a6fcbb0c127463eb5b9563c4ddb6c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "e6c06430e23ca87ae33169a6b1f9c70a3fd283655f5b5b29755fb83181f989e9",
-      "content_hash": "ac720c91566a3161935b5d3d56a43ecb0d81e6622979e6acf4369b8eb1b9b677",
+      "content_hash": "9b8c61d3c3fababb257672eb840cda650bd358f52fb1b69833841b1e879e1b5e",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "58f2abf6f6e0c3da62bc0850e71e12abd76c5064c793701c7b9330036713b163",
-      "content_hash": "acbdb383c2b60b5f68a3df624849093116f09cc1d3ae0fd5d39747237c861bb6",
+      "content_hash": "fd0842afe8d4e696f089aef6b2a2f1c89b13778874840f6a803be416db6be194",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "15cc8c3bbfe951da695384106eb78a44c7af28ddc002bcc83c8a7770229fe999",
-      "content_hash": "da380ebb0b50834835a2437a2ecb40064fb6847a7ac186535ff35dca8c0407e8",
+      "content_hash": "713d3c099f4b3935e54ee6289e9c213df1c48cc763e4218897ce5d4ce6c84f06",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "8e22417cbcbd602159a516e761bdf78173fc4f27bac6d92d91a4ccb968534395",
-      "content_hash": "55117e9fe0a73d8543a7cda7600b25e6f85b6aeecd06bb05060627ba535224cf",
+      "content_hash": "371e4101c7360bdb9cfb13603ead861c74e8786a005ca371fd606d74228ab3d5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "3a79850c94b81e29c6462a7ea70d45198252e3eeba2132c6e9206f7b4e4a5829",
-      "content_hash": "78568b9279efa3d11a4bb6e49460bfca42a1894f53699f000421b4005a8aec72",
+      "content_hash": "48bafe92adbaa51b304e290ca538d509f2b39f69531e7990003a430a8e364ef5",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "54ab819ae22bea9f786793a37196749cbacd72c60f58108898e9db044c534acf",
-      "content_hash": "7d8533c9908953107d6e692e42c14471c5ef5388922596818e3c594ca181b861",
+      "content_hash": "e579070af84c3a5b8ba5b5bebfd8527782081243f826eddc5a9a162713c7c1be",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "b283bdc62b7c2fce411becf6b31928d1b3502da28be7ad618531e3e1820fc147",
-      "content_hash": "f4fcbe98c3b3ecb45f9f44867cb26e36c8ee3ccae43f3d5de81470da23d9d488",
+      "content_hash": "47e769e5204a20740344945a46f61f02edbce308023420561152d430a76e15d6",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -138,7 +138,7 @@ sequenceDiagram
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -132,7 +132,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -73,7 +73,7 @@ pub enum ApiError {
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -20,7 +20,12 @@ Describe the operational runtime model, scheduling, and system deployment archit
 - Liveness:
 - Readiness:
 - Dependency health:
-- Synthetic transaction:
+- Synthetic transaction:## Incident Response
+- Detection:
+- Triage:
+- Mitigation:
+- Communication:
+- Post-mortem:
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -58,13 +63,6 @@ Describe the operational runtime model, scheduling, and system deployment archit
 - Zero-downtime migration strategy for production
 - Migration health checks and rollback triggers
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Incident Response
-- Detection:
-- Triage:
-- Mitigation:
-- Communication:
-- Post-mortem:
 
 ## Rollout Strategy
 - Blue/green deployment:
@@ -107,7 +105,7 @@ Use `tracing` + `tracing-subscriber` with structured JSON output and request cor
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -47,7 +47,7 @@ These files are the project-local contract for humans and agents.
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -83,7 +83,7 @@ Describe the security primitives and security controls implemented in this repos
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -19,7 +19,11 @@ stateDiagram-v2
 | aggregate_id | string | entity/workflow id |
 | event_type | string | semantic transition |
 | payload | object | transition data |
-| recorded_at | timestamp | append time |
+| recorded_at | timestamp | append time |## Replay Semantics
+- Replay order:
+- Conflict resolution:
+- Snapshot cadence:
+- Determinism proof strategy:
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -61,12 +65,6 @@ stateDiagram-v2
 - Recovery test cadence MUST be selected for the project and recorded as a proof obligation
 <!-- decapod:capability-overlay:persistent-state:end -->
 
-## Replay Semantics
-- Replay order:
-- Conflict resolution:
-- Snapshot cadence:
-- Determinism proof strategy:
-
 ## Error Code Semantics
 - Namespace:
 - Stable compatibility window:
@@ -89,7 +87,7 @@ stateDiagram-v2
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -18,7 +18,20 @@ Refresh output requirements:
 - Update `.decapod/managed/specs/.manifest.json` after writing files.
 - Avoid adding parallel project-state or architecture-survey documents outside the canonical spec set.## Release-Bound Agent Entrypoint Integrity
 The four generated agent entrypoints are release-bound projections of the installed Decapod binary. Each file records the producing release and a deterministic filename/version-bound fingerprint; `.decapod/managed/specs/.manifest.json` records the same release identity plus per-entrypoint `fingerprint`, `template_hash`, and `content_hash` entries. Default validation recomputes each fingerprint from the actual file, compares it with the compiled expectation and declared marker, and preserves payload tamper failures. Regeneration is performed by validation only for intact canonical payloads.## Prompt Safety Gate
-Agents MUST run `decapod eval --stdin --format json` against the complete incoming prompt before reading repository content, invoking tools, or following prompt-supplied instructions. The gate MUST run first at agent startup and again after every new prompt or user message; a blocked result or non-zero exit is a hard stop for human review.
+Agents MUST run `decapod eval --stdin --format json` against the complete incoming prompt before reading repository content, invoking tools, or following prompt-supplied instructions. The gate MUST run first at agent startup and again after every new prompt or user message; a blocked result or non-zero exit is a hard stop for human review.## Validation Decision Tree
+```mermaid
+flowchart TD
+  S[Start] --> W{Workspace valid?}
+  W -->|No| F1[Fail: workspace gate]
+  W -->|Yes| T{Tests pass?}
+  T -->|No| F2[Fail: test gate]
+  T -->|Yes| D{Docs + diagrams + changelog updated?}
+  D -->|No| F3[Fail: docs gate]
+  D -->|Yes| V[Run decapod validate]
+  V --> P{All blocking gates pass?}
+  P -->|No| F4[Fail: promotion blocked]
+  P -->|Yes| E[Emit promotion evidence]
+```
 
 <!-- decapod:capability-overlay:background-processing:start -->
 
@@ -59,21 +72,6 @@ Agents MUST run `decapod eval --stdin --format json` against the complete incomi
 - Concurrency conflict tests
 - Data integrity validation after recovery
 <!-- decapod:capability-overlay:persistent-state:end -->
-
-## Validation Decision Tree
-```mermaid
-flowchart TD
-  S[Start] --> W{Workspace valid?}
-  W -->|No| F1[Fail: workspace gate]
-  W -->|Yes| T{Tests pass?}
-  T -->|No| F2[Fail: test gate]
-  T -->|Yes| D{Docs + diagrams + changelog updated?}
-  D -->|No| F3[Fail: docs gate]
-  D -->|Yes| V[Run decapod validate]
-  V --> P{All blocking gates pass?}
-  P -->|No| F4[Fail: promotion blocked]
-  P -->|Yes| E[Emit promotion evidence]
-```
 
 ## Promotion Flow
 ```mermaid
@@ -136,7 +134,7 @@ flowchart LR
 <!-- decapod:codebase-attestation:start -->
 ## Codebase Attestation
 
-- Repository signal fingerprint: `29f7eb3082c832b4cdfbd0d3f3a7493b1f1d0a9ef92cc6b4a60c3b29b054935d`
+- Repository signal fingerprint: `2922f42f59ddf6cd3ce5e4e3970c58caa8900a555733ec86f7a2c3d81f87a75b`
 - Significant implementation surfaces: `.github/` (8 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (97 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -1,0 +1,31 @@
+name: Decapod Validate
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Decapod
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/decapod
+          key: ${{ runner.os }}-decapod-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+      - name: Install Decapod
+        run: |
+          if ! command -v decapod &> /dev/null; then
+            cargo install decapod
+          fi
+      - name: Decapod Validate
+        env:
+          DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
+        run: |
+          decapod init --proof --force
+          decapod validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.86.0 -->
-<!-- decapod-fingerprint: 5ed40e31f7809cacc8d649422a3861a3b5ffd14a6b36211f233cd1c53439ae09 -->
+<!-- decapod-release: 0.86.2 -->
+<!-- decapod-fingerprint: 776d7696f5579c5188091323d94fcb1fff0a1f3cb9cf692d00de934ef06c1915 -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.86.0 -->
-<!-- decapod-fingerprint: a87ab96b237b15f3690b92464bef3dd6d88b0df149e2cf4cf9d2844e6d78d31f -->
+<!-- decapod-release: 0.86.2 -->
+<!-- decapod-fingerprint: ee5ad891871fc9e76265288fd2fe90c39b8bef52e7732d171953b705edb8b90d -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.86.0 -->
-<!-- decapod-fingerprint: 4c8de5f5f223767fbcbbfdccb50079555683d9e63b7450401e573a454f10325f -->
+<!-- decapod-release: 0.86.2 -->
+<!-- decapod-fingerprint: e32646bb33972e6d0b21f4b6fd0fa2bfe4b6eab68f71d572be86ea7453630910 -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.86.0 -->
-<!-- decapod-fingerprint: d0c632e45105641484c29838e27964c336850ae819ff81dc43126e6eb94ce823 -->
+<!-- decapod-release: 0.86.2 -->
+<!-- decapod-fingerprint: 777afd971370e9116098c70836946a05fab951412600e7da718ae1e7e5539c34 -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/src/decapod/core/auth.rs
+++ b/src/decapod/core/auth.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const CLOUD_ACCESS_TOKEN_ENV: &str = "DECAPOD_ACCESS_TOKEN";
 
@@ -174,13 +175,31 @@ pub fn store_machine_session(session: &CloudSession) -> Result<(), DecapodError>
     let bytes = serde_json::to_vec_pretty(&record).map_err(|error| {
         DecapodError::SessionError(format!("failed to serialize cloud session: {error}"))
     })?;
-    fs::write(&path, bytes).map_err(DecapodError::IoError)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
-            .map_err(DecapodError::IoError)?;
+    let parent = path.parent().ok_or_else(|| {
+        DecapodError::SessionError("cloud session path has no parent directory".to_string())
+    })?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temp_path = parent.join(format!(
+        ".session_token.json.tmp-{}-{nonce}",
+        std::process::id()
+    ));
+    let write_result = (|| {
+        fs::write(&temp_path, bytes).map_err(DecapodError::IoError)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600))
+                .map_err(DecapodError::IoError)?;
+        }
+        fs::rename(&temp_path, &path).map_err(DecapodError::IoError)
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
     }
+    write_result?;
     Ok(())
 }
 

--- a/src/decapod/core/entrypoint_integrity.rs
+++ b/src/decapod/core/entrypoint_integrity.rs
@@ -24,25 +24,25 @@ pub struct EntrypointExpectation {
     pub fingerprint: &'static str,
 }
 
-// These values are the v0.85.0 release manifest. Keep them immutable for the
+// These values are the v0.86.2 release manifest. Keep them immutable for the
 // lifetime of that release; a later release must update them deliberately and
 // regenerate the four root entrypoints through Decapod.
 pub const EXPECTED_ENTRYPOINTS: [EntrypointExpectation; 4] = [
     EntrypointExpectation {
         surface: "AGENTS.md",
-        fingerprint: "474bd898a0e8fdb49bfb37a6dd5738257c1c1448364ea54c5c2ac6e694fa328b",
+        fingerprint: "776d7696f5579c5188091323d94fcb1fff0a1f3cb9cf692d00de934ef06c1915",
     },
     EntrypointExpectation {
         surface: "CLAUDE.md",
-        fingerprint: "3ce334a1f7e27b6b20a40bcf58bca19b40556aeb01ffbb6ab1013e95904cacb3",
+        fingerprint: "ee5ad891871fc9e76265288fd2fe90c39b8bef52e7732d171953b705edb8b90d",
     },
     EntrypointExpectation {
         surface: "GEMINI.md",
-        fingerprint: "20e49b230f4fef9495d1461acf726ef0db73636fcc9e2ba4043208e0b6f3d076",
+        fingerprint: "777afd971370e9116098c70836946a05fab951412600e7da718ae1e7e5539c34",
     },
     EntrypointExpectation {
         surface: "CODEX.md",
-        fingerprint: "f9b4112e7dfd92ee25f2aaa4306cb309dc8fdb484f34e8d1009db28b1403ef50",
+        fingerprint: "e32646bb33972e6d0b21f4b6fd0fa2bfe4b6eab68f71d572be86ea7453630910",
     },
 ];
 

--- a/src/decapod/core/error.rs
+++ b/src/decapod/core/error.rs
@@ -15,10 +15,17 @@ use std::io;
 #[serde(rename_all = "snake_case")]
 pub enum CloudAuthStatus {
     AuthRequired,
+    Missing,
     OnboardingPending,
     Expired,
+    RefreshFailed,
     Unauthorized,
+    Revoked,
+    UnauthorizedIdentity,
+    RepositoryDenied,
     Offline,
+    ProviderUnavailable,
+    NonInteractive,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/decapod/core/propodus.rs
+++ b/src/decapod/core/propodus.rs
@@ -262,12 +262,30 @@ fn map_auth_request_error(error: PropodusClientError) -> PropodusClientError {
             "the cloud service could not be reached",
             "restore network access, then rerun the original command",
         ),
-        PropodusClientError::Service { status: 403, .. }
-        | PropodusClientError::Authentication(_) => cloud_auth_error(
-            CloudAuthStatus::Unauthorized,
-            "the cloud service rejected this repository session",
-            "run `decapod cloud login` to renew the machine session, then rerun the original command",
+        PropodusClientError::Service {
+            status: 403, code, ..
+        } => {
+            let status = match code.as_str() {
+                "repository_not_authorized" => CloudAuthStatus::RepositoryDenied,
+                "identity_not_authorized" | "unauthorized_identity" => {
+                    CloudAuthStatus::UnauthorizedIdentity
+                }
+                _ => CloudAuthStatus::Unauthorized,
+            };
+            cloud_auth_error(
+                status,
+                "the cloud service rejected this repository session",
+                "verify GitHub authorization for this repository, then rerun the original command",
+            )
+        }
+        PropodusClientError::Service { status, .. } if status >= 500 => cloud_auth_error(
+            CloudAuthStatus::ProviderUnavailable,
+            "the cloud service is temporarily unavailable",
+            "restore provider availability, then rerun the original command",
         ),
+        PropodusClientError::Authentication(diagnostic) => {
+            PropodusClientError::Authentication(diagnostic)
+        }
         other => other,
     }
 }
@@ -292,7 +310,7 @@ impl PropodusClient<CurlTransport> {
         let credential = auth::load_cloud_credential(None)
             .map_err(|_| {
                 cloud_auth_error(
-                    CloudAuthStatus::AuthRequired,
+                    CloudAuthStatus::Missing,
                     "no cloud machine session is configured",
                     "run `decapod cloud login`, complete the browser handoff, then rerun the original command",
                 )
@@ -421,11 +439,27 @@ fn complete_cloud_onboarding<T: PropodusTransport>(
     transport: T,
     expired_machine_session: bool,
 ) -> Result<auth::CloudCredential, PropodusClientError> {
-    let endpoints = CloudOnboardingEndpoints::new(&config.api_url)
-        .map_err(|error| PropodusClientError::Configuration(error.to_string()))?;
     let interactive = std::io::stdin().is_terminal()
         && std::env::var_os("GITHUB_ACTIONS").is_none()
         && std::env::var_os("DECAPOD_HEADLESS").is_none();
+    complete_cloud_onboarding_with_mode(
+        config,
+        identity,
+        transport,
+        expired_machine_session,
+        interactive,
+    )
+}
+
+fn complete_cloud_onboarding_with_mode<T: PropodusTransport>(
+    config: &PropodusConfig,
+    identity: &RepositoryIdentity,
+    transport: T,
+    expired_machine_session: bool,
+    interactive: bool,
+) -> Result<auth::CloudCredential, PropodusClientError> {
+    let endpoints = CloudOnboardingEndpoints::new(&config.api_url)
+        .map_err(|error| PropodusClientError::Configuration(error.to_string()))?;
     let pending = auth::load_pending_cloud_onboarding()
         .map_err(|_| {
             cloud_auth_error(
@@ -438,6 +472,7 @@ fn complete_cloud_onboarding<T: PropodusTransport>(
             pending.api_url == config.api_url && pending.repo_id == identity.canonical_name
         });
 
+    let had_pending_flow = pending.is_some();
     let (flow_id, url, expires_at) = if let Some(pending) = pending {
         (pending.flow_id, pending.url, pending.expires_at)
     } else {
@@ -481,10 +516,16 @@ fn complete_cloud_onboarding<T: PropodusTransport>(
         return Err(cloud_auth_error(
             if expired_machine_session {
                 CloudAuthStatus::Expired
-            } else {
+            } else if had_pending_flow {
                 CloudAuthStatus::OnboardingPending
+            } else {
+                CloudAuthStatus::NonInteractive
             },
-            "browser onboarding is required before the cloud command can continue",
+            if had_pending_flow {
+                "browser onboarding is still pending"
+            } else {
+                "browser onboarding is required before the cloud command can continue"
+            },
             "complete the printed onboarding URL, then rerun the original command",
         ));
     }
@@ -631,7 +672,7 @@ fn refresh_cloud_session<T: PropodusTransport>(
         .map_err(|error| PropodusClientError::Configuration(error.to_string()))?;
     let request = CloudSessionRefreshRequest::new(session_id, refresh_token).map_err(|_| {
         cloud_auth_error(
-            CloudAuthStatus::Expired,
+            CloudAuthStatus::RefreshFailed,
             "the machine session refresh credentials are invalid",
             "run `decapod cloud login` to renew the machine session",
         )
@@ -642,7 +683,7 @@ fn refresh_cloud_session<T: PropodusTransport>(
         .map_err(map_auth_request_error)?;
     CloudSessionExchangeResponse::into_session(decode_json(&response.body)?).map_err(|_| {
         cloud_auth_error(
-            CloudAuthStatus::Expired,
+            CloudAuthStatus::RefreshFailed,
             "the machine session could not be refreshed",
             "run `decapod cloud login` to renew the machine session",
         )
@@ -954,11 +995,21 @@ fn map_http_error(response: PropodusHttpResponse) -> PropodusClientError {
             )
         });
     match response.status {
-        401 => cloud_auth_error(
-            CloudAuthStatus::Unauthorized,
-            "the cloud service rejected the machine session",
-            "run `decapod cloud login` to renew the machine session, then rerun the original command",
-        ),
+        401 => {
+            let status = match code.as_str() {
+                "session_revoked" | "revoked" => CloudAuthStatus::Revoked,
+                "token_expired" | "session_expired" => CloudAuthStatus::Expired,
+                "identity_not_authorized" | "unauthorized_identity" => {
+                    CloudAuthStatus::UnauthorizedIdentity
+                }
+                _ => CloudAuthStatus::Unauthorized,
+            };
+            cloud_auth_error(
+                status,
+                "the cloud service rejected the machine session",
+                "run `decapod cloud login` to renew the machine session, then rerun the original command",
+            )
+        }
         403 => PropodusClientError::Service {
             status: response.status,
             code,
@@ -966,6 +1017,11 @@ fn map_http_error(response: PropodusHttpResponse) -> PropodusClientError {
         },
         404 => PropodusClientError::NotFound(message),
         409 => PropodusClientError::Conflict(message),
+        500..=599 => cloud_auth_error(
+            CloudAuthStatus::ProviderUnavailable,
+            "the cloud service is temporarily unavailable",
+            "restore provider availability, then rerun the original command",
+        ),
         _ => PropodusClientError::Service {
             status: response.status,
             code,
@@ -990,7 +1046,7 @@ fn percent_encode(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
 
     #[derive(Clone)]
     struct OnboardingStartTransport;
@@ -1041,6 +1097,79 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Default)]
+    struct NoRequestTransport {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl PropodusTransport for NoRequestTransport {
+        fn request(
+            &self,
+            _method: &str,
+            _url: &str,
+            _bearer: &str,
+            _body: Option<&[u8]>,
+        ) -> Result<PropodusHttpResponse, PropodusClientError> {
+            *self.calls.lock().unwrap() += 1;
+            Err(PropodusClientError::Validation(
+                "unexpected provider request".to_string(),
+            ))
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct AuthorizedExchangeTransport {
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl PropodusTransport for AuthorizedExchangeTransport {
+        fn request(
+            &self,
+            method: &str,
+            url: &str,
+            _bearer: &str,
+            _body: Option<&[u8]>,
+        ) -> Result<PropodusHttpResponse, PropodusClientError> {
+            self.calls.lock().unwrap().push(format!("{method} {url}"));
+            if method == "POST" && url.ends_with("/api/onboarding/start") {
+                return Ok(PropodusHttpResponse {
+                    status: 200,
+                    body: br#"{"flow_id":"flow-authorized","bootstrap_url":"https://propodus.example.test/handoff?flow=authorized","expires_at":"2099-01-01T00:00:00Z","poll_after_seconds":1}"#.to_vec(),
+                });
+            }
+            if method == "GET" && url.contains("/api/onboarding/status") {
+                return Ok(PropodusHttpResponse {
+                    status: 200,
+                    body: br#"{"flow_id":"flow-authorized","state":"authorized"}"#.to_vec(),
+                });
+            }
+            if method == "POST" && url.ends_with("/api/onboarding/exchange") {
+                return Ok(PropodusHttpResponse {
+                    status: 200,
+                    body: br#"{"transaction_id":"tx-authorized","repository_id":"DecapodLabs/decapod","code":"opaque-exchange-code"}"#.to_vec(),
+                });
+            }
+            if method == "POST" && url.ends_with("/api/auth/session/exchange") {
+                let response = CloudSessionExchangeResponse {
+                    credentials: Some(CloudSession {
+                        access_token: "access-after-exchange".to_string(),
+                        refresh_token: Some("refresh-after-exchange".to_string()),
+                        session_id: Some("session-after-exchange".to_string()),
+                        expires_at: Some("2099-01-01T00:00:00Z".to_string()),
+                    }),
+                    session: None,
+                };
+                return Ok(PropodusHttpResponse {
+                    status: 200,
+                    body: serde_json::to_vec(&response).unwrap(),
+                });
+            }
+            Err(PropodusClientError::Validation(
+                "unexpected provider request".to_string(),
+            ))
+        }
+    }
+
     fn auth_env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
@@ -1086,9 +1215,208 @@ mod tests {
         });
         assert_eq!(
             cloud_auth_diagnostic(&unauthorized).unwrap().status,
-            CloudAuthStatus::Unauthorized
+            CloudAuthStatus::RepositoryDenied
         );
         assert!(!unauthorized.to_string().contains("provider message"));
+
+        let revoked = map_http_error(PropodusHttpResponse {
+            status: 401,
+            body: br#"{"error":{"code":"session_revoked","message":"secret provider detail"}}"#
+                .to_vec(),
+        });
+        assert_eq!(
+            cloud_auth_diagnostic(&revoked).unwrap().status,
+            CloudAuthStatus::Revoked
+        );
+        assert!(!revoked.to_string().contains("secret provider detail"));
+
+        let provider = map_http_error(PropodusHttpResponse {
+            status: 503,
+            body: br#"{"error":{"code":"provider_down","message":"secret provider detail"}}"#
+                .to_vec(),
+        });
+        assert_eq!(
+            cloud_auth_diagnostic(&provider).unwrap().status,
+            CloudAuthStatus::ProviderUnavailable
+        );
+        assert!(!provider.to_string().contains("secret provider detail"));
+
+        let identity = map_auth_request_error(PropodusClientError::Service {
+            status: 403,
+            code: "identity_not_authorized".to_string(),
+            message: "secret provider detail".to_string(),
+        });
+        assert_eq!(
+            cloud_auth_diagnostic(&identity).unwrap().status,
+            CloudAuthStatus::UnauthorizedIdentity
+        );
+        assert!(!identity.to_string().contains("secret provider detail"));
+    }
+
+    #[test]
+    fn valid_machine_session_is_reused_without_onboarding_or_provider_requests() {
+        let _lock = auth_env_lock();
+        let data_home = tempfile::tempdir().expect("data home");
+        let old_data_home = std::env::var_os("XDG_DATA_HOME");
+        let old_token = std::env::var_os(auth::CLOUD_ACCESS_TOKEN_ENV);
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", data_home.path());
+            std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV);
+        }
+
+        auth::store_machine_session(&CloudSession {
+            access_token: "valid-access".to_string(),
+            refresh_token: Some("valid-refresh".to_string()),
+            session_id: Some("valid-session".to_string()),
+            expires_at: Some("2099-01-01T00:00:00Z".to_string()),
+        })
+        .expect("store valid machine session");
+        let identity = RepositoryIdentity {
+            canonical_name: "DecapodLabs/decapod".to_string(),
+            owner: "DecapodLabs".to_string(),
+            repository: "decapod".to_string(),
+            remote_url: "git@github.com:DecapodLabs/decapod.git".to_string(),
+        };
+        let config = PropodusConfig {
+            api_url: "https://propodus.example.test".to_string(),
+            repo_id: identity.canonical_name.clone(),
+        };
+        let transport = NoRequestTransport::default();
+        let first = ensure_cloud_session(&config, &identity, transport.clone())
+            .expect("valid machine session should be reusable");
+        let second = ensure_cloud_session(&config, &identity, transport.clone())
+            .expect("restart should reuse the same machine session");
+        assert_eq!(first.token, "valid-access");
+        assert_eq!(second.token, "valid-access");
+        assert_eq!(*transport.calls.lock().unwrap(), 0);
+
+        unsafe {
+            match old_data_home {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            match old_token {
+                Some(value) => std::env::set_var(auth::CLOUD_ACCESS_TOKEN_ENV, value),
+                None => std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn matching_pending_onboarding_is_reused_without_duplicate_start() {
+        let _lock = auth_env_lock();
+        let data_home = tempfile::tempdir().expect("data home");
+        let old_data_home = std::env::var_os("XDG_DATA_HOME");
+        let old_token = std::env::var_os(auth::CLOUD_ACCESS_TOKEN_ENV);
+        let old_headless = std::env::var_os("DECAPOD_HEADLESS");
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", data_home.path());
+            std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV);
+            std::env::set_var("DECAPOD_HEADLESS", "1");
+        }
+
+        let identity = RepositoryIdentity {
+            canonical_name: "DecapodLabs/decapod".to_string(),
+            owner: "DecapodLabs".to_string(),
+            repository: "decapod".to_string(),
+            remote_url: "git@github.com:DecapodLabs/decapod.git".to_string(),
+        };
+        let config = PropodusConfig {
+            api_url: "https://propodus.example.test".to_string(),
+            repo_id: identity.canonical_name.clone(),
+        };
+        auth::store_pending_cloud_onboarding(&auth::PendingCloudOnboarding {
+            api_url: config.api_url.clone(),
+            repo_id: identity.canonical_name.clone(),
+            flow_id: "flow-pending".to_string(),
+            url: "https://propodus.example.test/handoff?flow=pending".to_string(),
+            expires_at: "2099-01-01T00:00:00Z".to_string(),
+        })
+        .expect("store pending onboarding");
+
+        let transport = NoRequestTransport::default();
+        let error = ensure_cloud_session(&config, &identity, transport.clone())
+            .expect_err("headless pending onboarding should return a resumable state");
+        assert_eq!(
+            cloud_auth_diagnostic(&error).unwrap().status,
+            CloudAuthStatus::OnboardingPending
+        );
+        assert_eq!(*transport.calls.lock().unwrap(), 0);
+        assert!(auth::load_pending_cloud_onboarding().unwrap().is_some());
+
+        unsafe {
+            match old_data_home {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            match old_token {
+                Some(value) => std::env::set_var(auth::CLOUD_ACCESS_TOKEN_ENV, value),
+                None => std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV),
+            }
+            match old_headless {
+                Some(value) => std::env::set_var("DECAPOD_HEADLESS", value),
+                None => std::env::remove_var("DECAPOD_HEADLESS"),
+            }
+        }
+    }
+
+    #[test]
+    fn one_time_onboarding_and_session_exchange_persist_machine_session() {
+        let _lock = auth_env_lock();
+        let data_home = tempfile::tempdir().expect("data home");
+        let old_data_home = std::env::var_os("XDG_DATA_HOME");
+        let old_token = std::env::var_os(auth::CLOUD_ACCESS_TOKEN_ENV);
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", data_home.path());
+            std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV);
+        }
+
+        let identity = RepositoryIdentity {
+            canonical_name: "DecapodLabs/decapod".to_string(),
+            owner: "DecapodLabs".to_string(),
+            repository: "decapod".to_string(),
+            remote_url: "git@github.com:DecapodLabs/decapod.git".to_string(),
+        };
+        let config = PropodusConfig {
+            api_url: "https://propodus.example.test".to_string(),
+            repo_id: identity.canonical_name.clone(),
+        };
+        let transport = AuthorizedExchangeTransport::default();
+        let credential =
+            complete_cloud_onboarding_with_mode(&config, &identity, transport.clone(), false, true)
+                .expect("authorized onboarding should complete");
+        assert_eq!(credential.token, "access-after-exchange");
+        assert_eq!(
+            auth::load_machine_session().unwrap().unwrap().token,
+            "access-after-exchange"
+        );
+        assert!(auth::load_pending_cloud_onboarding().unwrap().is_none());
+        let calls = transport.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 4);
+        assert!(calls[0].ends_with("POST https://propodus.example.test/api/onboarding/start"));
+        assert!(calls[1].contains("GET https://propodus.example.test/api/onboarding/status"));
+        assert!(calls[2].ends_with("POST https://propodus.example.test/api/onboarding/exchange"));
+        assert!(calls[3].ends_with("POST https://propodus.example.test/api/auth/session/exchange"));
+        let files: Vec<_> = std::fs::read_dir(data_home.path().join("decapod"))
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert!(
+            !files
+                .iter()
+                .any(|name| name.to_string_lossy().contains("tmp"))
+        );
+
+        unsafe {
+            match old_data_home {
+                Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            match old_token {
+                Some(value) => std::env::set_var(auth::CLOUD_ACCESS_TOKEN_ENV, value),
+                None => std::env::remove_var(auth::CLOUD_ACCESS_TOKEN_ENV),
+            }
+        }
     }
 
     #[test]
@@ -1118,7 +1446,7 @@ mod tests {
             .expect_err("noninteractive onboarding must pause for the human handoff");
         assert_eq!(
             cloud_auth_diagnostic(&error).unwrap().status,
-            CloudAuthStatus::OnboardingPending
+            CloudAuthStatus::NonInteractive
         );
         assert!(
             data_home.path().join("decapod/onboarding.json").is_file(),
@@ -1176,6 +1504,15 @@ mod tests {
         assert_eq!(credential.token, "refreshed-access");
         assert_eq!(credential.source, auth::CredentialSource::MachineFile);
         assert_eq!(auth::load_pending_cloud_onboarding().unwrap(), None);
+        let stored = std::fs::read_to_string(data_home.path().join("decapod/session_token.json"))
+            .expect("rotated machine session");
+        assert!(stored.contains("refreshed-access"));
+        assert!(stored.contains("refreshed-refresh"));
+        assert!(
+            !std::fs::read_dir(data_home.path().join("decapod"))
+                .unwrap()
+                .any(|entry| entry.unwrap().file_name().to_string_lossy().contains("tmp"))
+        );
 
         unsafe {
             match old_data_home {

--- a/src/decapod/lib.rs
+++ b/src/decapod/lib.rs
@@ -2805,7 +2805,7 @@ fn requires_session_token(command: &Command) -> bool {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 struct AgentSessionRecord {
     agent_id: String,
     token: String,
@@ -3184,7 +3184,7 @@ fn mark_core_constitution_ingested(
 
 fn cleanup_expired_sessions(
     project_root: &Path,
-    store_root: &Path,
+    store_root: Option<&Path>,
 ) -> Result<Vec<String>, error::DecapodError> {
     let now = now_epoch_secs();
     let mut expired_agents = Vec::new();
@@ -3224,7 +3224,9 @@ fn cleanup_expired_sessions(
     }
 
     if !expired_agents.is_empty() {
-        todo::cleanup_stale_agent_assignments(store_root, &expired_agents, "session.expired")?;
+        if let Some(store_root) = store_root {
+            todo::cleanup_stale_agent_assignments(store_root, &expired_agents, "session.expired")?;
+        }
         for agent_id in &expired_agents {
             let _ = clear_agent_awareness(project_root, agent_id);
         }
@@ -3238,7 +3240,7 @@ fn ensure_session_valid() -> Result<(), error::DecapodError> {
     let project_root = find_decapod_project_root(&current_dir)?;
     let store_root = project_root.join(".decapod").join("data");
     fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
-    let _ = cleanup_expired_sessions(&project_root, &store_root)?;
+    let _ = cleanup_expired_sessions(&project_root, Some(&store_root))?;
 
     let agent_id = current_agent_id();
     let session = read_agent_session(&project_root, &agent_id)?;
@@ -3498,27 +3500,18 @@ fn install_decapod() -> Result<(), error::DecapodError> {
 fn run_session_command(session_cli: SessionCli) -> Result<(), error::DecapodError> {
     let current_dir = std::env::current_dir()?;
     let project_root = find_decapod_project_root(&current_dir)?;
+    let cloud_backend = cli::DecapodProjectConfig::load(&project_root)?
+        .repo
+        .effective_backend()
+        .is_cloud();
     let store_root = project_root.join(".decapod").join("data");
-    fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
-    let _ = cleanup_expired_sessions(&project_root, &store_root)?;
-
-    if matches!(session_cli.command, SessionCommand::Acquire)
-        && cli::DecapodProjectConfig::load(&project_root)?
-            .repo
-            .effective_backend()
-            .is_cloud()
-    {
-        match ensure_project_cloud_session(&project_root) {
-            Ok(_) => {}
-            Err(error @ error::DecapodError::CloudAuth(_)) => {
-                if let error::DecapodError::CloudAuth(diagnostic) = &error {
-                    print_cloud_auth_json_if_needed(diagnostic, None);
-                }
-                return Err(error);
-            }
-            Err(error) => return Err(error),
-        }
+    if !cloud_backend {
+        fs::create_dir_all(&store_root).map_err(error::DecapodError::IoError)?;
     }
+    let _ = cleanup_expired_sessions(
+        &project_root,
+        (!cloud_backend).then_some(store_root.as_path()),
+    )?;
 
     // Check and update version on session acquire
     if matches!(session_cli.command, SessionCommand::Acquire)
@@ -3533,39 +3526,65 @@ fn run_session_command(session_cli: SessionCli) -> Result<(), error::DecapodErro
     match session_cli.command {
         SessionCommand::Acquire => {
             let agent_id = current_agent_id();
-            if let Some(existing) = read_agent_session(&project_root, &agent_id)?
+            let newly_acquired = if let Some(existing) =
+                read_agent_session(&project_root, &agent_id)?
                 && existing.expires_at_epoch_secs > now_epoch_secs()
             {
-                println!(
-                    "Session already active for agent '{agent_id}'. Use 'decapod session status' for details."
-                );
-                return Ok(());
+                Some(None)
+            } else {
+                let issued = now_epoch_secs();
+                let expires = issued.saturating_add(session_ttl_secs());
+                let token = crate::core::ulid::new_ulid();
+                let temp_p = generate_ephemeral_password()?;
+                let rec = AgentSessionRecord {
+                    agent_id: agent_id.clone(),
+                    token: token.clone(),
+                    password_hash: hash_password(&temp_p, &token),
+                    issued_at_epoch_secs: issued,
+                    expires_at_epoch_secs: expires,
+                };
+                write_agent_session(&project_root, &rec)?;
+                clear_agent_awareness(&project_root, &agent_id)?;
+                Some(Some((rec, temp_p)))
+            };
+
+            // Local Decapod custody is established before any cloud request.
+            // A cloud failure is returned independently, leaving the local
+            // session available for governance and workspace operations.
+            if cloud_backend {
+                match ensure_project_cloud_session(&project_root) {
+                    Ok(_) => {}
+                    Err(error @ error::DecapodError::CloudAuth(_)) => {
+                        if let error::DecapodError::CloudAuth(diagnostic) = &error {
+                            print_cloud_auth_json_if_needed(diagnostic, None);
+                        }
+                        return Err(error);
+                    }
+                    Err(error) => return Err(error),
+                }
             }
 
-            let issued = now_epoch_secs();
-            let expires = issued.saturating_add(session_ttl_secs());
-            let token = crate::core::ulid::new_ulid();
-            let temp_p = generate_ephemeral_password()?;
-            let rec = AgentSessionRecord {
-                agent_id: agent_id.clone(),
-                token: token.clone(),
-                password_hash: hash_password(&temp_p, &token),
-                issued_at_epoch_secs: issued,
-                expires_at_epoch_secs: expires,
-            };
-            write_agent_session(&project_root, &rec)?;
-            clear_agent_awareness(&project_root, &agent_id)?;
-
-            println!("Session acquired successfully.");
-            println!("Agent: {agent_id}");
-            println!("Token: {token}");
-            println!("Password: {temp_p}");
-            println!("ExpiresAtEpoch: {expires}");
-            println!(
-                "Export before running other commands: DECAPOD_AGENT_ID='{}' and DECAPOD_SESSION_PASSWORD='<token>'",
-                rec.agent_id
-            );
-            println!("\nYou may now use other decapod commands.");
+            match newly_acquired {
+                Some(Some((rec, password))) => {
+                    println!("Session acquired successfully.");
+                    println!("Agent: {}", rec.agent_id);
+                    println!("Token: {}", rec.token);
+                    // The local session password is intentionally printed only
+                    // after cloud preflight succeeds; cloud diagnostics remain
+                    // stable JSON without mixing in custody secrets.
+                    println!("Password: {password}");
+                    println!("ExpiresAtEpoch: {}", rec.expires_at_epoch_secs);
+                    println!(
+                        "Export before running other commands: DECAPOD_AGENT_ID='{}' and DECAPOD_SESSION_PASSWORD='<token>'",
+                        rec.agent_id
+                    );
+                    println!("\nYou may now use other decapod commands.");
+                }
+                Some(None) => println!(
+                    "Session already active for agent '{agent_id}'. Use 'decapod session status' for details."
+                ),
+                None => {}
+            }
             Ok(())
         }
         SessionCommand::Status => {
@@ -3586,11 +3605,13 @@ fn run_session_command(session_cli: SessionCli) -> Result<(), error::DecapodErro
             let agent_id = current_agent_id();
             if remove_agent_session_files(&project_root, &agent_id)? {
                 clear_agent_awareness(&project_root, &agent_id)?;
-                let _ = todo::cleanup_stale_agent_assignments(
-                    &store_root,
-                    std::slice::from_ref(&agent_id),
-                    "session.release",
-                );
+                if !cloud_backend {
+                    let _ = todo::cleanup_stale_agent_assignments(
+                        &store_root,
+                        std::slice::from_ref(&agent_id),
+                        "session.release",
+                    );
+                }
                 println!("Session released");
             } else {
                 println!("No active session to release");

--- a/tests/cloud_backend_storage.rs
+++ b/tests/cloud_backend_storage.rs
@@ -15,6 +15,19 @@ fn git(dir: &std::path::Path, args: &[&str]) {
     );
 }
 
+fn machine_session_files(config_home: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let sessions = config_home.join("decapod/sessions");
+    let Ok(scopes) = std::fs::read_dir(sessions) else {
+        return Vec::new();
+    };
+    scopes
+        .filter_map(Result::ok)
+        .flat_map(|scope| std::fs::read_dir(scope.path()).into_iter().flatten())
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect()
+}
+
 #[test]
 fn test_cloud_opt_in_fails_closed_without_verified_remote() {
     let tmp = TempDir::new().expect("tempdir");
@@ -218,7 +231,7 @@ fn cloud_login_requires_a_project_origin() {
 }
 
 #[test]
-fn cloud_session_acquire_preflights_machine_auth_before_local_agent_session() {
+fn cloud_session_acquire_keeps_local_custody_when_cloud_preflight_fails() {
     let tmp = TempDir::new().expect("project tempdir");
     let data_home = TempDir::new().expect("credential data home");
     let config_home = TempDir::new().expect("config home");
@@ -252,7 +265,19 @@ fn cloud_session_acquire_preflights_machine_auth_before_local_agent_session() {
         serde_json::from_slice(&session_out.stdout).expect("stable cloud auth JSON");
     assert_eq!(diagnostic["schema_version"], "decapod.cloud.auth.v1");
     assert_eq!(diagnostic["status"], "offline");
-    assert!(!String::from_utf8_lossy(&session_out.stderr).contains("Bearer"));
+    let stdout = String::from_utf8_lossy(&session_out.stdout);
+    let stderr = String::from_utf8_lossy(&session_out.stderr);
+    assert!(!stdout.contains("Token:") && !stdout.contains("Password:"));
+    assert!(!stdout.contains("session_token") && !stderr.contains("Bearer"));
+    assert_eq!(machine_session_files(config_home.path()).len(), 1);
+    assert!(
+        !tmp.path().join(".decapod/data/todo.db").exists(),
+        "cloud session acquisition must not initialize local todo SQLite"
+    );
+    assert!(
+        !tmp.path().join(".decapod/session_token.json").exists(),
+        "cloud session acquisition must not write repository credentials"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1100
Fixes #1101
Fixes #1102

- Acquire local Decapod session custody before any cloud preflight.
- Reuse valid machine-local Propodus sessions across process restarts.
- Refresh expired access credentials with atomic rotation persistence.
- Resume matching pending onboarding flows and complete one-time exchanges.
- Keep cloud credentials outside the repository and avoid local SQLite fallback in cloud mode.
- Return typed, redacted cloud-auth outcomes and preserve safe headless behavior.

## Evidence

- Deterministic Propodus/session unit tests and cloud-backend integration tests use fake transports and synthetic credential values only.
- Full serialized test suite, formatting, Clippy, Decapod validation, projection checks, QA checks, and release checks were run.
- Protected `propodus_live` proof remains an ignored deployment-only gate requiring GitHub-provided secrets; no real credentials were handled locally.
- No Propodus files or SSH private keys were modified or handled.

## Governance

- Refreshed living specs and release-bound entrypoint projections.
- Included plan, claims, trajectory, and validation artifacts.
- Existing baseline warnings and the pre-existing release-source-tree policy failure are recorded in the trajectory.