### PR TITLE
fix(ci): restore release-bound sync so release-plz PRs pass validation

### DIFF
--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -45,7 +45,7 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:4cbb6a2d71a61ec80aee245af2c92a29acdce448f11d573ada652c120c0cd6d9",
+  "artifact_hash": "sha256:b6640322b5196546a33eb8fabae5f284f989aa550e9cf44568a24258fc2d4624",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
@@ -95,6 +95,13 @@
         "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "kind": "trajectory_step_recorded",
         "detail": "trajectory:validation_01KZQN7VNYJXAG3R82TPR2XGBP"
+      },
+      {
+        "sequence": 6,
+        "event_id": "event:6",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
+        "kind": "trajectory_step_recorded",
+        "detail": "trajectory:validation_01KZQN7VNYJXAG3R82TPR2XGBP"
       }
     ],
     "trajectories": {
@@ -140,12 +147,31 @@
             ],
             "validation_findings": [],
             "custody_event_id": "event:5"
+          },
+          {
+            "sequence": 6,
+            "action": "validation",
+            "command": "decapod validate",
+            "scope": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json"
+            ],
+            "observations": [
+              ".decapod/governance/trajectory.json",
+              ".decapod/governance/validation.json",
+              "validation epoch ve_17594b87f275c43f completed with zero failures"
+            ],
+            "proof_refs": [
+              "decapod validate"
+            ],
+            "validation_findings": [],
+            "custody_event_id": "event:6"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 5
+    "next_sequence": 6
   }
 }

--- a/.decapod/governance/trajectory.json
+++ b/.decapod/governance/trajectory.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
-  "run_id": "validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-  "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-  "task_id": "bugs_01kzqh54ng9wz5em",
+  "run_id": "validation_01KZQN7VNYJXAG3R82TPR2XGBP",
+  "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
+  "task_id": "cicd_01kzqmx8p3vpves3",
   "original_intent": "Produce proof artifacts for a repository validation completion.",
   "derived_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
   "destination": "validation completion",
@@ -33,9 +33,8 @@
     }
   ],
   "evidence": [
-    "validation epoch ve_1a71ad91c62afcf2 completed with zero failures",
-    "validation epoch ve_dab22850cf95c9e2 completed with zero failures",
-    "validation epoch ve_e711d7b776ab6c91 completed with zero failures"
+    "validation epoch ve_17594b87f275c43f completed with zero failures",
+    "validation epoch ve_a5263aa2b264e85e completed with zero failures"
   ],
   "shortcut_risk_signals": [],
   "unresolved_assumptions": [],
@@ -46,12 +45,12 @@
     "shortcut_risk": "supported",
     "completion_proof": "supported"
   },
