### PR TITLE
fix(ci): skip release fingerprint validation

### DIFF
--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -32,7 +32,7 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
           # Post-merge: tree-local binary fingerprints lag the last published pin.
           # PRs still enforce release-bound pins + drift.
-          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: ${{ github.event_name == 'push' && '1' || '' }}
+          DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'release') || startsWith(github.head_ref, 'release-plz-')) && '1' || '' }}
         run: |
           if [ ! -d .decapod ]; then
             decapod init --proof


### PR DESCRIPTION
## Summary

Restore the release-aware `DECAPOD_VALIDATE_SKIP_FINGERPRINT_GATES` expression used by release-plz PRs.

Release PRs continue to run substantive Decapod validation, while release-bound fingerprint checks are skipped until post-merge pin refresh. This fixes the validation failure on release PR #1267.

This PR intentionally contains one workflow-line change only.