-  "artifact_hash": "sha256:43799e1d76d625c198d1329df977a06265248d5f6658adec4300c30738eaf4db",
+  "artifact_hash": "sha256:4cbb6a2d71a61ec80aee245af2c92a29acdce448f11d573ada652c120c0cd6d9",
   "custody": {
     "schema_version": "1.0.0",
     "intents": {
-      "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2": {
-        "id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+      "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP": {
+        "id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "raw_intent": "Produce proof artifacts for a repository validation completion.",
         "refined_intent": "Run the bounded validation gates and bind the successful receipt to a trajectory.",
         "acceptance_criteria": [],
@@ -74,90 +73,34 @@
       {
         "sequence": 2,
         "event_id": "event:2",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "kind": "created"
       },
       {
         "sequence": 3,
         "event_id": "event:3",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "kind": "refined"
       },
       {
         "sequence": 4,
         "event_id": "event:4",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
+        "detail": "trajectory:validation_01KZQN7VNYJXAG3R82TPR2XGBP"
       },
       {
         "sequence": 5,
         "event_id": "event:5",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 6,
-        "event_id": "event:6",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 7,
-        "event_id": "event:7",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 8,
-        "event_id": "event:8",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 9,
-        "event_id": "event:9",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 10,
-        "event_id": "event:10",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 11,
-        "event_id": "event:11",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 12,
-        "event_id": "event:12",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
-      },
-      {
-        "sequence": 13,
-        "event_id": "event:13",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "kind": "trajectory_step_recorded",
-        "detail": "trajectory:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2"
+        "detail": "trajectory:validation_01KZQN7VNYJXAG3R82TPR2XGBP"
       }
     ],
     "trajectories": {
-      "validation_01KZQJ7SHV5J8QG1NDAGHR7MK2": {
-        "id": "validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-        "intent_id": "intent:validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
+      "validation_01KZQN7VNYJXAG3R82TPR2XGBP": {
+        "id": "validation_01KZQN7VNYJXAG3R82TPR2XGBP",
+        "intent_id": "intent:validation_01KZQN7VNYJXAG3R82TPR2XGBP",
         "evidence_only": true,
         "steps": [
           {
@@ -171,7 +114,7 @@
             "observations": [
               ".decapod/governance/trajectory.json",
               ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
+              "validation epoch ve_a5263aa2b264e85e completed with zero failures"
             ],
             "proof_refs": [
               "decapod validate"
@@ -190,171 +133,19 @@
             "observations": [
               ".decapod/governance/trajectory.json",
               ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
+              "validation epoch ve_17594b87f275c43f completed with zero failures"
             ],
             "proof_refs": [
               "decapod validate"
             ],
             "validation_findings": [],
             "custody_event_id": "event:5"
-          },
-          {
-            "sequence": 6,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:6"
-          },
-          {
-            "sequence": 7,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:7"
-          },
-          {
-            "sequence": 8,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:8"
-          },
-          {
-            "sequence": 9,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:9"
-          },
-          {
-            "sequence": 10,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_1a71ad91c62afcf2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:10"
-          },
-          {
-            "sequence": 11,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_dab22850cf95c9e2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:11"
-          },
-          {
-            "sequence": 12,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_dab22850cf95c9e2 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:12"
-          },
-          {
-            "sequence": 13,
-            "action": "validation",
-            "command": "decapod validate",
-            "scope": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json"
-            ],
-            "observations": [
-              ".decapod/governance/trajectory.json",
-              ".decapod/governance/validation.json",
-              "validation epoch ve_e711d7b776ab6c91 completed with zero failures"
-            ],
-            "proof_refs": [
-              "decapod validate"
-            ],
-            "validation_findings": [],
-            "custody_event_id": "event:13"
           }
         ]
       }
     },
     "summaries": {},
     "knowledge_candidates": [],
-    "next_sequence": 13
+    "next_sequence": 5
   }
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -1,38 +1,38 @@
 {
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
-  "decapod_release": "0.96.15",
-  "git_revision": "68528443af95ea54927d4c5f06d4b86928c74a0d",
-  "repo_signal_fingerprint": "9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106",
-  "trajectory_run_id": "validation_01KZQJ7SHV5J8QG1NDAGHR7MK2",
-  "trajectory_artifact_hash": "sha256:43799e1d76d625c198d1329df977a06265248d5f6658adec4300c30738eaf4db",
+  "decapod_release": "0.96.16",
+  "git_revision": "3d82ff719979bcf4b6632e328adbe15e461dcace",
+  "repo_signal_fingerprint": "a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce",
+  "trajectory_run_id": "validation_01KZQN7VNYJXAG3R82TPR2XGBP",
+  "trajectory_artifact_hash": "sha256:4cbb6a2d71a61ec80aee245af2c92a29acdce448f11d573ada652c120c0cd6d9",
   "validation_epoch": {
     "schema_version": "1.0.0",
-    "epoch_id": "ve_e711d7b776ab6c91",
-    "evaluator_identity": "decapod-validate@0.96.15",
-    "evaluator_set_hash": "sha256:ab1e1aa29c767e0818f95c541c2cc888c10fad851d7411f2a3cd31c4f735e575",
-    "constitution_version": "embedded-docs@0.96.15",
-    "constitution_hash": "sha256:234f0a57f982dbc73234f886961f8e936ea0ef4d0f71ab3250ead14bacb5d017",
+    "epoch_id": "ve_17594b87f275c43f",
+    "evaluator_identity": "decapod-validate@0.96.16",
+    "evaluator_set_hash": "sha256:7389e50a806a379d91a5de113f961ec65c7f4f0b3b01829f03dc1592fbf483f8",
+    "constitution_version": "embedded-docs@0.96.16",
+    "constitution_hash": "sha256:25ef35c2250b0041d210ad484699c099e9ad6251969770230631192f6db9b67e",
     "validation_profile": "default",
     "validation_profile_hash": "sha256:37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f",
     "proof_rubric": "decapod-validate/current-proof-v1",
     "proof_rubric_hash": "sha256:99e8ef25629da391e9b479db9fff52b82f340224f7a69d8a88d2992ae8e90466",
-    "generated_specs_manifest_hash": "sha256:2932f525ff23879f23460c5d5667f9f831f2c912908cc7f6b7072064550b45e2",
-    "generated_specs_fingerprint": "9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106",
+    "generated_specs_manifest_hash": "sha256:23c0f3d5e4b0373933c81d1199c80daf5fe9b23e5b406199639b42aa397a984e",
+    "generated_specs_fingerprint": "a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce",
     "material_hashes": {
-      "constitution:core/DECAPOD": "sha256:234f0a57f982dbc73234f886961f8e936ea0ef4d0f71ab3250ead14bacb5d017",
-      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:7ecc1e4be40988792b680ca035930567a41a2832821195516d9c421883e18099",
-      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:47a80e6cd127ae62aa8679a8fa23d8b19eb266f2acb52bd78bcd22ce1713cbe7",
-      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:2e4749e4d61164ca925a8b82be04422547e885dede23d8f477825f9b4ef5b45c",
-      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:69ba8ebf44d19bba56a163d2d6d8c3902773966c1169ad7fd3c0accba50c4a37",
-      "generated_spec:.decapod/managed/specs/README.md": "sha256:21f15bcc435f7375abfb61c54bb791ffaeef78f4f1052c9eb6b86225a5c28dcc",
-      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:7a92bf3462bf8136878b9cc3e3039aeb0e2fe10f30faee175988daf8d228ef6c",
-      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:863988a64e0f583bb292140f02c3794affd1a64717ef8fbe8031342144610f72",
-      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:df572fac22d3609cb85cbdd88ccffd9d413ca6eab0fb98be70d939f07f4ebd84",
-      "generated_specs_fingerprint": "9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106",
-      "generated_specs_manifest": "sha256:2932f525ff23879f23460c5d5667f9f831f2c912908cc7f6b7072064550b45e2",
+      "constitution:core/DECAPOD": "sha256:25ef35c2250b0041d210ad484699c099e9ad6251969770230631192f6db9b67e",
+      "generated_spec:.decapod/managed/specs/ARCHITECTURE.md": "sha256:36ee66f91e94f079b35cc0dd3e474c339ef82847590579738249cd9af4bedbcf",
+      "generated_spec:.decapod/managed/specs/INTENT.md": "sha256:8f8a5ceb18db956c63b5d13432ec638ef74ae6b73eeefb051e868a0214a34719",
+      "generated_spec:.decapod/managed/specs/INTERFACES.md": "sha256:41540b81e425d092a4fec15c17ec765655c7fc38da74b77d977fab12dbd8adf9",
+      "generated_spec:.decapod/managed/specs/OPERATIONS.md": "sha256:123d2538cdeeca3be145926067d303cb5fe6456c9b33b4d0189df3052056f6c8",
+      "generated_spec:.decapod/managed/specs/README.md": "sha256:7d2ac7b9f3d6c022b9edefe8ebdfc084c1544435f0fe5d555b04cdb615330e2c",
+      "generated_spec:.decapod/managed/specs/SECURITY.md": "sha256:4ef4fffa3aae706dc92020288ad2fb74b009df2d800f72a0e37ea39242aa52c0",
+      "generated_spec:.decapod/managed/specs/SEMANTICS.md": "sha256:6cb8e901859229e169322e66ae59757515d548f3cb1ea4163297dc1dde2a69fd",
+      "generated_spec:.decapod/managed/specs/VALIDATION.md": "sha256:d596058d433f363faa92b959bfccc712d7e2a6bed5a0e49e6e00ac2a7adb5e8c",
+      "generated_specs_fingerprint": "a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce",
+      "generated_specs_manifest": "sha256:23c0f3d5e4b0373933c81d1199c80daf5fe9b23e5b406199639b42aa397a984e",
       "living_spec_material:.decapod/managed/specs/ARCHITECTURE.md": "sha256:9778ab6f55f71ed7148de3fcac664da0b1bd8f8ffb5e08502c0680e4a7079a66",
-      "living_spec_material:.decapod/managed/specs/INTENT.md": "sha256:40631fca6c060191d526b6335581b89578194178faf508643b4f9c6bca1f78a2",
+      "living_spec_material:.decapod/managed/specs/INTENT.md": "sha256:8ffdcc7b64ca4c49a8663d06f550f6fd97725bc30ca704256b7e47b9b23fcc17",
       "living_spec_material:.decapod/managed/specs/INTERFACES.md": "sha256:40c9447bc92b699f0afa06a05964184def458d6fa99842d01870f4ba8ec50ed4",
       "living_spec_material:.decapod/managed/specs/OPERATIONS.md": "sha256:ec5471307de529b96d7bff3bf7c7d5c7db1d15af54a43075d25642393eefb9b4",
       "living_spec_material:.decapod/managed/specs/README.md": "sha256:9a468ca90c8b47d562fa7e3dff0886761788ddcef5fe76d42627684aa2176dd3",
@@ -44,10 +44,10 @@
     }
   },
   "status": "ok",
-  "pass_count": 190,
+  "pass_count": 189,
   "fail_count": 0,
   "warn_count": 2,
-  "elapsed_ms": 1603,
+  "elapsed_ms": 1398,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 0,
   "failures": [],
@@ -58,51 +58,55 @@
   "gate_timings": [
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 1004
+      "elapsed_ms": 826
     },
     {
       "name": "validate_control_plane_contract",
-      "elapsed_ms": 223
+      "elapsed_ms": 243
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 125
+      "elapsed_ms": 100
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 61
+      "elapsed_ms": 56
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 35
+      "elapsed_ms": 42
     },
     {
       "name": "validate_obligations",
-      "elapsed_ms": 32
+      "elapsed_ms": 37
     },
     {
       "name": "validate_embedded_self_contained",
-      "elapsed_ms": 15
-    },
-    {
-      "name": "validate_archive_integrity",
-      "elapsed_ms": 12
+      "elapsed_ms": 17
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 9
+      "elapsed_ms": 11
+    },
+    {
+      "name": "validate_archive_integrity",
+      "elapsed_ms": 11
     },
     {
       "name": "validate_interface_contract_bootstrap",
-      "elapsed_ms": 8
+      "elapsed_ms": 10
     },
     {
       "name": "validate_repomap_determinism",
-      "elapsed_ms": 5
+      "elapsed_ms": 6
     },
     {
       "name": "validate_legacy_jsonl_retired",
       "elapsed_ms": 3
+    },
+    {
+      "name": "validate_knowledge_integrity",
+      "elapsed_ms": 2
     },
     {
       "name": "validate_override_authority",
@@ -113,12 +117,8 @@
       "elapsed_ms": 2
     },
     {
-      "name": "validate_knowledge_integrity",
-      "elapsed_ms": 2
-    },
-    {
       "name": "validate_generated_artifact_whitelist",
-      "elapsed_ms": 1
+      "elapsed_ms": 2
     },
     {
       "name": "validate_database_schema_versions",
@@ -129,15 +129,19 @@
       "elapsed_ms": 1
     },
     {
+      "name": "validate_health_cache_integrity",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_watcher_audit",
+      "elapsed_ms": 1
+    },
+    {
       "name": "validate_federation_gates",
       "elapsed_ms": 1
     },
     {
       "name": "validate_lcm_immutability",
-      "elapsed_ms": 1
-    },
-    {
-      "name": "validate_watcher_audit",
       "elapsed_ms": 1
     },
     {
@@ -153,10 +157,6 @@
       "elapsed_ms": 1
     },
     {
-      "name": "validate_health_cache_integrity",
-      "elapsed_ms": 1
-    },
-    {
       "name": "validate_research_claims_if_present",
       "elapsed_ms": 0
     },
@@ -169,15 +169,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_watcher_purity",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_heartbeat_invocation_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_canon_mutation",
       "elapsed_ms": 0
     },
     {
@@ -185,15 +177,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_risk_map_violations",
+      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
       "name": "validate_trajectory_artifacts_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_project_config_toml",
       "elapsed_ms": 0
     },
     {
@@ -205,11 +193,15 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_docs_templates_bucket",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_spec_drift",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_docs_templates_bucket",
+      "name": "validate_risk_map_violations",
       "elapsed_ms": 0
     },
     {
@@ -217,7 +209,15 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_canon_mutation",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_context_capsule_policy_contract",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_watcher_purity",
       "elapsed_ms": 0
     },
     {
@@ -233,14 +233,6 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_coplayer_policy_tightening",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_root_dockerfile_seed_detection",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_internalization_artifacts_if_present",
       "elapsed_ms": 0
     },
@@ -249,7 +241,15 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_coplayer_policy_tightening",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_context_capsules_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_root_dockerfile_seed_detection",
       "elapsed_ms": 0
     },
     {
@@ -261,11 +261,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_stale_workspaces",
+      "name": "validate_tooling_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_tooling_gate",
+      "name": "validate_stale_workspaces",
       "elapsed_ms": 0
     },
     {
@@ -290,5 +290,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:0bbb1d562d4063e634e974f015540685ae19d66ee768667969925eb8d053b087"
+  "receipt_hash": "sha256:e10c4fa1962f3885dabb00f7f9d173c7870fdaaac9ba7d6b7be56dc76278a5a0"
 }

--- a/.decapod/governance/validation.json
+++ b/.decapod/governance/validation.json
@@ -2,10 +2,10 @@
   "schema_version": "1.0.0",
   "kind": "validation_receipt",
   "decapod_release": "0.96.16",
-  "git_revision": "3d82ff719979bcf4b6632e328adbe15e461dcace",
+  "git_revision": "7047e07ee249e6abb514aac9c4389e6e0cf70535",
   "repo_signal_fingerprint": "a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce",
   "trajectory_run_id": "validation_01KZQN7VNYJXAG3R82TPR2XGBP",
-  "trajectory_artifact_hash": "sha256:4cbb6a2d71a61ec80aee245af2c92a29acdce448f11d573ada652c120c0cd6d9",
+  "trajectory_artifact_hash": "sha256:b6640322b5196546a33eb8fabae5f284f989aa550e9cf44568a24258fc2d4624",
   "validation_epoch": {
     "schema_version": "1.0.0",
     "epoch_id": "ve_17594b87f275c43f",
@@ -44,10 +44,10 @@
     }
   },
   "status": "ok",
-  "pass_count": 189,
+  "pass_count": 190,
   "fail_count": 0,
   "warn_count": 2,
-  "elapsed_ms": 1398,
+  "elapsed_ms": 1530,
   "drift_findings": [],
   "temporary_artifacts_cleaned": 0,
   "failures": [],
@@ -58,35 +58,35 @@
   "gate_timings": [
     {
       "name": "validate_machine_contract",
-      "elapsed_ms": 826
+      "elapsed_ms": 1006
     },
     {
       "name": "validate_control_plane_contract",
-      "elapsed_ms": 243
+      "elapsed_ms": 235
     },
     {
       "name": "validate_project_specs_docs",
-      "elapsed_ms": 100
+      "elapsed_ms": 71
     },
     {
       "name": "validate_markdown_primitives_roundtrip_gate",
-      "elapsed_ms": 56
+      "elapsed_ms": 58
     },
     {
       "name": "validate_schema_determinism",
-      "elapsed_ms": 42
-    },
-    {
-      "name": "validate_obligations",
       "elapsed_ms": 37
     },
     {
-      "name": "validate_embedded_self_contained",
-      "elapsed_ms": 17
+      "name": "validate_obligations",
+      "elapsed_ms": 33
     },
     {
       "name": "validate_no_legacy_namespaces",
-      "elapsed_ms": 11
+      "elapsed_ms": 14
+    },
+    {
+      "name": "validate_embedded_self_contained",
+      "elapsed_ms": 13
     },
     {
       "name": "validate_archive_integrity",
@@ -94,19 +94,15 @@
     },
     {
       "name": "validate_interface_contract_bootstrap",
-      "elapsed_ms": 10
+      "elapsed_ms": 8
     },
     {
       "name": "validate_repomap_determinism",
-      "elapsed_ms": 6
+      "elapsed_ms": 5
     },
     {
       "name": "validate_legacy_jsonl_retired",
       "elapsed_ms": 3
-    },
-    {
-      "name": "validate_knowledge_integrity",
-      "elapsed_ms": 2
     },
     {
       "name": "validate_override_authority",
@@ -118,22 +114,18 @@
     },
     {
       "name": "validate_generated_artifact_whitelist",
-      "elapsed_ms": 2
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_knowledge_integrity",
+      "elapsed_ms": 1
     },
     {
       "name": "validate_database_schema_versions",
       "elapsed_ms": 1
     },
     {
-      "name": "validate_lineage_hard_gate",
-      "elapsed_ms": 1
-    },
-    {
-      "name": "validate_health_cache_integrity",
-      "elapsed_ms": 1
-    },
-    {
-      "name": "validate_watcher_audit",
+      "name": "validate_lcm_immutability",
       "elapsed_ms": 1
     },
     {
@@ -141,7 +133,11 @@
       "elapsed_ms": 1
     },
     {
-      "name": "validate_lcm_immutability",
+      "name": "validate_watcher_audit",
+      "elapsed_ms": 1
+    },
+    {
+      "name": "validate_lineage_hard_gate",
       "elapsed_ms": 1
     },
     {
@@ -157,6 +153,10 @@
       "elapsed_ms": 1
     },
     {
+      "name": "validate_health_cache_integrity",
+      "elapsed_ms": 1
+    },
+    {
       "name": "validate_research_claims_if_present",
       "elapsed_ms": 0
     },
@@ -169,11 +169,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_heartbeat_invocation_gate",
+      "name": "validate_repo_map",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_repo_map",
+      "name": "validate_heartbeat_invocation_gate",
       "elapsed_ms": 0
     },
     {
@@ -193,27 +193,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_docs_templates_bucket",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_spec_drift",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_risk_map_violations",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_state_commit_gate",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_canon_mutation",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_context_capsule_policy_contract",
       "elapsed_ms": 0
     },
     {
@@ -221,7 +201,31 @@
       "elapsed_ms": 0
     },
     {
+      "name": "validate_spec_drift",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_canon_mutation",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_state_commit_gate",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_docs_templates_bucket",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsule_policy_contract",
+      "elapsed_ms": 0
+    },
+    {
       "name": "validate_workunit_manifests_if_present",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_root_dockerfile_seed_detection",
       "elapsed_ms": 0
     },
     {
@@ -229,15 +233,7 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_risk_map",
-      "elapsed_ms": 0
-    },
-    {
       "name": "validate_internalization_artifacts_if_present",
-      "elapsed_ms": 0
-    },
-    {
-      "name": "validate_recursive_improvement_passes_if_present",
       "elapsed_ms": 0
     },
     {
@@ -245,11 +241,15 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_context_capsules_if_present",
+      "name": "validate_recursive_improvement_passes_if_present",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_root_dockerfile_seed_detection",
+      "name": "validate_risk_map",
+      "elapsed_ms": 0
+    },
+    {
+      "name": "validate_context_capsules_if_present",
       "elapsed_ms": 0
     },
     {
@@ -269,11 +269,11 @@
       "elapsed_ms": 0
     },
     {
-      "name": "validate_git_protected_branch",
+      "name": "validate_git_push_pr_gate",
       "elapsed_ms": 0
     },
     {
-      "name": "validate_git_push_pr_gate",
+      "name": "validate_git_protected_branch",
       "elapsed_ms": 0
     }
   ],
@@ -290,5 +290,5 @@
       "Use `decapod validate -v --format json` to inspect the affected gate output."
     ]
   },
-  "receipt_hash": "sha256:e10c4fa1962f3885dabb00f7f9d173c7870fdaaac9ba7d6b7be56dc76278a5a0"
+  "receipt_hash": "sha256:1a732f44ed9ae6166188a7d51eb77687eb99f73b32caa2a8a01a7b1f6277018d"
 }

--- a/.decapod/managed/Dockerfile.decapod
+++ b/.decapod/managed/Dockerfile.decapod
@@ -4,9 +4,10 @@
 # mutate project-specific packages and commands in workspace branches.
 # The image tag and DECAPOD_VERSION below are the release pin; keep them aligned.
 # Workspace creation and validation refresh this pin only when the evaluating Decapod release changes.
-ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.96.15-debian
+
+ARG DECAPOD_IMAGE=ghcr.io/decapodlabs/decapod:v0.96.16-debian
 FROM $DECAPOD_IMAGE
-ARG DECAPOD_VERSION=0.96.15
+ARG DECAPOD_VERSION=0.96.16
 ARG DECAPOD_WORKSPACE_PATH=unknown
 ARG DECAPOD_USE_LOCAL_BINARY=0
 LABEL org.opencontainers.image.base.name="$DECAPOD_IMAGE"

--- a/.decapod/managed/specs/.manifest.json
+++ b/.decapod/managed/specs/.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.1.0",
   "template_version": "scaffold-v4",
-  "generated_at": "1786425388Z",
-  "repo_signal_fingerprint": "9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106",
+  "generated_at": "1786426888Z",
+  "repo_signal_fingerprint": "a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce",
   "declared_capabilities": [
     "agent-helper",
     "authentication",
@@ -17,81 +17,81 @@
   ],
   "capability_definition_version": "1.0.0",
   "config_input_hash": "5d58d6605113462c598e20231a013125ce3dfb904315517285c4d6015253ea3e",
-  "spec_input_hash": "b29a5fde80dc26419219e20625be1ae538a43c6da1704f02fcc3adcc396783ea",
-  "decapod_release": "0.96.15",
+  "spec_input_hash": "41181390aa09fa22a5eb67972dd01e9b53061b5008bb4f8e052cf2c4b2cc0e98",
+  "decapod_release": "0.96.16",
   "entrypoints": [
     {
       "path": "AGENTS.md",
-      "template_hash": "bca671552c54040bc43f54f4c054e25cc594ff9a1bc0b841cce680790c95a689",
-      "content_hash": "bca671552c54040bc43f54f4c054e25cc594ff9a1bc0b841cce680790c95a689",
-      "fingerprint": "e8c12c650831ad18cccf92ff5bb9bbe6d0b0998d8813dd421259c30b99ca69c4"
+      "template_hash": "a14c8bbda36d58d85a45ca6ceb20f07473d8d8d162c54dc5ce99d6c69d25a44a",
+      "content_hash": "a14c8bbda36d58d85a45ca6ceb20f07473d8d8d162c54dc5ce99d6c69d25a44a",
+      "fingerprint": "be3935eddddd14e244f616db6eb1924671e61ee4218f747400c5a7f079210b4d"
     },
     {
       "path": "CLAUDE.md",
-      "template_hash": "518805dd6838375f4007183f9972a38345a37592794eade7717566c5f6225a2e",
-      "content_hash": "518805dd6838375f4007183f9972a38345a37592794eade7717566c5f6225a2e",
-      "fingerprint": "31e8b6a1e48735260fdbac84c68a3b12a23bce47b76e5f92b5582f9fc9c76dc6"
+      "template_hash": "ee314c780b69489036b47f8bc8161240318b96da56adc5879b09c40440932342",
+      "content_hash": "ee314c780b69489036b47f8bc8161240318b96da56adc5879b09c40440932342",
+      "fingerprint": "80d270c5b07dc5be715c323111789c8ce01ed15fe5df7000bfd176db8574c51a"
     },
     {
       "path": "GEMINI.md",
-      "template_hash": "e94810c9ac434f19d546da67ebf9d528218eb13760344e7f66241f862f7c2205",
-      "content_hash": "e94810c9ac434f19d546da67ebf9d528218eb13760344e7f66241f862f7c2205",
-      "fingerprint": "f96ffde2588c1e2aed1c57240847ec9e80351985e2c99b078ed3921722ce73de"
+      "template_hash": "de97f11d9c6657d4e8f624b9dba510b811fb4328d23e6a6c5816e2e3fbe2c2bd",
+      "content_hash": "de97f11d9c6657d4e8f624b9dba510b811fb4328d23e6a6c5816e2e3fbe2c2bd",
+      "fingerprint": "a35188e7ed65f37a8b5dc96135f889b9cad249add1ea24cb89feffa898fa0a0a"
     },
     {
       "path": "CODEX.md",
-      "template_hash": "5cee9ec3725fa325f4e0df5727a8d377c1645787604d793c7e61ac7eb6f80d8c",
-      "content_hash": "5cee9ec3725fa325f4e0df5727a8d377c1645787604d793c7e61ac7eb6f80d8c",
-      "fingerprint": "0a71174811031d9b328cf07270937fd8ae8cd2dda79dabe5f61cbc3344029e26"
+      "template_hash": "02fca6f9bb3243c7aa6467a1bc0856f1de30f8f356f8a539d854b8540c72912e",
+      "content_hash": "02fca6f9bb3243c7aa6467a1bc0856f1de30f8f356f8a539d854b8540c72912e",
+      "fingerprint": "3d6e82bc47cbc8c34081655642e21c6570a1aa9cc5b9ecf188154a72ebc2b10d"
     }
   ],
   "files": [
     {
       "path": ".decapod/managed/specs/README.md",
       "template_hash": "02625ac2fa4e54265e89da47f12456b24346a5c13cfe1de52ce41ad1c864c497",
-      "content_hash": "21f15bcc435f7375abfb61c54bb791ffaeef78f4f1052c9eb6b86225a5c28dcc",
+      "content_hash": "7d2ac7b9f3d6c022b9edefe8ebdfc084c1544435f0fe5d555b04cdb615330e2c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTENT.md",
       "template_hash": "2627369573dd814dcf187b14dba49b37e4f8641f1106fbfde5e89e319141ee6c",
-      "content_hash": "47a80e6cd127ae62aa8679a8fa23d8b19eb266f2acb52bd78bcd22ce1713cbe7",
+      "content_hash": "8f8a5ceb18db956c63b5d13432ec638ef74ae6b73eeefb051e868a0214a34719",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/ARCHITECTURE.md",
       "template_hash": "2b28b729b2515295b98cdc7e1d69a6b2d9698151e9bf2c5f2b86191fbebc91df",
-      "content_hash": "7ecc1e4be40988792b680ca035930567a41a2832821195516d9c421883e18099",
+      "content_hash": "36ee66f91e94f079b35cc0dd3e474c339ef82847590579738249cd9af4bedbcf",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/INTERFACES.md",
       "template_hash": "6dd3c2a4490dc32996dbf9dc1510d8b11aa01ac518f0a0c553100aff7c19a19d",
-      "content_hash": "2e4749e4d61164ca925a8b82be04422547e885dede23d8f477825f9b4ef5b45c",
+      "content_hash": "41540b81e425d092a4fec15c17ec765655c7fc38da74b77d977fab12dbd8adf9",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/VALIDATION.md",
       "template_hash": "c2883ed632c25ad60a8e6fceebf5394052e263e149c1d24948776aa68fc5883b",
-      "content_hash": "df572fac22d3609cb85cbdd88ccffd9d413ca6eab0fb98be70d939f07f4ebd84",
+      "content_hash": "d596058d433f363faa92b959bfccc712d7e2a6bed5a0e49e6e00ac2a7adb5e8c",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SEMANTICS.md",
       "template_hash": "c96df961831c8fbbcf87609051c8b8e340bbb5e51ef5391714246cb94dbbd305",
-      "content_hash": "863988a64e0f583bb292140f02c3794affd1a64717ef8fbe8031342144610f72",
+      "content_hash": "6cb8e901859229e169322e66ae59757515d548f3cb1ea4163297dc1dde2a69fd",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/OPERATIONS.md",
       "template_hash": "0636ac7163dd3a9369fbe46b80df87ecfd43f3f6215c0b761876d9e57236956c",
-      "content_hash": "69ba8ebf44d19bba56a163d2d6d8c3902773966c1169ad7fd3c0accba50c4a37",
+      "content_hash": "123d2538cdeeca3be145926067d303cb5fe6456c9b33b4d0189df3052056f6c8",
       "fingerprint": ""
     },
     {
       "path": ".decapod/managed/specs/SECURITY.md",
       "template_hash": "8fb631ecae9f794c52d9e2360461d40fd83eec40476ce293d1f423d1135de681",
-      "content_hash": "7a92bf3462bf8136878b9cc3e3039aeb0e2fe10f30faee175988daf8d228ef6c",
+      "content_hash": "4ef4fffa3aae706dc92020288ad2fb74b009df2d800f72a0e37ea39242aa52c0",
       "fingerprint": ""
     }
   ]

--- a/.decapod/managed/specs/ARCHITECTURE.md
+++ b/.decapod/managed/specs/ARCHITECTURE.md
@@ -183,7 +183,7 @@ sequenceDiagram
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/INTENT.md
+++ b/.decapod/managed/specs/INTENT.md
@@ -184,10 +184,13 @@ flowchart LR
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->
 
 ## Honest composition note (#1233 review)
 `PUBLICATION_BUNDLE_CURRENCY` is a HEAD load/presence predicate; fingerprint and living-spec attestation remain sibling gates.
+
+## Release-bound sync for release-plz PRs (#1236)
+release-plz version bumps change `Cargo.toml` (and thus `repo_signal_fingerprint`) without regenerating entrypoint pins. Validation must not hard-fail those PRs on drift; `release-artifact-sync` and the post-release-plz heal step regenerate pins/specs and commit them.

--- a/.decapod/managed/specs/INTERFACES.md
+++ b/.decapod/managed/specs/INTERFACES.md
@@ -112,7 +112,7 @@ pub enum ApiError {
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/OPERATIONS.md
+++ b/.decapod/managed/specs/OPERATIONS.md
@@ -168,7 +168,7 @@ Use `tracing` + `tracing-subscriber` with structured JSON output and request cor
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/README.md
+++ b/.decapod/managed/specs/README.md
@@ -71,7 +71,7 @@ This change establishes two repository invariants:
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SECURITY.md
+++ b/.decapod/managed/specs/SECURITY.md
@@ -111,7 +111,7 @@ Describe the security primitives and security controls implemented in this repos
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/SEMANTICS.md
+++ b/.decapod/managed/specs/SEMANTICS.md
@@ -116,7 +116,7 @@ stateDiagram-v2
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.decapod/managed/specs/VALIDATION.md
+++ b/.decapod/managed/specs/VALIDATION.md
@@ -230,7 +230,7 @@ Proof-completion bindings:
 
 ## Codebase Attestation
 
-- Repository signal fingerprint: `9b9d1508e071f9cc191083b2d637dc37f27f8823dff256b2de6172b49bdcb106`
-- Significant implementation surfaces: `.github/` (9 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
+- Repository signal fingerprint: `a4af6e8584f3f38d36d13da8a0e1dafea7d8823d8d516717b9e5663f05086dce`
+- Significant implementation surfaces: `.github/` (10 files), `Cargo.lock/` (1 files), `Cargo.toml/` (1 files), `README.md/` (1 files), `docs/` (1 files), `src/` (101 files), `tests/` (4 files)
 - Refreshed from the current codebase by `decapod specs.refresh`
 <!-- decapod:codebase-attestation:end -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,8 @@ jobs:
       - name: Ensure no spec or entrypoint drift
         # validate rewrites generated_at every run; that is not semantic drift.
         # Release-bound projections must be refreshed by the agent and committed
-        # with the code PR. Release-only commits are excluded from push CI.
+        # with the code PR. release-plz PRs are healed by release-artifact-sync.
+        if: github.event_name != 'pull_request' || (!contains(github.event.pull_request.labels.*.name, 'release') && !startsWith(github.head_ref, 'release-plz-'))
         run: |
           set -euo pipefail
           MANIFEST=".decapod/managed/specs/.manifest.json"

--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -30,16 +30,18 @@ jobs:
       - name: Decapod Validate
         env:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
-          # Post-merge: tree-local binary fingerprints lag the last published pin.
-          # PRs still enforce release-bound pins + drift.
-          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: ${{ github.event_name == 'push' && '1' || '' }}
+          # Post-merge tree-local pins lag the last published fingerprint.
+          # release-plz PRs heal via release-artifact-sync (skip hard fingerprint fails).
+          # Code PRs still enforce release-bound pins + drift below.
+          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'release') || startsWith(github.head_ref, 'release-plz-')) && '1' || '' }}
         run: |
           if [ ! -d .decapod ]; then
             decapod init --proof
           fi
           decapod validate --refresh-specs
       - name: Ensure no spec or entrypoint drift
-        if: github.event_name == 'pull_request'
+        # release-plz bumps Cargo.toml without pins; release-artifact-sync heals those PRs.
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'release') && !startsWith(github.head_ref, 'release-plz-')
         # validate rewrites generated_at every run; that is not semantic drift.
         # Normalize it to HEAD before the exit-code check so only real content,
         # entrypoint, Dockerfile, or manifest hash drift fails CI.

--- a/.github/workflows/release-artifact-sync.yml
+++ b/.github/workflows/release-artifact-sync.yml
@@ -1,0 +1,196 @@
+name: Release Artifact Sync
+
+# Root cause (since #1170 / v0.95.4):
+# release-plz bumps Cargo.toml/CHANGELOG without regenerating release-bound
+# entrypoint pins, managed Dockerfile headers, or living-spec attestations.
+# CI then runs `validate --refresh-specs` and fails the drift gate.
+#
+# A prior PR-only sync raced with fast release-PR merge: by the time the job
+# finished, the branch was deleted and the push recreated an orphan that never
+# landed on master.
+#
+# Master is ruleset-protected (PR required, required signatures, no direct
+# update). Never push healed artifacts straight to master — open/update a PR.
+#
+# This workflow heals:
+#   1. open release-plz / release-labeled PRs (before merge when possible), and
+#   2. master pin lag via a dedicated chore PR after merge/release.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  push:
+    branches: [master]
+    paths:
+      - 'Cargo.toml'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'CODEX.md'
+      - 'GEMINI.md'
+      - '.decapod/managed/**'
+      - '.github/workflows/release-artifact-sync.yml'
+
+concurrency:
+  group: release-artifact-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-release-bound-artifacts:
+    name: Sync release-bound entrypoints and specs
+    runs-on: ubuntu-latest
+    # PR path: only release-plz / release-labeled same-repo PRs.
+    # Push path: master after version/pin/spec changes.
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      || (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && (
+          contains(github.event.pull_request.labels.*.name, 'release')
+          || startsWith(github.head_ref, 'release-plz-')
+        )
+      )
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: DecapodLabs
+
+      - uses: actions/checkout@v4
+        with:
+          # On PR events, check out the PR head. On master push, check out master.
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.1
+
+      - name: Detect stale release pins
+        id: detect
+        run: |
+          set -euo pipefail
+          cargo_ver="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          pin_ver="$(sed -n 's/^<!-- decapod-release: \(.*\) -->/\1/p' AGENTS.md | head -1 || true)"
+          echo "cargo_version=${cargo_ver}" >> "$GITHUB_OUTPUT"
+          echo "pin_version=${pin_ver}" >> "$GITHUB_OUTPUT"
+          if [ -n "${cargo_ver}" ] && [ -n "${pin_ver}" ] && [ "${cargo_ver}" = "${pin_ver}" ]; then
+            # Still refresh when only fingerprint/attestation drift is possible
+            # (e.g. Dockerfile ARG). Always build + validate below.
+            echo "pins_match=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pins_match=false" >> "$GITHUB_OUTPUT"
+            echo "Stale pins: Cargo.toml=${cargo_ver} AGENTS.md=${pin_ver}"
+          fi
+
+      - name: Build evaluating binary
+        run: cargo build --release --locked
+
+      - name: Refresh release-bound artifacts
+        env:
+          DECAPOD_VALIDATE_SKIP_GIT_GATES: "1"
+          # Healing job: tree-local binary pins lag the last published fingerprint
+          # until refresh rewrites them. Skip fingerprint hard-fails; pin-version
+          # match is still enforced below.
+          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: "1"
+        run: |
+          set -euo pipefail
+          BIN=./target/release/decapod
+          chmod +x "$BIN"
+          # Self-heal stale release pins (entrypoint headers + Dockerfile).
+          "$BIN" validate --refresh-specs || true
+          # Explicit specs.refresh rewrites living-spec MD attestations.
+          "$BIN" rpc --op specs.refresh || true
+          "$BIN" validate --refresh-specs --format json >/tmp/validate.json || true
+          python3 - <<'PY'
+          import json
+          try:
+              report = json.load(open("/tmp/validate.json"))
+              status = report.get("report", report).get("status")
+              print(f"validate status after refresh: {status}")
+          except Exception as exc:
+              print(f"validate json unavailable: {exc}")
+          PY
+          # Normalize generated_at so only material pin/spec drift is committed.
+          MANIFEST=".decapod/managed/specs/.manifest.json"
+          if git cat-file -e "HEAD:${MANIFEST}" 2>/dev/null && [ -f "${MANIFEST}" ]; then
+            OLD=$(git show "HEAD:${MANIFEST}" | sed -n 's/.*"generated_at": "\([^"]*\)".*/\1/p' | head -1 || true)
+            if [ -n "${OLD:-}" ]; then
+              sed -i "s/\"generated_at\": \"[^\"]*\"/\"generated_at\": \"${OLD}\"/" "${MANIFEST}"
+            fi
+          fi
+
+          cargo_ver="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          pin_ver="$(sed -n 's/^<!-- decapod-release: \(.*\) -->/\1/p' AGENTS.md | head -1 || true)"
+          if [ -n "${cargo_ver}" ] && [ -n "${pin_ver}" ] && [ "${cargo_ver}" != "${pin_ver}" ]; then
+            echo "::error::Release pin heal failed: Cargo.toml=${cargo_ver} AGENTS.md=${pin_ver}"
+            echo "refresh_entrypoint_metadata did not rewrite entrypoints; investigate template/body mismatch."
+            exit 1
+          fi
+
+      - name: Commit regenerated artifacts
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Commit as the GitHub App identity so merges attribute correctly.
+          # Ruleset required_signatures applies to master only; branch pushes
+          # (PR heads / chore/*) are not under that ruleset. Do not push to master.
+          git config user.name "decapod-release-manager[bot]"
+          git config user.email "261518511+decapod-release-manager[bot]@users.noreply.github.com"
+          git add \
+            AGENTS.md CLAUDE.md CODEX.md GEMINI.md \
+            .decapod/managed/Dockerfile.decapod \
+            .decapod/managed/specs/ \
+            || true
+          if git diff --cached --quiet; then
+            echo "No release-bound artifact drift to commit."
+            exit 0
+          fi
+          git commit -m "chore: sync release-bound entrypoints and living specs"
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            # Never recreate a deleted release-plz branch after the PR merged.
+            git push origin "HEAD:${PR_HEAD}"
+            exit 0
+          fi
+
+          # Master path: open/update a PR. Direct push to master is blocked by
+          # ruleset (PR required + required signatures + update protection).
+          BRANCH="chore/release-bound-sync"
+          git fetch origin master
+          # Rebase-free force is intentional: this branch is bot-owned heal tip.
+          git push --force origin "HEAD:${BRANCH}"
+          if gh pr list --state open --head "${BRANCH}" --json number --jq 'length' | grep -qx '0'; then
+            gh pr create \
+              --base master \
+              --head "${BRANCH}" \
+              --title "chore: sync release-bound entrypoints and living specs" \
+              --label release \
+              --body "$(cat <<'EOF'
+              ## Summary
+              Automated heal of release-bound entrypoint pins, managed Dockerfile headers, and living-spec attestations after a master version/pin drift.
+
+              Master is ruleset-protected (PR required, signed commits). This PR is the only supported way for CI to land release-bound regenerations.
+
+              ## Test plan
+              - [ ] Confirm AGENTS/CLAUDE/CODEX/GEMINI release pins match Cargo.toml
+              - [ ] Confirm .decapod/managed/Dockerfile.decapod pins match
+              - [ ] Merge after review (release label skips material-specs/governance artifact gates)
+              EOF
+              )"
+          else
+            echo "Updated existing open PR for ${BRANCH}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,99 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
-      # Release publishing is intentionally limited to the release/tag path.
-      # Release-bound projections are refreshed by the agent before the code PR.
-      # No post-merge artifact-heal commit is created here.
+      # release-plz only rewrites Cargo.toml/CHANGELOG. Since #1170 the drift
+      # gate fails unless entrypoint pins + living-spec attestations match the
+      # new binary version. Sync immediately in this job so a fast merge cannot
+      # leave master with stale pins (the PR-only sync race).
+      - name: Sync release-bound artifacts after release-plz
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          DECAPOD_VALIDATE_SKIP_GIT_GATES: "1"
+          # Tree-local binary pins lag the last published release fingerprint
+          # until this heal step commits regenerated markers. Do not hard-fail
+          # validate on fingerprint mismatch while regenerating.
+          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: "1"
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config user.name "decapod-release-manager[bot]"
+          git config user.email "261518511+decapod-release-manager[bot]@users.noreply.github.com"
+
+          # Prefer an open release PR branch; otherwise heal master if pins lag.
+          BRANCH="$(gh pr list --state open --label release --json headRefName --jq '.[0].headRefName // empty' || true)"
+          if [ -z "${BRANCH}" ]; then
+            BRANCH="$(gh pr list --state open --json headRefName,title --jq '.[] | select(.title|test("(?i)release v")) | .headRefName' | head -1 || true)"
+          fi
+
+          OPEN_PR_AFTER=0
+          if [ -n "${BRANCH}" ]; then
+            echo "Syncing open release PR branch: ${BRANCH}"
+            git fetch origin "${BRANCH}"
+            git checkout -B "${BRANCH}" "origin/${BRANCH}"
+            PUSH_REF="${BRANCH}"
+          else
+            git fetch origin master
+            git checkout -B master origin/master
+            cargo_ver="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+            pin_ver="$(sed -n 's/^<!-- decapod-release: \(.*\) -->/\1/p' AGENTS.md | head -1 || true)"
+            if [ -n "${cargo_ver}" ] && [ -n "${pin_ver}" ] && [ "${cargo_ver}" = "${pin_ver}" ]; then
+              echo "No open release PR and pins already match Cargo.toml (${cargo_ver})."
+              exit 0
+            fi
+            # Master is ruleset-protected (PR required + required signatures).
+            # Never push heal commits directly to master — use a chore branch + PR.
+            echo "No open release PR; opening heal PR (Cargo=${cargo_ver} pin=${pin_ver})."
+            PUSH_REF="chore/release-bound-sync"
+            OPEN_PR_AFTER=1
+          fi
+
+          cargo build --release --locked
+          BIN=./target/release/decapod
+          chmod +x "$BIN"
+          "$BIN" validate --refresh-specs || true
+          "$BIN" rpc --op specs.refresh || true
+          "$BIN" validate --refresh-specs || true
+
+          MANIFEST=".decapod/managed/specs/.manifest.json"
+          if git cat-file -e "HEAD:${MANIFEST}" 2>/dev/null && [ -f "${MANIFEST}" ]; then
+            OLD=$(git show "HEAD:${MANIFEST}" | sed -n 's/.*"generated_at": "\([^"]*\)".*/\1/p' | head -1 || true)
+            if [ -n "${OLD:-}" ]; then
+              sed -i "s/\"generated_at\": \"[^\"]*\"/\"generated_at\": \"${OLD}\"/" "${MANIFEST}"
+            fi
+          fi
+
+          cargo_ver="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          pin_ver="$(sed -n 's/^<!-- decapod-release: \(.*\) -->/\1/p' AGENTS.md | head -1 || true)"
+          if [ -n "${cargo_ver}" ] && [ -n "${pin_ver}" ] && [ "${cargo_ver}" != "${pin_ver}" ]; then
+            echo "::error::Failed to heal release pins after release-plz (Cargo=${cargo_ver} pin=${pin_ver})."
+            exit 1
+          fi
+
+          git add \
+            AGENTS.md CLAUDE.md CODEX.md GEMINI.md \
+            .decapod/managed/Dockerfile.decapod \
+            .decapod/managed/specs/ \
+            || true
+          if git diff --cached --quiet; then
+            echo "No release-bound artifact drift to commit."
+            exit 0
+          fi
+          git commit -m "chore: sync release-bound entrypoints and living specs"
+          if [ "${OPEN_PR_AFTER}" = "1" ]; then
+            git push --force origin "HEAD:${PUSH_REF}"
+            if gh pr list --state open --head "${PUSH_REF}" --json number --jq 'length' | grep -qx '0'; then
+              gh pr create \
+                --base master \
+                --head "${PUSH_REF}" \
+                --title "chore: sync release-bound entrypoints and living specs" \
+                --label release \
+                --body "Automated post-release-plz heal of release-bound entrypoints/specs. Master ruleset forbids direct push."
+            else
+              echo "Updated existing open PR for ${PUSH_REF}"
+            fi
+          else
+            git push origin "HEAD:${PUSH_REF}"
+          fi
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: "ubuntu-24.04"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.96.15 -->
-<!-- decapod-fingerprint: e8c12c650831ad18cccf92ff5bb9bbe6d0b0998d8813dd421259c30b99ca69c4 -->
+<!-- decapod-release: 0.96.16 -->
+<!-- decapod-fingerprint: be3935eddddd14e244f616db6eb1924671e61ee4218f747400c5a7f079210b4d -->
 # AGENTS.md — Universal Agent Contract
 
 This is a Decapod-managed repository. **Strict Dependency: You are strictly bound to the Decapod governance kernel.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.96.15 -->
-<!-- decapod-fingerprint: 31e8b6a1e48735260fdbac84c68a3b12a23bce47b76e5f92b5582f9fc9c76dc6 -->
+<!-- decapod-release: 0.96.16 -->
+<!-- decapod-fingerprint: 80d270c5b07dc5be715c323111789c8ce01ed15fe5df7000bfd176db8574c51a -->
 # CLAUDE.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.96.15 -->
-<!-- decapod-fingerprint: 0a71174811031d9b328cf07270937fd8ae8cd2dda79dabe5f61cbc3344029e26 -->
+<!-- decapod-release: 0.96.16 -->
+<!-- decapod-fingerprint: 3d6e82bc47cbc8c34081655642e21c6570a1aa9cc5b9ecf188154a72ebc2b10d -->
 # CODEX.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,5 @@
-<!-- decapod-release: 0.96.15 -->
-<!-- decapod-fingerprint: f96ffde2588c1e2aed1c57240847ec9e80351985e2c99b078ed3921722ce73de -->
+<!-- decapod-release: 0.96.16 -->
+<!-- decapod-fingerprint: a35188e7ed65f37a8b5dc96135f889b9cad249add1ea24cb89feffa898fa0a0a -->
 # GEMINI.md - Agent Entrypoint
 
 You are working in a Decapod-managed repository.

--- a/tests/release_workflow_policy.rs
+++ b/tests/release_workflow_policy.rs
@@ -318,9 +318,30 @@ fn material_specs_gate_skips_release_labeled_prs() {
         "material-specs job must fail closed on fingerprint-only refreshes"
     );
     assert!(
-        workflow.contains(
-            "if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'release')"
-        ),
+        workflow.contains("!contains(github.event.pull_request.labels.*.name, 'release')"),
         "release-labeled PRs must not be forced through the material living-specs gate"
+    );
+}
+
+#[test]
+fn release_pr_skips_spec_entrypoint_drift_gate() {
+    // Regression for release PR #1236 / actions run 31461500432:
+    // release-plz bumps Cargo.toml (repo_signal changes) without entrypoint
+    // pins; validate --refresh-specs rewrites the manifest and the drift gate
+    // must not hard-fail the release PR. Heal is owned by release-artifact-sync.
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let validate = fs::read_to_string(root.join(".github/workflows/decapod-validate.yml"))
+        .expect("read decapod-validate workflow");
+    let ci = fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read CI workflow");
+
+    assert!(
+        validate.contains("startsWith(github.head_ref, 'release-plz-')")
+            && validate.contains("!contains(github.event.pull_request.labels.*.name, 'release')"),
+        "decapod-validate drift gate must skip release-plz / release-labeled PRs"
+    );
+    assert!(
+        ci.contains("startsWith(github.head_ref, 'release-plz-')")
+            && ci.contains("Ensure no spec or entrypoint drift"),
+        "CI drift gate must also skip release-plz / release-labeled PRs"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the validation failure on release PR #1236 ([actions run 31461500432](https://github.com/DecapodLabs/decapod/actions/runs/31461500432/job/93685740793)).

### Root cause
`decapod validate` itself **passed** (`fail=0`). The follow-up step **Ensure no spec or entrypoint drift** failed because:

1. release-plz only rewrote `Cargo.toml` / CHANGELOG for `0.96.15 → 0.96.16`
2. `Cargo.toml` is part of `repo_signal_fingerprint`
3. `validate --refresh-specs` rewrote `.decapod/managed/specs/.manifest.json` with the new fingerprint
4. The PR drift gate then hard-failed on that regenerate

Entrypoints on the release PR still pinned **0.96.15** while Cargo was **0.96.16**. The heal path that used to fix this (`release-artifact-sync` + post-release-plz sync in `release.yml`) was removed in `b05051c8` (“keep release merges outside validation”), which left the known #1170-class regression exposed again.

### Fix
1. **Restore** `.github/workflows/release-artifact-sync.yml` — heal open release-plz / release-labeled PRs and open a chore PR for master pin lag
2. **Restore** `Sync release-bound artifacts after release-plz` in `release.yml`
3. **Skip** fingerprint hard-fails + drift gate for release-plz / release-labeled PRs in `decapod-validate.yml` and CI (heal owns those PRs; code PRs still enforce drift)
4. **Heal master pins** to **0.96.16** (entrypoints, Dockerfile, specs) left stale after the #1236 merge

### Test plan
- [x] `cargo test --test release_workflow_policy` (11 pass, including new drift-skip regression)
- [x] Installed `decapod` 0.96.16 validate → `fail=0` with 0.96.16 entrypoint pins
- [ ] CI green on this PR
- [ ] Next release-plz PR should get healed pins / not fail the drift step

### Related
- Failed job: https://github.com/DecapodLabs/decapod/actions/runs/31461500432/job/93685740793
- Release PR: #1236 (already merged with the drift failure)
- Policy coverage: `tests/release_workflow_policy.rs` (restored expectations for release-bound sync)